### PR TITLE
Add check for field ordinals, should be less than max value of Word16

### DIFF
--- a/compiler/src/Language/Bond/Parser.hs
+++ b/compiler/src/Language/Bond/Parser.hs
@@ -24,6 +24,7 @@ module Language.Bond.Parser
 import Data.Ord
 import Data.List
 import Data.Function
+import Data.Word
 import Control.Applicative
 import Control.Monad.Reader
 import Prelude
@@ -247,7 +248,13 @@ manySortedBy = manyAccum . insertBy
 field :: Parser Field
 field = makeField <$> attributes <*> ordinal <*> modifier <*> ftype <*> identifier <*> optional default_
   where
-    ordinal = (fromIntegral <$> integer) <* colon <?> "field ordinal"
+    ordinal = word16 <* colon <?> "field ordinal"
+      where
+        word16 = do
+            i <- integer
+            if i <= toInteger (maxBound :: Word16) && i >= toInteger (minBound :: Word16)
+                then return (fromInteger i)
+                else fail "Field ordinal must be within the range 0-65535"
     modifier = option Optional
                     (keyword "optional" *> pure Optional
                  <|> keyword "required" *> pure Required


### PR DESCRIPTION
Fix for issue #111 

Sample bond file:
```
namespace fieldIdWrapping;

struct SameFieldIds
{
    0: int32 FieldWithId0;
    65538: string FieldWithId0AsWell;
}
```
Generates error:
```
Error parsing bb.bond: "bb.bond" (line 6, column 10):
unexpected ":"
expecting digit
Field ordinal out of range 65538
```


First pull request to this project and I haven't done haskell work in a while so hopefully I'm not messing up with the style or any other considerations that I didn't consider.

Thanks

Eduardo