### PR TITLE
Added Syntax Highlighting support for Notepad++

### DIFF
--- a/tools/syntax/Notepad/README.md
+++ b/tools/syntax/Notepad/README.md
@@ -1,0 +1,6 @@
+#Installation Instructions for the Bond UDL:
+
+
+Import "bond.xml" via the Notepad++ menu,
+
+```Language > Define your Language... > Import```

--- a/tools/syntax/Notepad/bond.xml
+++ b/tools/syntax/Notepad/bond.xml
@@ -1,0 +1,64 @@
+<NotepadPlus>
+    <UserLang name="Bond" ext="bond" udlVersion="2.1">
+        <Settings>
+            <Global caseIgnored="no" allowFoldOfComments="yes" foldCompact="no" forcePureLC="0" decimalSeparator="2" />
+            <Prefix Keywords1="no" Keywords2="no" Keywords3="no" Keywords4="no" Keywords5="no" Keywords6="yes" Keywords7="no" Keywords8="no" />
+        </Settings>
+        <KeywordLists>
+            <Keywords name="Comments">00// 01 02((EOL)) 03/* 04*/</Keywords>
+            <Keywords name="Numbers, prefix1"></Keywords>
+            <Keywords name="Numbers, prefix2">0x</Keywords>
+            <Keywords name="Numbers, extras1">A B C D E F a b c d e f </Keywords>
+            <Keywords name="Numbers, extras2"></Keywords>
+            <Keywords name="Numbers, suffix1"></Keywords>
+            <Keywords name="Numbers, suffix2"></Keywords>
+            <Keywords name="Numbers, range"></Keywords>
+            <Keywords name="Operators1">;  : = ,</Keywords>
+            <Keywords name="Operators2"></Keywords>
+            <Keywords name="Folders in code1, open"></Keywords>
+            <Keywords name="Folders in code1, middle"></Keywords>
+            <Keywords name="Folders in code1, close"></Keywords>
+            <Keywords name="Folders in code2, open"></Keywords>
+            <Keywords name="Folders in code2, middle"></Keywords>
+            <Keywords name="Folders in code2, close"></Keywords>
+            <Keywords name="Folders in comment, open">{</Keywords>
+            <Keywords name="Folders in comment, middle"></Keywords>
+            <Keywords name="Folders in comment, close">}</Keywords>
+            <Keywords name="Keywords1">int8&#x000D;&#x000A;uint8&#x000D;&#x000A;int16&#x000D;&#x000A;uint16&#x000D;&#x000A;int32&#x000D;&#x000A;uint32&#x000D;&#x000A;int64&#x000D;&#x000A;uint64&#x000D;&#x000A;blob&#x000D;&#x000A;bool&#x000D;&#x000A;float&#x000D;&#x000A;double&#x000D;&#x000A;string&#x000D;&#x000A;wstring&#x000D;&#x000A;&#x000D;&#x000A;&#x000D;&#x000A;&#x000D;&#x000A;&#x000D;&#x000A;</Keywords>
+            <Keywords name="Keywords2">struct&#x000D;&#x000A;enum&#x000D;&#x000A;namespace&#x000D;&#x000A;import&#x000D;&#x000A;view_of&#x000D;&#x000A;using&#x000D;&#x000A;&#x000D;&#x000A;</Keywords>
+            <Keywords name="Keywords3">true&#x000D;&#x000A;false&#x000D;&#x000A;nothing</Keywords>
+            <Keywords name="Keywords4">vector&#x000D;&#x000A;map&#x000D;&#x000A;list&#x000D;&#x000A;nullable&#x000D;&#x000A;set</Keywords>
+            <Keywords name="Keywords5">required&#x000D;&#x000A;optional&#x000D;&#x000A;required_optional&#x000D;&#x000A;</Keywords>
+            <Keywords name="Keywords6">a&#x000D;&#x000A;b&#x000D;&#x000A;c&#x000D;&#x000A;d&#x000D;&#x000A;e&#x000D;&#x000A;f&#x000D;&#x000A;g&#x000D;&#x000A;h&#x000D;&#x000A;i&#x000D;&#x000A;j&#x000D;&#x000A;k&#x000D;&#x000A;l&#x000D;&#x000A;m&#x000D;&#x000A;n&#x000D;&#x000A;o&#x000D;&#x000A;p&#x000D;&#x000A;q&#x000D;&#x000A;r&#x000D;&#x000A;s&#x000D;&#x000A;t&#x000D;&#x000A;u&#x000D;&#x000A;v&#x000D;&#x000A;w&#x000D;&#x000A;x&#x000D;&#x000A;y&#x000D;&#x000A;z&#x000D;&#x000A;A&#x000D;&#x000A;B&#x000D;&#x000A;C&#x000D;&#x000A;D&#x000D;&#x000A;E&#x000D;&#x000A;F&#x000D;&#x000A;G&#x000D;&#x000A;H&#x000D;&#x000A;I&#x000D;&#x000A;J&#x000D;&#x000A;K&#x000D;&#x000A;L&#x000D;&#x000A;M&#x000D;&#x000A;N&#x000D;&#x000A;O&#x000D;&#x000A;P&#x000D;&#x000A;Q&#x000D;&#x000A;R&#x000D;&#x000A;S&#x000D;&#x000A;T&#x000D;&#x000A;U&#x000D;&#x000A;V&#x000D;&#x000A;W&#x000D;&#x000A;X&#x000D;&#x000A;Y&#x000D;&#x000A;Z</Keywords>
+            <Keywords name="Keywords7"></Keywords>
+            <Keywords name="Keywords8"></Keywords>
+            <Keywords name="Delimiters">00&lt; 01 02&gt; 03&quot; 04 05&quot; 06[ 07 08] 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
+        </KeywordLists>
+        <Styles>
+            <WordsStyle name="DEFAULT" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="COMMENTS" fgColor="008000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="LINE COMMENTS" fgColor="008000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="NUMBERS" fgColor="0000FF" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS1" fgColor="204A87" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS2" fgColor="204A87" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS3" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS4" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS5" fgColor="000000" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS6" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS7" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS8" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="OPERATORS" fgColor="000000" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE1" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE2" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN COMMENT" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS1" fgColor="000000" bgColor="FFFFFF" fontStyle="1" nesting="50373897" />
+            <WordsStyle name="DELIMITERS2" fgColor="800000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS3" fgColor="400080" bgColor="FFFFFF" fontStyle="0" nesting="16777218" />
+            <WordsStyle name="DELIMITERS4" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS5" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS6" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS7" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS8" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+        </Styles>
+    </UserLang>
+</NotepadPlus>


### PR DESCRIPTION
I added in formatting for all the regex criteria from the sublime file  and from the documentation, including hex prefixes and numerical suffixes.
As for the style, I used the clean highlighting scheme in code from "Young Person's Guide to Bond" page:
https://microsoft.github.io/bond/manual/bond_cpp.html#idl-syntax

Let me know if I'm missing anything.