### PR TITLE
Replace dynamic exception specifications with portable boost config specifier

### DIFF
--- a/cpp/inc/bond/core/config.h
+++ b/cpp/inc/bond/core/config.h
@@ -71,3 +71,6 @@
 #define BOND_CALL  
 #define BOND_NO_INLINE  __attribute__((noinline))
 #endif
+
+#define BOND_NOEXCEPT BOOST_NOEXCEPT_OR_NOTHROW
+

--- a/cpp/inc/bond/core/exception.h
+++ b/cpp/inc/bond/core/exception.h
@@ -19,21 +19,21 @@ class Exception
       public SerializableExceptionBase
 {
 public:
-    const char* what() const throw()
+    const char* what() const BOND_NOEXCEPT
     {
         return message.c_str();
     }
 
-    virtual ~Exception() throw()
+    virtual ~Exception() BOND_NOEXCEPT
     {}
 
 protected:
-    Exception(const char* msg) throw()
+    Exception(const char* msg) BOND_NOEXCEPT
     {
         message = msg;
     }
 
-    Exception() throw()
+    Exception() BOND_NOEXCEPT
     {}
 };
 

--- a/cpp/inc/bond/core/protocol.h
+++ b/cpp/inc/bond/core/protocol.h
@@ -113,14 +113,14 @@ uses_marshaled_bonded
 
 struct ValueReader
 {
-    // Constructors that explicitly declared throw() are needed for 
+    // Constructors that explicitly declared noexcept are needed for
     // boost::variant to use optimized code path. 
-    ValueReader() throw()
+    ValueReader() BOND_NOEXCEPT
         : pointer(NULL)
     {}
 
     template <typename U>
-    ValueReader(boost::reference_wrapper<U> value) throw()
+    ValueReader(boost::reference_wrapper<U> value) BOND_NOEXCEPT
         : pointer(&static_cast<const U&>(value))
     {}
 
@@ -131,12 +131,12 @@ struct ValueReader
     {}
 
     template <typename U>
-    ValueReader(boost::shared_ptr<U> value) throw()
+    ValueReader(boost::shared_ptr<U> value) BOND_NOEXCEPT
         : instance(boost::static_pointer_cast<const void>(value)),
           pointer(instance.get())
     {}
     
-    ValueReader(const ValueReader& value) throw()
+    ValueReader(const ValueReader& value) BOND_NOEXCEPT
         : instance(value.instance),
           pointer(value.pointer)
     {}

--- a/cpp/inc/bond/protocol/compact_binary.h
+++ b/cpp/inc/bond/protocol/compact_binary.h
@@ -163,11 +163,11 @@ public:
     }
 
     
-    // This identical to compiler generated ctor except for throw() declaration.
+    // This identical to compiler generated ctor except for noexcept declaration.
     // Copy ctor that is explicitly declared throw() is needed for boost::variant
     // to use optimized code path. 
     /// @brief Copy constructor
-    CompactBinaryReader(const CompactBinaryReader& that) throw()
+    CompactBinaryReader(const CompactBinaryReader& that) BOND_NOEXCEPT
         : _input(that._input),
           _version(that._version)
     {}

--- a/cpp/inc/bond/protocol/fast_binary.h
+++ b/cpp/inc/bond/protocol/fast_binary.h
@@ -115,11 +115,11 @@ public:
     {}
 
 
-    // This identical to compiler generated ctor except for throw() declaration.
+    // This identical to compiler generated ctor except for noexcept declaration.
     // Copy ctor that is explicitly declared throw() is needed for boost::variant
     // to use optimized code path. 
     /// @brief Copy constructor
-    FastBinaryReader(const FastBinaryReader& that) throw()
+    FastBinaryReader(const FastBinaryReader& that) BOND_NOEXCEPT
         : _input(that._input)
     {}
 

--- a/cpp/inc/bond/protocol/simple_binary.h
+++ b/cpp/inc/bond/protocol/simple_binary.h
@@ -45,11 +45,11 @@ public:
     }
 
 
-    // This identical to compiler generated ctor except for throw() declaration.
+    // This identical to compiler generated ctor except for noexcept declaration.
     // Copy ctor that is explicitly declared throw() is needed for boost::variant
     // to use optimized code path. 
     /// @brief Copy constructor
-    SimpleBinaryReader(const SimpleBinaryReader& that) throw()
+    SimpleBinaryReader(const SimpleBinaryReader& that) BOND_NOEXCEPT
         : _input(that._input),
           _version(that._version)
     {}


### PR DESCRIPTION
This PR replaces the dynamic exception specifications that are deprecated in newer versions of the C++ standard with a macro that's configured by boost. 

This should hopefully preserve the optimizations in boost::variant, though I can't confirm first-hand if that's the case.