### PR TITLE
Allow split python struct defs across many files

### DIFF
--- a/python/inc/bond/python/converters.h
+++ b/python/inc/bond/python/converters.h
@@ -122,7 +122,8 @@ static PyObject* identity_unaryfunc(PyObject* x)
     return x;
 }
 
-unaryfunc py_object_identity = identity_unaryfunc;
+
+static unaryfunc py_object_identity = identity_unaryfunc;
 
 
 // Conversion policy from Python list to a list container
@@ -423,7 +424,7 @@ struct nullable_maybe_converter
 };
 
 
-void register_builtin_convereters()
+inline void register_builtin_converters()
 {
     static bool registered;
 

--- a/python/inc/bond/python/struct.h
+++ b/python/inc/bond/python/struct.h
@@ -326,7 +326,7 @@ private:
                 struct_<bond::SchemaDef>()
                     .def();
 
-                register_builtin_convereters();
+                register_builtin_converters();
             }
         }
 


### PR DESCRIPTION
- Define py_object_identity as static
- Inline register_builtin_converters for linker
- Fix typo of name register_builtin_converters