### PR TITLE
haskell support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ include (PythonTest)
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -C ${CMAKE_CFG_INTDIR} --output-on-failure)
 
 add_subdirectory (compiler)
+add_subdirectory (haskell/runtime)
 add_subdirectory (cpp)
 add_python_subdirectory (python)
 add_subdirectory (examples)

--- a/compiler/Bond/Schema.hs
+++ b/compiler/Bond/Schema.hs
@@ -277,7 +277,7 @@ isBaseField name = getAny . optional (foldMapFields (Any.(name==).fieldName))
 
 data Import = Import FilePath
 
-data Language = Cpp | Cs | CSharp | Java deriving (Eq)
+data Language = Cpp | Cs | CSharp | Java | Haskell deriving (Eq, Show)
 
 data Namespace = 
     Namespace 

--- a/compiler/Bond/Template/Haskell/Decl.hs
+++ b/compiler/Bond/Template/Haskell/Decl.hs
@@ -1,0 +1,635 @@
+{-# LANGUAGE PatternGuards, NamedFieldPuns, RecordWildCards #-}
+module Bond.Template.Haskell.Decl (mkHaskellDecl) where
+import Data.Char
+import Data.Maybe
+import Data.List (intercalate, mapAccumL)
+import Language.Haskell.Exts
+import Language.Haskell.Exts.SrcLoc
+import System.FilePath
+import qualified Data.Set as S
+import Bond.Schema
+import Bond.Template.TypeMapping
+ 
+internalModule :: ModuleName
+internalModule = ModuleName "B'"
+ 
+baseStructField :: Name
+baseStructField = Ident "base'"
+ 
+capitalize :: String -> String
+capitalize (h : t) = toUpper h : t
+capitalize [] = error "capitalize: empty string"
+ 
+uncapitalize :: String -> String
+uncapitalize (h : t) = toLower h : t
+uncapitalize [] = error "uncapitalize: empty string"
+ 
+mkIdent :: String -> Name
+mkIdent = Ident . capitalize
+ 
+mkVar :: String -> Name
+mkVar = Ident . uncapitalize
+ 
+tyQualCon :: QualifiedName -> String -> Language.Haskell.Exts.Type
+tyQualCon m t = TyCon $ Qual (mkModuleName m t) (mkIdent t)
+ 
+qualInt :: String -> QName
+qualInt = Qual internalModule . Ident
+ 
+unqual :: String -> QName
+unqual = UnQual . Ident
+ 
+tyInt :: String -> Language.Haskell.Exts.Type
+tyInt = TyCon . qualInt
+ 
+floatLit :: Real a => a -> Exp
+floatLit n | n >= 0 = Lit $ Frac $ toRational n
+floatLit n = NegApp $ floatLit $ abs n
+ 
+intLit :: Integral a => a -> Exp
+intLit n | n >= 0 = Lit $ Int $ fromIntegral n
+intLit n = NegApp $ intLit $ abs n
+ 
+parenIntLit :: Integral a => a -> Exp
+parenIntLit n | n >= 0 = intLit n
+parenIntLit n = Paren $ intLit n
+ 
+declTypeInfo ::
+             MappingContext -> Declaration -> (QualifiedName, String)
+declTypeInfo mapping decl
+  = (getDeclNamespace mapping decl, declName decl)
+ 
+typeParamConstraint :: String -> TypeParam -> Asst
+typeParamConstraint className t
+  = ClassA (qualInt className) [TyVar $ mkVar $ paramName t]
+ 
+stdConstraints :: [TypeParam] -> [Asst]
+stdConstraints = concatMap paramConstraint
+  where paramConstraint t
+          = [ClassA (qualInt "BondBinary") [TyVar $ mkVar $ paramName t],
+             typeParamConstraint "WireType" t, typeParamConstraint "Default" t]
+ 
+declModule :: MappingContext -> Declaration -> ModuleName
+declModule mapping = uncurry mkModuleName . declTypeInfo mapping
+ 
+hsType ::
+       MappingContext -> Bond.Schema.Type -> Language.Haskell.Exts.Type
+hsType _ BT_Int8 = tyInt "Int8"
+hsType _ BT_Int16 = tyInt "Int16"
+hsType _ BT_Int32 = tyInt "Int32"
+hsType _ BT_Int64 = tyInt "Int64"
+hsType _ BT_UInt8 = tyInt "Word8"
+hsType _ BT_UInt16 = tyInt "Word16"
+hsType _ BT_UInt32 = tyInt "Word32"
+hsType _ BT_UInt64 = tyInt "Word64"
+hsType _ BT_Float = tyInt "Float"
+hsType _ BT_Double = tyInt "Double"
+hsType _ BT_Bool = tyInt "Bool"
+hsType _ BT_String = tyInt "Utf8"
+hsType _ BT_WString = tyInt "Utf16"
+hsType _ BT_MetaName = error "BT_MetaName"
+hsType _ BT_MetaFullName = error "BT_MetaFullName"
+hsType _ BT_Blob = tyInt "Blob"
+hsType _ (BT_IntTypeArg _) = error "BT_IntTypeArg"
+hsType c (BT_Maybe type_) = hsType c (BT_Nullable type_)
+hsType c (BT_Nullable element)
+  = TyApp (tyInt "Maybe") (hsType c element)
+hsType c (BT_List element) = TyList $ hsType c element
+hsType c (BT_Vector element)
+  = TyApp (tyInt "Vector") (hsType c element)
+hsType c (BT_Set element)
+  = TyApp (tyInt "HashSet") (hsType c element)
+hsType c (BT_Map key value)
+  = TyApp (TyApp (tyInt "Map") (hsType c key)) (hsType c value)
+hsType c (BT_Bonded type_)
+  = TyApp (tyInt "Bonded") (hsType c type_)
+hsType _ (BT_TypeParam type_) = TyVar $ mkVar $ paramName type_
+hsType _ (BT_UserDefined Alias{..} _)
+  = error "BT_UserDefined Alias"
+hsType c (BT_UserDefined decl [])
+  = uncurry tyQualCon $ declTypeInfo c decl
+hsType c (BT_UserDefined decl params)
+  = TyApp (uncurry tyQualCon $ declTypeInfo c decl) $
+      foldr1 TyApp $ map (hsType c) params
+ 
+wireType :: Bond.Schema.Type -> QName
+wireType BT_Int8 = qualInt "BT_INT8"
+wireType BT_Int16 = qualInt "BT_INT16"
+wireType BT_Int32 = qualInt "BT_INT32"
+wireType BT_Int64 = qualInt "BT_INT64"
+wireType BT_UInt8 = qualInt "BT_UINT8"
+wireType BT_UInt16 = qualInt "BT_UINT16"
+wireType BT_UInt32 = qualInt "BT_UINT32"
+wireType BT_UInt64 = qualInt "BT_UINT64"
+wireType BT_Float = qualInt "BT_FLOAT"
+wireType BT_Double = qualInt "BT_DOUBLE"
+wireType BT_Bool = qualInt "BT_BOOL"
+wireType BT_String = qualInt "BT_STRING"
+wireType BT_WString = qualInt "BT_WSTRING"
+wireType BT_MetaName = error "BT_MetaName"
+wireType BT_MetaFullName = error "BT_MetaFullName"
+wireType BT_Blob = qualInt "BT_LIST"
+wireType (BT_IntTypeArg _) = error "BT_IntTypeArg"
+wireType (BT_Maybe t) = wireType t
+wireType (BT_Nullable _) = qualInt "BT_LIST"
+wireType (BT_List _) = qualInt "BT_LIST"
+wireType (BT_Vector _) = qualInt "BT_LIST"
+wireType (BT_Set _) = qualInt "BT_SET"
+wireType (BT_Map _ _) = qualInt "BT_MAP"
+wireType (BT_Bonded t) = wireType t
+wireType (BT_TypeParam _) = error "BT_TypeParam"
+wireType (BT_UserDefined Enum{} _) = qualInt "BT_INT32"
+wireType (BT_UserDefined _ _) = qualInt "BT_STRUCT"
+ 
+importTemplate :: ImportDecl
+importTemplate
+  = ImportDecl{importLoc = noLoc, importModule = undefined,
+               importQualified = True, importSrc = False, importSafe = False,
+               importPkg = Nothing, importAs = Nothing, importSpecs = Nothing}
+ 
+defaultImport :: ImportDecl
+defaultImport
+  = importTemplate{importModule = ModuleName "Bond.Imports",
+                   importAs = Just internalModule}
+ 
+convertNamespace :: QualifiedName -> [String]
+convertNamespace = map capitalize
+ 
+convertTypeName :: String -> String
+convertTypeName = capitalize
+ 
+mkModuleName :: QualifiedName -> String -> ModuleName
+mkModuleName ns t
+  = ModuleName $
+      intercalate "." $ convertNamespace ns ++ [convertTypeName t]
+ 
+mkFileName :: QualifiedName -> String -> FilePath
+mkFileName ns t
+  = foldr1 (</>) (convertNamespace ns) </>
+      (convertTypeName t ++ ".hs")
+ 
+mkHaskellDecl ::
+              MappingContext -> Declaration -> (FilePath, String)
+mkHaskellDecl mapping e@Enum{..} = (filename, prettyPrint code)
+  where namespace = getIdlNamespace mapping
+        filename = mkFileName namespace declName
+        moduleName = mkModuleName namespace declName
+        typeName = Ident $ convertTypeName declName
+        code
+          = Module noLoc moduleName
+              [LanguagePragma noLoc
+                 [Ident "GeneralizedNewtypeDeriving", Ident "DeriveDataTypeable"]]
+              Nothing
+              Nothing
+              [defaultImport]
+              decls
+        decls
+          = dataDecl :
+              defaultDecl : wiretypeDecl : bondBinaryDecl : typesig : values
+        dataDecl
+          = DataDecl noLoc NewType [] typeName []
+              [QualConDecl noLoc [] [] (ConDecl typeName [tyInt "Int32"])]
+              [(unqual "Show", []), (unqual "Eq", []), (unqual "Ord", []),
+               (qualInt "Hashable", []), (qualInt "Data", []),
+               (qualInt "Typeable", [])]
+        defaultDecl = defaultInstance mapping e
+        wiretypeDecl = wiretypeInstance e
+        bondBinaryDecl = bondBinaryInstance e
+        typesig
+          = TypeSig noLoc (map (mkVar . constantName) enumConstants)
+              (TyCon $ UnQual typeName)
+        values
+          = let mkval _ Constant{constantName, constantValue = Just i}
+                  = (i + 1, (constantName, i))
+                mkval i Constant{constantName} = (i + 1, (constantName, i))
+                constVals = snd $ mapAccumL mkval 0 enumConstants
+              in map mkConst constVals
+        mkConst (constName, val)
+          = PatBind noLoc (PVar $ mkVar constName)
+              (UnGuardedRhs $ App (Con $ UnQual typeName) (parenIntLit val))
+              (BDecls [])
+mkHaskellDecl mapping s@Struct{..} = (filename, prettyPrint code)
+  where namespace = getIdlNamespace mapping
+        filename = mkFileName namespace declName
+        moduleName = mkModuleName namespace declName
+        typeName = Ident $ convertTypeName declName
+        code
+          = Module noLoc moduleName
+              [LanguagePragma noLoc
+                 [Ident "ScopedTypeVariables", Ident "TypeFamilies",
+                  Ident "DeriveDataTypeable"]]
+              Nothing
+              (Just [EThingAll $ UnQual typeName])
+              imports
+              decls
+        decls
+          = [dataDecl, defaultDecl, wiretypeDecl, bondBinaryDecl,
+             bondStructDecl]
+        dataDecl
+          = DataDecl noLoc DataType [] typeName typeParams
+              [QualConDecl noLoc [] [] (RecDecl typeName fields)]
+              [(unqual "Show", []), (unqual "Eq", []), (qualInt "Data", []),
+               (qualInt "Typeable", [])]
+        typeParams = map mkTypeParam declParams
+        mkTypeParam TypeParam{paramName} = UnkindedVar $ mkVar paramName
+        mkField Field{fieldName, fieldType}
+          = ([mkVar fieldName], hsType mapping fieldType)
+        ownFields = map mkField structFields
+        fields
+          | Just base <- structBase =
+            ([baseStructField], hsType mapping base) : ownFields
+          | otherwise = ownFields
+        fieldModules
+          = S.fromList $
+              concatMap (getTypeModules mapping . fieldType) structFields
+        modules
+          | Just base <- structBase =
+            foldr S.insert fieldModules (getTypeModules mapping base)
+          | otherwise = fieldModules
+        imports
+          = defaultImport :
+              map (\ m -> importTemplate{importModule = m})
+                (S.toList $ S.delete moduleName modules)
+        defaultDecl = defaultInstance mapping s
+        wiretypeDecl = wiretypeInstance s
+        bondBinaryDecl = bondBinaryInstance s
+        bondStructDecl = bondStructInstance mapping s
+mkHaskellDecl _ _ = ("/dev/null", "empty")
+ 
+makeType ::
+         Bool -> Name -> [TypeParam] -> Language.Haskell.Exts.Type
+makeType _ typeName [] = TyCon $ UnQual typeName
+makeType needParen typeName params
+  | needParen = TyParen type'
+  | otherwise = type'
+  where type'
+          = foldl (\ v t -> TyApp v (TyVar $ mkVar $ paramName t))
+              (TyCon $ UnQual typeName)
+              params
+ 
+defaultInstance :: MappingContext -> Declaration -> Decl
+defaultInstance _ Enum{declName}
+  = InstDecl noLoc Nothing [] [] (qualInt "Default")
+      [TyCon $ unqual $ convertTypeName declName]
+      [InsDecl $
+         PatBind noLoc (PVar $ Ident "defaultValue")
+           (UnGuardedRhs $
+              App (Con $ unqual $ convertTypeName declName) (intLit (0 :: Int)))
+           (BDecls []),
+       InsDecl $
+         PatBind noLoc (PVar $ Ident "equalToDefault")
+           (UnGuardedRhs $ Var $ UnQual $ Symbol "==")
+           (BDecls [])]
+defaultInstance mapping
+  Struct{declName, declParams, structBase, structFields}
+  = InstDecl noLoc Nothing [] constraints (qualInt "Default")
+      [makeType True (Ident $ convertTypeName declName) declParams]
+      [InsDecl $
+         PatBind noLoc (PVar $ Ident "defaultValue")
+           (UnGuardedRhs $
+              RecConstr (unqual $ convertTypeName declName) defaults)
+           (BDecls []),
+       InsDecl $
+         FunBind
+           [Match noLoc (Ident "equalToDefault") [PWildCard, PWildCard]
+              Nothing
+              (UnGuardedRhs $ Con $ unqual "False")
+              (BDecls [])]]
+  where constraints = map (typeParamConstraint "Default") declParams
+        fields = map (mkDefaultValue mapping) structFields
+        defaults
+          = if isNothing structBase then fields else
+              FieldUpdate (UnQual baseStructField) (Var $ qualInt "defaultValue")
+                : fields
+defaultInstance _ _ = error "defaultInstance not implemented"
+ 
+mkDefaultValue ::
+               MappingContext -> Bond.Schema.Field -> FieldUpdate
+mkDefaultValue mapping Field{fieldName, fieldType, fieldDefault}
+  = FieldUpdate (UnQual $ mkVar fieldName) (defValue fieldDefault)
+  where defValue Nothing = Var $ qualInt "defaultValue"
+        defValue (Just (DefaultBool v)) = Con $ unqual $ show v
+        defValue (Just (DefaultInteger v)) = intLit v
+        defValue (Just (DefaultFloat v)) = floatLit v
+        defValue (Just (DefaultString v))
+          = App (Var $ qualInt "fromString") (Lit $ String v)
+        defValue (Just (DefaultEnum v))
+          = let BT_UserDefined decl [] = fieldType in
+              Var $ Qual (declModule mapping decl) (mkVar v)
+        defValue (Just DefaultNothing) = Con $ unqual "Nothing"
+ 
+getTypeModules ::
+               MappingContext -> Bond.Schema.Type -> [ModuleName]
+getTypeModules mapping = go
+  where go (BT_UserDefined decl args)
+          = declModule mapping decl : concatMap go args
+        go (BT_Map key value) = go key ++ go value
+        go (BT_List element) = go element
+        go (BT_Vector element) = go element
+        go (BT_Set element) = go element
+        go (BT_Nullable element) = go element
+        go (BT_Bonded element) = go element
+        go _ = []
+ 
+wiretypeInstance :: Declaration -> Decl
+wiretypeInstance Enum{declName}
+  = InstDecl noLoc Nothing [] [] (qualInt "WireType")
+      [TyCon $ unqual $ convertTypeName declName]
+      [InsDecl $
+         FunBind
+           [Match noLoc (Ident "getWireType") [PWildCard] Nothing
+              (UnGuardedRhs (Con $ qualInt "BT_INT32"))
+              (BDecls [])]]
+wiretypeInstance Struct{declName, declParams}
+  = InstDecl noLoc Nothing [] [] (qualInt "WireType")
+      [makeType True (Ident $ convertTypeName declName) declParams]
+      [InsDecl $
+         FunBind
+           [Match noLoc (Ident "getWireType") [PWildCard] Nothing
+              (UnGuardedRhs (Con $ qualInt "BT_STRUCT"))
+              (BDecls [])]]
+wiretypeInstance _ = error "wiretypeInstance not implemented"
+ 
+bondBinaryInstance :: Declaration -> Decl
+bondBinaryInstance Enum{declName}
+  = InstDecl noLoc Nothing [] [] (qualInt "BondBinary")
+      [TyCon $ unqual $ convertTypeName declName]
+      [InsDecl $
+         FunBind
+           [Match noLoc (Ident "bondPut")
+              [PParen
+                 (PApp (unqual $ convertTypeName declName) [PVar $ Ident "v"])]
+              Nothing
+              (UnGuardedRhs $
+                 App (Var $ qualInt "bondPutInt32") (Var $ unqual "v"))
+              (BDecls [])],
+       InsDecl $
+         PatBind noLoc (PVar $ Ident "bondGet")
+           (UnGuardedRhs $
+              InfixApp
+                (InfixApp (Var $ unqual "return") (QVarOp $ UnQual $ Symbol ".")
+                   (App (Var $ unqual "fmap")
+                      (Con $ unqual $ convertTypeName declName)))
+                (QVarOp $ UnQual $ Symbol "=<<")
+                (Var $ qualInt "bondGet"))
+           (BDecls [])]
+bondBinaryInstance Struct{declName, declParams}
+  = InstDecl noLoc Nothing [] (stdConstraints declParams)
+      (qualInt "BondBinary")
+      [makeType True (Ident $ convertTypeName declName) declParams]
+      [InsDecl $
+         PatBind noLoc (PVar $ Ident "bondPut")
+           (UnGuardedRhs $ Var $ qualInt "bondPutStruct")
+           (BDecls []),
+       InsDecl $
+         PatBind noLoc (PVar $ Ident "bondGet")
+           (UnGuardedRhs $ Var $ qualInt "bondGetStruct")
+           (BDecls [])]
+bondBinaryInstance _ = error "bondBinaryInstance not implemented"
+ 
+bondStructInstance :: MappingContext -> Declaration -> Decl
+bondStructInstance mapping decl@Struct{}
+  = InstDecl noLoc Nothing [] (stdConstraints (declParams decl))
+      (qualInt "BondStruct")
+      [typeId]
+      [InsType noLoc (TyApp (TyCon $ unqual "Base") typeId) baseId,
+       InsDecl
+         (FunBind
+            [Match noLoc (Ident "bondGetInfo") [PWildCard] Nothing
+               (UnGuardedRhs
+                  (App
+                     (App (Con $ qualInt "StructInfo")
+                        (Paren $
+                           ExpTypeSig noLoc (Con $ qualInt "Proxy")
+                             (TyApp (TyCon $ qualInt "Proxy") typeId)))
+                     baseProxy))
+               (BDecls [])]),
+       InsDecl $
+         FunBind
+           [Match noLoc (Ident "bondGetSchema") [PWildCard] Nothing
+              (UnGuardedRhs $
+                 App (Con $ qualInt "StructSchema")
+                   (List $ map makeFieldSchema (structFields decl)))
+              (BDecls [])],
+       InsDecl (FunBind [setBase]), InsDecl setFieldFunc, InsDecl getBase,
+       InsDecl checkField, InsDecl putField]
+  where typeId
+          = makeType True (Ident $ convertTypeName (declName decl))
+              (declParams decl)
+        baseId
+          | Just base <- structBase decl = hsType mapping base
+          | otherwise = TyCon $ qualInt "VoidBase"
+        baseProxy
+          | Just base <- structBase decl =
+            Paren $
+              App (Con $ unqual "Just")
+                (Paren $
+                   ExpTypeSig noLoc (Con $ qualInt "Proxy")
+                     (TyApp (TyCon $ qualInt "Proxy") (hsType mapping base)))
+          | otherwise = Con $ unqual "Nothing"
+        recVar = Ident "v'"
+        baseVar = Ident "b'"
+        valueVar = Ident "val'"
+        ordVar = Ident "ord'"
+        typeVar = Ident "type'tag"
+        setFuncName = Ident "bondSetField"
+        setFieldFunc
+          | length (structFields decl) < 20 =
+            FunBind $
+              map (makeSetFunc setFuncName) (structFields decl) ++
+                [defaultSetFunc setFuncName]
+          | otherwise =
+            PatBind noLoc (PVar $ Ident "bondSetField")
+              (UnGuardedRhs $ Var $ unqual "setField0")
+              (BDecls $ setBondDecls (0 :: Int) (structFields decl))
+        setBondDecls _ [] = []
+        setBondDecls idx fields
+          = let funcName = Ident $ "setField" ++ show idx
+                nextName = Ident $ "setField" ++ show (idx + 1)
+                (fs, rest) = splitAt 20 fields
+                lastDecl
+                  | null rest = defaultSetFunc funcName
+                  | otherwise =
+                    Match noLoc funcName [PVar ordVar, PVar typeVar] Nothing
+                      (UnGuardedRhs $
+                         App (App (Var $ UnQual nextName) (Var $ UnQual ordVar))
+                           (Var $ UnQual typeVar))
+                      (BDecls [])
+                code = FunBind $ map (makeSetFunc funcName) fs ++ [lastDecl]
+              in code : setBondDecls (idx + 1) rest
+        makeFieldSchema
+          Field{fieldOrdinal, fieldName, fieldType = BT_TypeParam t}
+          = App
+              (App
+                 (App (Con $ qualInt "FieldInfo")
+                    (Lit $ String $ uncapitalize fieldName))
+                 (Paren $
+                    App (Var $ qualInt "getWireType")
+                      (Paren $
+                         ExpTypeSig noLoc (Con $ qualInt "Proxy")
+                           (TyApp (TyCon $ qualInt "Proxy") (TyVar $ mkVar $ paramName t)))))
+              (Paren $ App (Con $ qualInt "Ordinal") (intLit fieldOrdinal))
+        makeFieldSchema Field{fieldOrdinal, fieldName, fieldType}
+          = App
+              (App
+                 (App (Con $ qualInt "FieldInfo")
+                    (Lit $ String $ uncapitalize fieldName))
+                 (Con $ wireType fieldType))
+              (Paren $ App (Con $ qualInt "Ordinal") (intLit fieldOrdinal))
+        getBase
+          | isNothing (structBase decl) =
+            FunBind
+              [Match noLoc (Ident "bondGetBase") [PWildCard] Nothing
+                 (UnGuardedRhs $
+                    App (Var $ unqual "error") (Lit $ String "no base struct"))
+                 (BDecls [])]
+          | otherwise =
+            PatBind noLoc (PVar $ Ident "bondGetBase")
+              (UnGuardedRhs $ Var $ UnQual baseStructField)
+              (BDecls [])
+        setBase
+          | isNothing (structBase decl) =
+            Match noLoc (Ident "bondSetBase") [PWildCard, PWildCard] Nothing
+              (UnGuardedRhs $
+                 App (Var $ unqual "error") (Lit $ String "no base struct"))
+              (BDecls [])
+          | otherwise =
+            Match noLoc (Ident "bondSetBase") [PVar recVar, PVar baseVar]
+              Nothing
+              (UnGuardedRhs $
+                 RecUpdate (Var $ UnQual recVar)
+                   [FieldUpdate (UnQual baseStructField) (Var $ UnQual baseVar)])
+              (BDecls [])
+        makeSetFunc funcname
+          Field{fieldOrdinal, fieldName, fieldType = BT_TypeParam t}
+          = Match noLoc funcname
+              [PParen
+                 (PApp (qualInt "Ordinal")
+                    [PLit Signless (Int $ fromIntegral fieldOrdinal)]),
+               PVar typeVar]
+              Nothing
+              (GuardedRhss
+                 [GuardedRhs noLoc
+                    [Qualifier
+                       (InfixApp (Var $ UnQual typeVar) (QVarOp $ UnQual $ Symbol "==")
+                          (App (Var $ qualInt "getWireType")
+                             (Paren $
+                                ExpTypeSig noLoc (Con $ qualInt "Proxy")
+                                  (TyApp (TyCon $ qualInt "Proxy")
+                                     (TyVar $ mkVar $ paramName t)))))]
+                    (InfixApp
+                       (InfixApp (Var $ unqual "return") (QVarOp $ UnQual $ Symbol ".")
+                          (App (Var $ unqual "fmap")
+                             (Paren $
+                                Lambda noLoc [PVar valueVar, PVar recVar]
+                                  (RecUpdate (Var $ UnQual recVar)
+                                     [FieldUpdate (UnQual $ mkVar fieldName)
+                                        (Var $ UnQual valueVar)]))))
+                       (QVarOp $ UnQual $ Symbol "=<<")
+                       (Var $ qualInt "bondGet"))])
+              (BDecls [])
+        makeSetFunc funcname
+          Field{fieldOrdinal, fieldName, fieldType,
+                fieldDefault = Just DefaultNothing}
+          = Match noLoc funcname
+              [PParen
+                 (PApp (qualInt "Ordinal")
+                    [PLit Signless (Int $ fromIntegral fieldOrdinal)]),
+               PApp (wireType fieldType) []]
+              Nothing
+              (UnGuardedRhs $
+                 InfixApp
+                   (InfixApp (Var $ unqual "return") (QVarOp $ UnQual $ Symbol ".")
+                      (App (Var $ unqual "fmap")
+                         (Paren $
+                            Lambda noLoc [PVar valueVar, PVar recVar]
+                              (RecUpdate (Var $ UnQual recVar)
+                                 [FieldUpdate (UnQual $ mkVar fieldName)
+                                    (App (Con $ unqual "Just") (Var $ UnQual valueVar))]))))
+                   (QVarOp $ UnQual $ Symbol "=<<")
+                   (Var $ qualInt "bondGet"))
+              (BDecls [])
+        makeSetFunc funcname Field{fieldOrdinal, fieldName, fieldType}
+          = Match noLoc funcname
+              [PParen
+                 (PApp (qualInt "Ordinal")
+                    [PLit Signless (Int $ fromIntegral fieldOrdinal)]),
+               PApp (wireType fieldType) []]
+              Nothing
+              (UnGuardedRhs $
+                 InfixApp
+                   (InfixApp (Var $ unqual "return") (QVarOp $ UnQual $ Symbol ".")
+                      (App (Var $ unqual "fmap")
+                         (Paren $
+                            Lambda noLoc [PVar valueVar, PVar recVar]
+                              (RecUpdate (Var $ UnQual recVar)
+                                 [FieldUpdate (UnQual $ mkVar fieldName)
+                                    (Var $ UnQual valueVar)]))))
+                   (QVarOp $ UnQual $ Symbol "=<<")
+                   (Var $ qualInt "bondGet"))
+              (BDecls [])
+        defaultSetFunc funcname
+          = Match noLoc funcname [PWildCard, PWildCard] Nothing
+              (UnGuardedRhs $
+                 App (Var $ unqual "return") (Con $ unqual "Nothing"))
+              (BDecls [])
+        checkField
+          = FunBind $
+              map makeCheckFunc (structFields decl) ++ [defaultCheckFunc]
+        makeCheckFunc Field{fieldOrdinal, fieldName}
+          = Match noLoc (Ident "bondFieldHasDefaultValue")
+              [PVar recVar,
+               PParen $
+                 PApp (qualInt "Ordinal")
+                   [PLit Signless (Int $ fromIntegral fieldOrdinal)]]
+              Nothing
+              (UnGuardedRhs $
+                 InfixApp
+                   (App (Var $ UnQual $ mkVar fieldName) (Var $ UnQual recVar))
+                   (QVarOp $ qualInt "equalToDefault")
+                   (App (Var $ UnQual $ mkVar fieldName)
+                      (Paren $
+                         ExpTypeSig noLoc (Var $ qualInt "defaultValue")
+                           (makeType False (Ident $ convertTypeName (declName decl))
+                              (declParams decl)))))
+              (BDecls [])
+        defaultCheckFunc
+          = Match noLoc (Ident "bondFieldHasDefaultValue")
+              [PWildCard, PWildCard]
+              Nothing
+              (UnGuardedRhs $
+                 App (Var $ unqual "error") (Lit $ String "unknown ordinal"))
+              (BDecls [])
+        putField
+          = FunBind $ map makePutFunc (structFields decl) ++ [defaultPutFunc]
+        makePutFunc
+          Field{fieldOrdinal, fieldName, fieldDefault = Just DefaultNothing}
+          = Match noLoc (Ident "bondPutField")
+              [PVar recVar,
+               PParen $
+                 PApp (qualInt "Ordinal")
+                   [PLit Signless (Int $ fromIntegral fieldOrdinal)]]
+              Nothing
+              (UnGuardedRhs $
+                 App (Var $ qualInt "bondPutMaybe")
+                   (Paren $
+                      App (Var $ UnQual $ mkVar fieldName) (Var $ UnQual recVar)))
+              (BDecls [])
+        makePutFunc Field{fieldOrdinal, fieldName}
+          = Match noLoc (Ident "bondPutField")
+              [PVar recVar,
+               PParen $
+                 PApp (qualInt "Ordinal")
+                   [PLit Signless (Int $ fromIntegral fieldOrdinal)]]
+              Nothing
+              (UnGuardedRhs $
+                 App (Var $ qualInt "bondPut")
+                   (Paren $
+                      App (Var $ UnQual $ mkVar fieldName) (Var $ UnQual recVar)))
+              (BDecls [])
+        defaultPutFunc
+          = Match noLoc (Ident "bondPutField") [PWildCard, PWildCard] Nothing
+              (UnGuardedRhs $
+                 App (Var $ unqual "error") (Lit $ String "unknown ordinal"))
+              (BDecls [])
+bondStructInstance _ _ = error "bondStructInstance not implemented"

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -27,7 +27,8 @@ set (sources
     Bond/Template/Cpp/Types_h.hs
     Bond/Template/Cpp/Util.hs
     Bond/Template/Cs/Types_cs.hs
-    Bond/Template/Cs/Util.hs)
+    Bond/Template/Cs/Util.hs
+    Bond/Template/Haskell/Decl.hs)
 
 set (output_dir ${CMAKE_CURRENT_BINARY_DIR})
 set (output ${output_dir}/build/gbc/gbc${CMAKE_EXECUTABLE_SUFFIX})

