### PR TITLE
Update DeserializeJson.expressions following change in JSON codegen

### DIFF
--- a/cs/src/core/Bond.csproj
+++ b/cs/src/core/Bond.csproj
@@ -58,6 +58,7 @@
     <Compile Include="io\safe\OutputBuffer.cs" />
     <Compile Include="ISchemaField.cs" />
     <Compile Include="Marshaler.cs" />
+    <Compile Include="MultipleTypeDeserializer.cs" />
     <Compile Include="properties\AssemblyInfo.cs" />
     <Compile Include="Property.cs" />
     <Compile Include="protocols\CompactBinary.cs" />

--- a/cs/src/core/MultipleTypeDeserializer.cs
+++ b/cs/src/core/MultipleTypeDeserializer.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Bond
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq.Expressions;
+    using Bond.Expressions;
+
+    /// <summary>
+    /// MultiTypeDeserializer is used to deserialize more than one type from protocol R, allowing compiled
+    /// delegates to be reused across types.
+    /// </summary>
+    /// <typeparam name="R">Protocol reader type</typeparam>
+    public class MultipleTypeDeserializer<R>
+    {
+        readonly IFactory objectFactory; 
+
+        readonly Dictionary<Type, Func<R, object>> compiledDeserializeFuncs = new Dictionary<Type, Func<R, object>>();
+        readonly object compiledFuncsSync = new object();
+
+        readonly Dictionary<Type, DeserializerTransform<R>.TypeState> sharedTypeStates = 
+            new Dictionary<Type, DeserializerTransform<R>.TypeState>();
+        readonly object typeStatesSync = new object();
+
+        Func<R, object>[] deferredDeserializeFuncs = new Func<R, object>[50];
+
+        public MultipleTypeDeserializer(IFactory objectFactory)
+        {
+            this.objectFactory = objectFactory;
+        }
+
+        public MultipleTypeDeserializer()
+        {
+        }
+
+        public void AddType(Type type, RuntimeSchema schema)
+        {
+            AddType(type, ParserFactory<R>.Create(schema));
+        }
+
+        public void AddType(Type type)
+        {
+            AddType(type, ParserFactory<R>.Create(type));
+        }
+
+        private void AddType(Type type, IParser parser)
+        {
+            lock (compiledFuncsSync)
+            {
+                if (compiledDeserializeFuncs.ContainsKey(type)) return;
+            }
+
+            var transform = objectFactory == null
+                ? new DeserializerTransform<R>(
+                    HandleDeserializeExpression,
+                    (r, i) => deferredDeserializeFuncs[i](r), 
+                    null, 
+                    null,
+                    sharedTypeStates,
+                    typeStatesSync,
+                    noInlining: true)
+                : new DeserializerTransform<R>(
+                    HandleDeserializeExpression,
+                    (r, i) => deferredDeserializeFuncs[i](r),
+                    (t1, t2) => objectFactory.CreateObject(t1, t2),
+                    (t1, t2, count) => objectFactory.CreateContainer(t1, t2, count),
+                    sharedTypeStates,
+                    typeStatesSync,
+                    noInlining: true);
+
+            transform.Generate(parser, type);
+        }
+
+        private void HandleDeserializeExpression(Expression<Func<R, object>> expression, Type objectType, int index)
+        {
+            Func<R, object> func;
+            if (deferredDeserializeFuncs.Length > index && deferredDeserializeFuncs[index] != null)
+            {
+                // We already have a func for this type, ignore.
+            }
+
+            func = expression.Compile();
+            lock (compiledFuncsSync)
+            {
+                compiledDeserializeFuncs[objectType] = func;
+            }
+
+            // Resize deferred array if needed
+            var length = deferredDeserializeFuncs.Length;
+            if (length <= index)
+            {
+                var newLength = Math.Max(length*2, index + 1);
+                var newDeferred = new Func<R, object>[newLength];
+                Array.Copy(deferredDeserializeFuncs, newDeferred, length);
+
+                // Ensure an atomic operation puts in place a valid resized array. 
+                // Calling Array.Resize might create an interim state where the deferredDeserializeFunc array does 
+                // not have all the content.
+                deferredDeserializeFuncs = newDeferred;
+            }
+            deferredDeserializeFuncs[index] = func;
+        }
+
+        /// <summary>
+        /// Deserialize an object of type T from a payload
+        /// </summary>
+        /// <typeparam name="T">Type representing a Bond schema</typeparam>
+        /// <param name="reader">Protocol reader representing the payload</param>
+        /// <returns>Deserialized object</returns>
+        public T Deserialize<T>(R reader)
+        {
+            return (T)Deserialize(reader, typeof(T));
+        }
+
+        public object Deserialize(R reader, Type type)
+        {
+            Func<R, object> func;
+            lock (compiledFuncsSync)
+            {
+                compiledDeserializeFuncs.TryGetValue(type, out func);
+            }
+
+            if (func == null)
+            {
+                AddType(type);
+            }
+
+            lock (compiledFuncsSync)
+            {
+                func = compiledDeserializeFuncs[type];
+            }
+
+            return func(reader);
+        }
+    }
+}

