### PR TITLE
Fix bug in JSON parsing when string value is a date

### DIFF
--- a/cs/src/json/expressions/json/SimpleJsonParser.cs
+++ b/cs/src/json/expressions/json/SimpleJsonParser.cs
@@ -121,10 +121,11 @@ namespace Bond.Expressions.Json
                 convertedValue = Reader.Value;
             }
             
-            var errorMessage = string.Format(
-                CultureInfo.InvariantCulture,
-                "Invalid input, expected JSON token of type {0}",
-                scalarTokenType);
+            var errorMessage = 
+                StringExpression.Format(
+                    "Invalid input, expected JSON token of type {0}, encountered {1}",
+                    Expression.Constant(scalarTokenType, typeof(object)),
+                    Expression.Convert(Reader.TokenType, typeof(object)));
 
             return
                 Expression.Block(
@@ -197,14 +198,19 @@ namespace Bond.Expressions.Json
                     Expression.Convert(Reader.LinePosition, typeof(object))));
         }
 
-        Expression ThrowUnexpectedInput(string errorMessage)
+        Expression ThrowUnexpectedInput(Expression errorMessage)
         {
             return ThrowExpression.InvalidDataException(
                 StringExpression.Format(
                     "{0} (line {1} position {2})",
-                    Expression.Constant(errorMessage),
+                    errorMessage,
                     Expression.Convert(Reader.LineNumber, typeof(object)),
                     Expression.Convert(Reader.LinePosition, typeof(object))));
+        }
+
+        Expression ThrowUnexpectedInput(string errorMessage)
+        {
+            return ThrowUnexpectedInput(Expression.Constant(errorMessage));
         }
 
         Expression ProcessField(ParameterExpression requiredFields, IEnumerable<TransformSchemaPair> transforms)

--- a/cs/src/json/protocols/SimpleJsonReader.cs
+++ b/cs/src/json/protocols/SimpleJsonReader.cs
@@ -20,6 +20,9 @@ namespace Bond.Protocols
         public SimpleJsonReader(TextReader reader)
         {
             this.reader = new JsonTextReader(reader);
+            this.reader.DateParseHandling = DateParseHandling.None;
+            this.reader.FloatParseHandling = FloatParseHandling.Double;
+
             eof = false;
         }
 

--- a/cs/test/core/JsonParsingTests.cs
+++ b/cs/test/core/JsonParsingTests.cs
@@ -2,13 +2,10 @@
 {
     using System;
     using System.IO;
-
     using Bond;
     using Bond.Protocols;
-
-    using NUnit.Framework;
-
     using Newtonsoft.Json;
+    using NUnit.Framework;
 
     [TestFixture]
     public class JsonParsingTests
@@ -680,6 +677,16 @@ World", target._str);
             Assert.AreEqual(10, target.nb.Array[target.nb.Offset]);
             Assert.AreEqual(11, target.nb.Array[target.nb.Offset + 1]);
             
+        }
+        
+        [Test]
+        public void JsonParsing_DateAsString()
+        {
+            const string json = @"{""value"":""2015-02-26T13:18:13.1521765-08:00""}";
+
+            var target = ParseJson<Box<string>>(json);
+
+            Assert.AreEqual("2015-02-26T13:18:13.1521765-08:00", target.value);
         }
 
         private static T ParseJson<T>(string json) where T : new()

--- a/cs/test/core/UnitTest.bond
+++ b/cs/test/core/UnitTest.bond
@@ -652,6 +652,7 @@ struct IdAttribute
 {
     0: TypeAttribute field = DefaultAttribute;
 }
+
 struct classT {}
 struct structT {}
 struct GenericConflict<structT : value>


### PR DESCRIPTION
When reading string fields, the SimpleJsonParser expects to find a JsonToken of
type String. But if the string value matches a date format, the actual JsonToken
that is seen is of type Date. To fix this, we are setting the JsonTextReader to not
try to parse strings as dates.

Also improve the exception text when reading unenxpected input to help know
what JsonToken was actually read, and fix a similar possible issue with parsing
doubles.