### PR TITLE
Support for serialization and deserialization of IReadOnly... interfaces in c#

### DIFF
--- a/cs/src/core/expressions/DeserializerTransform.cs
+++ b/cs/src/core/expressions/DeserializerTransform.cs
@@ -4,6 +4,7 @@
 namespace Bond.Expressions
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
@@ -245,101 +246,33 @@ namespace Bond.Expressions
 
                         parameters = new[] { index, array };
                     }
-                    else if (container.Type.IsArray)
+                    else if (container.Type.IsArray || schemaType.IsArray)
                     {
-                        var arrayElemType = container.Type.GetValueType();
-                        var containerResizeMethod = arrayResize.MakeGenericMethod(arrayElemType);
-
-                        if (initialize)
+                        if(initialize && (!container.Type.IsArray && schemaType.IsArray))
                         {
-                            beforeLoop = 
-                                Expression.Assign(container, newContainer(container.Type, schemaType, count));
+                            var array = Expression.Variable(schemaType, "tmpArray");
+                            var arrayInit = ArrayHandler(parser, array, schemaType, initialize, valueParser, elementType, next, count);
+                            return Expression.Block(
+                                new[] { array },
+                                arrayInit,
+                                Expression.Assign(container, array));
                         }
 
-                        if (arrayElemType == typeof(byte))
-                        {
-                            var parseBlob = parser.Blob(count);
-                            if (parseBlob != null)
-                            {
-                                var blob = Expression.Variable(typeof(ArraySegment<byte>), "blob");
-                                return Expression.Block(
-                                    new[] { blob },
-                                    beforeLoop,
-                                    Expression.Assign(blob, parseBlob),
-                                    Expression.Call(null, bufferBlockCopy, new[]
-                                    {
-                                        Expression.Property(blob, "Array"),
-                                        Expression.Property(blob, "Offset"),
-                                        container,
-                                        Expression.Constant(0),
-                                        count
-                                    }));
-                            }
-                        }
-
-                        var i = Expression.Variable(typeof(int), "i");
-
-                        beforeLoop = Expression.Block(
-                            beforeLoop,
-                            Expression.Assign(i, Expression.Constant(0)));
-
-                        // Resize the array if we've run out of room
-                        var maybeResize =
-                            Expression.IfThen(
-                                Expression.Equal(i, Expression.ArrayLength(container)),
-                                Expression.Call(
-                                    containerResizeMethod,
-                                    container,
-                                    Expression.Multiply(
-                                        Expression.Condition(
-                                            Expression.LessThan(i, Expression.Constant(32)),
-                                            Expression.Constant(32),
-                                            i),
-                                        Expression.Constant(2))));
-
-                        // Puts a single element into the array.
-                        addItem = Expression.Block(
-                            maybeResize,
-                            Value(
-                                valueParser,
-                                Expression.ArrayAccess(container, i),
-                                elementType,
-                                itemSchemaType,
-                                initialize: true),
-                            Expression.PostIncrementAssign(i));
-
-                        // Expanding the array potentially leaves many blank
-                        // entries; this resize will get rid of them.
-                        afterLoop = Expression.IfThen(
-                            Expression.GreaterThan(Expression.ArrayLength(container), i),
-                            Expression.Call(containerResizeMethod, container, i));
-
-                        parameters = new[] { i };
+                        return ArrayHandler(parser, container, schemaType, initialize, valueParser, elementType, next, count);
                     }
                     else
                     {
-                        var item = Expression.Variable(container.Type.GetValueType(), container + "_item");
-
-                        if (initialize)
+                        if(initialize && !typeof(ICollection<>).MakeGenericType(container.Type.GetGenericArguments()).IsAssignableFrom(container.Type))
                         {
-                            beforeLoop = Expression.Assign(container, newContainer(container.Type, schemaType, count));
-                        }
-                        else
-                        {
-                            var capacity = container.Type.GetDeclaredProperty("Capacity", count.Type);
-                            if (capacity != null)
-                            {
-                                beforeLoop = Expression.Assign(Expression.Property(container, capacity), count);
-                            }
+                            var collection = Expression.Variable(schemaType, "tmpCollection");
+                            var collectionInit = CollectionHandler(collection, schemaType, initialize, valueParser, elementType, next, count);
+                            return Expression.Block(
+                                new[] { collection },
+                                collectionInit,
+                                Expression.Assign(container, collection));
                         }
 
-                        var add = container.Type.GetMethod(typeof(ICollection<>), "Add", item.Type);
-
-                        addItem = Expression.Block(
-                            Value(valueParser, item, elementType, itemSchemaType, initialize: true),
-                            Expression.Call(container, add, item));
-
-                        parameters = new[] { item };
+                        return CollectionHandler(container, schemaType, initialize, valueParser, elementType, next, count);
                     }
 
                     return Expression.Block(
@@ -351,6 +284,119 @@ namespace Bond.Expressions
                 });
         }
 