--- a/cs/test/core/Core.csproj
+++ b/cs/test/core/Core.csproj
@@ -40,6 +40,7 @@
     <Compile Include="InterfaceTests.cs" />
     <Compile Include="JsonParsingTests.cs" />
     <Compile Include="MetaInitializationTests.cs" />
+    <Compile Include="MultipleTypeDeserializerTests.cs" />
     <Compile Include="properties\AssemblyInfo.cs" />
     <Compile Include="Random.cs" />
     <Compile Include="SerializationTests.cs" />

--- a/cs/test/core/MultipleTypeDeserializerTests.cs
+++ b/cs/test/core/MultipleTypeDeserializerTests.cs
@@ -1,0 +1,106 @@
+﻿namespace UnitTest
+{
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading.Tasks;
+    using Bond;
+    using Bond.IO.Safe;
+    using Bond.Protocols;
+    using NUnit.Framework;
+    using UnitTest.Aliases;
+
+    [TestFixture]
+    public class MultipleTypeDeserializerTests
+    {
+        readonly static Type[] AllBondTypes = 
+            Assembly.GetExecutingAssembly()
+                .GetExportedTypes()
+                .Where(t => t.IsDefined(typeof(SchemaAttribute), false) && !t.ContainsGenericParameters)
+                .ToArray();
+
+        [Test]
+        public void MultipleTypeDeserializer_AddAllTypes_SingleThreaded()
+        {
+            var deserializer = new MultipleTypeDeserializer<SimpleBinaryReader<InputBuffer>>();
+
+            foreach (var bondType in AllBondTypes)
+            {
+                try
+                {
+                    deserializer.AddType(bondType);
+                }
+                catch
+                {
+                    Console.WriteLine("Failed adding " + bondType);
+                    throw;
+                }
+            }
+        }
+
+        [Test]
+        public void MultipleTypeDeserializer_AddAllTypes_MultiThreaded()
+        {
+            var deserializer = new MultipleTypeDeserializer<SimpleBinaryReader<InputBuffer>>();
+
+            Parallel.ForEach(
+                AllBondTypes,
+                bondType =>
+                {
+                    try
+                    {
+                        deserializer.AddType(bondType);
+                    }
+                    catch
+                    {
+                        Console.WriteLine("Failed adding " + bondType);
+                        throw;
+                    }
+                });
+        }
+
+        [Test]
+        public void MultipleTypeDeserializer_Roundtrip()
+        {
+            var deserializer = new MultipleTypeDeserializer<CompactBinaryReader<InputBuffer>>();
+
+            var methodInfo = typeof (MultipleTypeDeserializerTests).GetMethod("RoundTrip", BindingFlags.NonPublic | BindingFlags.Static);
+            
+            RoundTrip<BlobAlias>(null);
+            foreach (var bondType in AllBondTypes)
+            {
+
+//            }
+                //          Parallel.ForEach(
+                //            AllBondTypes,
+                //          bondType =>
+                {
+                    try
+                    {
+                        methodInfo.MakeGenericMethod(bondType).Invoke(null, new object[] {deserializer});
+                    }
+                    catch
+                    {
+                        Console.WriteLine("Failed round trip on type " + bondType);
+                    }
+                }
+                //);
+            }
+        }
+
+        static void RoundTrip<T>(MultipleTypeDeserializer<CompactBinaryReader<InputBuffer>> deserializer)
+        {
+            var randomObj = UnitTest.Random.Init<T>();
+            var output = new OutputBuffer();
+            Serialize.To(new CompactBinaryWriter<OutputBuffer>(output), randomObj);
+
+            var input = new InputBuffer(output.Data);
+            var reader = new CompactBinaryReader<InputBuffer>(input);
+            var deserialized = Deserialize<T>.From(reader);
+            
+            // deserializer.Deserialize<T>(reader);
+
+            Assert.IsTrue(Comparer.Equal(randomObj, deserialized));
+        }
+    }
+}

