### PR TITLE
Add support for Deserializer without inlining

### DIFF
--- a/cs/src/core/Clone.cs
+++ b/cs/src/core/Clone.cs
@@ -60,6 +60,7 @@ namespace Bond
             clone = Generate(type, 
                 new DeserializerTransform<object>(
                     (o, i) => clone[i](o),
+                    true,
                     (t1, t2) => objectFactory.CreateObject(t1, t2),
                     (t1, t2, count) => objectFactory.CreateContainer(t1, t2, count)));
         }

--- a/cs/src/core/Deserializer.cs
+++ b/cs/src/core/Deserializer.cs
@@ -31,7 +31,7 @@ namespace Bond
             return Cache<R>.Instance.Deserialize<T>(reader);
         }
     }
-    
+
     /// <summary>
     /// Deserializer for a protocol reader R
     /// </summary>
@@ -39,7 +39,18 @@ namespace Bond
     public class Deserializer<R>
     {
         internal readonly Func<R, object>[] deserialize;
-        readonly IFactory objectFactory;
+
+        /// <summary>
+        /// Create a deserializer instance for specified type and payload schema, using a custom object factory
+        /// </summary>
+        /// <param name="type">Type representing a Bond schema</param>
+        /// <param name="schema">Schema of the payload</param>
+        /// <param name="factory">Factory to create objects during deserialization</param>
+        /// <param name="inlineNested">Inline nested types if possible (optimizes for reduction of execution time
+        /// at the expense of initialization time and memory)</param>
+        public Deserializer(Type type, RuntimeSchema schema, IFactory factory, bool inlineNested)
+            : this(type, ParserFactory<R>.Create(schema), factory, inlineNested)
+        { }
 
         /// <summary>
         /// Create a deserializer instance for specified type and payload schema, using a custom object factory
@@ -48,18 +59,28 @@ namespace Bond
         /// <param name="schema">Schema of the payload</param>
         /// <param name="factory">Factory to create objects during deserialization</param>
         public Deserializer(Type type, RuntimeSchema schema, IFactory factory)
-            : this(type, ParserFactory<R>.Create(schema), factory)
-        {}
+            : this(type, ParserFactory<R>.Create(schema), factory, inlineNested: true)
+        { }
 
-        
         /// <summary>
         /// Create a deserializer instance for specified type and payload schema
         /// </summary>
         /// <param name="type">Type representing a Bond schema</param>
         /// <param name="schema">Schema of the payload</param>
         public Deserializer(Type type, RuntimeSchema schema)
-            : this(type, ParserFactory<R>.Create(schema))
-        {}
+            : this(type, ParserFactory<R>.Create(schema), factory: null, inlineNested: true)
+        { }
+
+        /// <summary>
+        /// Create a deserializer instance for specified type, using a custom object factory
+        /// </summary>
+        /// <param name="type">Type representing a Bond schema</param>
+        /// <param name="factory">Factory to create objects during deserialization</param>
+        /// <param name="inlineNested">Inline nested types if possible (optimizes for reduction of execution time
+        /// at the expense of initialization time and memory)</param>
+        public Deserializer(Type type, IFactory factory, bool inlineNested)
+            : this(type, ParserFactory<R>.Create(type), factory, inlineNested)
+        { }
 
         /// <summary>
         /// Create a deserializer instance for specified type, using a custom object factory
@@ -67,7 +88,7 @@ namespace Bond
         /// <param name="type">Type representing a Bond schema</param>
         /// <param name="factory">Factory to create objects during deserialization</param>
         public Deserializer(Type type, IFactory factory)
-            : this(type, ParserFactory<R>.Create(type), factory)
+            : this(type, ParserFactory<R>.Create(type), factory, inlineNested: true)
         { }
 
         /// <summary>
@@ -75,8 +96,8 @@ namespace Bond
         /// </summary>
         /// <param name="type">Type representing a Bond schema</param>
         public Deserializer(Type type)
-            : this(type, ParserFactory<R>.Create(type))
-        {}
+            : this(type, ParserFactory<R>.Create(type), factory: null, inlineNested: true)
+        { }
 
         public Deserializer(Assembly precompiledAssembly, Type type)
         {
@@ -85,23 +106,25 @@ namespace Bond
             deserialize = new[] { (Func<R, object>)property.GetValue(null) };
         }
 
-        Deserializer(Type type, IParser parser)
+        Deserializer(Type type, IParser parser, IFactory factory, bool inlineNested)
         {
-            deserialize = new DeserializerTransform<R>(
-                    (r, i) => deserialize[i](r))
-                .Generate(parser, type)
-                .Select(lambda => lambda.Compile()).ToArray();
-        }
-
-        Deserializer(Type type, IParser parser, IFactory factory)
-        {
-            objectFactory = factory;
-            deserialize = new DeserializerTransform<R>(
+            DeserializerTransform<R> transform;
+            if (factory != null)
+            {
+                transform = new DeserializerTransform<R>(
                     (r, i) => deserialize[i](r),
-                    (t1, t2) => objectFactory.CreateObject(t1, t2),
-                    (t1, t2, count) => objectFactory.CreateContainer(t1, t2, count))
-                .Generate(parser, type)
-                .Select(lambda => lambda.Compile()).ToArray();
+                    inlineNested,
+                    (t1, t2) => factory.CreateObject(t1, t2),
+                    (t1, t2, count) => factory.CreateContainer(t1, t2, count));
+            }
+            else
+            {
+                transform = new DeserializerTransform<R>(
+                    (r, i) => deserialize[i](r),
+                    inlineNested);
+            }
+
+            deserialize = transform.Generate(parser, type).Select(lambda => lambda.Compile()).ToArray();
         }
 
         /// <summary>
@@ -114,7 +137,7 @@ namespace Bond
         {
             return (T)deserialize[0](reader);
         }
-        
+
         /// <summary>
         /// Deserialize an object from a payload
         /// </summary>
@@ -144,13 +167,13 @@ namespace Bond
         /// <param name="bonded">IBonded&lt;T> instance representing payload</param>
         /// <remarks>Implemented as an extension method to avoid ICloneable&lt;R> constraint on Deserializer&lt;R></remarks>
         /// <returns>Deserialized object</returns>
-        public static T Deserialize<T, R>(this Deserializer<R> deserializer, IBonded<T> bonded) 
+        public static T Deserialize<T, R>(this Deserializer<R> deserializer, IBonded<T> bonded)
             where R : ICloneable<R>
         {
             var b = bonded as Bonded<T, R>;
             if (b == null)
                 throw new InvalidOperationException(string.Format("Expected Bonded<{0}, {1}>", typeof(T), typeof(R)));
-            
+
             return (T)deserializer.deserialize[0](b.reader.Clone());
         }
     }

