### PR TITLE
Add example showing how import can be used

### DIFF
--- a/cs/cs.sln
+++ b/cs/cs.sln
@@ -157,6 +157,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "untagged_protocols", "..\ex
 		{43CBBA9B-C4BC-4E64-8733-7B72562D2E91} = {43CBBA9B-C4BC-4E64-8733-7B72562D2E91}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "import", "..\examples\cs\core\import\import.csproj", "{2962BDD2-D939-4059-BC89-EAC4E83A24AA}"
+	ProjectSection(ProjectDependencies) = postProject
+		{2E6E238C-9017-445C-9611-66DA780609BE} = {2E6E238C-9017-445C-9611-66DA780609BE}
+		{43CBBA9B-C4BC-4E64-8733-7B72562D2E91} = {43CBBA9B-C4BC-4E64-8733-7B72562D2E91}
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		CollectionInterfaces|Any CPU = CollectionInterfaces|Any CPU
@@ -826,6 +832,31 @@ Global
 		{65B9537D-2E7B-424A-9EBB-8E85FEB65F6F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{65B9537D-2E7B-424A-9EBB-8E85FEB65F6F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{65B9537D-2E7B-424A-9EBB-8E85FEB65F6F}.Release|Win32.ActiveCfg = Release|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.CollectionInterfaces|Any CPU.ActiveCfg = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.CollectionInterfaces|Any CPU.Build.0 = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.CollectionInterfaces|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.CollectionInterfaces|Mixed Platforms.Build.0 = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.CollectionInterfaces|Win32.ActiveCfg = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Fields|Any CPU.ActiveCfg = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Fields|Any CPU.Build.0 = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Fields|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Fields|Mixed Platforms.Build.0 = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Fields|Win32.ActiveCfg = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Net40|Any CPU.ActiveCfg = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Net40|Any CPU.Build.0 = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Net40|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Net40|Mixed Platforms.Build.0 = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Net40|Win32.ActiveCfg = Debug|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA}.Release|Win32.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -852,5 +883,6 @@ Global
 		{BC61F8E8-D536-49FC-A1B4-11AD57B9B3FF} = {621A2166-EEE0-4A27-88AA-5BE5AC996452}
 		{ADAD1274-18F2-4E45-85B6-792CE91A2D2D} = {621A2166-EEE0-4A27-88AA-5BE5AC996452}
 		{65B9537D-2E7B-424A-9EBB-8E85FEB65F6F} = {621A2166-EEE0-4A27-88AA-5BE5AC996452}
+		{2962BDD2-D939-4059-BC89-EAC4E83A24AA} = {621A2166-EEE0-4A27-88AA-5BE5AC996452}
 	EndGlobalSection
 EndGlobal

--- a/examples/cs/core/import/common/common.bond
+++ b/examples/cs/core/import/common/common.bond
@@ -1,0 +1,8 @@
+﻿namespace Examples.Common
+
+enum Priority
+{
+    Low;
+    Normal;
+    High;
+}

--- a/examples/cs/core/import/common/protocol/header.bond
+++ b/examples/cs/core/import/common/protocol/header.bond
@@ -1,0 +1,7 @@
+﻿namespace Examples.Common.Protocol
+
+struct Header
+{
+    0: string Origin;
+    1: string Destination;
+}

--- a/examples/cs/core/import/import.csproj
+++ b/examples/cs/core/import/import.csproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\..\..\..\cs\build\Bond.CSharp.props" />
+  <PropertyGroup>
+    <ProjectGuid>{2962BDD2-D939-4059-BC89-EAC4E83A24AA}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>import</RootNamespace>
+    <AssemblyName>import</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Set up where gbc will look to resolve import statements. -->
+    <BondImportDirectory Include="common" />
+  </ItemGroup>
+  <ItemGroup>
+    <BondCodegen Include="schema.bond" />
+    <!-- Importing doesn't include the types in the importee's generated
+         code. We still need an implementation of those types. Here, we
+         chose to run codegen on the imported files. Another option would be
+         to run codegen in a different project and reference that project
+         (e.g., a common library shared across a bunch of different consumer
+         projects) -->
+    <BondCodegen Include="common\common.bond" />
+    <BondCodegen Include="common\protocol\header.bond" />
+    <!-- Resharper Workaround -->
+    <Compile Include="$(IntermediateOutputPath)\schema_types.cs" Condition="False" />
+    <Compile Include="$(IntermediateOutputPath)\common_types.cs" Condition="False" />
+    <Compile Include="$(IntermediateOutputPath)\header_types.cs" Condition="False" />
+    <!-- End Resharper Workaround -->
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Attributes">
+      <HintPath>$(BOND_BINARY_PATH)\net45\Bond.Attributes.dll</HintPath>
+    </Reference>
+    <Reference Include="Bond">
+      <HintPath>$(BOND_BINARY_PATH)\net45\Bond.dll</HintPath>
+    </Reference>
+    <Reference Include="Bond.IO">
+      <HintPath>$(BOND_BINARY_PATH)\net45\Bond.IO.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(BOND_PATH)\build\Bond.CSharp.targets" />
+</Project>

--- a/examples/cs/core/import/program.cs
+++ b/examples/cs/core/import/program.cs
@@ -1,0 +1,34 @@
+﻿namespace Examples
+{
+    using System.Diagnostics;
+    using Bond;
+    using Bond.Protocols;
+    using Bond.IO.Unsafe;
+
+    using Examples.Common;
+    using Examples.Common.Protocol;
+
+    static class Program
+    {
+        static void Main()
+        {
+            var src = new Message
+                          {
+                              Header = new Header { Origin = "contoso.com", Destination = "fabrikam.com" },
+                              Priority = Priority.Normal,
+                              MessagePayload = 42
+                          };
+
+            var output = new OutputBuffer();
+            var writer = new CompactBinaryWriter<OutputBuffer>(output);
+
+            Serialize.To(writer, src);
+
+            var input = new InputBuffer(output.Data);
+            var reader = new CompactBinaryReader<InputBuffer>(input);
+
+            var dst = Deserialize<Message>.From(reader);
+            Debug.Assert(Comparer.Equal(src, dst));
+        }
+    }
+}

--- a/examples/cs/core/import/schema.bond
+++ b/examples/cs/core/import/schema.bond
@@ -1,0 +1,12 @@
+﻿import "common.bond"
+import "protocol/header.bond"
+
+namespace Examples
+
+struct Message
+{
+    // To use a type from a different namespace, use its fully qualified name.
+    0: Examples.Common.Protocol.Header Header;
+    1: Examples.Common.Priority Priority;
+    2: uint32 MessagePayload;
+}


### PR DESCRIPTION
This started off in a [pull request to add support for paths with spaces](https://github.com/Microsoft/bond/pull/29#discussion_r24217432) but has been split into its own request.

From the comments in that PR, we wanted the example to have a partial path. This one has that.