### PR TITLE
Support Serializers without nested struct inlining

### DIFF
--- a/cs/src/core/Serializer.cs
+++ b/cs/src/core/Serializer.cs
@@ -66,11 +66,18 @@ namespace Bond
         /// Create a serializer for specified type
         /// </summary>
         /// <param name="type">Type representing a Bond schema</param>
-        public Serializer(Type type)
+        public Serializer(Type type) : this(type, inlineNested: true) { }
+
+        /// <summary>
+        /// Create a serializer for specified type
+        /// </summary>
+        /// <param name="type">Type representing a Bond schema</param>
+        /// <param name="inlineNested">Indicates whether nested struct serialization code may be inlined</param>
+        public Serializer(Type type, bool inlineNested)
         {
             var parser = new ObjectParser(type);
             serialize = SerializerGeneratorFactory<object, W>.Create(
-                    (o, w, i) => serialize[i](o, w), type)
+                    (o, w, i) => serialize[i](o, w), type, inlineNested)
                 .Generate(parser)
                 .Select(lambda => lambda.Compile()).ToArray();
         }

--- a/cs/src/core/expressions/ObjectParser.cs
+++ b/cs/src/core/expressions/ObjectParser.cs
@@ -180,7 +180,7 @@ namespace Bond.Expressions
         {
             if (schemaType.IsBonded())
             {
-                return handler(PrunedExpression.Convert(value, typeof(IBonded)));
+                return handler(value);
             }
             
             var bondedType = typeof(Bonded<>).MakeGenericType(objectType);

--- a/cs/src/core/expressions/SerializerGeneratorFactory.cs
+++ b/cs/src/core/expressions/SerializerGeneratorFactory.cs
@@ -6,25 +6,26 @@ namespace Bond.Expressions
     using System;
     using System.Globalization;
     using System.Linq.Expressions;
+    using System.Reflection;
 
     internal static class SerializerGeneratorFactory<R, W>
     {
         public static ISerializerGenerator<R, W> Create<S>(
-            Expression<Action<R, W, int>> deferredSerialize, S schema)
+            Expression<Action<R, W, int>> deferredSerialize, S schema, bool inlineNested = true)
         {
-            return Cache<S>.Create(deferredSerialize, schema);
+            return Cache<S>.Create(deferredSerialize, schema, inlineNested);
         }
 
         static class Cache<S>
         {
-            public static readonly Func<Expression<Action<R, W, int>>, S, ISerializerGenerator<R, W>> Create;
+            public static readonly Func<Expression<Action<R, W, int>>, S, bool, ISerializerGenerator<R, W>> Create;
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage(
                 "Microsoft.Design", "CA1065:DoNotRaiseExceptionsInUnexpectedLocations")]
             static Cache()
             {
                 Type generator;
-                
+
                 var attribute = typeof(W).GetAttribute<SerializerAttribute>();
                 if (attribute == null)
                 {
@@ -39,19 +40,21 @@ namespace Bond.Expressions
                     }
 
                     generator = attribute.Type.MakeGenericType(typeof(R), typeof(W));
-                
+
                     if (!typeof(ISerializerGenerator<R, W>).IsAssignableFrom(generator))
                     {
                         throw new InvalidOperationException(
                             string.Format(
                                 CultureInfo.InvariantCulture,
                                 "Serializer generator {0} specified for writer {1} is not an ISerializerGenerator.",
-                                generator,
-                                typeof(W)));
+                                generator, typeof(W)));
                     }
                 }
 
-                var ctor = generator.GetConstructor(typeof(Expression<Action<R, W, int>>), typeof(S));
+                var ctor = 
+                    generator.GetConstructor(typeof(Expression<Action<R, W, int>>), typeof(S), typeof(bool)) ?? 
+                    generator.GetConstructor(typeof(Expression<Action<R, W, int>>), typeof(S));
+
                 if (ctor == null)
                 {
                     throw new InvalidOperationException(
@@ -63,9 +66,19 @@ namespace Bond.Expressions
 
                 var deferredSerialize = Expression.Parameter(typeof(Expression<Action<R, W, int>>));
                 var schema = Expression.Parameter(typeof(S));
-                Create = Expression.Lambda<Func<Expression<Action<R, W, int>>, S, ISerializerGenerator<R, W>>>(
-                    Expression.New(ctor, deferredSerialize, schema), deferredSerialize, schema)
-                    .Compile();
+                var inlineNested = Expression.Parameter(typeof(bool));
+
+                var newExpression = 
+                    ctor.GetParameters().Length == 3
+                        ? Expression.New(ctor, deferredSerialize, schema, inlineNested)
+                        : Expression.New(ctor, deferredSerialize, schema);
+
+                Create =
+                    Expression.Lambda<Func<Expression<Action<R, W, int>>, S, bool, ISerializerGenerator<R, W>>>(
+                        newExpression,
+                        deferredSerialize,
+                        schema,
+                        inlineNested).Compile();
             }
         }
     }