--- a/compiler/Options.hs
+++ b/compiler/Options.hs
@@ -42,6 +42,14 @@ data Options
         , fields :: Bool
         , jobs :: Maybe Int
         }
+    | Haskell
+        { files :: [FilePath]
+        , import_dir :: [FilePath]
+        , output_dir :: FilePath
+        , using :: [String]
+        , namespace :: [String]
+        , jobs :: Maybe Int
+        }
       deriving (Show, Data, Typeable)
 
 cpp :: Options
@@ -70,8 +78,14 @@ cs = Cs
     name "c#" &= 
     help "Generate C# code"
 
+haskell :: Options
+haskell = Haskell { }
+    &=
+    name "haskell" &=
+    help "Generate Haskell code"
+
 mode :: Mode (CmdArgs Options)
-mode = cmdArgsMode $ modes [cpp, cs] &= 
+mode = cmdArgsMode $ modes [cpp, cs, haskell] &=
     program "gbc" &= 
     help "Compile Bond schema definition file and generate specified output" &=
     summary ("Bond Compiler " ++ majorVersion ++ "." ++ minorVersion ++ ", (C) Microsoft")

--- a/compiler/cabal_build.cmake
+++ b/compiler/cabal_build.cmake
@@ -15,6 +15,15 @@ if ($ENV{APPVEYOR})
 endif()
 
 execute_process (
+    COMMAND ${Haskell_CABAL_EXECUTABLE} install   --with-compiler=${Haskell_GHC_EXECUTABLE} --jobs ${GHC_OPTIONS} happy
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE error)
+
+if (error)
+    message (FATAL_ERROR)
+endif()
+
+execute_process (
     COMMAND ${Haskell_CABAL_EXECUTABLE} install   --with-compiler=${Haskell_GHC_EXECUTABLE} --only-dependencies --jobs ${GHC_OPTIONS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     RESULT_VARIABLE error)

--- a/compiler/gbc.cabal
+++ b/compiler/gbc.cabal
@@ -59,4 +59,6 @@ executable gbc
                     mtl >= 2.1,
                     directory >= 1.1,
                     async >= 2.0.1.0,
-                    monad-loops >= 0.4
+                    monad-loops >= 0.4,
+                    haskell-src-exts,
+                    containers

--- a/haskell/runtime/Bond/API.hs
+++ b/haskell/runtime/Bond/API.hs
@@ -1,0 +1,25 @@
+module Bond.API (
+    BondBinaryProto,
+    BondGet,
+    BondPut,
+    bondGet,
+    bondPut,
+    deserializeCompact,
+    serializeCompact,
+    deserializeCompactV1,
+    serializeCompactV1,
+    deserializeFast,
+    serializeFast,
+    deserializeSimple,
+    serializeSimple,
+    deserializeSimpleV1,
+    serializeSimpleV1,
+    makeBonded,
+    unpackBonded
+  ) where
+
+import Bond.BinaryProto (BondGet, BondPut, BondBinaryProto, bondGet, bondPut)
+import Bond.FastBinary (deserializeFast, serializeFast)
+import Bond.CompactBinary (deserializeCompactV1, serializeCompactV1, deserializeCompact, serializeCompact)
+import Bond.SimpleBinary (deserializeSimpleV1, serializeSimpleV1, deserializeSimple, serializeSimple)
+import Bond.Bonded (unpackBonded, makeBonded)

--- a/haskell/runtime/Bond/BinaryProto.hs
+++ b/haskell/runtime/Bond/BinaryProto.hs
@@ -1,0 +1,198 @@
+{-# LANGUAGE ScopedTypeVariables, EmptyDataDecls, GeneralizedNewtypeDeriving, TypeFamilies, GADTs #-}
+module Bond.BinaryProto (
+        BondBinary(..),
+        BondStruct(..),
+        BondBinaryProto(..),
+        BondGet(..),
+        BondPutM(..),
+        BondPut,
+        StructInfo(..),
+        VoidBase,
+--        fromWireType,
+--        toWireType
+--    skipBinaryValue
+  ) where
+
+import Bond.Default
+import Bond.Types
+import Bond.Wire
+import Control.Applicative
+import Data.Binary.Get
+import Data.Binary.Put
+import Data.Hashable
+import Bond.Schema
+import Data.Proxy
+import qualified Data.HashSet as H
+import qualified Data.Map as M
+import qualified Data.Vector as V
+
+class WireType a => BondBinary a where
+    -- | Read field value.
+    -- Returns Just a if ok, Nothing if schema mismatch, fails on irrecoverable error
+    bondGet :: BondBinaryProto t => BondGet t (Maybe a)
+    -- | Put field into stream.
+    bondPut :: BondBinaryProto t => a -> BondPut t
+
+data StructInfo a b where
+    StructInfo :: (BondStruct a, BondStruct b, Base a ~ b) => Proxy a -> Maybe (Proxy b) -> StructInfo a b
+
+class (Default a, BondBinary a) => BondStruct a where
+    type Base a :: *
+    bondGetSchema :: Proxy a -> StructSchema
+    bondGetInfo :: Proxy a -> StructInfo a (Base a)
+    bondSetField :: BondBinaryProto t => Ordinal -> ItemType -> BondGet t (Maybe (a -> a))
+    bondSetBase :: a -> Base a -> a
+    bondGetBase :: a -> Base a
+    bondFieldHasDefaultValue :: a -> Ordinal -> Bool
+    bondPutField :: BondBinaryProto t => a -> Ordinal -> BondPut t
+
+data VoidBase
+instance Default VoidBase where
+    defaultValue = error "call to VoidBase"
+    equalToDefault = error "call to VoidBase"
+instance WireType VoidBase where
+    getWireType = error "call to VoidBase"
+instance BondBinary VoidBase where
+    bondGet = error "call to VoidBase"
+    bondPut = error "call to VoidBase"
+instance BondStruct VoidBase where
+    type Base VoidBase = VoidBase
+    bondGetSchema = error "call to VoidBase"
+    bondGetInfo = error "call to VoidBase"
+    bondSetField = error "call to VoidBase"
+    bondSetBase = error "call to VoidBase"
+    bondGetBase = error "call to VoidBase"
+    bondFieldHasDefaultValue = error "call to VoidBase"
+    bondPutField = error "call to VoidBase"
+
+newtype BondGet t a = BondGet (Get a)
+    deriving (Functor, Applicative, Monad)
+newtype BondPutM t a = BondPut (PutM a)
+    deriving (Functor, Applicative, Monad)
+type BondPut t = BondPutM t ()
+
+class BondBinaryProto t where
+    bondPutBool :: Bool -> BondPut t
+    bondPutUInt8 :: Word8 -> BondPut t
+    bondPutUInt16 :: Word16 -> BondPut t
+    bondPutUInt32 :: Word32 -> BondPut t
+    bondPutUInt64 :: Word64 -> BondPut t
+    bondPutInt8 :: Int8 -> BondPut t
+    bondPutInt16 :: Int16 -> BondPut t
+    bondPutInt32 :: Int32 -> BondPut t
+    bondPutInt64 :: Int64 -> BondPut t
+    bondPutFloat :: Float -> BondPut t
+    bondPutDouble :: Double -> BondPut t
+    bondPutString :: Utf8 -> BondPut t
+    bondPutWString :: Utf16 -> BondPut t
+    bondPutBlob :: Blob -> BondPut t
+    bondPutList :: BondBinary a => [a] -> BondPut t
+    bondPutVector :: BondBinary a => V.Vector a -> BondPut t
+    bondPutSet :: BondBinary a => H.HashSet a -> BondPut t
+    bondPutMap :: (BondBinary k, BondBinary v) => M.Map k v -> BondPut t
+    bondPutNullable :: BondBinary a => Maybe a -> BondPut t
+    bondPutMaybe :: BondBinary a => Maybe a -> BondPut t
+    bondPutBonded :: BondStruct a => Bonded a -> BondPut t
+    bondPutStruct :: BondStruct a => a -> BondPut t
+
+    bondGetBool :: BondGet t (Maybe Bool)
+    bondGetUInt8 :: BondGet t (Maybe Word8)
+    bondGetUInt16 :: BondGet t (Maybe Word16)
+    bondGetUInt32 :: BondGet t (Maybe Word32)
+    bondGetUInt64 :: BondGet t (Maybe Word64)
+    bondGetInt8 :: BondGet t (Maybe Int8)
+    bondGetInt16 :: BondGet t (Maybe Int16)
+    bondGetInt32 :: BondGet t (Maybe Int32)
+    bondGetInt64 :: BondGet t (Maybe Int64)
+    bondGetFloat :: BondGet t (Maybe Float)
+    bondGetDouble :: BondGet t (Maybe Double)
+    bondGetString :: BondGet t (Maybe Utf8)
+    bondGetWString :: BondGet t (Maybe Utf16)
+    bondGetBlob :: BondGet t (Maybe Blob)
+    bondGetList :: BondBinary a => BondGet t (Maybe [a])
+    bondGetVector :: BondBinary a => BondGet t (Maybe (V.Vector a))
+    bondGetSet :: (Eq a, Hashable a, BondBinary a) => BondGet t (Maybe (H.HashSet a))
+    bondGetMap :: (Ord k, BondBinary k, BondBinary v) => BondGet t (Maybe (M.Map k v))
+    bondGetNullable :: BondBinary a => BondGet t (Maybe (Maybe a))
+    bondGetBonded :: BondStruct a => BondGet t (Maybe (Bonded a))
+    bondGetStruct :: BondStruct a => BondGet t (Maybe a)
+
+instance BondBinary Float where
+    bondGet = bondGetFloat
+    bondPut = bondPutFloat
+
+instance BondBinary Double where
+    bondGet = bondGetDouble
+    bondPut = bondPutDouble
+
+instance BondBinary Bool where
+    bondGet = bondGetBool
+    bondPut = bondPutBool
+
+instance BondBinary Int8 where
+    bondGet = bondGetInt8
+    bondPut = bondPutInt8
+
+instance BondBinary Int16 where
+    bondGet = bondGetInt16
+    bondPut = bondPutInt16
+
+instance BondBinary Int32 where
+    bondGet = bondGetInt32
+    bondPut = bondPutInt32
+
+instance BondBinary Int64 where
+    bondGet = bondGetInt64
+    bondPut = bondPutInt64
+
+instance BondBinary Word8 where
+    bondGet = bondGetUInt8
+    bondPut = bondPutUInt8
+
+instance BondBinary Word16 where
+    bondGet = bondGetUInt16
+    bondPut = bondPutUInt16
+
+instance BondBinary Word32 where
+    bondGet = bondGetUInt32
+    bondPut = bondPutUInt32
+
+instance BondBinary Word64 where
+    bondGet = bondGetUInt64
+    bondPut = bondPutUInt64
+
+instance BondBinary Utf8 where
+    bondGet = bondGetString
+    bondPut = bondPutString
+
+instance BondBinary Utf16 where
+    bondGet = bondGetWString
+    bondPut = bondPutWString
+
+instance BondBinary Blob where
+    bondGet = bondGetBlob
+    bondPut = bondPutBlob
+
+instance BondBinary a => BondBinary [a] where
+    bondGet = bondGetList
+    bondPut = bondPutList
+
+instance BondBinary a => BondBinary (V.Vector a) where
+    bondGet = bondGetVector
+    bondPut = bondPutVector
+
+instance (Eq a, Hashable a, BondBinary a) => BondBinary (H.HashSet a) where
+    bondGet = bondGetSet
+    bondPut = bondPutSet
+
+instance (Ord k, BondBinary k, BondBinary v) => BondBinary (M.Map k v) where
+    bondGet = bondGetMap
+    bondPut = bondPutMap
+
+instance BondBinary a => BondBinary (Maybe a) where
+    bondGet = bondGetNullable
+    bondPut = bondPutNullable
+
+instance BondStruct a => BondBinary (Bonded a) where
+    bondGet = bondGetBonded
+    bondPut = bondPutBonded

--- a/haskell/runtime/Bond/Bonded.hs
+++ b/haskell/runtime/Bond/Bonded.hs
@@ -1,4 +1,3 @@
-{-# Language FlexibleContexts, AllowAmbiguousTypes #-}
 module Bond.Bonded (
         makeBonded,
         unpackBonded,

--- a/haskell/runtime/Bond/Bonded.hs
+++ b/haskell/runtime/Bond/Bonded.hs
@@ -1,0 +1,50 @@
+{-# Language FlexibleContexts, AllowAmbiguousTypes #-}
+module Bond.Bonded (
+        makeBonded,
+        unpackBonded,
+        streamBonded
+    ) where
+
+import Bond.BinaryProto
+import {-# SOURCE #-} Bond.CompactBinary
+import {-# SOURCE #-} Bond.FastBinary
+import Bond.SimpleBinary
+import Bond.Stream
+import Bond.Types
+import Data.Binary.Get
+import qualified Data.ByteString.Lazy as Lazy
+
+type BondDecoder a = Lazy.ByteString -> Either (Lazy.ByteString, Int64, String) (Lazy.ByteString, Int64, a)
+
+unpackBonded :: BondStruct a => Bonded a -> Either String a
+unpackBonded (BondedObject v) = Right v
+unpackBonded (BondedStream proto s)
+    = let decoder = getDecoder proto
+       in case decoder s of
+            Right (rest, _, msg) | Lazy.null rest -> Right msg
+            Right (_, _, _) -> Left "Not all input consumed"
+            Left (_, _, msg) -> Left msg
+
+makeBonded :: a -> Bonded a
+makeBonded = BondedObject
+
+streamBonded :: BondBinaryProto t => ProtoSig -> Lazy.ByteString -> BondPutM t StreamStruct
+streamBonded sig s | sig == compactV1Sig = go compactV1ToStream
+                   | sig == compactSig = go compactToStream
+                   | sig == fastSig = go fastToStream
+    where
+    go f = let BondGet decoder = f
+            in case runGetOrFail decoder s of
+                Right (rest, _, msg) | Lazy.null rest -> return msg
+                Right (_, _, _) -> fail "Not all input consumed"
+                Left (_, _, msg) -> fail msg
+streamBonded _ _ = error "internal error: unstreamable protocol"
+
+getDecoder :: BondStruct a => ProtoSig -> BondDecoder a
+getDecoder proto
+    | proto == compactV1Sig = deserializeCompactV1
+    | proto == compactSig = deserializeCompact
+    | proto == simpleV1Sig = deserializeSimpleV1
+    | proto == simpleSig = deserializeSimple
+    | proto == fastSig = deserializeFast
+getDecoder _ = const $ Left (Lazy.empty, 0, "unknown protocol or version")

--- a/haskell/runtime/Bond/Cast.hs
+++ b/haskell/runtime/Bond/Cast.hs
@@ -1,0 +1,34 @@
+{-# Language FlexibleContexts #-}
+module Bond.Cast (
+        wordToFloat,
+        floatToWord,
+        wordToDouble,
+        doubleToWord
+    ) where
+
+import Control.Monad.ST (runST, ST)
+import Data.Array.ST (newArray, readArray, MArray, STUArray)
+import Data.Array.Unsafe (castSTUArray)
+import Data.Word
+
+{-# INLINE wordToFloat #-}
+wordToFloat :: Word32 -> Float
+wordToFloat x = runST (cast x)
+
+{-# INLINE floatToWord #-}
+floatToWord :: Float -> Word32
+floatToWord x = runST (cast x)
+
+{-# INLINE wordToDouble #-}
+wordToDouble :: Word64 -> Double
+wordToDouble x = runST (cast x)
+
+{-# INLINE doubleToWord #-}
+doubleToWord :: Double -> Word64
+doubleToWord x = runST (cast x)
+
+{-# INLINE cast #-}
+cast :: (MArray (STUArray s) a (ST s),
+         MArray (STUArray s) b (ST s)) =>
+        a -> ST s b
+cast x = newArray (0 :: Int, 0) x >>= castSTUArray >>= flip readArray 0

--- a/haskell/runtime/Bond/CompactBinary.hs
+++ b/haskell/runtime/Bond/CompactBinary.hs
@@ -1,0 +1,767 @@
+{-# LANGUAGE ScopedTypeVariables, EmptyDataDecls, GADTs, MultiWayIf, InstanceSigs #-}
+module Bond.CompactBinary (
+    deserializeCompactV1,
+    serializeCompactV1,
+    deserializeCompact,
+    serializeCompact,
+    compactV1ToStream,
+    streamToCompactV1,
+    compactToStream,
+    streamToCompact,
+    CompactBinaryV1Proto,
+    CompactBinaryProto,
+    ZigZagInt(..),     -- export for testing
+    zigzagToWord,      -- export for testing
+    wordToZigZag       -- export for testing
+  ) where
+
+import Bond.BinaryProto
+import Bond.Bonded
+import Bond.Cast
+import Bond.Default
+import Bond.Schema
+import Bond.Stream
+import Bond.Types
+import Bond.Wire
+import Control.Applicative
+import Control.Monad
+import Data.Binary.Get
+import Data.Binary.Put
+import Data.Bits
+import Data.Maybe
+import Data.Proxy
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as Lazy
+import qualified Data.HashSet as H
+import qualified Data.Map as M
+import qualified Data.Vector as V
+
+checkWireType :: WireType a => Proxy a -> ItemType -> Bool
+checkWireType p t = getWireType p == t
+
+data CompactBinaryV1Proto
+data CompactBinaryProto
+
+class BondBinaryProto t => Skippable t where
+    skipValue :: ItemType -> BondGet t ()
+
+newtype EncodedWord = EncodedWord { unWord :: Word64 }
+newtype ZigZagInt = ZigZagInt { fromZigZag :: Int64 }
+    deriving (Show, Eq)
+
+zigzagToWord :: ZigZagInt -> EncodedWord
+zigzagToWord (ZigZagInt i) | i >= 0 = EncodedWord $ 2 * fromIntegral i
+zigzagToWord (ZigZagInt i) = EncodedWord $ (2 * fromIntegral (abs i)) - 1
+
+wordToZigZag :: EncodedWord -> ZigZagInt
+wordToZigZag (EncodedWord w) | even w = ZigZagInt $ fromIntegral (w `div` 2)
+wordToZigZag (EncodedWord w) = ZigZagInt $ negate $ fromIntegral ((w - 1) `div` 2) + 1
+
+putEncodedWord :: EncodedWord -> BondPut t
+putEncodedWord (EncodedWord i) | i < 128 = BondPut $ putWord8 $ fromIntegral i
+putEncodedWord (EncodedWord i) = do
+    let iLow = fromIntegral $ i .&. 0x7F
+    BondPut $ putWord8 $ iLow `setBit` 7
+    putEncodedWord $ EncodedWord (i `shiftR` 7)
+
+getEncodedWord :: BondGet t EncodedWord
+getEncodedWord = EncodedWord <$> step 0
+    where
+    step :: Int -> BondGet t Word64
+    step n | n > 9 = fail "EncodedWord: sequence too long"
+    step n = do
+        b <- fromIntegral <$> BondGet getWord8
+        rest <- if b `testBit` 7 then step (n + 1)  else return (0 :: Word64)
+        return $ (b `clearBit` 7) .|. (rest `shiftL` 7)
+
+getVarInt :: BondGet t Int
+getVarInt = BondGet $ step 0
+    where
+    step :: Int -> Get Int
+    step n | n > 4 = fail "VarInt: sequence too long"
+    step n = do
+        b <- fromIntegral <$> getWord8
+        rest <- if b `testBit` 7 then step (n + 1)  else return (0 :: Int)
+        return $ (b `clearBit` 7) .|. (rest `shiftL` 7)
+
+putVarInt :: Int -> BondPut t
+putVarInt i | i < 0 = error "VarInt with negative value"
+putVarInt i | i < 128 = BondPut $ putWord8 $ fromIntegral i
+putVarInt i = let iLow = fromIntegral $ i .&. 0x7F
+               in do
+                    BondPut $ putWord8 $ iLow `setBit` 7
+                    putVarInt (i `shiftR` 7)
+
+typeIdOf :: forall a. WireType a => a -> Word8
+typeIdOf _ =  fromIntegral $ fromEnum $ getWireType (Proxy :: Proxy a)
+
+wireTypeOf :: forall a. WireType a => a -> ItemType
+wireTypeOf _ =  getWireType (Proxy :: Proxy a)
+
+wireType :: Word8 -> ItemType
+wireType = toEnum . fromIntegral
+
+instance BondBinaryProto CompactBinaryV1Proto where
+    bondPutBool True = BondPut $ putWord8 1
+    bondPutBool False = BondPut $ putWord8 0
+    bondPutUInt8 = BondPut . putWord8
+    bondPutUInt16 = putEncodedWord . EncodedWord . fromIntegral
+    bondPutUInt32 = putEncodedWord . EncodedWord . fromIntegral
+    bondPutUInt64 = putEncodedWord . EncodedWord . fromIntegral
+    bondPutInt8 = BondPut . putWord8 . fromIntegral
+    bondPutInt16 = putEncodedWord . zigzagToWord . ZigZagInt . fromIntegral
+    bondPutInt32 = putEncodedWord . zigzagToWord . ZigZagInt . fromIntegral
+    bondPutInt64 = putEncodedWord . zigzagToWord . ZigZagInt . fromIntegral
+    bondPutFloat = BondPut . putWord32le . floatToWord
+    bondPutDouble = BondPut . putWord64le . doubleToWord
+    bondPutString (Utf8 s) = do
+        putVarInt $ fromIntegral $ BS.length s
+        BondPut $ putByteString s
+    bondPutWString (Utf16 s) = do
+        putVarInt $ fromIntegral $ BS.length s `div` 2
+        BondPut $ putByteString s
+    bondPutList xs = do
+        BondPut $ putWord8 $ typeIdOf (head xs)
+        putVarInt $ length xs
+        mapM_ bondPut xs
+    bondPutMaybe Nothing = return ()
+    bondPutMaybe (Just v) = bondPut v
+    bondPutNullable = bondPutList . maybeToList
+    bondPutSet = bondPutList . H.toList
+    bondPutMap = putMap
+    bondPutVector xs = do
+        BondPut $ putWord8 $ typeIdOf (V.head xs)
+        putVarInt $ V.length xs
+        V.mapM_ bondPut xs
+    bondPutBlob (Blob b) = do
+        BondPut $ putWord8 $ fromIntegral $ fromEnum BT_INT8
+        putVarInt $ BS.length b
+        BondPut $ putByteString b
+    bondPutBonded (BondedObject a) = bondPut a
+    bondPutBonded (BondedStream sig s) | sig == compactV1Sig = BondPut $ putLazyByteString s
+    bondPutBonded b@(BondedStream sig _) | sig == simpleV1Sig || sig == simpleSig = do
+        let ret = unpackBonded b
+        case ret of
+            Left err -> fail err
+            Right a -> bondPut a
+    bondPutBonded (BondedStream sig s) = streamBonded sig s >>= streamToCompactV1 
+    bondPutStruct = saveStruct BT_STOP (bondGetInfo Proxy)
+
+    bondGetBool = do
+        v <- BondGet getWord8
+        return $ Just $ v /= 0
+    bondGetUInt8 = Just <$> BondGet getWord8
+    bondGetUInt16 = Just . fromIntegral . unWord <$> getEncodedWord
+    bondGetUInt32 = Just . fromIntegral . unWord <$> getEncodedWord
+    bondGetUInt64 = Just . fromIntegral . unWord <$> getEncodedWord
+    bondGetInt8 = Just . fromIntegral <$> BondGet getWord8
+    bondGetInt16 = Just . fromIntegral . fromZigZag . wordToZigZag <$> getEncodedWord
+    bondGetInt32 = Just . fromIntegral . fromZigZag . wordToZigZag <$> getEncodedWord
+    bondGetInt64 = Just . fromIntegral . fromZigZag . wordToZigZag <$> getEncodedWord
+    bondGetFloat = Just . wordToFloat <$> BondGet getWord32le
+    bondGetDouble = Just . wordToDouble <$> BondGet getWord64le
+    bondGetString = do
+        n <- getVarInt
+        Just . Utf8 <$> BondGet (getByteString n)
+    bondGetWString = do
+        n <- getVarInt
+        Just . Utf16 <$> BondGet (getByteString $ n * 2)
+    bondGetBlob = do
+        tag <- wireType <$> BondGet getWord8
+        n <- getVarInt
+        if tag == BT_INT8
+            then Just . Blob <$> BondGet (getByteString n)
+            else do
+                replicateM_ n (skipValue tag)
+                return Nothing
+    bondGetList = getListV1
+    bondGetSet = liftM H.fromList <$> getListV1
+    bondGetMap = getMap
+    bondGetVector = liftM V.fromList <$> getListV1
+    bondGetNullable = do
+        v <- getListV1
+        return $ case v of
+            Just [x] -> Just $ Just x
+            Just [] -> Just Nothing
+            _ -> Nothing
+    bondGetBonded :: forall a. BondStruct a => BondGet CompactBinaryV1Proto (Maybe (Bonded a))
+    bondGetBonded = do
+        let try (BondGet g) = BondGet $ lookAhead g
+        size <- try $ do
+            start <- BondGet bytesRead
+            skipValueV1 (getWireType (Proxy :: Proxy a))
+            end <- BondGet bytesRead
+            return (end - start)
+        Just . BondedStream compactV1Sig <$> BondGet (getLazyByteString size)
+    bondGetStruct = Just <$> readStruct (bondGetInfo Proxy)
+
+instance Skippable CompactBinaryV1Proto where
+    skipValue = skipValueV1
+
+skipValueV1 :: ItemType -> BondGet CompactBinaryV1Proto ()
+skipValueV1 = skipValueCommon
+
+getMap :: forall a b t. (Skippable t, BondBinaryProto t, Ord a, BondBinary a, BondBinary b) => BondGet t (Maybe (M.Map a b))
+getMap = do
+    ktag <- wireType <$> BondGet getWord8
+    vtag <- wireType <$> BondGet getWord8
+    n <- getVarInt
+    if checkWireType (Proxy :: Proxy a) ktag && checkWireType (Proxy :: Proxy b) vtag
+        then do
+            elems <- replicateM n $ do
+                k <- bondGet
+                v <- bondGet
+                return $ seqPair (k, v)
+            return $ M.fromList <$> sequence elems
+        else do
+            replicateM_ n $ do
+                skipValue ktag
+                skipValue vtag
+            return Nothing
+    where
+    seqPair (Just a, Just b) = Just (a, b)
+    seqPair _ = Nothing
+
+putMap :: (BondBinaryProto t, BondBinary a, BondBinary b) => M.Map a b -> BondPut t
+putMap m = do
+    BondPut $ putWord8 $ typeIdOf (head $ M.keys m)
+    BondPut $ putWord8 $ typeIdOf (head $ M.elems m)
+    putVarInt $ M.size m
+    forM_ (M.toList m) $ \(k, v) -> do
+        bondPut k
+        bondPut v
+
+getListV1 :: forall a. BondBinary a => BondGet CompactBinaryV1Proto (Maybe [a])
+getListV1 = do
+    tag <- wireType <$> BondGet getWord8
+    n <- getVarInt
+    if checkWireType (Proxy :: Proxy a) tag
+        then do
+            elems <- replicateM n bondGet
+            return $ sequence elems
+        else do
+            replicateM_ n (skipValue tag)
+            return Nothing
+
+getFieldHeader :: BondGet t (ItemType, Ordinal)
+getFieldHeader = do
+    tag <- BondGet getWord8
+    case tag `shiftR` 5 of
+        6 -> do
+            n <- BondGet getWord8
+            return (wireType (tag .&. 31), Ordinal (fromIntegral n))
+        7 -> do
+            n <- BondGet getWord16le
+            return (wireType (tag .&. 31), Ordinal n)
+        n -> return (wireType (tag .&. 31), Ordinal (fromIntegral n))
+
+putFieldHeader :: ItemType -> Ordinal -> BondPut t
+putFieldHeader t (Ordinal n) = let tbits = fromIntegral $ fromEnum t
+                                   nbits = fromIntegral n
+                                in if | n <= 5 -> BondPut $ putWord8 $ tbits .|. (nbits `shiftL` 5)
+                                      | n <= 255 -> do
+                                                BondPut $ putWord8 $ tbits .|. 0xC0
+                                                BondPut $ putWord8 nbits
+                                      | otherwise -> do
+                                                BondPut $ putWord8 $ tbits .|. 0xE0
+                                                BondPut $ putWord16le n
+
+readStruct :: forall a b t. (Skippable t, BondBinaryProto t) => StructInfo a b -> BondGet t a
+readStruct (StructInfo _ pb) = do
+    def <- case pb of
+        Nothing -> return defaultValue
+        Just p -> do
+            base <- readStruct (bondGetInfo p)
+            return $ bondSetBase defaultValue base
+    getFields def
+
+getFields :: forall a t. (BondStruct a, Skippable t, BondBinaryProto t) => a -> BondGet t a
+getFields def = do
+    update <- loop id
+    return $ update def
+    where
+    try :: BondGet t (Maybe (b -> b)) -> BondGet t (Maybe (b -> b))
+    try (BondGet g) = BondGet $ lookAheadM g
+    loop f = do
+        (tag, n) <- getFieldHeader
+        case tag of
+            BT_STOP -> return f
+            BT_STOP_BASE -> return f -- XXX think later
+            _ -> do
+                fieldMod <- try $ bondSetField n tag
+                case fieldMod of
+                    Just func -> loop (func . f)
+                    Nothing -> do
+                        skipValue tag
+                        loop f
+
+saveStruct :: BondBinaryProto t => ItemType -> StructInfo a b -> a -> BondPut t
+saveStruct stop (StructInfo pa pb) a = do
+    when (isJust pb) $ saveStruct BT_STOP_BASE (bondGetInfo $ fromJust pb) (bondGetBase a)
+    putFields (bondGetSchema pa)
+    BondPut $ putWord8 $ fromIntegral $ fromEnum stop
+    where
+    putFields (StructSchema fields) = forM_ fields $ \(FieldInfo _ t n) -> unless (bondFieldHasDefaultValue a n) $ do
+        putFieldHeader t n
+        bondPutField a n
+
+skipVarInt :: BondGet t ()
+skipVarInt = loop
+    where
+    loop = do
+        v <- BondGet getWord8
+        when (v `testBit` 7) loop
+
+skipValueCommon :: Skippable t => ItemType -> BondGet t ()
+skipValueCommon BT_STOP = fail "internal error: skipValue BT_STOP"
+skipValueCommon BT_STOP_BASE = fail "internal error: skipValue BT_STOP_BASE"
+skipValueCommon BT_BOOL = BondGet $ skip 1
+skipValueCommon BT_UINT8 = BondGet $ skip 1
+skipValueCommon BT_UINT16 = skipVarInt
+skipValueCommon BT_UINT32 = skipVarInt
+skipValueCommon BT_UINT64 = skipVarInt
+skipValueCommon BT_FLOAT = BondGet $ skip 4
+skipValueCommon BT_DOUBLE = BondGet $ skip 8
+skipValueCommon BT_INT8 = BondGet $ skip 1
+skipValueCommon BT_INT16 = skipVarInt
+skipValueCommon BT_INT32 = skipVarInt
+skipValueCommon BT_INT64 = skipVarInt
+skipValueCommon BT_STRING = do
+    n <- getVarInt
+    BondGet $ skip n
+skipValueCommon BT_WSTRING = do
+    n <- getVarInt
+    BondGet $ skip (n * 2)
+skipValueCommon BT_LIST = do
+    t <- wireType <$> BondGet getWord8
+    n <- getVarInt
+    replicateM_ n (skipValue t)
+skipValueCommon BT_SET = skipValue BT_LIST
+skipValueCommon BT_MAP = do
+    tkey <- wireType <$> BondGet getWord8
+    tvalue <- wireType <$> BondGet getWord8
+    n <- getVarInt
+    replicateM_ n $ do
+        skipValue tkey
+        skipValue tvalue
+skipValueCommon BT_STRUCT = loop
+    where
+    loop = do
+        (t, _) <- getFieldHeader
+        case t of
+            BT_STOP -> return ()
+            BT_STOP_BASE -> loop
+            _ -> do
+                    skipValue t
+                    loop
+
+deserializeCompactV1 :: forall a. BondStruct a => Lazy.ByteString -> Either (Lazy.ByteString, Int64, String) (Lazy.ByteString, Int64, a) 
+deserializeCompactV1 = let BondGet g = bondGet :: BondGet CompactBinaryV1Proto (Maybe a)
+                        in runGetOrFail (fromJust <$> g)
+
+serializeCompactV1 :: BondStruct a => a -> Lazy.ByteString
+serializeCompactV1 v = let BondPut g = bondPut v :: BondPut CompactBinaryV1Proto
+                        in runPut g
+
+compactV1ToStream :: BondGet CompactBinaryV1Proto StreamStruct
+compactV1ToStream = loop (StreamStruct Nothing [])
+    where
+    getElem t = do
+      case t of
+        BT_STOP -> error "internal error: getElem BT_STOP"
+        BT_STOP_BASE -> error "internal error: getElem BT_STOP_BASE"
+        BT_BOOL -> do
+            Just v <- bondGetBool
+            return $ SeBool v
+        BT_UINT8 -> do
+            Just v <- bondGetUInt8
+            return $ SeUInt8 v
+        BT_UINT16 -> do
+            Just v <- bondGetUInt16
+            return $ SeUInt16 v
+        BT_UINT32 -> do
+            Just v <- bondGetUInt32
+            return $ SeUInt32 v
+        BT_UINT64 -> do
+            Just v <- bondGetUInt64
+            return $ SeUInt64 v
+        BT_FLOAT -> do
+            Just v <- bondGetFloat
+            return $ SeFloat v
+        BT_DOUBLE -> do
+            Just v <- bondGetDouble
+            return $ SeDouble v
+        BT_STRING -> do
+            Just v <- bondGetString
+            return $ SeString v
+        BT_STRUCT -> do
+            s <- compactV1ToStream
+            return $ SeStruct s
+        BT_LIST -> do
+            tag <- wireType <$> BondGet getWord8
+            n <- getVarInt
+            elems <- replicateM n (getElem tag)
+            return $ SeList tag elems
+        BT_SET -> do
+            tag <- wireType <$> BondGet getWord8
+            n <- getVarInt
+            elems <- replicateM n (getElem tag)
+            return $ SeSet tag elems
+        BT_MAP -> do
+            ktag <- wireType <$> BondGet getWord8
+            vtag <- wireType <$> BondGet getWord8
+            n <- getVarInt
+            elems <- replicateM n $ do
+                k <- getElem ktag
+                v <- getElem vtag
+                return (k, v)
+            return $ SeMap (ktag, vtag) elems
+        BT_INT8 -> do
+            Just v <- bondGetInt8
+            return $ SeInt8 v
+        BT_INT16 -> do
+            Just v <- bondGetInt16
+            return $ SeInt16 v
+        BT_INT32 -> do
+            Just v <- bondGetInt32
+            return $ SeInt32 v
+        BT_INT64 -> do
+            Just v <- bondGetInt64
+            return $ SeInt64 v
+        BT_WSTRING -> do
+            Just v <- bondGetWString
+            return $ SeWString v
+    loop st = do
+        (tag, n) <- getFieldHeader
+        case tag of
+            BT_STOP -> return st
+            BT_STOP_BASE -> loop (StreamStruct (Just st) [])
+            _ -> do
+                e <- getElem tag
+                loop $ st { ssElems = ssElems st ++ [(n, e)] }
+
+streamToCompactV1 :: StreamStruct -> BondPut CompactBinaryV1Proto
+streamToCompactV1 struct = do
+    putStreamStruct struct
+    BondPut $ putWord8 $ fromIntegral $ fromEnum BT_STOP
+    where
+    putStreamStruct st = do
+        when (isJust $ ssBase st) $ do
+            putStreamStruct (fromJust $ ssBase st)
+            BondPut $ putWord8 $ fromIntegral $ fromEnum BT_STOP_BASE
+        mapM_ putField (ssElems st)
+    putField (n, e) = do
+        putFieldHeader (elemItemType e) n
+        putElem e
+    putElem (SeBool v) = bondPutBool v
+    putElem (SeUInt8 v) = bondPutUInt8 v
+    putElem (SeUInt16 v) = bondPutUInt16 v
+    putElem (SeUInt32 v) = bondPutUInt32 v
+    putElem (SeUInt64 v) = bondPutUInt64 v
+    putElem (SeFloat v) = bondPutFloat v
+    putElem (SeDouble v) = bondPutDouble v
+    putElem (SeString v) = bondPutString v
+    putElem (SeStruct v) = streamToCompactV1 v
+    putElem (SeList tag xs) = do
+        BondPut $ putWord8 $ fromIntegral $ fromEnum tag
+        putVarInt $ length xs
+        mapM_ putElem xs
+    putElem (SeSet tag xs) = do
+        BondPut $ putWord8 $ fromIntegral $ fromEnum tag
+        putVarInt $ length xs
+        mapM_ putElem xs
+    putElem (SeMap (ktag, vtag) xs) = do
+        BondPut $ putWord8 $ fromIntegral $ fromEnum ktag
+        BondPut $ putWord8 $ fromIntegral $ fromEnum vtag
+        putVarInt $ length xs
+        forM_ xs $ \(k, v) -> do
+            putElem k
+            putElem v
+    putElem (SeInt8 v) = do
+        bondPutInt8 v
+    putElem (SeInt16 v) = do
+        bondPutInt16 v
+    putElem (SeInt32 v) = do
+        bondPutInt32 v
+    putElem (SeInt64 v) = do
+        bondPutInt64 v
+    putElem (SeWString v) = do
+        bondPutWString v
+
+instance BondBinaryProto CompactBinaryProto where
+    bondPutBool True = BondPut $ putWord8 1
+    bondPutBool False = BondPut $ putWord8 0
+    bondPutUInt8 = BondPut . putWord8
+    bondPutUInt16 = putEncodedWord . EncodedWord . fromIntegral
+    bondPutUInt32 = putEncodedWord . EncodedWord . fromIntegral
+    bondPutUInt64 = putEncodedWord . EncodedWord . fromIntegral
+    bondPutInt8 = BondPut . putWord8 . fromIntegral
+    bondPutInt16 = putEncodedWord . zigzagToWord . ZigZagInt . fromIntegral
+    bondPutInt32 = putEncodedWord . zigzagToWord . ZigZagInt . fromIntegral
+    bondPutInt64 = putEncodedWord . zigzagToWord . ZigZagInt . fromIntegral
+    bondPutFloat = BondPut . putWord32le . floatToWord
+    bondPutDouble = BondPut . putWord64le . doubleToWord
+    bondPutString (Utf8 s) = do
+        putVarInt $ fromIntegral $ BS.length s
+        BondPut $ putByteString s
+    bondPutWString (Utf16 s) = do
+        putVarInt $ fromIntegral $ BS.length s `div` 2
+        BondPut $ putByteString s
+    bondPutList xs = do
+        putV2ListHeader (wireTypeOf $ head xs) (length xs)
+        mapM_ bondPut xs
+    bondPutMaybe Nothing = return ()
+    bondPutMaybe (Just v) = bondPut v
+    bondPutNullable = bondPutList . maybeToList
+    bondPutSet = bondPutList . H.toList
+    bondPutMap = putMap
+    bondPutVector xs = do
+        putV2ListHeader (wireTypeOf $ V.head xs) (V.length xs)
+        V.mapM_ bondPut xs
+    bondPutBlob (Blob b) = do
+        putV2ListHeader BT_INT8 (BS.length b)
+        BondPut $ putByteString b
+    bondPutBonded (BondedObject a) = bondPut a
+    bondPutBonded (BondedStream sig s) | sig == compactSig = BondPut $ putLazyByteString s
+    bondPutBonded b@(BondedStream sig _) | sig == simpleV1Sig || sig == simpleSig = do
+        let ret = unpackBonded b
+        case ret of
+            Left err -> fail err
+            Right a -> bondPut a
+    bondPutBonded (BondedStream sig s) = streamBonded sig s >>= streamToCompact 
+    bondPutStruct = putStruct (bondGetInfo Proxy)
+
+    bondGetBool = do
+        v <- BondGet getWord8
+        return $ Just $ v /= 0
+    bondGetUInt8 = Just <$> BondGet getWord8
+    bondGetUInt16 = Just . fromIntegral . unWord <$> getEncodedWord
+    bondGetUInt32 = Just . fromIntegral . unWord <$> getEncodedWord
+    bondGetUInt64 = Just . fromIntegral . unWord <$> getEncodedWord
+    bondGetInt8 = Just . fromIntegral <$> BondGet getWord8
+    bondGetInt16 = Just . fromIntegral . fromZigZag . wordToZigZag <$> getEncodedWord
+    bondGetInt32 = Just . fromIntegral . fromZigZag . wordToZigZag <$> getEncodedWord
+    bondGetInt64 = Just . fromIntegral . fromZigZag . wordToZigZag <$> getEncodedWord
+    bondGetFloat = Just . wordToFloat <$> BondGet getWord32le
+    bondGetDouble = Just . wordToDouble <$> BondGet getWord64le
+    bondGetString = do
+        n <- getVarInt
+        Just . Utf8 <$> BondGet (getByteString n)
+    bondGetWString = do
+        n <- getVarInt
+        Just . Utf16 <$> BondGet (getByteString $ n * 2)
+    bondGetBlob = do
+        (tag, n) <- getV2ListHeader
+        if tag == BT_INT8
+            then Just . Blob <$> BondGet (getByteString n)
+            else do
+                replicateM_ n (skipValue tag)
+                return Nothing
+    bondGetList = getList
+    bondGetSet = liftM H.fromList <$> getList
+    bondGetMap = getMap
+    bondGetVector = liftM V.fromList <$> getList
+    bondGetNullable = do
+        v <- getList
+        return $ case v of
+            Just [x] -> Just $ Just x
+            Just [] -> Just Nothing
+            _ -> Nothing
+    bondGetBonded :: forall a. BondStruct a => BondGet CompactBinaryProto (Maybe (Bonded a))
+    bondGetBonded = do
+        let try (BondGet g) = BondGet $ lookAhead g
+        size <- try $ do
+            start <- BondGet bytesRead
+            skipValueV2 (getWireType (Proxy :: Proxy a))
+            end <- BondGet bytesRead
+            return (end - start)
+        Just . BondedStream compactSig <$> BondGet (getLazyByteString size)
+    bondGetStruct = Just <$> getStruct (bondGetInfo Proxy)
+
+instance Skippable CompactBinaryProto where
+    skipValue = skipValueV2
+
+getV2ListHeader :: BondGet CompactBinaryProto (ItemType, Int)
+getV2ListHeader = do
+    v <- BondGet getWord8
+    if v `shiftR` 5 /= 0
+        then return (wireType (v .&. 0x1f), fromIntegral (v `shiftR` 5) - 1)
+        else do
+                num <- getVarInt
+                return (wireType v, num)
+
+putV2ListHeader :: ItemType -> Int -> BondPut CompactBinaryProto
+putV2ListHeader t n = do
+    let tag = fromIntegral $ fromEnum t
+    if n < 7
+        then BondPut $ putWord8 $ tag .|. fromIntegral ((1 + n) `shiftL` 5)
+        else do
+            BondPut $ putWord8 tag
+            putVarInt n
+
+skipValueV2 :: ItemType -> BondGet CompactBinaryProto ()
+skipValueV2 BT_LIST = do
+    (tag, n) <- getV2ListHeader
+    replicateM_ n (skipValue tag)
+skipValueV2 BT_STRUCT = do
+    len <- getVarInt
+    BondGet $ skip len
+skipValueV2 t = skipValueCommon t
+
+getList :: forall a. BondBinary a => BondGet CompactBinaryProto (Maybe [a])
+getList = do
+    (tag, n) <- getV2ListHeader
+    if checkWireType (Proxy :: Proxy a) tag
+        then do
+            elems <- replicateM n bondGet
+            return $ sequence elems
+        else do
+            replicateM_ n (skipValue tag)
+            return Nothing
+
+putStruct :: StructInfo a b -> a -> BondPut CompactBinaryProto
+putStruct p v = do
+    let BondPut writer = saveStruct BT_STOP p v :: BondPut CompactBinaryProto
+    let bs = runPut writer
+    putVarInt $ fromIntegral $ Lazy.length bs
+    BondPut $ putLazyByteString bs
+
+getStruct :: forall a b. StructInfo a b -> BondGet CompactBinaryProto a
+getStruct p = do
+    void getVarInt -- FIXME use "isolate" from Data.Binary >= 0.7.2.0
+    readStruct p
+
+deserializeCompact :: forall a. BondStruct a => Lazy.ByteString -> Either (Lazy.ByteString, Int64, String) (Lazy.ByteString, Int64, a) 
+deserializeCompact = let BondGet g = bondGet :: BondGet CompactBinaryProto (Maybe a)
+                      in runGetOrFail (fromJust <$> g)
+
+serializeCompact :: BondStruct a => a -> Lazy.ByteString
+serializeCompact v = let BondPut g = bondPut v :: BondPut CompactBinaryProto
+                      in runPut g
+
+compactToStream :: BondGet CompactBinaryProto StreamStruct
+compactToStream = do
+    void getVarInt
+    loop (StreamStruct Nothing [])
+    where
+    getElem t = do
+      case t of
+        BT_STOP -> error "internal error: getElem BT_STOP"
+        BT_STOP_BASE -> error "internal error: getElem BT_STOP_BASE"
+        BT_BOOL -> do
+            Just v <- bondGetBool
+            return $ SeBool v
+        BT_UINT8 -> do
+            Just v <- bondGetUInt8
+            return $ SeUInt8 v
+        BT_UINT16 -> do
+            Just v <- bondGetUInt16
+            return $ SeUInt16 v
+        BT_UINT32 -> do
+            Just v <- bondGetUInt32
+            return $ SeUInt32 v
+        BT_UINT64 -> do
+            Just v <- bondGetUInt64
+            return $ SeUInt64 v
+        BT_FLOAT -> do
+            Just v <- bondGetFloat
+            return $ SeFloat v
+        BT_DOUBLE -> do
+            Just v <- bondGetDouble
+            return $ SeDouble v
+        BT_STRING -> do
+            Just v <- bondGetString
+            return $ SeString v
+        BT_STRUCT -> do
+            s <- compactToStream
+            return $ SeStruct s
+        BT_LIST -> do
+            (tag, n) <- getV2ListHeader
+            elems <- replicateM n (getElem tag)
+            return $ SeList tag elems
+        BT_SET -> do
+            (tag, n) <- getV2ListHeader
+            elems <- replicateM n (getElem tag)
+            return $ SeSet tag elems
+        BT_MAP -> do
+            ktag <- wireType <$> BondGet getWord8
+            vtag <- wireType <$> BondGet getWord8
+            n <- getVarInt
+            elems <- replicateM n $ do
+                k <- getElem ktag
+                v <- getElem vtag
+                return (k, v)
+            return $ SeMap (ktag, vtag) elems
+        BT_INT8 -> do
+            Just v <- bondGetInt8
+            return $ SeInt8 v
+        BT_INT16 -> do
+            Just v <- bondGetInt16
+            return $ SeInt16 v
+        BT_INT32 -> do
+            Just v <- bondGetInt32
+            return $ SeInt32 v
+        BT_INT64 -> do
+            Just v <- bondGetInt64
+            return $ SeInt64 v
+        BT_WSTRING -> do
+            Just v <- bondGetWString
+            return $ SeWString v
+    loop st = do
+        (tag, n) <- getFieldHeader
+        case tag of
+            BT_STOP -> return st
+            BT_STOP_BASE -> loop (StreamStruct (Just st) [])
+            _ -> do
+                e <- getElem tag
+                loop $ st { ssElems = ssElems st ++ [(n, e)] }
+
+streamToCompact :: StreamStruct -> BondPut CompactBinaryProto
+streamToCompact struct = do
+    let BondPut writer = do
+        putStreamStruct struct
+        BondPut $ putWord8 $ fromIntegral $ fromEnum BT_STOP
+    let bs = runPut writer
+    putVarInt $ fromIntegral $ Lazy.length bs
+    BondPut $ putLazyByteString bs
+    where
+    putStreamStruct st = do
+        when (isJust $ ssBase st) $ do
+            putStreamStruct (fromJust $ ssBase st)
+            BondPut $ putWord8 $ fromIntegral $ fromEnum BT_STOP_BASE
+        mapM_ putField (ssElems st)
+    putField (n, e) = do
+        putFieldHeader (elemItemType e) n
+        putElem e
+    putElem (SeBool v) = bondPutBool v
+    putElem (SeUInt8 v) = bondPutUInt8 v
+    putElem (SeUInt16 v) = bondPutUInt16 v
+    putElem (SeUInt32 v) = bondPutUInt32 v
+    putElem (SeUInt64 v) = bondPutUInt64 v
+    putElem (SeFloat v) = bondPutFloat v
+    putElem (SeDouble v) = bondPutDouble v
+    putElem (SeString v) = bondPutString v
+    putElem (SeStruct v) = streamToCompact v
+    putElem (SeList tag xs) = do
+        putV2ListHeader tag (length xs)
+        mapM_ putElem xs
+    putElem (SeSet tag xs) = do
+        putV2ListHeader tag (length xs)
+        mapM_ putElem xs
+    putElem (SeMap (ktag, vtag) xs) = do
+        BondPut $ putWord8 $ fromIntegral $ fromEnum ktag
+        BondPut $ putWord8 $ fromIntegral $ fromEnum vtag
+        putVarInt $ length xs
+        forM_ xs $ \(k, v) -> do
+            putElem k
+            putElem v
+    putElem (SeInt8 v) = do
+        bondPutInt8 v
+    putElem (SeInt16 v) = do
+        bondPutInt16 v
+    putElem (SeInt32 v) = do
+        bondPutInt32 v
+    putElem (SeInt64 v) = do
+        bondPutInt64 v
+    putElem (SeWString v) = do
+        bondPutWString v

--- a/haskell/runtime/Bond/CompactBinary.hs-boot
+++ b/haskell/runtime/Bond/CompactBinary.hs-boot
@@ -1,0 +1,22 @@
+{-# LANGUAGE ScopedTypeVariables, EmptyDataDecls, GADTs, MultiWayIf, InstanceSigs #-}
+module Bond.CompactBinary (
+    deserializeCompactV1,
+    deserializeCompact,
+    compactV1ToStream,
+    compactToStream
+  ) where
+
+import Bond.BinaryProto
+import Bond.Stream
+import Data.Int
+import qualified Data.ByteString.Lazy as Lazy
+
+data CompactBinaryV1Proto
+data CompactBinaryProto
+
+deserializeCompactV1 :: forall a. BondStruct a => Lazy.ByteString -> Either (Lazy.ByteString, Int64, String) (Lazy.ByteString, Int64, a) 
+
+deserializeCompact :: forall a. BondStruct a => Lazy.ByteString -> Either (Lazy.ByteString, Int64, String) (Lazy.ByteString, Int64, a) 
+
+compactToStream :: BondGet CompactBinaryProto StreamStruct
+compactV1ToStream :: BondGet CompactBinaryV1Proto StreamStruct

--- a/haskell/runtime/Bond/CompactBinary.hs-boot
+++ b/haskell/runtime/Bond/CompactBinary.hs-boot
@@ -1,4 +1,4 @@
-{-# LANGUAGE ScopedTypeVariables, EmptyDataDecls, GADTs, MultiWayIf, InstanceSigs #-}
+{-# LANGUAGE ScopedTypeVariables, EmptyDataDecls, GADTs #-}
 module Bond.CompactBinary (
     deserializeCompactV1,
     deserializeCompact,

--- a/haskell/runtime/Bond/Default.hs
+++ b/haskell/runtime/Bond/Default.hs
@@ -1,0 +1,84 @@
+module Bond.Default (
+    Default(..)
+  ) where
+
+import Bond.Types
+import qualified Data.ByteString as BS
+import qualified Data.HashSet as H
+import qualified Data.Map as M
+import qualified Data.Vector as V
+
+class Default a where
+    defaultValue :: a
+    -- optimized type-aware comparison with default value
+    equalToDefault :: a -> a -> Bool
+
+instance Default Bool where
+    defaultValue = False
+    equalToDefault = (==)
+instance Default Double where
+    defaultValue = 0
+    equalToDefault = (==)
+instance Default Float where
+    defaultValue = 0
+    equalToDefault = (==)
+instance Default Int8 where
+    defaultValue = 0
+    equalToDefault = (==)
+instance Default Int16 where
+    defaultValue = 0
+    equalToDefault = (==)
+instance Default Int32 where
+    defaultValue = 0
+    equalToDefault = (==)
+instance Default Int64 where
+    defaultValue = 0
+    equalToDefault = (==)
+instance Default Word8 where
+    defaultValue = 0
+    equalToDefault = (==)
+instance Default Word16 where
+    defaultValue = 0
+    equalToDefault = (==)
+instance Default Word32 where
+    defaultValue = 0
+    equalToDefault = (==)
+instance Default Word64 where
+    defaultValue = 0
+    equalToDefault = (==)
+instance Default (Maybe a) where
+    defaultValue = Nothing
+    -- default value for nullable is always null (CPP codegen even crashes when default is set)
+    equalToDefault Nothing Nothing = True
+    equalToDefault _ _ = False
+instance Default [a] where
+    defaultValue = []
+    -- default value for list is always []
+    equalToDefault a b = null a && null b
+instance Default Blob where
+    defaultValue = Blob BS.empty
+    -- default value for blob is always BS.empty
+    equalToDefault (Blob a) (Blob b) = BS.null a && BS.null b
+instance Default Utf8 where
+    defaultValue = Utf8 BS.empty
+    equalToDefault = (==)
+instance Default Utf16 where
+    defaultValue = Utf16 BS.empty
+    equalToDefault = (==)
+instance Default (Map a b) where
+    defaultValue = M.empty
+    -- default value for map is always M.empty
+    equalToDefault a b = M.null a && M.null b
+instance Default (HashSet a) where
+    defaultValue = H.empty
+    -- default value for set is always H.empty
+    equalToDefault a b = H.null a && H.null b
+instance Default (Vector a) where
+    defaultValue = V.empty
+    -- default value for vector is always V.empty
+    equalToDefault a b = V.null a && V.null b
+instance Default a => Default (Bonded a) where
+    defaultValue = BondedObject defaultValue
+    -- Default value check is performed to decide if field needs to be written.
+    -- Bonded streams must always be written.
+    equalToDefault _ _ = False

--- a/haskell/runtime/Bond/FastBinary.hs
+++ b/haskell/runtime/Bond/FastBinary.hs
@@ -1,0 +1,416 @@
+{-# LANGUAGE ScopedTypeVariables, EmptyDataDecls, GADTs, MultiWayIf, InstanceSigs #-}
+module Bond.FastBinary (
+    fastToStream,
+    deserializeFast,
+    serializeFast,
+    FastBinaryProto
+  ) where
+
+import Bond.BinaryProto
+import Bond.Bonded
+import Bond.Cast
+import Bond.Default
+import Bond.Schema
+import Bond.Stream
+import Bond.Types
+import Bond.Wire
+import Control.Applicative
+import Control.Monad
+import Data.Binary.Get
+import Data.Binary.Put
+import Data.Bits
+import Data.Maybe
+import Data.Proxy
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as Lazy
+import qualified Data.HashSet as H
+import qualified Data.Map as M
+import qualified Data.Vector as V
+
+checkWireType :: WireType a => Proxy a -> ItemType -> Bool
+checkWireType p t = getWireType p == t
+
+data FastBinaryProto
+
+getVarInt :: BondGet t Int
+getVarInt = BondGet $ step 0
+    where
+    step :: Int -> Get Int
+    step n | n > 4 = fail "VarInt: sequence too long"
+    step n = do
+        b <- fromIntegral <$> getWord8
+        rest <- if b `testBit` 7 then step (n + 1)  else return (0 :: Int)
+        return $ (b `clearBit` 7) .|. (rest `shiftL` 7)
+
+putVarInt :: Int -> BondPut t
+putVarInt i | i < 0 = error "VarInt with negative value"
+putVarInt i | i < 128 = BondPut $ putWord8 $ fromIntegral i
+putVarInt i = let iLow = fromIntegral $ i .&. 0x7F
+               in do
+                    BondPut $ putWord8 $ iLow `setBit` 7
+                    putVarInt (i `shiftR` 7)
+
+typeIdOf :: forall a. WireType a => a -> Word8
+typeIdOf _ =  fromIntegral $ fromEnum $ getWireType (Proxy :: Proxy a)
+
+wireType :: Word8 -> ItemType
+wireType = toEnum . fromIntegral
+
+instance BondBinaryProto FastBinaryProto where
+    bondPutBool True = BondPut $ putWord8 1
+    bondPutBool False = BondPut $ putWord8 0
+    bondPutUInt8 = BondPut . putWord8
+    bondPutUInt16 = BondPut . putWord16le
+    bondPutUInt32 = BondPut . putWord32le
+    bondPutUInt64 = BondPut . putWord64le
+    bondPutInt8 = BondPut . putWord8 . fromIntegral
+    bondPutInt16 = BondPut . putWord16le . fromIntegral
+    bondPutInt32 = BondPut . putWord32le . fromIntegral
+    bondPutInt64 = BondPut . putWord64le . fromIntegral
+    bondPutFloat = BondPut . putWord32le . floatToWord
+    bondPutDouble = BondPut . putWord64le . doubleToWord
+    bondPutString (Utf8 s) = do
+        putVarInt $ fromIntegral $ BS.length s
+        BondPut $ putByteString s
+    bondPutWString (Utf16 s) = do
+        putVarInt $ fromIntegral $ BS.length s `div` 2
+        BondPut $ putByteString s
+    bondPutList xs = do
+        BondPut $ putWord8 $ typeIdOf (head xs)
+        putVarInt $ length xs
+        mapM_ bondPut xs
+    bondPutMaybe Nothing = return ()
+    bondPutMaybe (Just v) = bondPut v
+    bondPutNullable = bondPutList . maybeToList
+    bondPutSet = bondPutList . H.toList
+    bondPutMap m = do
+        BondPut $ putWord8 $ typeIdOf (head $ M.keys m)
+        BondPut $ putWord8 $ typeIdOf (head $ M.elems m)
+        putVarInt $ M.size m
+        forM_ (M.toList m) $ \(k, v) -> do
+            bondPut k
+            bondPut v
+    bondPutVector xs = do
+        BondPut $ putWord8 $ typeIdOf (V.head xs)
+        putVarInt $ V.length xs
+        V.mapM_ bondPut xs
+    bondPutBlob (Blob b) = do
+        BondPut $ putWord8 $ fromIntegral $ fromEnum BT_INT8
+        putVarInt $ BS.length b
+        BondPut $ putByteString b
+    bondPutBonded (BondedObject a) = bondPut a
+    bondPutBonded (BondedStream sig s) | sig == fastSig = BondPut $ putLazyByteString s
+    bondPutBonded b@(BondedStream sig _) | sig == simpleV1Sig || sig == simpleSig = do
+        let ret = unpackBonded b
+        case ret of
+            Left err -> fail err
+            Right a -> bondPut a
+    bondPutBonded (BondedStream sig s) = streamBonded sig s >>= streamToFast
+    bondPutStruct = saveStruct BT_STOP (bondGetInfo Proxy)
+
+    bondGetBool = do
+        v <- BondGet getWord8
+        return $ Just $ v /= 0
+    bondGetUInt8 = Just <$> BondGet getWord8
+    bondGetUInt16 = Just <$> BondGet getWord16le
+    bondGetUInt32 = Just <$> BondGet getWord32le
+    bondGetUInt64 = Just <$> BondGet getWord64le
+    bondGetInt8 = Just . fromIntegral <$> BondGet getWord8
+    bondGetInt16 = Just . fromIntegral <$> BondGet getWord16le
+    bondGetInt32 = Just . fromIntegral <$> BondGet getWord32le
+    bondGetInt64 = Just . fromIntegral <$> BondGet getWord64le
+    bondGetFloat = Just . wordToFloat <$> BondGet getWord32le
+    bondGetDouble = Just . wordToDouble <$> BondGet getWord64le
+    bondGetString = do
+        n <- getVarInt
+        Just . Utf8 <$> BondGet (getByteString n)
+    bondGetWString = do
+        n <- getVarInt
+        Just . Utf16 <$> BondGet (getByteString $ n * 2)
+    bondGetBlob = do
+        tag <- wireType <$> BondGet getWord8
+        n <- getVarInt
+        if tag == BT_INT8
+            then Just . Blob <$> BondGet (getByteString n)
+            else do
+                replicateM_ n (skipValue tag)
+                return Nothing
+    bondGetList = getList
+    bondGetSet = liftM H.fromList <$> getList
+    bondGetMap = getMap
+    bondGetVector = liftM V.fromList <$> getList
+    bondGetNullable = do
+        v <- getList
+        return $ case v of
+            Just [x] -> Just $ Just x
+            Just [] -> Just Nothing
+            _ -> Nothing
+    bondGetBonded :: forall a. BondStruct a => BondGet FastBinaryProto (Maybe (Bonded a))
+    bondGetBonded = do
+        let try (BondGet g) = BondGet $ lookAhead g
+        size <- try $ do
+            start <- BondGet bytesRead
+            skipValue (getWireType (Proxy :: Proxy a))
+            end <- BondGet bytesRead
+            return (end - start)
+        Just . BondedStream fastSig <$> BondGet (getLazyByteString size)
+    bondGetStruct = Just <$> readStruct (bondGetInfo Proxy)
+
+getMap :: forall a b t. (BondBinaryProto t, Ord a, BondBinary a, BondBinary b) => BondGet t (Maybe (M.Map a b))
+getMap = do
+    ktag <- wireType <$> BondGet getWord8
+    vtag <- wireType <$> BondGet getWord8
+    n <- getVarInt
+    if checkWireType (Proxy :: Proxy a) ktag && checkWireType (Proxy :: Proxy b) vtag
+        then do
+            elems <- replicateM n $ do
+                k <- bondGet
+                v <- bondGet
+                return $ seqPair (k, v)
+            return $ M.fromList <$> sequence elems
+        else do
+            replicateM_ n $ do
+                skipValue ktag
+                skipValue vtag
+            return Nothing
+    where
+    seqPair (Just a, Just b) = Just (a, b)
+    seqPair _ = Nothing
+
+getList :: forall a. BondBinary a => BondGet FastBinaryProto (Maybe [a])
+getList = do
+    tag <- wireType <$> BondGet getWord8
+    n <- getVarInt
+    if checkWireType (Proxy :: Proxy a) tag
+        then do
+            elems <- replicateM n bondGet
+            return $ sequence elems
+        else do
+            replicateM_ n (skipValue tag)
+            return Nothing
+
+getFieldHeader :: BondGet t (ItemType, Ordinal)
+getFieldHeader = do
+    tag <- wireType <$> BondGet getWord8
+    n <- if tag == BT_STOP || tag == BT_STOP_BASE then return 0 else BondGet getWord16le
+    return (tag, Ordinal n)
+
+readStruct :: forall a b t. BondBinaryProto t => StructInfo a b -> BondGet t a
+readStruct (StructInfo _ pb) = do
+    def <- case pb of
+        Nothing -> return defaultValue
+        Just p -> do
+            base <- readStruct (bondGetInfo p)
+            return $ bondSetBase defaultValue base
+    getFields def
+
+getFields :: forall a t. (BondStruct a, BondBinaryProto t) => a -> BondGet t a
+getFields def = do
+    update <- loop id
+    return $ update def
+    where
+    try :: BondGet t (Maybe (b -> b)) -> BondGet t (Maybe (b -> b))
+    try (BondGet g) = BondGet $ lookAheadM g
+    loop f = do
+        (tag, n) <- getFieldHeader
+        case tag of
+            BT_STOP -> return f
+            BT_STOP_BASE -> return f -- XXX think later
+            _ -> do
+                fieldMod <- try $ bondSetField n tag
+                case fieldMod of
+                    Just func -> loop (func . f)
+                    Nothing -> do
+                        skipValue tag
+                        loop f
+
+putFieldHeader :: ItemType -> Ordinal -> BondPut FastBinaryProto
+putFieldHeader t (Ordinal n) = do
+    BondPut $ putWord8 $ fromIntegral $ fromEnum t
+    BondPut $ putWord16le n
+
+saveStruct :: ItemType -> StructInfo a b -> a -> BondPut FastBinaryProto
+saveStruct stop (StructInfo pa pb) a = do
+    when (isJust pb) $ saveStruct BT_STOP_BASE (bondGetInfo $ fromJust pb) (bondGetBase a)
+    putFields (bondGetSchema pa)
+    BondPut $ putWord8 $ fromIntegral $ fromEnum stop
+    where
+    putFields (StructSchema fields) = forM_ fields $ \(FieldInfo _ t n) -> unless (bondFieldHasDefaultValue a n) $ do
+        putFieldHeader t n
+        bondPutField a n
+
+skipValue :: ItemType -> BondGet t ()
+skipValue BT_STOP = fail "internal error: skipValue BT_STOP"
+skipValue BT_STOP_BASE = fail "internal error: skipValue BT_STOP_BASE"
+skipValue BT_BOOL = BondGet $ skip 1
+skipValue BT_UINT8 = BondGet $ skip 1
+skipValue BT_UINT16 = BondGet $ skip 2
+skipValue BT_UINT32 = BondGet $ skip 4
+skipValue BT_UINT64 = BondGet $ skip 8
+skipValue BT_FLOAT = BondGet $ skip 4
+skipValue BT_DOUBLE = BondGet $ skip 8
+skipValue BT_INT8 = BondGet $ skip 1
+skipValue BT_INT16 = BondGet $ skip 2
+skipValue BT_INT32 = BondGet $ skip 4
+skipValue BT_INT64 = BondGet $ skip 8
+skipValue BT_STRING = do
+    n <- getVarInt
+    BondGet $ skip n
+skipValue BT_WSTRING = do
+    n <- getVarInt
+    BondGet $ skip (n * 2)
+skipValue BT_LIST = do
+    t <- wireType <$> BondGet getWord8
+    n <- getVarInt
+    replicateM_ n (skipValue t)
+skipValue BT_SET = skipValue BT_LIST
+skipValue BT_MAP = do
+    tkey <- wireType <$> BondGet getWord8
+    tvalue <- wireType <$> BondGet getWord8
+    n <- getVarInt
+    replicateM_ n $ do
+        skipValue tkey
+        skipValue tvalue
+skipValue BT_STRUCT = loop
+    where
+    loop = do
+        (t, _) <- getFieldHeader
+        case t of
+            BT_STOP -> return ()
+            BT_STOP_BASE -> loop
+            _ -> do
+                    skipValue t
+                    loop
+
+deserializeFast :: forall a. BondStruct a => Lazy.ByteString -> Either (Lazy.ByteString, Int64, String) (Lazy.ByteString, Int64, a) 
+deserializeFast = let BondGet g = bondGet :: BondGet FastBinaryProto (Maybe a)
+                   in runGetOrFail (fromJust <$> g)
+
+serializeFast :: BondStruct a => a -> Lazy.ByteString
+serializeFast v = let BondPut g = bondPut v :: BondPut FastBinaryProto
+                   in runPut g
+
+fastToStream :: BondGet FastBinaryProto StreamStruct
+fastToStream = loop (StreamStruct Nothing [])
+    where
+    getElem t = do
+      case t of
+        BT_STOP -> error "internal error: getElem BT_STOP"
+        BT_STOP_BASE -> error "internal error: getElem BT_STOP_BASE"
+        BT_BOOL -> do
+            Just v <- bondGetBool
+            return $ SeBool v
+        BT_UINT8 -> do
+            Just v <- bondGetUInt8
+            return $ SeUInt8 v
+        BT_UINT16 -> do
+            Just v <- bondGetUInt16
+            return $ SeUInt16 v
+        BT_UINT32 -> do
+            Just v <- bondGetUInt32
+            return $ SeUInt32 v
+        BT_UINT64 -> do
+            Just v <- bondGetUInt64
+            return $ SeUInt64 v
+        BT_FLOAT -> do
+            Just v <- bondGetFloat
+            return $ SeFloat v
+        BT_DOUBLE -> do
+            Just v <- bondGetDouble
+            return $ SeDouble v
+        BT_STRING -> do
+            Just v <- bondGetString
+            return $ SeString v
+        BT_STRUCT -> do
+            s <- fastToStream
+            return $ SeStruct s
+        BT_LIST -> do
+            tag <- wireType <$> BondGet getWord8
+            n <- getVarInt
+            elems <- replicateM n (getElem tag)
+            return $ SeList tag elems
+        BT_SET -> do
+            tag <- wireType <$> BondGet getWord8
+            n <- getVarInt
+            elems <- replicateM n (getElem tag)
+            return $ SeSet tag elems
+        BT_MAP -> do
+            ktag <- wireType <$> BondGet getWord8
+            vtag <- wireType <$> BondGet getWord8
+            n <- getVarInt
+            elems <- replicateM n $ do
+                k <- getElem ktag
+                v <- getElem vtag
+                return (k, v)
+            return $ SeMap (ktag, vtag) elems
+        BT_INT8 -> do
+            Just v <- bondGetInt8
+            return $ SeInt8 v
+        BT_INT16 -> do
+            Just v <- bondGetInt16
+            return $ SeInt16 v
+        BT_INT32 -> do
+            Just v <- bondGetInt32
+            return $ SeInt32 v
+        BT_INT64 -> do
+            Just v <- bondGetInt64
+            return $ SeInt64 v
+        BT_WSTRING -> do
+            Just v <- bondGetWString
+            return $ SeWString v
+    loop st = do
+        (tag, n) <- getFieldHeader
+        case tag of
+            BT_STOP -> return st
+            BT_STOP_BASE -> loop (StreamStruct (Just st) [])
+            _ -> do
+                e <- getElem tag
+                loop $ st { ssElems = ssElems st ++ [(n, e)] }
+
+streamToFast :: StreamStruct -> BondPut FastBinaryProto
+streamToFast struct = do
+    putStreamStruct struct
+    BondPut $ putWord8 $ fromIntegral $ fromEnum BT_STOP
+    where
+    putStreamStruct st = do
+        when (isJust $ ssBase st) $ do
+            putStreamStruct (fromJust $ ssBase st)
+            BondPut $ putWord8 $ fromIntegral $ fromEnum BT_STOP_BASE
+        mapM_ putField (ssElems st)
+    putField (n, e) = do
+        putFieldHeader (elemItemType e) n
+        putElem e
+    putElem (SeBool v) = bondPutBool v
+    putElem (SeUInt8 v) = bondPutUInt8 v
+    putElem (SeUInt16 v) = bondPutUInt16 v
+    putElem (SeUInt32 v) = bondPutUInt32 v
+    putElem (SeUInt64 v) = bondPutUInt64 v
+    putElem (SeFloat v) = bondPutFloat v
+    putElem (SeDouble v) = bondPutDouble v
+    putElem (SeString v) = bondPutString v
+    putElem (SeStruct v) = streamToFast v
+    putElem (SeList tag xs) = do
+        BondPut $ putWord8 $ fromIntegral $ fromEnum tag
+        putVarInt $ length xs
+        mapM_ putElem xs
+    putElem (SeSet tag xs) = do
+        BondPut $ putWord8 $ fromIntegral $ fromEnum tag
+        putVarInt $ length xs
+        mapM_ putElem xs
+    putElem (SeMap (ktag, vtag) xs) = do
+        BondPut $ putWord8 $ fromIntegral $ fromEnum ktag
+        BondPut $ putWord8 $ fromIntegral $ fromEnum vtag
+        putVarInt $ length xs
+        forM_ xs $ \(k, v) -> do
+            putElem k
+            putElem v
+    putElem (SeInt8 v) = do
+        bondPutInt8 v
+    putElem (SeInt16 v) = do
+        bondPutInt16 v
+    putElem (SeInt32 v) = do
+        bondPutInt32 v
+    putElem (SeInt64 v) = do
+        bondPutInt64 v
+    putElem (SeWString v) = do
+        bondPutWString v

--- a/haskell/runtime/Bond/FastBinary.hs-boot
+++ b/haskell/runtime/Bond/FastBinary.hs-boot
@@ -1,0 +1,16 @@
+{-# LANGUAGE ScopedTypeVariables, EmptyDataDecls, GADTs, MultiWayIf, InstanceSigs #-}
+module Bond.FastBinary (
+    deserializeFast,
+    fastToStream
+  ) where
+
+import Bond.BinaryProto
+import Bond.Stream
+import Data.Int
+import qualified Data.ByteString.Lazy as Lazy
+
+data FastBinaryProto
+
+deserializeFast :: forall a. BondStruct a => Lazy.ByteString -> Either (Lazy.ByteString, Int64, String) (Lazy.ByteString, Int64, a) 
+
+fastToStream :: BondGet FastBinaryProto StreamStruct

--- a/haskell/runtime/Bond/FastBinary.hs-boot
+++ b/haskell/runtime/Bond/FastBinary.hs-boot
@@ -1,4 +1,4 @@
-{-# LANGUAGE ScopedTypeVariables, EmptyDataDecls, GADTs, MultiWayIf, InstanceSigs #-}
+{-# LANGUAGE ScopedTypeVariables, EmptyDataDecls, GADTs #-}
 module Bond.FastBinary (
     deserializeFast,
     fastToStream

--- a/haskell/runtime/Bond/Imports.hs
+++ b/haskell/runtime/Bond/Imports.hs
@@ -14,3 +14,4 @@ import Bond.Types as X
 import Bond.Wire as X
 import Data.Hashable (Hashable)
 import Data.Data
+import Data.Proxy

--- a/haskell/runtime/Bond/Imports.hs
+++ b/haskell/runtime/Bond/Imports.hs
@@ -1,0 +1,16 @@
+module Bond.Imports (
+    module X,
+    Data,
+    Hashable,
+    Proxy(..),
+    Typeable
+  ) where
+
+import Bond.BinaryProto as X
+import Bond.CompactBinary as X
+import Bond.Default as X
+import Bond.Schema as X
+import Bond.Types as X
+import Bond.Wire as X
+import Data.Hashable (Hashable)
+import Data.Data

--- a/haskell/runtime/Bond/Schema.hs
+++ b/haskell/runtime/Bond/Schema.hs
@@ -1,0 +1,6 @@
+module Bond.Schema where
+
+import Bond.Wire
+
+data FieldInfo = FieldInfo { fiName :: String, fiType :: ItemType, fiOrdinal :: Ordinal }
+newtype StructSchema = StructSchema [FieldInfo]

--- a/haskell/runtime/Bond/SimpleBinary.hs
+++ b/haskell/runtime/Bond/SimpleBinary.hs
@@ -1,0 +1,281 @@
+{-# LANGUAGE ScopedTypeVariables, EmptyDataDecls, GADTs #-}
+module Bond.SimpleBinary (
+    deserializeSimpleV1,
+    serializeSimpleV1,
+    deserializeSimple,
+    serializeSimple,
+    SimpleBinaryV1Proto,
+    SimpleBinaryProto
+  ) where
+
+import Bond.BinaryProto
+import Bond.Cast
+import Bond.Default
+import Bond.Schema
+import Bond.Types
+import Control.Applicative
+import Control.Monad
+import Data.Binary.Get
+import Data.Binary.Put
+import Data.Bits
+import Data.Maybe
+import Data.Proxy
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as Lazy
+import qualified Data.HashSet as H
+import qualified Data.Map as M
+import qualified Data.Vector as V
+
+data SimpleBinaryV1Proto
+data SimpleBinaryProto
+
+instance BondBinaryProto SimpleBinaryV1Proto where
+    bondPutBool True = BondPut $ putWord8 1
+    bondPutBool False = BondPut $ putWord8 0
+    bondPutUInt8 = BondPut . putWord8
+    bondPutUInt16 = BondPut . putWord16le
+    bondPutUInt32 = BondPut . putWord32le
+    bondPutUInt64 = BondPut . putWord64le
+    bondPutInt8 = BondPut . putWord8 . fromIntegral
+    bondPutInt16 = BondPut . putWord16le . fromIntegral
+    bondPutInt32 = BondPut . putWord32le . fromIntegral
+    bondPutInt64 = BondPut . putWord64le . fromIntegral
+    bondPutFloat = BondPut . putWord32le . floatToWord
+    bondPutDouble = BondPut . putWord64le . doubleToWord
+    bondPutString (Utf8 s) = do
+        BondPut $ putWord32le $ fromIntegral $ BS.length s
+        BondPut $ putByteString s
+    bondPutWString (Utf16 s) = do
+        BondPut $ putWord32le $ fromIntegral $ BS.length s `div` 2
+        BondPut $ putByteString s
+    bondPutList xs = do
+        BondPut $ putWord32le $ fromIntegral $ length xs
+        mapM_ bondPut xs
+    bondPutMaybe Nothing = fail "can't put defaultNothing value to simple stream"
+    bondPutMaybe (Just v) = bondPut v
+    bondPutNullable = bondPutList . maybeToList
+    bondPutSet = bondPutList . H.toList
+    bondPutMap m = do
+        BondPut $ putWord32le $ fromIntegral $ M.size m
+        forM_ (M.toList m) $ \(k, v) -> do
+            bondPut k
+            bondPut v
+    bondPutVector xs = do
+        BondPut $ putWord32le $ fromIntegral $ V.length xs
+        V.mapM_ bondPut xs
+    bondPutBlob (Blob b) = do
+        BondPut $ putWord32le $ fromIntegral $ BS.length b
+        BondPut $ putByteString b
+    bondPutBonded (BondedObject a) = do
+        let bs = serializeSimpleV1 a
+        putBonded simpleV1Sig bs
+    bondPutBonded (BondedStream sig s) = putBonded sig s
+    bondPutStruct = saveStruct (bondGetInfo Proxy)
+
+    bondGetBool = do
+        v <- BondGet getWord8
+        return $ Just $ v /= 0
+    bondGetUInt8 = Just <$> BondGet getWord8
+    bondGetUInt16 = Just <$> BondGet getWord16le
+    bondGetUInt32 = Just <$> BondGet getWord32le
+    bondGetUInt64 = Just <$> BondGet getWord64le
+    bondGetInt8 = Just . fromIntegral <$> BondGet getWord8
+    bondGetInt16 = Just . fromIntegral <$> BondGet getWord16le
+    bondGetInt32 = Just . fromIntegral <$> BondGet getWord32le
+    bondGetInt64 = Just . fromIntegral <$> BondGet getWord64le
+    bondGetFloat = Just . wordToFloat <$> BondGet getWord32le
+    bondGetDouble = Just . wordToDouble <$> BondGet getWord64le
+    bondGetString = do
+        n <- BondGet getWord32le
+        Just . Utf8 <$> BondGet (getByteString $ fromIntegral n)
+    bondGetWString = do
+        n <- BondGet getWord32le
+        Just . Utf16 <$> BondGet (getByteString $ fromIntegral $ n * 2)
+    bondGetBlob = do
+        n <- BondGet getWord32le
+        Just . Blob <$> BondGet (getByteString $ fromIntegral n)
+    bondGetList = getListV1
+    bondGetSet = liftM H.fromList <$> getListV1
+    bondGetMap = getMap (fromIntegral <$> BondGet getWord32le)
+    bondGetVector = liftM V.fromList <$> getListV1
+    bondGetNullable = do
+        v <- getListV1
+        return $ case v of
+            Just [x] -> Just $ Just x
+            Just [] -> Just Nothing
+            _ -> Nothing
+    bondGetBonded = getBonded
+    bondGetStruct = Just <$> readStruct (bondGetInfo Proxy)
+
+getMap :: (BondBinary a, BondBinary k, BondBinaryProto t, Ord k) => BondGet t Int -> BondGet t (Maybe (Map k a))
+getMap getLen = do
+    n <- getLen
+    elems <- replicateM n $ do
+        k <- bondGet
+        v <- bondGet
+        return $ seqPair (k, v)
+    return $ M.fromList <$> sequence elems
+    where
+    seqPair (Just a, Just b) = Just (a, b)
+    seqPair _ = Nothing
+
+getListV1 :: BondBinary a => BondGet SimpleBinaryV1Proto (Maybe [a])
+getListV1 = do
+    n <- fromIntegral <$> BondGet getWord32le
+    elems <- replicateM n bondGet
+    return $ sequence elems
+
+getBonded :: BondBinaryProto t => BondBinary a => BondGet t (Maybe (Bonded a))
+getBonded = do
+    size <- BondGet getWord32le
+    sig <- BondGet getWord32be
+    bs <- BondGet $ getLazyByteString (fromIntegral $ size - 4)
+    return $ Just $ BondedStream (ProtoSig sig) bs
+
+putBonded :: BondBinaryProto t => ProtoSig -> Lazy.ByteString -> BondPut t
+putBonded (ProtoSig sig) s = do
+    BondPut $ putWord32le $ fromIntegral (4 + Lazy.length s)
+    BondPut $ putWord32be sig
+    BondPut $ putLazyByteString s
+
+readStruct :: BondBinaryProto t => StructInfo a b -> BondGet t a
+readStruct (StructInfo pa pb) = do
+    def <- case pb of
+        Nothing -> return defaultValue
+        Just p -> do
+            base <- readStruct (bondGetInfo p)
+            return $ bondSetBase defaultValue base
+    update <- foldM setField id schema
+    return $ update def
+    where
+    StructSchema schema = bondGetSchema pa
+    setField f fi = do
+        fieldMod <- bondSetField (fiOrdinal fi) (fiType fi)
+        case fieldMod of
+            Just func -> return (func . f)
+            Nothing -> fail "error reading simple protocol field"
+
+saveStruct :: BondBinaryProto t => StructInfo a b -> a -> BondPut t
+saveStruct (StructInfo pa pb) a = do
+    when (isJust pb) $ saveStruct (bondGetInfo $ fromJust pb) (bondGetBase a)
+    putFields (bondGetSchema pa)
+    where
+    putFields (StructSchema fields) = forM_ fields $ \(FieldInfo _ _ n) -> bondPutField a n
+
+deserializeSimpleV1 :: forall a. BondStruct a => Lazy.ByteString -> Either (Lazy.ByteString, Int64, String) (Lazy.ByteString, Int64, a) 
+deserializeSimpleV1 = let BondGet g = bondGet :: BondGet SimpleBinaryV1Proto (Maybe a)
+                       in runGetOrFail (fromJust <$> g)
+
+serializeSimpleV1 :: BondStruct a => a -> Lazy.ByteString
+serializeSimpleV1 v = let BondPut g = bondPut v :: BondPut SimpleBinaryV1Proto
+                       in runPut g
+
+instance BondBinaryProto SimpleBinaryProto where
+    bondPutBool True = BondPut $ putWord8 1
+    bondPutBool False = BondPut $ putWord8 0
+    bondPutUInt8 = BondPut . putWord8
+    bondPutUInt16 = BondPut . putWord16le
+    bondPutUInt32 = BondPut . putWord32le
+    bondPutUInt64 = BondPut . putWord64le
+    bondPutInt8 = BondPut . putWord8 . fromIntegral
+    bondPutInt16 = BondPut . putWord16le . fromIntegral
+    bondPutInt32 = BondPut . putWord32le . fromIntegral
+    bondPutInt64 = BondPut . putWord64le . fromIntegral
+    bondPutFloat = BondPut . putWord32le . floatToWord
+    bondPutDouble = BondPut . putWord64le . doubleToWord
+    bondPutString (Utf8 s) = do
+        putVarInt $ BS.length s
+        BondPut $ putByteString s
+    bondPutWString (Utf16 s) = do
+        putVarInt $ BS.length s `div` 2
+        BondPut $ putByteString s
+    bondPutList xs = do
+        putVarInt $ length xs
+        mapM_ bondPut xs
+    bondPutMaybe Nothing = fail "can't put defaultNothing value to simple stream"
+    bondPutMaybe (Just v) = bondPut v
+    bondPutNullable = bondPutList . maybeToList
+    bondPutSet = bondPutList . H.toList
+    bondPutMap m = do
+        putVarInt $ M.size m
+        forM_ (M.toList m) $ \(k, v) -> do
+            bondPut k
+            bondPut v
+    bondPutVector xs = do
+        putVarInt $ V.length xs
+        V.mapM_ bondPut xs
+    bondPutBlob (Blob b) = do
+        putVarInt $ BS.length b
+        BondPut $ putByteString b
+    bondPutBonded (BondedObject a) = do
+        let bs = serializeSimple a
+        putBonded simpleSig bs
+    bondPutBonded (BondedStream sig s) = putBonded sig s
+    bondPutStruct = saveStruct (bondGetInfo Proxy)
+
+    bondGetBool = do
+        v <- BondGet getWord8
+        return $ Just $ v /= 0
+    bondGetUInt8 = Just <$> BondGet getWord8
+    bondGetUInt16 = Just <$> BondGet getWord16le
+    bondGetUInt32 = Just <$> BondGet getWord32le
+    bondGetUInt64 = Just <$> BondGet getWord64le
+    bondGetInt8 = Just . fromIntegral <$> BondGet getWord8
+    bondGetInt16 = Just . fromIntegral <$> BondGet getWord16le
+    bondGetInt32 = Just . fromIntegral <$> BondGet getWord32le
+    bondGetInt64 = Just . fromIntegral <$> BondGet getWord64le
+    bondGetFloat = Just . wordToFloat <$> BondGet getWord32le
+    bondGetDouble = Just . wordToDouble <$> BondGet getWord64le
+    bondGetString = do
+        n <- getVarInt
+        Just . Utf8 <$> BondGet (getByteString n)
+    bondGetWString = do
+        n <- getVarInt
+        Just . Utf16 <$> BondGet (getByteString $ n * 2)
+    bondGetBlob = do
+        n <- getVarInt
+        Just . Blob <$> BondGet (getByteString n)
+    bondGetList = getList
+    bondGetSet = liftM H.fromList <$> getList
+    bondGetMap = getMap getVarInt
+    bondGetVector = liftM V.fromList <$> getList
+    bondGetNullable = do
+        v <- getList
+        return $ case v of
+            Just [x] -> Just $ Just x
+            Just [] -> Just Nothing
+            _ -> Nothing
+    bondGetBonded = getBonded
+    bondGetStruct = Just <$> readStruct (bondGetInfo Proxy)
+
+getList :: BondBinary a => BondGet SimpleBinaryProto (Maybe [a])
+getList = do
+    n <- getVarInt
+    elems <- replicateM n bondGet
+    return $ sequence elems
+
+getVarInt :: BondGet t Int
+getVarInt = BondGet $ step 0
+    where
+    step :: Int -> Get Int
+    step n | n > 4 = fail "VarInt: sequence too long"
+    step n = do
+        b <- fromIntegral <$> getWord8
+        rest <- if b `testBit` 7 then step (n + 1)  else return (0 :: Int)
+        return $ (b `clearBit` 7) .|. (rest `shiftL` 7)
+
+putVarInt :: Int -> BondPut t
+putVarInt i | i < 0 = error "VarInt with negative value"
+putVarInt i | i < 128 = BondPut $ putWord8 $ fromIntegral i
+putVarInt i = let iLow = fromIntegral $ i .&. 0x7F
+               in do
+                    BondPut $ putWord8 $ iLow `setBit` 7
+                    putVarInt (i `shiftR` 7)
+
+deserializeSimple :: forall a. BondStruct a => Lazy.ByteString -> Either (Lazy.ByteString, Int64, String) (Lazy.ByteString, Int64, a) 
+deserializeSimple = let BondGet g = bondGet :: BondGet SimpleBinaryProto (Maybe a)
+                     in runGetOrFail (fromJust <$> g)
+
+serializeSimple :: BondStruct a => a -> Lazy.ByteString
+serializeSimple v = let BondPut g = bondPut v :: BondPut SimpleBinaryProto
+                     in runPut g

--- a/haskell/runtime/Bond/Stream.hs
+++ b/haskell/runtime/Bond/Stream.hs
@@ -1,0 +1,46 @@
+module Bond.Stream where
+
+import Bond.Types
+import Bond.Wire
+
+data StreamStruct = StreamStruct { ssBase :: Maybe StreamStruct, ssElems :: [(Ordinal, StreamElement)] }
+    deriving Show
+
+data StreamElement =
+      SeBool Bool
+    | SeUInt8 Word8
+    | SeUInt16 Word16
+    | SeUInt32 Word32
+    | SeUInt64 Word64
+    | SeFloat Float
+    | SeDouble Double
+    | SeString Utf8
+    | SeStruct StreamStruct
+    | SeList ItemType [StreamElement]
+    | SeSet ItemType [StreamElement]
+    | SeMap (ItemType, ItemType) [(StreamElement, StreamElement)]
+    | SeInt8 Int8
+    | SeInt16 Int16
+    | SeInt32 Int32
+    | SeInt64 Int64
+    | SeWString Utf16
+    deriving Show
+
+elemItemType :: StreamElement -> ItemType
+elemItemType (SeBool _) = BT_BOOL
+elemItemType (SeUInt8 _) = BT_UINT8
+elemItemType (SeUInt16 _) = BT_UINT16
+elemItemType (SeUInt32 _) = BT_UINT32
+elemItemType (SeUInt64 _) = BT_UINT64
+elemItemType (SeFloat _) = BT_FLOAT
+elemItemType (SeDouble _) = BT_DOUBLE
+elemItemType (SeString _) = BT_STRING
+elemItemType (SeStruct _) = BT_STRUCT
+elemItemType (SeList _ _) = BT_LIST
+elemItemType (SeSet _ _) = BT_SET
+elemItemType (SeMap _ _) = BT_MAP
+elemItemType (SeInt8 _) = BT_INT8
+elemItemType (SeInt16 _) = BT_INT16
+elemItemType (SeInt32 _) = BT_INT32
+elemItemType (SeInt64 _) = BT_INT64
+elemItemType (SeWString _) = BT_WSTRING

--- a/haskell/runtime/Bond/Types.hs
+++ b/haskell/runtime/Bond/Types.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving, DeriveDataTypeable #-}
+module Bond.Types (
+    Blob(..),
+    Bonded(..),
+    Bool,
+    Double,
+    EncodedString(..),
+    Float,
+    H.HashSet,
+    Int,
+    Int16,
+    Int32,
+    Int64,
+    Int8,
+    Maybe,
+    M.Map,
+    Utf16(..),
+    Utf8(..),
+    V.Vector,
+    Word16,
+    Word32,
+    Word64,
+    Word8,
+    ProtoSig(..),
+    compactSig,
+    compactV1Sig,
+    fastSig,
+    simpleSig,
+    simpleV1Sig
+  ) where
+
+import Data.Data
+import Data.Int
+import Data.Word
+import Data.Hashable
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as Lazy
+import qualified Data.HashSet as H
+import qualified Data.Map as M
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified Data.Vector as V
+
+newtype Utf8 = Utf8 BS.ByteString
+    deriving (Eq, Ord, Hashable, Data, Typeable)
+
+newtype Utf16 = Utf16 BS.ByteString
+    deriving (Eq, Ord, Hashable, Data, Typeable)
+
+newtype Blob = Blob BS.ByteString
+    deriving (Show, Eq, Ord, Hashable, Data, Typeable)
+
+class EncodedString a where
+    fromString :: String -> a
+
+instance EncodedString Utf8 where fromString = Utf8 . T.encodeUtf8 . T.pack
+instance EncodedString Utf16 where fromString = Utf16 . T.encodeUtf16LE . T.pack
+
+instance Show Utf8 where show (Utf8 s) = show $ T.unpack $ T.decodeUtf8 s
+instance Show Utf16 where show (Utf16 s) = show $ T.unpack $ T.decodeUtf16LE s
+
+newtype ProtoSig = ProtoSig Word32
+    deriving (Eq, Data, Typeable)
+
+compactSig, compactV1Sig, simpleSig, simpleV1Sig, fastSig :: ProtoSig
+compactSig = ProtoSig 0x43420200
+compactV1Sig = ProtoSig 0x43420100
+simpleSig = ProtoSig 0x53500200
+simpleV1Sig = ProtoSig 0x53500100
+fastSig = ProtoSig 0x4D460100
+
+data Bonded a = BondedStream ProtoSig Lazy.ByteString | BondedObject a
+    deriving (Data, Typeable)
+
+instance Show a => Show (Bonded a) where
+    show BondedStream{} = "BondedStream"
+    show (BondedObject v) = show v
+
+instance Eq a => Eq (Bonded a) where
+    (BondedObject v1) == (BondedObject v2) = v1 == v2
+    _ == _ = True
+--    (BondedStream s1 p1 v1) == (BondedStream s2 p1 v1) = unpackBonded p1 v1 s1 == unpackBonded p2 v2 s2

--- a/haskell/runtime/Bond/Wire.hs
+++ b/haskell/runtime/Bond/Wire.hs
@@ -1,0 +1,67 @@
+module Bond.Wire (
+    FieldTag(..),
+    ItemType(..),
+    ListHead(..),
+    MapHead(..),
+    Ordinal(..),
+    StringHead(..),
+    WireType(..)
+  ) where
+
+import Bond.Types
+import Data.Proxy
+
+data ItemType =
+      BT_STOP
+    | BT_STOP_BASE
+    | BT_BOOL
+    | BT_UINT8
+    | BT_UINT16
+    | BT_UINT32
+    | BT_UINT64
+    | BT_FLOAT
+    | BT_DOUBLE
+    | BT_STRING
+    | BT_STRUCT
+    | BT_LIST
+    | BT_SET
+    | BT_MAP
+    | BT_INT8
+    | BT_INT16
+    | BT_INT32
+    | BT_INT64
+    | BT_WSTRING
+    deriving (Show, Enum, Eq)
+
+class WireType a where
+    getWireType :: Proxy a -> ItemType
+
+instance WireType Bool where getWireType _ = BT_BOOL
+instance WireType Double where getWireType _ = BT_DOUBLE
+instance WireType Float where getWireType _ = BT_FLOAT
+instance WireType Int8 where getWireType _ = BT_INT8
+instance WireType Int16 where getWireType _ = BT_INT16
+instance WireType Int32 where getWireType _ = BT_INT32
+instance WireType Int64 where getWireType _ = BT_INT64
+instance WireType Word8 where getWireType _ = BT_UINT8
+instance WireType Word16 where getWireType _ = BT_UINT16
+instance WireType Word32 where getWireType _ = BT_UINT32
+instance WireType Word64 where getWireType _ = BT_UINT64
+instance WireType (Maybe a) where getWireType _ = BT_LIST
+instance WireType [a] where getWireType _ = BT_LIST
+instance WireType Blob where getWireType _ = BT_LIST
+instance WireType Utf8 where getWireType _ = BT_STRING
+instance WireType Utf16 where getWireType _ = BT_WSTRING
+instance WireType (Map a b) where getWireType _ = BT_MAP
+instance WireType (HashSet a) where getWireType _ = BT_SET
+instance WireType (Vector a) where getWireType _ = BT_LIST
+instance WireType (Bonded a) where getWireType _ = BT_STRUCT
+
+newtype Ordinal = Ordinal Word16
+    deriving (Eq, Show)
+
+data FieldTag = FieldTag ItemType Ordinal
+
+data ListHead = ListHead (Maybe ItemType) Int
+data MapHead = MapHead (Maybe ItemType) (Maybe ItemType) Int
+newtype StringHead = StringHead Int

--- a/haskell/runtime/CMakeLists.txt
+++ b/haskell/runtime/CMakeLists.txt
@@ -1,0 +1,66 @@
+cmake_minimum_required (VERSION 2.8.12)
+
+set (CMAKE_MODULE_PATH
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
+
+# required Haskell components
+find_package (Cabal 1.18.0.0 REQUIRED)
+find_package (GHC 7.4.1.0 REQUIRED)
+
+set (sources
+    bond.cabal
+    Bond/API.hs
+    Bond/BinaryProto.hs
+    Bond/Bonded.hs
+    Bond/Cast.hs
+    Bond/CompactBinary.hs
+    Bond/CompactBinary.hs-boot
+    Bond/Default.hs
+    Bond/FastBinary.hs
+    Bond/FastBinary.hs-boot
+    Bond/Imports.hs
+    Bond/Schema.hs
+    Bond/SimpleBinary.hs
+    Bond/Stream.hs
+    Bond/Types.hs
+    Bond/Wire.hs
+    tests/CompatTest.hs)
+
+set (output_dir ${CMAKE_CURRENT_BINARY_DIR})
+set (output ${output_dir}/build/build-done)
+set (testoutput ${output_dir}/build/test-done)
+
+add_custom_command (
+    COMMAND ${CMAKE_COMMAND} 
+        ${CMAKE_BINARY_DIR} 
+        -N
+        -P sandbox_init.cmake
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/cabal.sandbox.config)
+
+add_custom_command (
+    DEPENDS compiler ${GCB_EXECUTABLE} ${sources} ${CMAKE_CURRENT_SOURCE_DIR}/cabal.sandbox.config
+    COMMAND ${CMAKE_COMMAND} 
+        ${CMAKE_BINARY_DIR}
+        -N
+        -Doutput_dir=${output_dir} 
+        -Dgbc=${GBC_EXECUTABLE} 
+        -P cabal_build.cmake
+    COMMAND ${CMAKE_COMMAND} -E touch ${output}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT ${output})
+
+add_custom_command (
+    DEPENDS ${sources} ${output} ${CMAKE_CURRENT_SOURCE_DIR}/cabal.sandbox.config
+    COMMAND ${CMAKE_COMMAND} 
+        ${CMAKE_BINARY_DIR}
+        -N
+        -Doutput_dir=${output_dir} 
+        -P cabal_test.cmake
+    COMMAND ${CMAKE_COMMAND} -E touch ${testoutput}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT ${testoutput})
+
+add_custom_target (haskell ALL
+    SOURCES ${sources}
+    DEPENDS ${output} ${testoutput})

--- a/haskell/runtime/bond.cabal
+++ b/haskell/runtime/bond.cabal
@@ -65,6 +65,7 @@ library
                     bytestring >= 0.10,
                     containers >= 0.5,
                     hashable >= 1.2,
+                    tagged >= 0.5,
                     text >= 1.2,
                     unordered-containers >= 0.2,
                     vector >= 0.10
@@ -78,6 +79,7 @@ test-suite compat
                     binary >= 0.7,
                     bytestring >= 0.10,
                     HUnit >= 1.2,
+                    filepath >= 1.0,
                     test-framework >= 0.8,
                     test-framework-hunit >= 0.2,
                     test-framework-quickcheck2 >= 0.2,

--- a/haskell/runtime/bond.cabal
+++ b/haskell/runtime/bond.cabal
@@ -1,0 +1,84 @@
+-- The name of the package.
+name:               bond
+
+-- The package version.  See the Haskell package versioning policy (PVP) 
+-- for standards guiding when and how versions should be incremented.
+-- http://www.haskell.org/haskellwiki/Package_versioning_policy
+-- PVP summary:     +-+------- breaking API changes
+--                  | | +----- non-breaking API additions
+--                  | | | +--- code changes with no API change
+version:            3.0.2.0
+
+-- A short (one-line) description of the package.
+synopsis:           Bond Library
+
+-- A longer description of the package.
+-- description:         
+
+-- URL for the project homepage or repository.
+homepage:           https://github.com/Microsoft/bond
+
+-- The license under which the package is released.
+license:            MIT
+
+-- The file containing the license text.
+-- license-file:    LICENSE
+
+-- The package author(s).
+author:             Andrey Sverdlichenko
+
+-- An email address to which users can send suggestions, bug reports, and 
+-- patches.
+maintainer:         andreys@microsoft.com
+
+-- A copyright notice.
+copyright:          Copyright (C) Microsoft. All rights reserved.
+
+category:           Language
+
+build-type:         Simple
+
+-- Constraint on the version of Cabal needed to build this package.
+cabal-version:      >=1.8
+
+
+library
+  ghc-options:      -O2 -W -Wall
+  
+  exposed-modules:  Bond.API,
+                    Bond.Imports
+
+  other-modules:    Bond.BinaryProto,
+                    Bond.Bonded,
+                    Bond.CompactBinary,
+                    Bond.Default,
+                    Bond.FastBinary,
+                    Bond.Schema,
+                    Bond.SimpleBinary,
+                    Bond.Stream,
+                    Bond.Types,
+                    Bond.Wire
+  
+  build-depends:    base >=4.5,
+                    array >= 0.4,
+                    binary >= 0.7,
+                    bytestring >= 0.10,
+                    containers >= 0.5,
+                    hashable >= 1.2,
+                    text >= 1.2,
+                    unordered-containers >= 0.2,
+                    vector >= 0.10
+
+test-suite compat
+  type:             exitcode-stdio-1.0
+  main-is:          CompatTest.hs
+  hs-source-dirs:   tests, generated
+  ghc-options:      -O2 -W -Wall
+  build-depends:    base >= 4.5,
+                    binary >= 0.7,
+                    bytestring >= 0.10,
+                    HUnit >= 1.2,
+                    test-framework >= 0.8,
+                    test-framework-hunit >= 0.2,
+                    test-framework-quickcheck2 >= 0.2,
+                    bond

--- a/haskell/runtime/cabal_build.cmake
+++ b/haskell/runtime/cabal_build.cmake
@@ -1,0 +1,51 @@
+# This is a workaround for Windows quirks.
+# CMake Visual Studio generator translates add_custom_command into a batch file
+# embedded in Visual Studio project. Batch files have problems with paths that
+# contain non-ascii characters because they are limited to DOS encoding. It so
+# happens that cabal is quite likely to be installed in such a path because by
+# default cabal install uses directory under %APPDATA% which contains user name.
+# As a workaround we execute this .cmake script as a custom command and use CMake
+# cache to get access to variables set during configuration.
+
+cmake_policy (SET CMP0012 NEW)
+
+if ($ENV{APPVEYOR})
+    # AppVeyor Azure VMs have limited memory, limit ghc heap to 192 MB
+    set (GHC_OPTIONS --ghc-option=+RTS --ghc-option=-M192m --ghc-option=-RTS)
+endif()
+
+execute_process (
+    COMMAND ${gbc} haskell -o generated ../../test/compat/schemas/compat.bond ../../test/compat/schemas/compat2.bond ../../test/compat/schemas/compat_common.bond ../../test/compat/schemas/compat_no_generics.bond
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE error)
+
+if (error)
+    message (FATAL_ERROR)
+endif()
+
+execute_process (
+    COMMAND ${Haskell_CABAL_EXECUTABLE} install --enable-tests --with-compiler=${Haskell_GHC_EXECUTABLE} --only-dependencies --jobs ${GHC_OPTIONS}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE error)
+
+if (error)
+    message (FATAL_ERROR)
+endif()
+
+execute_process (
+    COMMAND ${Haskell_CABAL_EXECUTABLE} configure --enable-tests --with-compiler=${Haskell_GHC_EXECUTABLE} --builddir=${output_dir}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE error)
+
+if (error)
+    message (FATAL_ERROR)
+endif()
+
+execute_process (
+    COMMAND ${Haskell_CABAL_EXECUTABLE} build     --with-ghc=${Haskell_GHC_EXECUTABLE} --ghc-option=-O2 --ghc-option=-threaded --jobs --builddir=${output_dir}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE error)
+
+if (error)
+    message (FATAL_ERROR)
+endif()

--- a/haskell/runtime/cabal_test.cmake
+++ b/haskell/runtime/cabal_test.cmake
@@ -1,0 +1,25 @@
+# This is a workaround for Windows quirks.
+# CMake Visual Studio generator translates add_custom_command into a batch file
+# embedded in Visual Studio project. Batch files have problems with paths that
+# contain non-ascii characters because they are limited to DOS encoding. It so
+# happens that cabal is quite likely to be installed in such a path because by
+# default cabal install uses directory under %APPDATA% which contains user name.
+# As a workaround we execute this .cmake script as a custom command and use CMake
+# cache to get access to variables set during configuration.
+
+cmake_policy (SET CMP0012 NEW)
+
+if ($ENV{APPVEYOR})
+    # AppVeyor Azure VMs have limited memory, limit ghc heap to 192 MB
+    set (GHC_OPTIONS --ghc-option=+RTS --ghc-option=-M192m --ghc-option=-RTS)
+endif()
+
+execute_process (
+    COMMAND ${Haskell_CABAL_EXECUTABLE} test --builddir=${output_dir}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE error)
+
+if (error)
+    message (FATAL_ERROR)
+endif()
+

--- a/haskell/runtime/cabal_test.cmake
+++ b/haskell/runtime/cabal_test.cmake
@@ -15,7 +15,7 @@ if ($ENV{APPVEYOR})
 endif()
 
 execute_process (
-    COMMAND ${Haskell_CABAL_EXECUTABLE} test --builddir=${output_dir}
+    COMMAND ${Haskell_CABAL_EXECUTABLE} test --builddir=${output_dir} --test-option=${CMAKE_CURRENT_SOURCE_DIR}/../../test/compat/data
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     RESULT_VARIABLE error)
 

--- a/haskell/runtime/sandbox_init.cmake
+++ b/haskell/runtime/sandbox_init.cmake
@@ -1,0 +1,26 @@
+# This is a workaround for Windows quirks.
+# CMake Visual Studio generator translates add_custom_command into a batch file
+# embedded in Visual Studio project. Batch files have problems with paths that
+# contain non-ascii characters because they are limited to DOS encoding. It so
+# happens that cabal is quite likely to be installed in such a path because by
+# default cabal install uses directory under %APPDATA% which contains user name.
+# As a workaround we execute this .cmake script as a custom command and use CMake
+# cache to get access to variables set during configuration.
+execute_process (
+    COMMAND ${Haskell_CABAL_EXECUTABLE} sandbox init
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE error)
+
+if (error)
+    message (FATAL_ERROR)
+endif()
+
+execute_process (
+    COMMAND ${Haskell_CABAL_EXECUTABLE} sandbox add-source ../../compiler
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE error)
+
+if (error)
+    message (FATAL_ERROR)
+endif()
+

--- a/haskell/runtime/tests/CompatTest.hs
+++ b/haskell/runtime/tests/CompatTest.hs
@@ -1,0 +1,157 @@
+module Main where
+
+import Test.Framework (defaultMain, testGroup)
+import Test.Framework.Providers.HUnit
+import Test.Framework.Providers.QuickCheck2
+import Test.HUnit
+import Data.Int
+
+import Unittest.Compat.Compat
+import qualified Data.ByteString.Lazy as BS
+
+import Bond.API
+import Bond.Imports (BondStruct, zigzagToWord, wordToZigZag, ZigZagInt(..))
+
+type GetFunc a = BS.ByteString -> Either (BS.ByteString, Int64, String) (BS.ByteString, Int64, a)
+type PutFunc a = a -> BS.ByteString
+
+fastBinaryData, compactBinaryV1Data, compactBinaryV2Data, simpleBinaryV1Data, simpleBinaryV2Data :: String
+fastBinaryData = "/home/blaze/bond/test/compat/data/compat.fast.dat"
+compactBinaryV1Data = "/home/blaze/bond/test/compat/data/compat.compact.dat"
+compactBinaryV2Data = "/home/blaze/bond/test/compat/data/compat.compact2.dat"
+simpleBinaryV1Data = "/home/blaze/bond/test/compat/data/compat.simple.dat"
+simpleBinaryV2Data = "/home/blaze/bond/test/compat/data/compat.simple2.dat"
+
+runGetOrFail :: BondStruct a => GetFunc a -> BS.ByteString -> a
+runGetOrFail get s = case get s of
+                    Right (rest, _, msg) | BS.null rest -> msg
+                    Right (_, _, _) -> error "Not all input consumed"
+                    Left (_, _, msg) -> error msg
+
+main :: IO ()
+main = defaultMain [
+    testGroup "Fast Binary protocol" [
+        testCase "parsing existing data" $ testParseCompat deserializeFast fastBinaryData,
+        testCase "saving and parsing data" $ testParseOwnOutput deserializeFast serializeFast fastBinaryData,
+        testCase "saving and restoring Bonded a" $ testBonded deserializeFast serializeFast fastBinaryData,
+        testCase "testing Fast->CompactV1 transform" $ testRecode deserializeFast serializeCompactV1 deserializeCompactV1 fastBinaryData,
+        testCase "testing Fast->Compact transform" $ testRecode deserializeFast serializeCompact deserializeCompact fastBinaryData,
+        testCase "testing Fast->SimpleV1 transform" $ testRecodeNoDefaults deserializeFast serializeSimpleV1 deserializeSimpleV1 fastBinaryData,
+        testCase "testing Fast->Simple transform" $ testRecodeNoDefaults deserializeFast serializeSimple deserializeSimple fastBinaryData
+    ],
+    testGroup "Compact Binary protocol" [
+        testGroup "Version 1" [
+            testCase "parsing existing data" $ testParseCompat deserializeCompactV1 compactBinaryV1Data,
+            testCase "saving and parsing data" $ testParseOwnOutput deserializeCompactV1 serializeCompactV1 compactBinaryV1Data,
+            testCase "saving and restoring Bonded a" $ testBonded deserializeCompactV1 serializeCompactV1 compactBinaryV1Data,
+            testCase "testing CompactV1->Fast transform" $ testRecode deserializeCompactV1 serializeFast deserializeFast compactBinaryV1Data,
+            testCase "testing CompactV1->CompactV2 transform" $ testRecode deserializeCompactV1 serializeCompact deserializeCompact compactBinaryV1Data,
+            testCase "testing CompactV1->SimpleV1 transform" $ testRecodeNoDefaults deserializeCompactV1 serializeSimpleV1 deserializeSimpleV1 compactBinaryV1Data,
+            testCase "testing CompactV1->Simple transform" $ testRecodeNoDefaults deserializeCompactV1 serializeSimple deserializeSimple compactBinaryV1Data
+        ],
+        testGroup "Version 2" [
+            testCase "parsing existing data" $ testParseCompat deserializeCompact compactBinaryV2Data,
+            testCase "saving and parsing data" $ testParseOwnOutput deserializeCompact serializeCompact compactBinaryV2Data,
+            testCase "saving and restoring Bonded a" $ testBonded deserializeCompact serializeCompact compactBinaryV2Data,
+            testCase "testing CompactV2->Fast transform" $ testRecode deserializeCompact serializeFast deserializeFast compactBinaryV2Data,
+            testCase "testing CompactV2->CompactV1 transform" $ testRecode deserializeCompact serializeCompactV1 deserializeCompactV1 compactBinaryV2Data,
+            testCase "testing CompactV2->SimpleV1 transform" $ testRecodeNoDefaults deserializeCompact serializeSimpleV1 deserializeSimpleV1 compactBinaryV2Data,
+            testCase "testing CompactV2->Simple transform" $ testRecodeNoDefaults deserializeCompact serializeSimple deserializeSimple compactBinaryV2Data
+        ],
+        testProperty "check int conversion in CompactBinary" compactDecodeEncodeInt
+    ],
+    testGroup "Simple Binary protocol" [
+        testGroup "Version 1" [
+            testCase "parsing existing data" $ testParseCompat deserializeSimpleV1 simpleBinaryV1Data,
+            testCase "saving and parsing data" $ testParseOwnOutput deserializeSimpleV1 serializeSimpleV1 simpleBinaryV1Data,
+            testCase "saving and restoring Bonded a" $ testBonded deserializeSimpleV1 serializeSimpleV1 simpleBinaryV1Data,
+            testCase "testing SimpleV1->CompactV1 transform" $ testRecode deserializeSimpleV1 serializeCompactV1 deserializeCompactV1 simpleBinaryV1Data,
+            testCase "testing SimpleV1->Compact transform" $ testRecode deserializeSimpleV1 serializeCompact deserializeCompact simpleBinaryV1Data,
+            testCase "testing SimpleV1->Fast transform" $ testRecode deserializeSimpleV1 serializeFast deserializeFast simpleBinaryV1Data,
+            testCase "testing SimpleV1->SimpleV2 transform" $ testRecode deserializeSimpleV1 serializeSimple deserializeSimple simpleBinaryV1Data
+        ],
+        testGroup "Version 2" [
+            testCase "parsing existing data" $ testParseCompat deserializeSimple simpleBinaryV2Data,
+            testCase "saving and parsing data" $ testParseOwnOutput deserializeSimple serializeSimple simpleBinaryV2Data,
+            testCase "saving and restoring Bonded a" $ testBonded deserializeSimple serializeSimple simpleBinaryV2Data,
+            testCase "testing Simple->CompactV1 transform" $ testRecode deserializeSimple serializeCompactV1 deserializeCompactV1 simpleBinaryV2Data,
+            testCase "testing Simple->Compact transform" $ testRecode deserializeSimple serializeCompact deserializeCompact simpleBinaryV2Data,
+            testCase "testing Simple->Fast transform" $ testRecode deserializeSimple serializeFast deserializeFast simpleBinaryV2Data,
+            testCase "testing Simple->SimpleV1 transform" $ testRecode deserializeSimple serializeSimpleV1 deserializeSimpleV1 simpleBinaryV2Data
+        ]
+    ],
+    testCase "Check for identical read results" testAllReadSameData
+ ]
+
+testParseCompat :: GetFunc Compat -> String -> Assertion
+testParseCompat get file = do
+    b <- BS.readFile file
+    let parse = get b
+    uncurry assertBool $ case parse of
+                            Right (rest, _, _) | BS.null rest -> (undefined, True)
+                            Right (_, _, _) -> ("Not all input consumed", False)
+                            Left (_, _, msg) -> (msg, False)
+
+testParseOwnOutput :: GetFunc Compat -> PutFunc Compat -> String -> Assertion
+testParseOwnOutput get put file = do
+    b <- BS.readFile file
+    let s = runGetOrFail get b
+    let b' = put s
+    let s' = runGetOrFail get b'
+    assertEqual "Saved value do not match parsed one" s s'
+
+testBonded :: GetFunc Compat -> PutFunc Compat -> String -> Assertion
+testBonded get put file = do
+    b <- BS.readFile file
+    let s = runGetOrFail get b
+    let Right obj = unpackBonded (m_basicUnintialized s)
+    let sUnpacked = s { m_basicUnintialized = makeBonded obj }
+    let b' = put sUnpacked
+    let s' = runGetOrFail get b'
+    let Right obj' = unpackBonded (m_basicUnintialized s')
+    assertEqual "Saved Bonded value do not match parsed one" obj obj'
+
+testRecode :: GetFunc Compat -> PutFunc Compat -> GetFunc Compat -> String -> Assertion
+testRecode get put get' file = do
+    b <- BS.readFile file
+    let s = runGetOrFail get b
+    let b' = put s
+    let s' = runGetOrFail get' b'
+    assertEqual "Saved object is not equal to original" s s'
+
+testRecodeNoDefaults :: GetFunc Compat -> PutFunc Compat -> GetFunc Compat -> String -> Assertion
+testRecodeNoDefaults get put get' file = do
+    b <- BS.readFile file
+    let s = runGetOrFail get b
+    let sfix = s { m_defaults = Nothing } -- simple proto can't save defaultNothing
+    let b' = put sfix
+    let s' = runGetOrFail get' b'
+    assertEqual "Saved object is not equal to original" sfix s'
+
+testAllReadSameData :: Assertion
+testAllReadSameData = do
+    fastbin <- BS.readFile fastBinaryData
+    let fastrec = (runGetOrFail deserializeFast fastbin) :: Compat
+    cv1bin <- BS.readFile compactBinaryV1Data
+    let cv1rec = runGetOrFail deserializeCompactV1 cv1bin
+    cv2bin <- BS.readFile compactBinaryV2Data
+    let cv2rec = runGetOrFail deserializeCompact cv2bin
+    simple1bin <- BS.readFile simpleBinaryV1Data
+    let simple1rec = (runGetOrFail deserializeSimpleV1 simple1bin) :: Compat
+    simple2bin <- BS.readFile simpleBinaryV2Data
+    let simple2rec = runGetOrFail deserializeSimple simple2bin
+    assertEqual "FastBinary read do not match CompactBinary v1 read" fastrec cv1rec
+    assertEqual "FastBinary read do not match CompactBinary v2 read" fastrec cv2rec
+    assertEqual "SimpleBinary v1 read do not match SimpleBinary v2 read" simple1rec simple2rec
+    let simple1bonded = unpackBonded $ m_basicUnintialized simple1rec
+    let simple2bonded = unpackBonded $ m_basicUnintialized simple2rec
+    let compact1bonded = unpackBonded $ m_basicUnintialized cv1rec
+    let compact2bonded = unpackBonded $ m_basicUnintialized cv2rec
+    let fastbonded = unpackBonded $ m_basicUnintialized fastrec
+    assertEqual "FastBinary bonded read do not match CompactBinary v1 read" fastbonded compact1bonded
+    assertEqual "FastBinary bonded read do not match CompactBinary v2 read" fastbonded compact2bonded
+    assertEqual "FastBinary bonded read do not match SimpleBinary v1 read" fastbonded simple1bonded
+    assertEqual "FastBinary bonded read do not match SimpleBinary v2 read" fastbonded simple2bonded
+
+compactDecodeEncodeInt :: Int64 -> Bool
+compactDecodeEncodeInt x = ZigZagInt x == wordToZigZag (zigzagToWord $ ZigZagInt x)


### PR DESCRIPTION
It is a little bit strange to have bond compiler written in haskell and not able to generate haskell code. There, I fixed it. It is not yet equal to C++ and C# versions, but can handle most simple cases.

This patch adds "gbc haskell" mode, which behaves just like any other compiler mode, and runtime library with support for Simple, Compact and Fast protocols. Test suite successfully runs on compat data.

For now only compile-time schemas are supported, no runtime schemas yet. Mutually recursive structures also not yet supported.

Runtime library is build by cmake but not installed anywhere: I still to figure out how to install haskell libraries without cabal.