### PR TITLE
Fix compiler CMake permissions for OSX

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -58,7 +58,7 @@ add_custom_target (compiler
     DEPENDS ${output} ${completion})
 
 install (FILES ${output}
-    PERMISSIONS WORLD_EXECUTE
+    PERMISSIONS OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE
     DESTINATION bin)
 
 if(EXISTS "${completion_dir}" AND IS_DIRECTORY "${completion_dir}")


### PR DESCRIPTION
On OS X at least, the CMake permissions don't leave the gbc compiler executable by the current user. OWNER and GROUP need to both be specified.