+        Expression ArrayHandler(IParser parser, Expression container, Type schemaType, bool initialize, IParser valueParser, Expression elementType, Expression next, Expression count)
+        {
+            var itemSchemaType = schemaType.GetValueType();
+
+            var arrayElemType = container.Type.GetValueType();
+            var containerResizeMethod = arrayResize.MakeGenericMethod(arrayElemType);
+
+            Expression afterLoop = Expression.Empty();
+            Expression beforeLoop = Expression.Empty();
+            if (initialize)
+            {
+                beforeLoop = Expression.Assign(container, newContainer(container.Type, schemaType, count));
+            }
+
+            if (arrayElemType == typeof(byte))
+            {
+                var parseBlob = parser.Blob(count);
+                if (parseBlob != null)
+                {
+                    var blob = Expression.Variable(typeof(ArraySegment<byte>), "blob");
+
+                    return Expression.Block(
+                        new[] { blob },
+                        beforeLoop,
+                        Expression.Assign(blob, parseBlob),
+                        Expression.Call(null, bufferBlockCopy, new[]
+                        {
+                            Expression.Property(blob, "Array"),
+                            Expression.Property(blob, "Offset"),
+                            container,
+                            Expression.Constant(0),
+                            count
+                        }));
+                }
+            }
+
+            var i = Expression.Variable(typeof(int), "i");
+
+            beforeLoop = Expression.Block(
+                beforeLoop,
+                Expression.Assign(i, Expression.Constant(0)));
+
+            // Resize the array if we've run out of room
+            var maybeResize =
+                Expression.IfThen(
+                    Expression.Equal(i, Expression.ArrayLength(container)),
+                    Expression.Call(
+                        containerResizeMethod,
+                        container,
+                        Expression.Multiply(
+                            Expression.Condition(
+                                Expression.LessThan(i, Expression.Constant(32)),
+                                Expression.Constant(32),
+                                i),
+                            Expression.Constant(2))));
+
+            // Puts a single element into the array.
+            Expression addItem = Expression.Block(
+                maybeResize,
+                Value(
+                    valueParser,
+                    Expression.ArrayAccess(container, i),
+                    elementType,
+                    itemSchemaType,
+                    initialize: true),
+                Expression.PostIncrementAssign(i));
+
+            // Expanding the array potentially leaves many blank
+            // entries; this resize will get rid of them.
+            afterLoop = Expression.IfThen(
+                Expression.GreaterThan(Expression.ArrayLength(container), i),
+                Expression.Call(containerResizeMethod, container, i));
+
+            return Expression.Block(
+                new[] { i },
+                beforeLoop,
+                ControlExpression.While(next,
+                    addItem),
+                afterLoop);
+        }
+
+        Expression CollectionHandler(Expression container, Type schemaType, bool initialize, IParser valueParser, Expression elementType, Expression next, Expression count)
+        {
+            var itemSchemaType = schemaType.GetValueType();
+            var item = Expression.Variable(container.Type.GetValueType(), container + "_item");
+
+            Expression beforeLoop = Expression.Empty();
+            if (initialize)
+            {
+                beforeLoop = Expression.Assign(container, newContainer(container.Type, schemaType, count));
+            }
+            else
+            {
+                var capacity = container.Type.GetDeclaredProperty("Capacity", count.Type);
+                if (capacity != null)
+                {
+                    beforeLoop = Expression.Assign(Expression.Property(container, capacity), count);
+                }
+            }
+
+            var add = container.Type.GetMethod(typeof(ICollection<>), "Add", item.Type);
+
+            Expression addItem = Expression.Block(
+                Value(valueParser, item, elementType, itemSchemaType, initialize: true),
+                Expression.Call(container, add, item));
+
+            return Expression.Block(
+                new[] { item },
+                beforeLoop,
+                ControlExpression.While(next,
+                    addItem));
+        }
+
         Expression Map(IParser parser, Expression map, Type schemaType, bool initialize)
         {
             var itemSchemaType = schemaType.GetKeyValueType();
@@ -358,32 +404,50 @@ namespace Bond.Expressions
             return parser.Map(itemSchemaType.Key.GetBondDataType(), itemSchemaType.Value.GetBondDataType(),
                 (keyParser, valueParser, keyType, valueType, nextKey, nextValue, count) =>
                 {
-                    Expression init = Expression.Empty();
-
-                    var itemType = map.Type.GetKeyValueType();
-                    var key = Expression.Variable(itemType.Key, map + "_key");
-                    var value = Expression.Variable(itemType.Value, map + "_value");
-
-                    if (initialize)
+                    if (initialize && !typeof(IDictionary).IsAssignableFrom(map.Type))
                     {
-                        // TODO: should we use non-default Comparer
-                        init = Expression.Assign(map, newContainer(map.Type, schemaType, count));
+                        var dictionary = Expression.Variable(schemaType, "tmpDictionary");
+                        var dictionaryInit = MapHandler(dictionary, schemaType, true, keyParser, valueParser, keyType, valueType, nextKey, nextValue, count);
+                        return Expression.Block(
+                            new[] { dictionary },
+                            dictionaryInit,
+                            Expression.Assign(map, dictionary));
                     }
 
-                    var add = map.Type.GetDeclaredProperty(typeof(IDictionary<,>), "Item", value.Type);
-
-                    Expression addItem = Expression.Block(
-                        Value(keyParser, key, keyType, itemSchemaType.Key, initialize: true),
-                        nextValue,
-                        Value(valueParser, value, valueType, itemSchemaType.Value, initialize: true),
-                        Expression.Assign(Expression.Property(map, add, new Expression[] { key }), value));
-
-                    return Expression.Block(
-                        new [] { key, value },
-                        init,
-                        ControlExpression.While(nextKey,
-                            addItem));
+                    return MapHandler(map, schemaType, initialize, keyParser, valueParser, keyType, valueType, nextKey, nextValue, count);
                 });
+        }
+
+        Expression MapHandler(Expression map, Type schemaType, bool initialize, IParser keyParser, IParser valueParser,
+            Expression keyType, Expression valueType, Expression nextKey, Expression nextValue, Expression count)
+        {
+            var itemSchemaType = schemaType.GetKeyValueType();
+
+            Expression init = Expression.Empty();
+
+            var itemType = map.Type.GetKeyValueType();
+            var key = Expression.Variable(itemType.Key, map + "_key");
+            var value = Expression.Variable(itemType.Value, map + "_value");
+
+            if (initialize)
+            {
+                // TODO: should we use non-default Comparer
+                init = Expression.Assign(map, newContainer(map.Type, schemaType, count));
+            }
+
+            var add = map.Type.GetDeclaredProperty(typeof(IDictionary<,>), "Item", value.Type);
+
+            Expression addItem = Expression.Block(
+                Value(keyParser, key, keyType, itemSchemaType.Key, initialize: true),
+                nextValue,
+                Value(valueParser, value, valueType, itemSchemaType.Value, initialize: true),
+                Expression.Assign(Expression.Property(map, add, new Expression[] { key }), value));
+
+            return Expression.Block(
+                new[] { key, value },
+                init,
+                ControlExpression.While(nextKey,
+                    addItem));
         }
 
         Expression FieldValue(IParser parser, Expression var, Expression valueType, Type schemaType, bool initialize)