--- a/cs/src/core/expressions/SerializerTransform.cs
+++ b/cs/src/core/expressions/SerializerTransform.cs
@@ -81,7 +81,7 @@ namespace Bond.Expressions
 
                 body = Expression.Invoke(
                     deferredSerialize,
-                    parser.ReaderValue,
+                    PrunedExpression.Convert(parser.ReaderValue, parser.ReaderParam.Type),
                     writer,
                     Expression.Constant(index));
             }
@@ -100,19 +100,21 @@ namespace Bond.Expressions
         readonly ProtocolWriter<W> writer = new ProtocolWriter<W>();
         readonly Dictionary<RuntimeSchema, Serialize> serializeDelegates = 
             new Dictionary<RuntimeSchema, Serialize>(new TypeDefComparer());
+        readonly bool inlineNested;
         static readonly bool untaggedWriter =
             typeof (IUntaggedProtocolReader).IsAssignableFrom(typeof (W).GetAttribute<ReaderAttribute>().ReaderType);
         static readonly bool binaryWriter = untaggedWriter
             || typeof(ITaggedProtocolReader).IsAssignableFrom(typeof(W).GetAttribute<ReaderAttribute>().ReaderType);
-
-        public SerializerTransform(Expression<Action<R, W, int>> deferredSerialize, RuntimeSchema schema)
+        
+        public SerializerTransform(Expression<Action<R, W, int>> deferredSerialize, RuntimeSchema schema, bool inlineNested = true)
             : base(deferredSerialize)
         {
             runtimeSchema = schema;
+            this.inlineNested = inlineNested;
         }
 
-        public SerializerTransform(Expression<Action<R, W, int>> deferredSerialize, Type type)
-            : this(deferredSerialize, Schema.GetRuntimeSchema(type))
+        public SerializerTransform(Expression<Action<R, W, int>> deferredSerialize, Type type, bool inlineNested = true)
+            : this(deferredSerialize, Schema.GetRuntimeSchema(type), inlineNested)
         {}
 
         public override IEnumerable<Expression<Action<R, W>>> Generate(IParser parser)
@@ -145,7 +147,9 @@ namespace Bond.Expressions
             // Transcoding from tagged protocol with runtime schema generates enormous expression tree
             // and for large schemas JIT fails to compile resulting lambda (InvalidProgramException).
             // As a workaround we don't inline nested serialize expressions in this case.
-            var inline = !typeof(ITaggedProtocolReader).IsAssignableFrom(parser.ReaderParam.Type);
+            var inline = !typeof(ITaggedProtocolReader).IsAssignableFrom(parser.ReaderParam.Type) && 
+                (this.inlineNested || !schema.IsStruct);
+
             return GenerateSerialize(serialize, parser, writer.Param, inline);
         }
 
@@ -266,7 +270,8 @@ namespace Bond.Expressions
         {
             if (parser.IsBonded)
             {
-                return parser.Bonded(writer.WriteBonded);
+                return parser.Bonded(value =>
+                    writer.WriteBonded(PrunedExpression.Convert(value, typeof(IBonded))));
             }
 
             var switchCases = new List<DeferredSwitchCase>
@@ -317,7 +322,9 @@ namespace Bond.Expressions
             Debug.Assert(schema.HasValue);
 
             if (parser.IsBonded || (untaggedWriter && schema.IsBonded))
-                return parser.Bonded(writer.WriteBonded);
+                return parser.Bonded(value =>
+                    writer.WriteBonded(PrunedExpression.Convert(value, typeof(IBonded))));
+
 
             if (schema.IsStruct)
                 return GenerateSerialize(Struct, parser, schema);

--- a/cs/test/core/Util.cs
+++ b/cs/test/core/Util.cs
@@ -294,6 +294,16 @@ namespace UnitTest
             return output.Data;
         }
 
+        public static ArraySegment<byte> SerializeSafeCBNoInlining<T>(T obj)
+        {
+            var output = new Bond.IO.Safe.OutputBuffer(new byte[11]);
+            var writer = new CompactBinaryWriter<Bond.IO.Safe.OutputBuffer>(output);
+
+            var serializer = new Serializer<CompactBinaryWriter<Bond.IO.Safe.OutputBuffer>>(typeof(T), false);
+            serializer.Serialize(obj, writer);
+            return output.Data;
+        }
+
         public static T DeserializeCB<T>(Stream stream)
         {
             var input = new InputStream(stream);
@@ -721,6 +731,7 @@ namespace UnitTest
             memoryRoundtrip(SerializeSafeCB, DeserializeSafeCB<To>);
             memoryRoundtrip(SerializeSafeCB, DeserializeUnsafeCB<To>);
             memoryPointerRoundtrip(SerializeSafeCB, DeserializePointerCB<To>);
+            memoryRoundtrip(SerializeSafeCBNoInlining, DeserializeSafeCB<To>);
 
             streamMarshal(MarshalCB);
             streamMarshal(SerializerMarshalCB);


### PR DESCRIPTION
Add support to create a Serializer without inlining of nested types.
Serialization would be slightly slower, but compilation time can be significantly decreased for complex type graphs.