--- a/cs/src/core/expressions/DeserializerTransform.cs
+++ b/cs/src/core/expressions/DeserializerTransform.cs
@@ -16,6 +16,7 @@ namespace Bond.Expressions
 
         readonly NewObject newObject;
         readonly NewContainer newContainer;
+        readonly bool inlineNested;
         TypeAlias typeAlias;
 
         readonly Expression<Func<R, int, object>> deferredDeserialize;
@@ -35,6 +36,7 @@ namespace Bond.Expressions
 
         public DeserializerTransform(
             Expression<Func<R, int, object>> deferredDeserialize,
+            bool inlineNested = true,
             Expression<Func<Type, Type, object>> createObject = null,
             Expression<Func<Type, Type, int, object>> createContainer = null)
         {
@@ -69,6 +71,8 @@ namespace Bond.Expressions
             {
                 newContainer = (t1, t2, count) => New(t1, t2, count);
             }
+
+            this.inlineNested = inlineNested;
         }
 
         public IEnumerable<Expression<Func<R, object>>> Generate(IParser parser, Type type)
@@ -82,7 +86,7 @@ namespace Bond.Expressions
 
         Expression Deserialize(IParser parser, Expression var, Type objectType, Type schemaType, bool initialize)
         {
-            var inline = inProgress.Count != 0 && !inProgress.Contains(schemaType) && var != null;
+            var inline = inlineNested && inProgress.Count != 0 && !inProgress.Contains(schemaType) && var != null;
             Expression body;
 
             inProgress.Push(schemaType);


### PR DESCRIPTION
When the schemas dependency graph complexity increases, the expression
trees that are generated by the DeserializeTransform can become very
large, leading to long compilation times and high memory consumption.

This change adds some Deserializer constructors that support a flag to
disable expression inlining. As a result the runtime deserialization
operation will be slightly slower (with some added overhead of function
calls), but the initialization of the Deserializer is significantly
faster.