--- a/cs/test/expressions/DeserializeJson.expressions
+++ b/cs/test/expressions/DeserializeJson.expressions
@@ -121,7 +121,13 @@
                                                                                                                                 System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                                 "{0} (line {1} position {2})",
                                                                                                                                 .NewArray System.Object[] {
-                                                                                                                                    "Invalid input, expected JSON token of type Integer",
+                                                                                                                                    .Call System.String.Format(
+                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                            .Constant<System.Object>(Integer),
+                                                                                                                                            (System.Object)$reader.TokenType
+                                                                                                                                        }),
                                                                                                                                     (System.Object)$reader.LineNumber,
                                                                                                                                     (System.Object)$reader.LinePosition
                                                                                                                                 }))
@@ -198,7 +204,13 @@
                                                                                                 System.Globalization.CultureInfo.InvariantCulture,
                                                                                                 "{0} (line {1} position {2})",
                                                                                                 .NewArray System.Object[] {
-                                                                                                    "Invalid input, expected JSON token of type Integer",
+                                                                                                    .Call System.String.Format(
+                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                        .NewArray System.Object[] {
+                                                                                                            .Constant<System.Object>(Integer),
+                                                                                                            (System.Object)$reader.TokenType
+                                                                                                        }),
                                                                                                     (System.Object)$reader.LineNumber,
                                                                                                     (System.Object)$reader.LinePosition
                                                                                                 }))
@@ -218,7 +230,13 @@
                                                                                                 System.Globalization.CultureInfo.InvariantCulture,
                                                                                                 "{0} (line {1} position {2})",
                                                                                                 .NewArray System.Object[] {
-                                                                                                    "Invalid input, expected JSON token of type Float",
+                                                                                                    .Call System.String.Format(
+                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                        .NewArray System.Object[] {
+                                                                                                            .Constant<System.Object>(Float),
+                                                                                                            (System.Object)$reader.TokenType
+                                                                                                        }),
                                                                                                     (System.Object)$reader.LineNumber,
                                                                                                     (System.Object)$reader.LinePosition
                                                                                                 }))
@@ -297,7 +315,13 @@
                                                                                                             System.Globalization.CultureInfo.InvariantCulture,
                                                                                                             "{0} (line {1} position {2})",
                                                                                                             .NewArray System.Object[] {
-                                                                                                                "Invalid input, expected JSON token of type Integer",
+                                                                                                                .Call System.String.Format(
+                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                    .NewArray System.Object[] {
+                                                                                                                        .Constant<System.Object>(Integer),
+                                                                                                                        (System.Object)$reader.TokenType
+                                                                                                                    }),
                                                                                                                 (System.Object)$reader.LineNumber,
                                                                                                                 (System.Object)$reader.LinePosition
                                                                                                             }))
