### PR TITLE
Make test and examples projects are compilable with xbuild

### DIFF
--- a/cs/build/Bond.CSharp.targets
+++ b/cs/build/Bond.CSharp.targets
@@ -82,7 +82,7 @@
                       Lines="@(_BondCodegenWithDefaultOptions)"
                       Overwrite="true" />
 
-    <Exec Command="$(_BondCommand) @&quot;$(BondOutputDirectory)bondfiles.tmp&quot;"
+    <Exec Command="$(_BondCommand) $(BondOptions) @&quot;$(BondOutputDirectory)bondfiles.tmp&quot;"
           Condition="'@(_BondCodegenWithDefaultOptions)' != ''" />
 
     <!-- And for any files needing custom options we'll have to generate one by one -->

--- a/cs/test/core/Core.csproj
+++ b/cs/test/core/Core.csproj
@@ -44,7 +44,7 @@
     <Compile Include="InterfaceTests.cs" />
     <Compile Include="JsonParsingTests.cs" />
     <Compile Include="MetaInitializationTests.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="properties\AssemblyInfo.cs" />
     <Compile Include="Random.cs" />
     <Compile Include="SerializationTests.cs" />
     <Compile Include="SerializerGeneratorFactoryTests.cs" />

--- a/cs/test/core/UnitTest.bond
+++ b/cs/test/core/UnitTest.bond
@@ -1,4 +1,4 @@
-import "bond\core\bond.bond"
+import "bond/core/bond.bond"
 import "Aliases.bond"
 
 namespace UnitTest

--- a/cs/test/expressions/Expressions.csproj
+++ b/cs/test/expressions/Expressions.csproj
@@ -36,8 +36,8 @@
     <Reference Include="Bond.IO">
       <HintPath>..\..\src\io\$(OutputPath)\Bond.IO.dll</HintPath>
     </Reference>
-    <Reference Include="Bond.Json">
-      <HintPath>..\..\src\json\$(OutputPath)\Bond.Json.dll</HintPath>
+    <Reference Include="Bond.JSON">
+      <HintPath>..\..\src\json\$(OutputPath)\Bond.JSON.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildThisFileDirectory)\..\..\build\Common.Internal.targets" />

--- a/cs/test/expressions/schemas.bond
+++ b/cs/test/expressions/schemas.bond
@@ -1,4 +1,4 @@
-﻿import "bond\core\bond.bond"
+﻿import "bond/core/bond.bond"
 
 namespace ExpressionsTest
 


### PR DESCRIPTION
This is the second step of making solution compilable with xbuild.
It resolves all xbuild compilation issues except using references
to VisualStudio asseblies in test projects.
Fixed:
- wrong path dilimiter usage in bond files on linux system
- different case-sensitivity in file names
- passing global $(BondOptions) property to codegen process