@@ -439,7 +503,9 @@ namespace Bond.Expressions
             }
 
             if (schemaType.IsBondMap())
+            {
                 return Map(parser, var, schemaType, initialize);
+            }
             
             if (schemaType.IsBondContainer())
                 return Container(parser, var, schemaType, initialize);

--- a/cs/src/core/expressions/ObjectParser.cs
+++ b/cs/src/core/expressions/ObjectParser.cs
@@ -225,7 +225,16 @@ namespace Bond.Expressions
             if (container.Type.IsBondBlob())
                 return Expression.Property(container, "Count");
 
-            return Expression.Property(container, container.Type.GetDeclaredProperty(typeof(ICollection<>), "Count", typeof(int)));
+            Type genericParameter = container.Type.GetInterfaces().Union(new[] { container.Type })
+                .Where(type => type.IsGenericType())
+                .First(type => type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                .GenericTypeArguments
+                .First();
+            Type collectionType = typeof(ICollection<>).MakeGenericType(genericParameter);
+
+            return Expression.Property(
+                Expression.TypeAs(container, collectionType),
+                "Count");
         }
 
         Expression EnumerableContainer(ContainerItemHandler handler)

--- a/cs/test/core/Core.csproj
+++ b/cs/test/core/Core.csproj
@@ -42,6 +42,7 @@
     <Compile Include="MetaInitializationTests.cs" />
     <Compile Include="properties\AssemblyInfo.cs" />
     <Compile Include="Random.cs" />