@@ -434,7 +458,13 @@
                                                                                                                                                             System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                                                             "{0} (line {1} position {2})",
                                                                                                                                                             .NewArray System.Object[] {
-                                                                                                                                                                "Invalid input, expected JSON token of type Float",
+                                                                                                                                                                .Call System.String.Format(
+                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                                                        .Constant<System.Object>(Float),
+                                                                                                                                                                        (System.Object)$reader.TokenType
+                                                                                                                                                                    }),
                                                                                                                                                                 (System.Object)$reader.LineNumber,
                                                                                                                                                                 (System.Object)$reader.LinePosition
                                                                                                                                                             }))
@@ -550,7 +580,13 @@
                                                                                                                     System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                     "{0} (line {1} position {2})",
                                                                                                                     .NewArray System.Object[] {
-                                                                                                                        "Invalid input, expected JSON token of type Integer",
+                                                                                                                        .Call System.String.Format(
+                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                .Constant<System.Object>(Integer),
+                                                                                                                                (System.Object)$reader.TokenType
+                                                                                                                            }),
                                                                                                                         (System.Object)$reader.LineNumber,
                                                                                                                         (System.Object)$reader.LinePosition
                                                                                                                     }))
@@ -663,7 +699,13 @@
                                                                                                                                         System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                                         "{0} (line {1} position {2})",
                                                                                                                                         .NewArray System.Object[] {
-                                                                                                                                            "Invalid input, expected JSON token of type Integer",
+                                                                                                                                            .Call System.String.Format(
+                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                    .Constant<System.Object>(Integer),
+                                                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                                                }),
                                                                                                                                             (System.Object)$reader.LineNumber,
                                                                                                                                             (System.Object)$reader.LinePosition
                                                                                                                                         }))
@@ -687,7 +729,13 @@
                                                                                                                                             System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                                             "{0} (line {1} position {2})",
                                                                                                                                             .NewArray System.Object[] {
-                                                                                                                                                "Invalid input, expected JSON token of type Integer",
+                                                                                                                                                .Call System.String.Format(
+                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                                        .Constant<System.Object>(Integer),
+                                                                                                                                                        (System.Object)$reader.TokenType
+                                                                                                                                                    }),
                                                                                                                                                 (System.Object)$reader.LineNumber,
                                                                                                                                                 (System.Object)$reader.LinePosition
                                                                                                                                             }))
@@ -711,7 +759,13 @@
                                                                                                                                                 System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                                                 "{0} (line {1} position {2})",
                                                                                                                                                 .NewArray System.Object[] {
-                                                                                                                                                    "Invalid input, expected JSON token of type Integer",
+                                                                                                                                                    .Call System.String.Format(
+                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                            .Constant<System.Object>(Integer),
+                                                                                                                                                            (System.Object)$reader.TokenType
+                                                                                                                                                        }),
                                                                                                                                                     (System.Object)$reader.LineNumber,
                                                                                                                                                     (System.Object)$reader.LinePosition
                                                                                                                                                 }))
@@ -735,7 +789,13 @@
                                                                                                                                                     System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                                                     "{0} (line {1} position {2})",
                                                                                                                                                     .NewArray System.Object[] {
-                                                                                                                                                        "Invalid input, expected JSON token of type Integer",
+                                                                                                                                                        .Call System.String.Format(
+                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                                .Constant<System.Object>(Integer),
+                                                                                                                                                                (System.Object)$reader.TokenType
+                                                                                                                                                            }),
                                                                                                                                                         (System.Object)$reader.LineNumber,
                                                                                                                                                         (System.Object)$reader.LinePosition
                                                                                                                                                     }))
@@ -811,7 +871,13 @@
                                                                                                 System.Globalization.CultureInfo.InvariantCulture,
                                                                                                 "{0} (line {1} position {2})",
                                                                                                 .NewArray System.Object[] {
-                                                                                                    "Invalid input, expected JSON token of type Float",
+                                                                                                    .Call System.String.Format(
+                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                        .NewArray System.Object[] {
+                                                                                                            .Constant<System.Object>(Float),
+                                                                                                            (System.Object)$reader.TokenType
+                                                                                                        }),
                                                                                                     (System.Object)$reader.LineNumber,
                                                                                                     (System.Object)$reader.LinePosition
                                                                                                 }))
