### PR TITLE
Fix import directories with trailing slashes

### DIFF
--- a/cs/build/Bond.CSharp.targets
+++ b/cs/build/Bond.CSharp.targets
@@ -68,7 +68,7 @@
     <PropertyGroup>
       <_BondExe Condition="'$(OS)' != 'Unix' Or Exists('$(BOND_COMPILER_PATH)\gbc.exe')">"$(BOND_COMPILER_PATH)\gbc.exe"</_BondExe>
       <_BondExe Condition="'$(OS)' == 'Unix' And !Exists('$(BOND_COMPILER_PATH)\gbc.exe')">gbc</_BondExe>
-      <_BondImportDirs>--import-dir="$(BOND_INCLUDE_PATH)" @(BondImportDirectory -> '--import-dir=&quot;%(Identity)&quot;',' ')</_BondImportDirs>
+      <_BondImportDirs>--import-dir="$(BOND_INCLUDE_PATH)" @(BondImportDirectory -> '--import-dir=&quot;%(Identity)\.&quot;',' ')</_BondImportDirs>
       <_BondCommand>$(_BondExe) $(BondCodegenMode) $(_BondImportDirs) --namespace=bond=Bond --output-dir="$(BondOutputDirectory)\."</_BondCommand>
     </PropertyGroup>
 

--- a/cs/test/core/Core.csproj
+++ b/cs/test/core/Core.csproj
@@ -35,7 +35,7 @@
     <BondOptions>--collection-interfaces</BondOptions>
   </PropertyGroup>
   <ItemGroup>
-    <BondImportDirectory Include="import dir with spaces" />
+    <BondImportDirectory Include="import dir with spaces\" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AttributesTests.cs" />


### PR DESCRIPTION
When support for import directories with spaces in their paths was
added, that inadvertently broke codegen when one ended with a trailing
slash. We add a trailing \. like we do for the output directory to fix
that.