### PR TITLE
Remove unnecessary semicolons

### DIFF
--- a/cpp/inc/bond/core/blob.h
+++ b/cpp/inc/bond/core/blob.h
@@ -381,5 +381,5 @@ inline T blob_cast(const blob& from)
     }
 }
 
-}; // bond namespace
+} // namespace bond
 

--- a/cpp/inc/bond/core/bonded.h
+++ b/cpp/inc/bond/core/bonded.h
@@ -276,4 +276,4 @@ private:
 
 #pragma warning(pop)
 
-};
+} // namespace bond

--- a/cpp/inc/bond/core/bonded_void.h
+++ b/cpp/inc/bond/core/bonded_void.h
@@ -183,4 +183,4 @@ private:
     const bool _base;
 };
 
-};
+} // namespace bond

--- a/cpp/inc/bond/core/container_interface.h
+++ b/cpp/inc/bond/core/container_interface.h
@@ -121,4 +121,4 @@ template<typename T>
 void resize_string(T& str, uint32_t size);
 #endif
 
-};
+} // namespace bond

--- a/cpp/inc/bond/core/detail/inheritance.h
+++ b/cpp/inc/bond/core/detail/inheritance.h
@@ -186,6 +186,6 @@ protected:
     const bool _base;
 };
 
-}; // namespace detail
+} // namespace detail
 
-}; // namespace bond
+} // namespace bond

--- a/cpp/inc/bond/core/detail/protocol_visitors.h
+++ b/cpp/inc/bond/core/detail/protocol_visitors.h
@@ -261,7 +261,6 @@ inline void Merge(const T& var, ProtocolReader<Buffer>& reader)
 }
 
 
-}; // namespace detail
+} // namespace detail
 
-
-}; // namespace bond
+} // namespace bond

--- a/cpp/inc/bond/core/detail/tags.h
+++ b/cpp/inc/bond/core/detail/tags.h
@@ -87,4 +87,4 @@ is_modifying_transform
     : is_base_of<ModifyingTransform, T> {};
 
 
-};
+} // namespace bond

--- a/cpp/inc/bond/core/detail/typeid_value.h
+++ b/cpp/inc/bond/core/detail/typeid_value.h
@@ -800,7 +800,6 @@ inline MatchingMapByElement(T& var, BondDataType keyType, BondDataType elementTy
 }
 
 
+} // namespace detail
 
-}; // namespace detail
-
-}; // namespace bond
+} // namespace bond

--- a/cpp/inc/bond/core/nullable.h
+++ b/cpp/inc/bond/core/nullable.h
@@ -651,5 +651,5 @@ is_list_container<nullable<T, Allocator, useValue> >
     : true_type {};
 
 
-}; // namespace bond
+} // namespace bond
 

--- a/cpp/inc/bond/core/protocol.h
+++ b/cpp/inc/bond/core/protocol.h
@@ -214,4 +214,4 @@ struct ProtocolReader
 };
 
 
-};
+} // namespace bond

--- a/cpp/inc/bond/core/reflection.h
+++ b/cpp/inc/bond/core/reflection.h
@@ -251,7 +251,7 @@ bond::Metadata MetadataInit(const char* name, const char* qualified_name, const 
 }
 
 
-}; // namespace reflection
+} // namespace reflection
 
 
 const reflection::nothing nothing = {};
@@ -809,4 +809,4 @@ public:
     }
 };
 
-};
+} // namespace bond

--- a/cpp/inc/bond/core/schema.h
+++ b/cpp/inc/bond/core/schema.h
@@ -352,4 +352,4 @@ inline const std::map<std::string, T>& GetEnumNames()
 }
 
 
-}; // namespace bond
+} // namespace bond

--- a/cpp/inc/bond/core/transforms.h
+++ b/cpp/inc/bond/core/transforms.h
@@ -687,7 +687,7 @@ protected:
         {
             return AssignToField(typename boost::mpl::next<Fields>::type(), var, id, value);
         }