@@ -839,7 +905,13 @@
                                                                                                         System.Globalization.CultureInfo.InvariantCulture,
                                                                                                         "{0} (line {1} position {2})",
                                                                                                         .NewArray System.Object[] {
-                                                                                                            "Invalid input, expected JSON token of type Integer",
+                                                                                                            .Call System.String.Format(
+                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                .NewArray System.Object[] {
+                                                                                                                    .Constant<System.Object>(Integer),
+                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                }),
                                                                                                             (System.Object)$reader.LineNumber,
                                                                                                             (System.Object)$reader.LinePosition
                                                                                                         }))
@@ -864,7 +936,13 @@
                                                                                                         System.Globalization.CultureInfo.InvariantCulture,
                                                                                                         "{0} (line {1} position {2})",
                                                                                                         .NewArray System.Object[] {
-                                                                                                            "Invalid input, expected JSON token of type Integer",
+                                                                                                            .Call System.String.Format(
+                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                .NewArray System.Object[] {
+                                                                                                                    .Constant<System.Object>(Integer),
+                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                }),
                                                                                                             (System.Object)$reader.LineNumber,
                                                                                                             (System.Object)$reader.LinePosition
                                                                                                         }))
@@ -888,7 +966,13 @@
                                                                                                             System.Globalization.CultureInfo.InvariantCulture,
                                                                                                             "{0} (line {1} position {2})",
                                                                                                             .NewArray System.Object[] {
-                                                                                                                "Invalid input, expected JSON token of type Integer",
+                                                                                                                .Call System.String.Format(
+                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                    .NewArray System.Object[] {
+                                                                                                                        .Constant<System.Object>(Integer),
+                                                                                                                        (System.Object)$reader.TokenType
+                                                                                                                    }),
                                                                                                                 (System.Object)$reader.LineNumber,
                                                                                                                 (System.Object)$reader.LinePosition
                                                                                                             }))
@@ -912,7 +996,13 @@
                                                                                                                 System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                 "{0} (line {1} position {2})",
                                                                                                                 .NewArray System.Object[] {
-                                                                                                                    "Invalid input, expected JSON token of type String",
+                                                                                                                    .Call System.String.Format(
+                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                        .NewArray System.Object[] {
+                                                                                                                            .Constant<System.Object>(String),
+                                                                                                                            (System.Object)$reader.TokenType
+                                                                                                                        }),
                                                                                                                     (System.Object)$reader.LineNumber,
                                                                                                                     (System.Object)$reader.LinePosition
                                                                                                                 }))
@@ -936,7 +1026,13 @@
                                                                                                                     System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                     "{0} (line {1} position {2})",
                                                                                                                     .NewArray System.Object[] {
-                                                                                                                        "Invalid input, expected JSON token of type Boolean",
+                                                                                                                        .Call System.String.Format(
+                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                .Constant<System.Object>(Boolean),
+                                                                                                                                (System.Object)$reader.TokenType
+                                                                                                                            }),
                                                                                                                         (System.Object)$reader.LineNumber,
                                                                                                                         (System.Object)$reader.LinePosition
                                                                                                                     }))

--- a/cs/test/expressions/Program.cs
+++ b/cs/test/expressions/Program.cs
@@ -81,10 +81,14 @@
         public DeserializerDebugView(Type type)
         {
             var parser = ParserFactory<R>.Create(type);
-            var expressions = new DeserializerTransform<R>(
+            var expressions = new SortedDictionary<int, Expression<Func<R, object>>>();
+
+            new DeserializerTransform<R>(
+                (e, t, i) => expressions[i] = e,
                 (r, i) => deserialize[i](r))
                 .Generate(parser, type);
-            debugView = DebugViewHelper.ToString(expressions);
+            
+            debugView = DebugViewHelper.ToString(expressions.Values);
         }
 
         string IDebugView.DebugView { get { return debugView; } }


### PR DESCRIPTION
Expression changed because now when encountering unexpected JSON token, the actual token is formatted into the exception message.