### PR TITLE
Fix Bond.CSharp.targets to support BondOptions

### DIFF
--- a/cs/build/Bond.CSharp.targets
+++ b/cs/build/Bond.CSharp.targets
@@ -76,7 +76,7 @@
     <!-- We'll optimize to generate in a single command where possible -->
     <!-- Workaround for xbuild. It does not support ItemDefinitionGroup, so use Options only with MSBuild -->
     <ItemGroup>
-      <_BondCodegenWithDefaultOptions Include="@(BondCodegen)" Condition="'%(BondCodegen.Options)' == ''" />
+      <_BondCodegenWithDefaultOptions Include="@(BondCodegen)" Condition="'%(BondCodegen.Options)' == '$(BondOptions)'" />
     </ItemGroup>
 
     <WriteLinesToFile File="$(BondOutputDirectory)bondfiles.tmp"
@@ -88,7 +88,7 @@
 
     <!-- And for any files needing custom options we'll have to generate one by one -->
     <Exec Command="$(_BondCommand) %(BondCodegen.Options) &quot;%(BondCodegen.Identity)&quot;"
-          Condition="'%(BondCodegen.Options)' != ''" />
+          Condition="'%(BondCodegen.Options)' != '$(BondOptions)'" />
   </Target>
 
   <!--


### PR DESCRIPTION
A bug in the condition for the _BondCodegenWithDefaultOptions items was
causing a separate instance of gbc.exe to be launched per BondCodeGen
item when BondOptions wasn't empty.