### PR TITLE
Optimize Serializer for type-aliased blob fields

### DIFF
--- a/cs/src/core/expressions/ObjectParser.cs
+++ b/cs/src/core/expressions/ObjectParser.cs
@@ -324,11 +324,12 @@ namespace Bond.Expressions
         {
             Debug.Assert(schemaType.IsBondBlob());
 
+            var arraySegment = Expression.Variable(typeof(ArraySegment<byte>), "arraySegment");
             var count = Expression.Variable(typeof(int), "count");
             var index = Expression.Variable(typeof(int), "index");
             var end = Expression.Variable(typeof(int), "end");
             var blob = typeAlias.Convert(value, schemaType);
-            var item = Expression.ArrayIndex(Expression.Property(blob, "Array"), Expression.PostIncrementAssign(index));
+            var item = Expression.ArrayIndex(Expression.Property(arraySegment, "Array"), Expression.PostIncrementAssign(index));
 
             var loop = handler(
                 new ObjectParser(this, item, typeof(sbyte)),
@@ -337,9 +338,10 @@ namespace Bond.Expressions
                 count);
 
             return Expression.Block(
-                new[] { count, index, end },
-                Expression.Assign(index, Expression.Property(blob, "Offset")),
-                Expression.Assign(count, Expression.Property(blob, "Count")),
+                new[] { arraySegment, count, index, end },
+                Expression.Assign(arraySegment, blob),
+                Expression.Assign(index, Expression.Property(arraySegment, "Offset")),
+                Expression.Assign(count, Expression.Property(arraySegment, "Count")),
                 Expression.Assign(end, Expression.Add(index, count)),
                 loop);
         }

--- a/cs/test/expressions/SerializeCB.expressions
+++ b/cs/test/expressions/SerializeCB.expressions
@@ -334,11 +334,13 @@
                     .Constant<System.UInt16>(50),
                     .Constant<Bond.Metadata>(b));
                 .Block(
+                    System.ArraySegment`1[System.Byte] $arraySegment,
                     System.Int32 $count,
                     System.Int32 $index,
                     System.Int32 $end) {
-                    $index = ($Example.b).Offset;
-                    $count = ($Example.b).Count;
+                    $arraySegment = $Example.b;
+                    $index = $arraySegment.Offset;
+                    $count = $arraySegment.Count;
                     $end = $index + $count;
                     .Block() {
                         .Call $writer.WriteContainerBegin(

--- a/cs/test/expressions/SerializeSP.expressions
+++ b/cs/test/expressions/SerializeSP.expressions
@@ -334,11 +334,13 @@
                     .Constant<System.UInt16>(50),
                     .Constant<Bond.Metadata>(b));
                 .Block(
+                    System.ArraySegment`1[System.Byte] $arraySegment,
                     System.Int32 $count,
                     System.Int32 $index,
                     System.Int32 $end) {
-                    $index = ($Example.b).Offset;
-                    $count = ($Example.b).Count;
+                    $arraySegment = $Example.b;
+                    $index = $arraySegment.Offset;
+                    $count = $arraySegment.Count;
                     $end = $index + $count;
                     .Block() {
                         .Call $writer.WriteContainerBegin(

--- a/cs/test/expressions/SerializeXml.expressions
+++ b/cs/test/expressions/SerializeXml.expressions
@@ -334,11 +334,13 @@
                     .Constant<System.UInt16>(50),
                     .Constant<Bond.Metadata>(b));
                 .Block(
+                    System.ArraySegment`1[System.Byte] $arraySegment,
                     System.Int32 $count,
                     System.Int32 $index,
                     System.Int32 $end) {
-                    $index = ($Example.b).Offset;
-                    $count = ($Example.b).Count;
+                    $arraySegment = $Example.b;
+                    $index = $arraySegment.Offset;
+                    $count = $arraySegment.Count;
                     $end = $index + $count;
                     .Block() {
                         .Call $writer.WriteContainerBegin(


### PR DESCRIPTION
Reduce number of calls to BondTypeAliasConverter.Convert methods
for type-aliased blobs fields.