+    <Compile Include="ReadOnlyCollectionTests.cs" />
     <Compile Include="SerializationTests.cs" />
     <Compile Include="SerializerGeneratorFactoryTests.cs" />
     <Compile Include="GenericsTests.cs" />

--- a/cs/test/core/ReadOnlyCollectionTests.cs
+++ b/cs/test/core/ReadOnlyCollectionTests.cs
@@ -1,0 +1,53 @@
+﻿
+namespace UnitTest
+{
+    using NUnit.Framework;
+    using System.Collections.Generic;
+
+    [TestFixture]
+    class ReadOnlyCollectionTests
+    {
+        [Bond.Schema]
+           private class DTO
+        {
+            [Bond.Id(0), Bond.Type(typeof(Dictionary<string, string>))]
+            public IReadOnlyDictionary<string, string> d1 { get; set; }
+
+            [Bond.Id(1), Bond.Type(typeof(List<string>))]
+            public IReadOnlyCollection<string> d2 { get; set; }
+
+            [Bond.Id(2), Bond.Type(typeof(List<string>))]
+            public IEnumerable<string> d3 { get; set; }
+
+            [Bond.Id(3), Bond.Type(typeof(List<string>))]
+            public IReadOnlyList<string> d4 { get; set; }
+
+            [Bond.Id(4), Bond.Type(typeof(string[]))]
+            public IReadOnlyCollection<string> d5 { get; set; }
+
+            [Bond.Id(5), Bond.Type(typeof(string[]))]
+            public IEnumerable<string> d6 { get; set; }
+
+            [Bond.Id(6), Bond.Type(typeof(string[]))]
+            public IReadOnlyList<string> d7 { get; set; }
+
+            public bool Equals(DTO dto)
+            {
+                return d1.IsEqual<IReadOnlyDictionary<string, string>>(dto.d1) &&
+                    d2.IsEqual<IReadOnlyCollection<string>>(dto.d2) &&
+                    d3.IsEqual<IEnumerable<string>>(dto.d3) &&
+                    d4.IsEqual<IReadOnlyList<string>>(dto.d4) &&
+                    d5.IsEqual<IReadOnlyCollection<string>>(dto.d5) &&
+                    d6.IsEqual<IEnumerable<string>>(dto.d6) &&
+                    d7.IsEqual<IReadOnlyList<string>>(dto.d7);
+            }
+        }
+
+
+        [Test]
+           public void ReadOnlyCollections()
+        {
+            Util.AllSerializeDeserialize<DTO, DTO>(Random.Init<DTO>());
+        }
+    }
+}


### PR DESCRIPTION
Changed logic of DeserializerTransform in case of collection interfaces which can't be directly written to.
If a collection is supposed to be initialized, an object of schemaType will be created first and that object will be used for deserialization.
The object will then be assigned to the property with non-writable interface.