-    };
+    }
 
     
     template <typename V, typename X>
@@ -775,4 +775,4 @@ private:
     const Mappings&  _mappings;
 };
 
-}
+} // namespace bond

--- a/cpp/inc/bond/core/value.h
+++ b/cpp/inc/bond/core/value.h
@@ -1002,5 +1002,5 @@ inline DeserializeMap(X& var, BondDataType keyType, const T& element, Reader& in
     input.ReadContainerEnd();
 }
 
-};
+} // namespace bond
     

--- a/cpp/inc/bond/protocol/compact_binary.h
+++ b/cpp/inc/bond/protocol/compact_binary.h
@@ -778,4 +778,4 @@ bool is_protocol_version_same(const bond::CompactBinaryReader<Input>& reader,
     return reader._version == writer._version;
 }
 
-}; // namespace bond
+} // namespace bond

--- a/cpp/inc/bond/protocol/simple_binary.h
+++ b/cpp/inc/bond/protocol/simple_binary.h
@@ -337,6 +337,4 @@ template <typename Output> struct
 may_omit_fields<SimpleBinaryWriter<Output> >
     : false_type {};
 
-};
-
-
+} // namespace bond

--- a/examples/cpp/core/protocol_versions/protocol_versions.cpp
+++ b/examples/cpp/core/protocol_versions/protocol_versions.cpp
@@ -10,7 +10,7 @@ namespace bond
     {
         static const uint16_t value = v2;
     };
-};
+}
 
 #include "protocol_versions_reflection.h"
 

--- a/python/inc/bond/python/converters.h
+++ b/python/inc/bond/python/converters.h
@@ -129,7 +129,7 @@ struct list_container_from_python_list
     static unaryfunc* convertible(PyObject* obj)
     {
         return (PyList_Check(obj)) ? &py_object_identity : 0;
-    };
+    }
 
     static void extract(T& dst, const boost::python::object& src)
     {
@@ -309,7 +309,7 @@ struct blob_converter
     static unaryfunc* convertible(PyObject* obj)
     {
         return (PyString_Check(obj)) ? &obj->ob_type->tp_str : 0;
-    };
+    }
 
     static void extract(bond::blob& dst, const boost::python::object& src)
     {

--- a/python/inc/bond/python/struct.h
+++ b/python/inc/bond/python/struct.h
@@ -331,11 +331,11 @@ private:
         }
 
     private:
-        BOOST_PYTHON_FUNCTION_OVERLOADS(marshal_overloads, marshal, 1, 2);
-        BOOST_PYTHON_FUNCTION_OVERLOADS(serialize_overloads, serialize, 1, 2);
-        BOOST_PYTHON_FUNCTION_OVERLOADS(serialize_bonded_overloads, serialize_bonded, 1, 2);
-        BOOST_PYTHON_FUNCTION_OVERLOADS(deserialize_overloads, deserialize, 2, 3);
-        BOOST_PYTHON_FUNCTION_OVERLOADS(deserialize_schema_overloads, deserialize_schema, 3, 4);
+        BOOST_PYTHON_FUNCTION_OVERLOADS(marshal_overloads, marshal, 1, 2)
+        BOOST_PYTHON_FUNCTION_OVERLOADS(serialize_overloads, serialize, 1, 2)
+        BOOST_PYTHON_FUNCTION_OVERLOADS(serialize_bonded_overloads, serialize_bonded, 1, 2)
+        BOOST_PYTHON_FUNCTION_OVERLOADS(deserialize_overloads, deserialize, 2, 3)
+        BOOST_PYTHON_FUNCTION_OVERLOADS(deserialize_schema_overloads, deserialize_schema, 3, 4)
     
         static const bond::SchemaDef& schema(const U&)
         {


### PR DESCRIPTION
I'm trying to use bond on an embedded platform, for which the compiler considers unnecessary semicolons to be unforgivable syntax errors. This commit removes all the unused semicolons I could find in the tree.