### PR TITLE
Use scoped syntax to refer to BondDataType, ProtocolType, and Modifier

### DIFF
--- a/cpp/inc/bond/core/detail/cmdargs.h
+++ b/cpp/inc/bond/core/detail/cmdargs.h
@@ -99,7 +99,7 @@ public:
 
     bool IsOptional() const
     {
-        return metadata.modifier == bond::Optional;
+        return metadata.modifier == bond::Modifier::Optional;
     }
 
 private:

--- a/cpp/inc/bond/core/detail/metadata.h
+++ b/cpp/inc/bond/core/detail/metadata.h
@@ -210,17 +210,17 @@ GetTypeName(T, const qualified_name_tag&)
 {
     switch (get_type_id<T>::value)
     {
-        case BT_BOOL:   return "bool";
-        case BT_UINT8:  return "uint8";
-        case BT_UINT16: return "uint16";
-        case BT_UINT32: return "uint32";
-        case BT_UINT64: return "uint64";
-        case BT_FLOAT:  return "float";
-        case BT_DOUBLE: return "double";
-        case BT_INT8:   return "int8";
-        case BT_INT16:  return "int16";
-        case BT_INT32:  return "int32";
-        case BT_INT64:  return "int64";
+        case BondDataType::BT_BOOL:   return "bool";
+        case BondDataType::BT_UINT8:  return "uint8";
+        case BondDataType::BT_UINT16: return "uint16";
+        case BondDataType::BT_UINT32: return "uint32";
+        case BondDataType::BT_UINT64: return "uint64";
+        case BondDataType::BT_FLOAT:  return "float";
+        case BondDataType::BT_DOUBLE: return "double";
+        case BondDataType::BT_INT8:   return "int8";
+        case BondDataType::BT_INT16:  return "int16";
+        case BondDataType::BT_INT32:  return "int32";
+        case BondDataType::BT_INT64:  return "int64";
         default:        BOOST_ASSERT(false);
                         return "unknown_type";
     }

--- a/cpp/inc/bond/core/detail/omit_default.h
+++ b/cpp/inc/bond/core/detail/omit_default.h
@@ -94,7 +94,7 @@ omit_field(const Metadata& metadata, const T& value)
     (void)one_definition<may_omit_fields<Writer>, true_type>::value;
 
     // omit the field if it's optional and has default value
-    return metadata.modifier == Optional
+    return metadata.modifier == Modifier::Optional
         && is_default(value, metadata);
 }
 

--- a/cpp/inc/bond/core/detail/typeid_value.h
+++ b/cpp/inc/bond/core/detail/typeid_value.h
@@ -18,43 +18,43 @@ bool IsMatching(BondDataType type)
 {
     switch (type)
     {
-        case bond::BT_BOOL:
+        case bond::BondDataType::BT_BOOL:
             return is_matching<bool, T>::value;
 
-        case bond::BT_UINT8:
+        case bond::BondDataType::BT_UINT8:
             return is_matching<uint8_t, T>::value;
 
-        case bond::BT_UINT16:
+        case bond::BondDataType::BT_UINT16:
             return is_matching<uint16_t, T>::value;
 
-        case bond::BT_UINT32:
+        case bond::BondDataType::BT_UINT32:
             return is_matching<uint32_t, T>::value;
 
-        case bond::BT_UINT64:
+        case bond::BondDataType::BT_UINT64:
             return is_matching<uint64_t, T>::value;
 
-        case bond::BT_FLOAT:
+        case bond::BondDataType::BT_FLOAT:
             return is_matching<float, T>::value;
 
-        case bond::BT_DOUBLE:
+        case bond::BondDataType::BT_DOUBLE:
             return is_matching<double, T>::value;
 
-        case bond::BT_STRING:
+        case bond::BondDataType::BT_STRING:
             return is_matching<std::string, T>::value;
             
-        case bond::BT_WSTRING:
+        case bond::BondDataType::BT_WSTRING:
             return is_matching<std::wstring, T>::value;
 
-        case bond::BT_INT8:
+        case bond::BondDataType::BT_INT8:
             return is_matching<int8_t, T>::value;
 
-        case bond::BT_INT16:
+        case bond::BondDataType::BT_INT16:
             return is_matching<int16_t, T>::value;
 
-        case bond::BT_INT32:
+        case bond::BondDataType::BT_INT32:
             return is_matching<int32_t, T>::value;
 
-        case bond::BT_INT64:
+        case bond::BondDataType::BT_INT64:
             return is_matching<int64_t, T>::value;
 
         default:
@@ -69,43 +69,43 @@ inline bool BasicTypeField(uint16_t id, const Metadata& metadata, BondDataType t
 {
     switch (type)
     {
-        case bond::BT_BOOL:
+        case bond::BondDataType::BT_BOOL:
             return transform.Field(id, metadata, value<bool, Reader&>(input));
 
-        case bond::BT_UINT8:
+        case bond::BondDataType::BT_UINT8:
             return transform.Field(id, metadata, value<uint8_t, Reader&>(input));
 
-        case bond::BT_UINT16:
+        case bond::BondDataType::BT_UINT16:
             return transform.Field(id, metadata, value<uint16_t, Reader&>(input));
 
-        case bond::BT_UINT32:
+        case bond::BondDataType::BT_UINT32:
             return transform.Field(id, metadata, value<uint32_t, Reader&>(input));
 
-        case bond::BT_UINT64:
+        case bond::BondDataType::BT_UINT64:
             return transform.Field(id, metadata, value<uint64_t, Reader&>(input));
             
-        case bond::BT_FLOAT:
+        case bond::BondDataType::BT_FLOAT:
             return transform.Field(id, metadata, value<float, Reader&>(input));
 
-        case bond::BT_DOUBLE:
+        case bond::BondDataType::BT_DOUBLE:
             return transform.Field(id, metadata, value<double, Reader&>(input));
 
-        case bond::BT_STRING:
+        case bond::BondDataType::BT_STRING:
             return transform.Field(id, metadata, value<std::string, Reader&>(input));
 
-        case bond::BT_WSTRING:
+        case bond::BondDataType::BT_WSTRING:
             return transform.Field(id, metadata, value<std::wstring, Reader&>(input));
 
-        case bond::BT_INT8:
+        case bond::BondDataType::BT_INT8:
             return transform.Field(id, metadata, value<int8_t, Reader&>(input));
 
-        case bond::BT_INT16:
+        case bond::BondDataType::BT_INT16:
             return transform.Field(id, metadata, value<int16_t, Reader&>(input));
 
-        case bond::BT_INT32:
+        case bond::BondDataType::BT_INT32:
             return transform.Field(id, metadata, value<int32_t, Reader&>(input));
 
-        case bond::BT_INT64:
+        case bond::BondDataType::BT_INT64:
             return transform.Field(id, metadata, value<int64_t, Reader&>(input));
 
         default:
@@ -122,43 +122,43 @@ inline void BasicTypeContainer(T& var, BondDataType type, Reader& input, uint32_
 
     switch (type)
     {
-        case bond::BT_BOOL:
+        case bond::BondDataType::BT_BOOL:
             return DeserializeElements(var, value<bool, Reader&>(input, false), size);
 
-        case bond::BT_UINT8:
+        case bond::BondDataType::BT_UINT8:
             return DeserializeElements(var, value<uint8_t, Reader&>(input, false), size);
 
-        case bond::BT_UINT16:
+        case bond::BondDataType::BT_UINT16:
             return DeserializeElements(var, value<uint16_t, Reader&>(input, false), size);
 
-        case bond::BT_UINT32:
+        case bond::BondDataType::BT_UINT32:
             return DeserializeElements(var, value<uint32_t, Reader&>(input, false), size);
 
-        case bond::BT_UINT64:
+        case bond::BondDataType::BT_UINT64:
             return DeserializeElements(var, value<uint64_t, Reader&>(input, false), size);
 
-        case bond::BT_FLOAT:
+        case bond::BondDataType::BT_FLOAT:
             return DeserializeElements(var, value<float, Reader&>(input, false), size);
 
-        case bond::BT_DOUBLE:
+        case bond::BondDataType::BT_DOUBLE:
             return DeserializeElements(var, value<double, Reader&>(input, false), size);
 
-        case bond::BT_STRING:
+        case bond::BondDataType::BT_STRING:
             return DeserializeElements(var, value<std::string, Reader&>(input, false), size);
             
-        case bond::BT_WSTRING:
+        case bond::BondDataType::BT_WSTRING:
             return DeserializeElements(var, value<std::wstring, Reader&>(input, false), size);
 
-        case bond::BT_INT8:
+        case bond::BondDataType::BT_INT8:
             return DeserializeElements(var, value<int8_t, Reader&>(input, false), size);
 
-        case bond::BT_INT16:
+        case bond::BondDataType::BT_INT16:
             return DeserializeElements(var, value<int16_t, Reader&>(input, false), size);
 
-        case bond::BT_INT32:
+        case bond::BondDataType::BT_INT32:
             return DeserializeElements(var, value<int32_t, Reader&>(input, false), size);
 
-        case bond::BT_INT64:
+        case bond::BondDataType::BT_INT64:
             return DeserializeElements(var, value<int64_t, Reader&>(input, false), size);
 
         default:
@@ -194,7 +194,7 @@ inline MatchingTypeContainer(T& var, BondDataType type, Reader& input, uint32_t 
 {
     switch (type)
     {
-        case bond::BT_BOOL:
+        case bond::BondDataType::BT_BOOL:
             return DeserializeElements(var, value<bool, Reader&>(input, false), size);
 
         default:
@@ -213,7 +213,7 @@ inline MatchingTypeContainer(T& var, BondDataType type, Reader& input, uint32_t 
 {
     switch (type)
     {
-        case bond::BT_STRING:
+        case bond::BondDataType::BT_STRING:
             return DeserializeElements(var, value<std::string, Reader&>(input, false), size);
             
         default:
@@ -232,7 +232,7 @@ inline MatchingTypeContainer(T& var, BondDataType type, Reader& input, uint32_t 
 {
     switch (type)
     {
-        case bond::BT_WSTRING:
+        case bond::BondDataType::BT_WSTRING:
             return DeserializeElements(var, value<std::wstring, Reader&>(input, false), size);
 
         default:
@@ -251,10 +251,10 @@ inline MatchingTypeContainer(T& var, BondDataType type, Reader& input, uint32_t 
 {
     switch (type)
     {
-        case bond::BT_FLOAT:
+        case bond::BondDataType::BT_FLOAT:
             return DeserializeElements(var, value<float, Reader&>(input, false), size);
 
-        case bond::BT_DOUBLE:
+        case bond::BondDataType::BT_DOUBLE:
             return DeserializeElements(var, value<double, Reader&>(input, false), size);
 
         default:
@@ -273,16 +273,16 @@ inline MatchingTypeContainer(T& var, BondDataType type, Reader& input, uint32_t 
 {
     switch (type)
     {
-        case bond::BT_UINT8:
+        case bond::BondDataType::BT_UINT8:
             return DeserializeElements(var, value<uint8_t, Reader&>(input, false), size);
 
-        case bond::BT_UINT16:
+        case bond::BondDataType::BT_UINT16:
             return DeserializeElements(var, value<uint16_t, Reader&>(input, false), size);
 
-        case bond::BT_UINT32:
+        case bond::BondDataType::BT_UINT32:
             return DeserializeElements(var, value<uint32_t, Reader&>(input, false), size);
 
-        case bond::BT_UINT64:
+        case bond::BondDataType::BT_UINT64:
             return DeserializeElements(var, value<uint64_t, Reader&>(input, false), size);
 
         default:
@@ -301,16 +301,16 @@ inline MatchingTypeContainer(T& var, BondDataType type, Reader& input, uint32_t 
 {
     switch (type)
     {
-        case bond::BT_INT8:
+        case bond::BondDataType::BT_INT8:
             return DeserializeElements(var, value<int8_t, Reader&>(input, false), size);
 
-        case bond::BT_INT16:
+        case bond::BondDataType::BT_INT16:
             return DeserializeElements(var, value<int16_t, Reader&>(input, false), size);
 
-        case bond::BT_INT32:
+        case bond::BondDataType::BT_INT32:
             return DeserializeElements(var, value<int32_t, Reader&>(input, false), size);
 
-        case bond::BT_INT64:
+        case bond::BondDataType::BT_INT64:
             return DeserializeElements(var, value<int64_t, Reader&>(input, false), size);
 
         default:
@@ -352,7 +352,7 @@ inline MatchingMapByKey(T& var, BondDataType keyType, const E& element, Reader& 
 {
     switch (keyType)
     {
-        case bond::BT_BOOL:
+        case bond::BondDataType::BT_BOOL:
             return DeserializeMapElements(var, value<bool, Reader&>(input, false), element, size);
 
         default:
@@ -374,7 +374,7 @@ inline MatchingMapByKey(T& var, BondDataType keyType, const E& element, Reader& 
 {
     switch (keyType)
     {
-        case bond::BT_STRING:
+        case bond::BondDataType::BT_STRING:
             return DeserializeMapElements(var, value<std::string, Reader&>(input, false), element, size);
 
         default:
@@ -396,7 +396,7 @@ inline MatchingMapByKey(T& var, BondDataType keyType, const E& element, Reader& 
 {
     switch (keyType)
     {
-        case bond::BT_WSTRING:
+        case bond::BondDataType::BT_WSTRING:
             return DeserializeMapElements(var, value<std::wstring, Reader&>(input, false), element, size);
 
         default:
@@ -418,10 +418,10 @@ inline MatchingMapByKey(T& var, BondDataType keyType, const E& element, Reader& 
 {
     switch (keyType)
     {
-        case bond::BT_FLOAT:
+        case bond::BondDataType::BT_FLOAT:
             return DeserializeMapElements(var, value<float, Reader&>(input, false), element, size);
 
-        case bond::BT_DOUBLE:
+        case bond::BondDataType::BT_DOUBLE:
             return DeserializeMapElements(var, value<double, Reader&>(input, false), element, size);
 
         default:
@@ -443,16 +443,16 @@ inline MatchingMapByKey(T& var, BondDataType keyType, const E& element, Reader& 
 {
     switch (keyType)
     {
-        case bond::BT_UINT8:
+        case bond::BondDataType::BT_UINT8:
             return DeserializeMapElements(var, value<uint8_t, Reader&>(input, false), element, size);
 
-        case bond::BT_UINT16:
+        case bond::BondDataType::BT_UINT16:
             return DeserializeMapElements(var, value<uint16_t, Reader&>(input, false), element, size);
 
-        case bond::BT_UINT32:
+        case bond::BondDataType::BT_UINT32:
             return DeserializeMapElements(var, value<uint32_t, Reader&>(input, false), element, size);
 
-        case bond::BT_UINT64:
+        case bond::BondDataType::BT_UINT64:
             return DeserializeMapElements(var, value<uint64_t, Reader&>(input, false), element, size);
 
         default:
@@ -474,16 +474,16 @@ inline MatchingMapByKey(T& var, BondDataType keyType, const E& element, Reader& 
 {
     switch (keyType)
     {
-        case bond::BT_INT8:
+        case bond::BondDataType::BT_INT8:
             return DeserializeMapElements(var, value<int8_t, Reader&>(input, false), element, size);
 
-        case bond::BT_INT16:
+        case bond::BondDataType::BT_INT16:
             return DeserializeMapElements(var, value<int16_t, Reader&>(input, false), element, size);
 
-        case bond::BT_INT32:
+        case bond::BondDataType::BT_INT32:
             return DeserializeMapElements(var, value<int32_t, Reader&>(input, false), element, size);
 
-        case bond::BT_INT64:
+        case bond::BondDataType::BT_INT64:
             return DeserializeMapElements(var, value<int64_t, Reader&>(input, false), element, size);
 
         default:
@@ -506,43 +506,43 @@ inline MapByKey(T& var, BondDataType keyType, const E& element, Reader& input, u
 {
     switch (keyType)
     {
-        case bond::BT_BOOL:
+        case bond::BondDataType::BT_BOOL:
             return DeserializeMapElements(var, value<bool, Reader&>(input, false), element, size);
 
-        case bond::BT_UINT8:
+        case bond::BondDataType::BT_UINT8:
             return DeserializeMapElements(var, value<uint8_t, Reader&>(input, false), element, size);
 
-        case bond::BT_UINT16:
+        case bond::BondDataType::BT_UINT16:
             return DeserializeMapElements(var, value<uint16_t, Reader&>(input, false), element, size);
 
-        case bond::BT_UINT32:
+        case bond::BondDataType::BT_UINT32:
             return DeserializeMapElements(var, value<uint32_t, Reader&>(input, false), element, size);
 
-        case bond::BT_UINT64:
+        case bond::BondDataType::BT_UINT64:
             return DeserializeMapElements(var, value<uint64_t, Reader&>(input, false), element, size);
 
-        case bond::BT_FLOAT:
+        case bond::BondDataType::BT_FLOAT:
             return DeserializeMapElements(var, value<float, Reader&>(input, false), element, size);
 
-        case bond::BT_DOUBLE:
+        case bond::BondDataType::BT_DOUBLE:
             return DeserializeMapElements(var, value<double, Reader&>(input, false), element, size);
 
-        case bond::BT_STRING:
+        case bond::BondDataType::BT_STRING:
             return DeserializeMapElements(var, value<std::string, Reader&>(input, false), element, size);
             
-        case bond::BT_WSTRING:
+        case bond::BondDataType::BT_WSTRING:
             return DeserializeMapElements(var, value<std::wstring, Reader&>(input, false), element, size);
 
-        case bond::BT_INT8:
+        case bond::BondDataType::BT_INT8:
             return DeserializeMapElements(var, value<int8_t, Reader&>(input, false), element, size);
 
-        case bond::BT_INT16:
+        case bond::BondDataType::BT_INT16:
             return DeserializeMapElements(var, value<int16_t, Reader&>(input, false), element, size);
 
-        case bond::BT_INT32:
+        case bond::BondDataType::BT_INT32:
             return DeserializeMapElements(var, value<int32_t, Reader&>(input, false), element, size);
 
-        case bond::BT_INT64:
+        case bond::BondDataType::BT_INT64:
             return DeserializeMapElements(var, value<int64_t, Reader&>(input, false), element, size);
 
         default:
@@ -577,43 +577,43 @@ inline void MapByElement(T& var, BondDataType keyType, BondDataType elementType,
 {
     switch (elementType)
     {
-        case bond::BT_BOOL:
+        case bond::BondDataType::BT_BOOL:
             return MapByKey(var, keyType, value<bool, Reader&>(input, false), input, size);
 
-        case bond::BT_UINT8:
+        case bond::BondDataType::BT_UINT8:
             return MapByKey(var, keyType, value<uint8_t, Reader&>(input, false), input, size);
 
-        case bond::BT_UINT16:
+        case bond::BondDataType::BT_UINT16:
             return MapByKey(var, keyType, value<uint16_t, Reader&>(input, false), input, size);
 
-        case bond::BT_UINT32:
+        case bond::BondDataType::BT_UINT32:
             return MapByKey(var, keyType, value<uint32_t, Reader&>(input, false), input, size);
 
-        case bond::BT_UINT64:
+        case bond::BondDataType::BT_UINT64:
             return MapByKey(var, keyType, value<uint64_t, Reader&>(input, false), input, size);
 
-        case bond::BT_FLOAT:
+        case bond::BondDataType::BT_FLOAT:
             return MapByKey(var, keyType, value<float, Reader&>(input, false), input, size);
 
-        case bond::BT_DOUBLE:
+        case bond::BondDataType::BT_DOUBLE:
             return MapByKey(var, keyType, value<double, Reader&>(input, false), input, size);
 
-        case bond::BT_STRING:
+        case bond::BondDataType::BT_STRING:
             return MapByKey(var, keyType, value<std::string, Reader&>(input, false), input, size);
             
-        case bond::BT_WSTRING:
+        case bond::BondDataType::BT_WSTRING:
             return MapByKey(var, keyType, value<std::wstring, Reader&>(input, false), input, size);
 
-        case bond::BT_INT8:
+        case bond::BondDataType::BT_INT8:
             return MapByKey(var, keyType, value<int8_t, Reader&>(input, false), input, size);
 
-        case bond::BT_INT16:
+        case bond::BondDataType::BT_INT16:
             return MapByKey(var, keyType, value<int16_t, Reader&>(input, false), input, size);
 
-        case bond::BT_INT32:
+        case bond::BondDataType::BT_INT32:
             return MapByKey(var, keyType, value<int32_t, Reader&>(input, false), input, size);
 
-        case bond::BT_INT64:
+        case bond::BondDataType::BT_INT64:
             return MapByKey(var, keyType, value<int64_t, Reader&>(input, false), input, size);
 
         default:
@@ -653,7 +653,7 @@ inline MatchingMapByElement(T& var, BondDataType keyType, BondDataType elementTy
 {
     switch (elementType)
     {
-        case bond::BT_BOOL:
+        case bond::BondDataType::BT_BOOL:
             return MapByKey(var, keyType, value<bool, Reader&>(input, false), input, size);
 
         default:
@@ -675,7 +675,7 @@ inline MatchingMapByElement(T& var, BondDataType keyType, BondDataType elementTy
 {
     switch (elementType)
     {
-        case bond::BT_STRING:
+        case bond::BondDataType::BT_STRING:
             return MapByKey(var, keyType, value<std::string, Reader&>(input, false), input, size);
             
         default:
@@ -697,7 +697,7 @@ inline MatchingMapByElement(T& var, BondDataType keyType, BondDataType elementTy
 {
     switch (elementType)
     {
-        case bond::BT_WSTRING:
+        case bond::BondDataType::BT_WSTRING:
             return MapByKey(var, keyType, value<std::wstring, Reader&>(input, false), input, size);
 
         default:
@@ -719,10 +719,10 @@ inline MatchingMapByElement(T& var, BondDataType keyType, BondDataType elementTy
 {
     switch (elementType)
     {
-        case bond::BT_FLOAT:
+        case bond::BondDataType::BT_FLOAT:
             return MapByKey(var, keyType, value<float, Reader&>(input, false), input, size);
 
-        case bond::BT_DOUBLE:
+        case bond::BondDataType::BT_DOUBLE:
             return MapByKey(var, keyType, value<double, Reader&>(input, false), input, size);
 
         default:
@@ -744,16 +744,16 @@ inline MatchingMapByElement(T& var, BondDataType keyType, BondDataType elementTy
 {
     switch (elementType)
     {
-        case bond::BT_UINT8:
+        case bond::BondDataType::BT_UINT8:
             return MapByKey(var, keyType, value<uint8_t, Reader&>(input, false), input, size);
 
-        case bond::BT_UINT16:
+        case bond::BondDataType::BT_UINT16:
             return MapByKey(var, keyType, value<uint16_t, Reader&>(input, false), input, size);
 
-        case bond::BT_UINT32:
+        case bond::BondDataType::BT_UINT32:
             return MapByKey(var, keyType, value<uint32_t, Reader&>(input, false), input, size);
 
-        case bond::BT_UINT64:
+        case bond::BondDataType::BT_UINT64:
             return MapByKey(var, keyType, value<uint64_t, Reader&>(input, false), input, size);
 
         default:
@@ -775,16 +775,16 @@ inline MatchingMapByElement(T& var, BondDataType keyType, BondDataType elementTy
 {
     switch (elementType)
     {
-        case bond::BT_INT8:
+        case bond::BondDataType::BT_INT8:
             return MapByKey(var, keyType, value<int8_t, Reader&>(input, false), input, size);
 
-        case bond::BT_INT16:
+        case bond::BondDataType::BT_INT16:
             return MapByKey(var, keyType, value<int16_t, Reader&>(input, false), input, size);
 
-        case bond::BT_INT32:
+        case bond::BondDataType::BT_INT32:
             return MapByKey(var, keyType, value<int32_t, Reader&>(input, false), input, size);
 
-        case bond::BT_INT64:
+        case bond::BondDataType::BT_INT64:
             return MapByKey(var, keyType, value<int64_t, Reader&>(input, false), input, size);
 
         default:

--- a/cpp/inc/bond/core/detail/validate.h
+++ b/cpp/inc/bond/core/detail/validate.h
@@ -13,36 +13,36 @@ inline bool ValidateType(BondDataType src, BondDataType dst)
 {
     switch (src)
     {
-        case BT_UINT8:
-        case BT_UINT16:
-        case BT_UINT32:
+        case BondDataType::BT_UINT8:
+        case BondDataType::BT_UINT16:
+        case BondDataType::BT_UINT32:
             switch (dst)
             {
-                case BT_UINT16:
-                case BT_UINT32:
-                case BT_UINT64:
+                case BondDataType::BT_UINT16:
+                case BondDataType::BT_UINT32:
+                case BondDataType::BT_UINT64:
                     return src <= dst;
                 default:
                     break;  
             }
             break;
 
-        case BT_INT8:
-        case BT_INT16:
-        case BT_INT32:
+        case BondDataType::BT_INT8:
+        case BondDataType::BT_INT16:
+        case BondDataType::BT_INT32:
             switch (dst)
             {
-                case BT_INT16:
-                case BT_INT32:
-                case BT_INT64:
+                case BondDataType::BT_INT16:
+                case BondDataType::BT_INT32:
+                case BondDataType::BT_INT64:
                     return src <= dst;
                 default:
                     break;  
             }
             break;
 
-        case BT_FLOAT:
-            return (dst == BT_DOUBLE);
+        case BondDataType::BT_FLOAT:
+            return (dst == BondDataType::BT_DOUBLE);
 
 	default:
             break;
@@ -79,7 +79,7 @@ inline bool ValidateType(const RuntimeSchema& src,
         identical = false;
     }
     
-    if (dst.GetTypeId() == BT_STRUCT && !dst.GetType().bonded_type)
+    if (dst.GetTypeId() == BondDataType::BT_STRUCT && !dst.GetType().bonded_type)
     {        
         ValidateStruct(src, dst, list, identical);
         return true;
@@ -139,7 +139,7 @@ inline void ValidateFields(const RuntimeSchema& src,
 
         if (!f_src || f_src->id > f_dst->id)
         {
-            if (f_dst->metadata.modifier == Required)
+            if (f_dst->metadata.modifier == Modifier::Required)
             {
                 RequiredFieldMissingException(s_dst, *f_dst);
             }
@@ -148,8 +148,8 @@ inline void ValidateFields(const RuntimeSchema& src,
             continue;
         }
 
-        if (f_dst->metadata.modifier == Required &&
-            f_src->metadata.modifier == Optional)
+        if (f_dst->metadata.modifier == Modifier::Required &&
+            f_src->metadata.modifier == Modifier::Optional)
         {
             OptionalToRequiredException(s_src, s_dst, *f_src, *f_dst);
         }

--- a/cpp/inc/bond/core/parser.h
+++ b/cpp/inc/bond/core/parser.h
@@ -197,11 +197,11 @@ private:
                 continue;
             }
 
-            if (field.type.id == bond::BT_STRUCT)
+            if (field.type.id == bond::BondDataType::BT_STRUCT)
             {
                 done = transform.Field(field.id, field.metadata, bonded<void, Input>(_input, RuntimeSchema(schema, field)));
             }
-            else if (field.type.id == bond::BT_LIST || field.type.id == bond::BT_SET || field.type.id == bond::BT_MAP)
+            else if (field.type.id == bond::BondDataType::BT_LIST || field.type.id == bond::BondDataType::BT_SET || field.type.id == bond::BondDataType::BT_MAP)
             {
                 done = transform.Field(field.id, field.metadata, value<void, Input>(_input, RuntimeSchema(schema, field)));
             }
@@ -281,9 +281,9 @@ private:
             //
             // In both cases we emit remaining fields as unknown
             
-            for (; type != bond::BT_STOP; _input.ReadFieldEnd(), _input.ReadFieldBegin(type, id))
+            for (; type != bond::BondDataType::BT_STOP; _input.ReadFieldEnd(), _input.ReadFieldBegin(type, id))
             {
-                if (type == bond::BT_STOP_BASE)
+                if (type == bond::BondDataType::BT_STOP_BASE)
                     transform.UnknownEnd();
                 else
                     UnknownField(id, type, transform);
@@ -310,7 +310,7 @@ private:
                 // Exact match
                 NextField(Head(), transform);
             }
-            else if (Head::id >= id && type != bond::BT_STOP && type != bond::BT_STOP_BASE)
+            else if (Head::id >= id && type != bond::BondDataType::BT_STOP && type != bond::BondDataType::BT_STOP_BASE)
             {
                 // Unknown field or non-exact type match
                 UnknownFieldOrTypeMismatch(Head(), id, type, transform);
@@ -324,7 +324,7 @@ private:
             _input.ReadFieldEnd();
             _input.ReadFieldBegin(type, id);
 
-            if (Head::id < id || type == bond::BT_STOP || type == bond::BT_STOP_BASE)
+            if (Head::id < id || type == bond::BondDataType::BT_STOP || type == bond::BondDataType::BT_STOP_BASE)
             {
                 NextSchemaField: return ReadFields(typename boost::mpl::next<Fields>::type(), id, type, transform);
             }
@@ -336,7 +336,7 @@ private:
     void
     ReadFields(const boost::mpl::l_iter<boost::mpl::l_end>&, uint16_t& id, BondDataType& type, const Transform& transform)
     {
-        for (; type != bond::BT_STOP && type != bond::BT_STOP_BASE;
+        for (; type != bond::BondDataType::BT_STOP && type != bond::BondDataType::BT_STOP_BASE;
                _input.ReadFieldEnd(), _input.ReadFieldBegin(type, id))
         {
             UnknownField(id, type, transform);
@@ -389,10 +389,10 @@ private:
     UnknownFieldOrTypeMismatch(const T&, uint16_t id, BondDataType type, const Transform& transform)
     {
         if (id == T::id &&
-            type != bond::BT_LIST &&
-            type != bond::BT_SET &&
-            type != bond::BT_MAP &&
-            type != bond::BT_STRUCT)
+            type != bond::BondDataType::BT_LIST &&
+            type != bond::BondDataType::BT_SET &&
+            type != bond::BondDataType::BT_MAP &&
+            type != bond::BondDataType::BT_STRUCT)
         {
             return detail::BasicTypeField(T::id, T::metadata, type, transform, _input);
         }
@@ -426,13 +426,13 @@ private:
 
         for (;; _input.ReadFieldEnd(), _input.ReadFieldBegin(type, id))
         {
-            while (it != end && (it->id < id || type == bond::BT_STOP || type == bond::BT_STOP_BASE))
+            while (it != end && (it->id < id || type == bond::BondDataType::BT_STOP || type == bond::BondDataType::BT_STOP_BASE))
             {
                 const FieldDef& field = *it++;
                 transform.OmittedField(field.id, field.metadata, field.type.id);
             }
 
-            if (type == bond::BT_STOP || type == bond::BT_STOP_BASE)
+            if (type == bond::BondDataType::BT_STOP || type == bond::BondDataType::BT_STOP_BASE)
             {
                 break;
             }
@@ -441,7 +441,7 @@ private:
             {
                 const FieldDef& field = *it++;
 
-                if (type == bond::BT_STRUCT)
+                if (type == bond::BondDataType::BT_STRUCT)
                 {
                     if (field.type.id == type)
                     {
@@ -449,7 +449,7 @@ private:
                         continue;
                     }
                 }
-                else if (type == bond::BT_LIST || type == bond::BT_SET || type == bond::BT_MAP)
+                else if (type == bond::BondDataType::BT_LIST || type == bond::BondDataType::BT_SET || type == bond::BondDataType::BT_MAP)
                 {
                     if (field.type.id == type)
                     {
@@ -481,9 +481,9 @@ private:
             //
             // In both cases we emit remaining fields as unknown
             
-            for (; type != bond::BT_STOP; _input.ReadFieldEnd(), _input.ReadFieldBegin(type, id))
+            for (; type != bond::BondDataType::BT_STOP; _input.ReadFieldEnd(), _input.ReadFieldBegin(type, id))
             {
-                if (type == bond::BT_STOP_BASE)
+                if (type == bond::BondDataType::BT_STOP_BASE)
                 {
                     transform.UnknownEnd();
                 }
@@ -511,11 +511,11 @@ private:
     template <typename Transform>
     bool UnknownField(uint16_t id, BondDataType type, const Transform& transform)
     {
-        if (type == bond::BT_STRUCT)
+        if (type == bond::BondDataType::BT_STRUCT)
         {
             return transform.UnknownField(id, bonded<void, Input>(_input, GetRuntimeSchema<Unknown>()));
         }
-        else if (type == bond::BT_LIST || type == bond::BT_SET || type == bond::BT_MAP)
+        else if (type == bond::BondDataType::BT_LIST || type == bond::BondDataType::BT_SET || type == bond::BondDataType::BT_MAP)
             return transform.UnknownField(id, value<void, Input>(_input, type));
         else
             return detail::BasicTypeField(id, schema<Unknown>::type::metadata, type, BindUnknownField(transform), _input);
@@ -635,9 +635,9 @@ private:
             {
                 Reader input(_input, *field);
 
-                if (fieldDef.type.id == BT_STRUCT)
+                if (fieldDef.type.id == BondDataType::BT_STRUCT)
                     done = transform.Field(fieldDef.id, fieldDef.metadata, bonded<void, Input>(input, RuntimeSchema(schema, fieldDef)));
-                else if (fieldDef.type.id == BT_LIST || fieldDef.type.id == BT_SET || fieldDef.type.id == BT_MAP)
+                else if (fieldDef.type.id == BondDataType::BT_LIST || fieldDef.type.id == BondDataType::BT_SET || fieldDef.type.id == BondDataType::BT_MAP)
                     done = transform.Field(fieldDef.id, fieldDef.metadata, value<void, Input>(input, RuntimeSchema(schema, fieldDef)));
                 else
                     done = detail::BasicTypeField(fieldDef.id, fieldDef.metadata, fieldDef.type.id, transform, input);

--- a/cpp/inc/bond/core/reflection.h
+++ b/cpp/inc/bond/core/reflection.h
@@ -51,19 +51,19 @@ typedef std::map<std::string, std::string> Attributes;
 // field is required
 struct required_field_modifier
 {
-    static const bond::Modifier value = bond::Required;
+    static const bond::Modifier value = bond::Modifier::Required;
 };
 
 // field is optional
 struct optional_field_modifier 
 {
-    static const bond::Modifier value = bond::Optional;
+    static const bond::Modifier value = bond::Modifier::Optional;
 };
 
 // field is required optional
 struct required_optional_field_modifier
 {
-    static const bond::Modifier value = bond::RequiredOptional;
+    static const bond::Modifier value = bond::Modifier::RequiredOptional;
 };
 
 
@@ -713,51 +713,51 @@ get_type_id<std::pair<T1, T2> >::value = std::make_pair(
 
 template <> struct 
 get_type_id<bool>
-    : boost::integral_constant<BondDataType, BT_BOOL> {};
+    : boost::integral_constant<BondDataType, BondDataType::BT_BOOL> {};
 
 template <> struct 
 get_type_id<uint8_t>
-    : boost::integral_constant<BondDataType, BT_UINT8> {};
+    : boost::integral_constant<BondDataType, BondDataType::BT_UINT8> {};
 
 template <> struct 
 get_type_id<uint16_t>
-    : boost::integral_constant<BondDataType, BT_UINT16> {};
+    : boost::integral_constant<BondDataType, BondDataType::BT_UINT16> {};
 
 template <> struct 
 get_type_id<uint32_t>
-    : boost::integral_constant<BondDataType, BT_UINT32> {};
+    : boost::integral_constant<BondDataType, BondDataType::BT_UINT32> {};
 
 template <> struct 
 get_type_id<uint64_t>
-    : boost::integral_constant<BondDataType, BT_UINT64> {};
+    : boost::integral_constant<BondDataType, BondDataType::BT_UINT64> {};
 
 template <> struct 
 get_type_id<int8_t>
-    : boost::integral_constant<BondDataType, BT_INT8> {};
+    : boost::integral_constant<BondDataType, BondDataType::BT_INT8> {};
 
 template <> struct 
 get_type_id<int16_t>
-    : boost::integral_constant<BondDataType, BT_INT16> {};
+    : boost::integral_constant<BondDataType, BondDataType::BT_INT16> {};
 
 template <> struct 
 get_type_id<int32_t>
-    : boost::integral_constant<BondDataType, BT_INT32> {};
+    : boost::integral_constant<BondDataType, BondDataType::BT_INT32> {};
 
 template <> struct 
 get_type_id<int64_t>
-    : boost::integral_constant<BondDataType, BT_INT64> {};
+    : boost::integral_constant<BondDataType, BondDataType::BT_INT64> {};
 
 template <> struct 
 get_type_id<float>
-    : boost::integral_constant<BondDataType, BT_FLOAT> {};
+    : boost::integral_constant<BondDataType, BondDataType::BT_FLOAT> {};
 
 template <> struct 
 get_type_id<double>
-    : boost::integral_constant<BondDataType, BT_DOUBLE> {};
+    : boost::integral_constant<BondDataType, BondDataType::BT_DOUBLE> {};
 
 template <> struct
 get_type_id<void>
-    : boost::integral_constant<BondDataType, BT_UNAVAILABLE> {};
+    : boost::integral_constant<BondDataType, BondDataType::BT_UNAVAILABLE> {};
 
 template <typename T> struct 
 get_type_id
@@ -766,12 +766,12 @@ get_type_id
 
     static const BondDataType value = 
         is_enum<T>::value           ? get_type_id<int32_t>::value :
-        is_bond_type<T>::value      ? BT_STRUCT :
-        is_set_container<U>::value  ? BT_SET :
-        is_map_container<U>::value  ? BT_MAP :
-        is_list_container<U>::value ? BT_LIST :
-        is_string<U>::value         ? BT_STRING :
-        is_wstring<U>::value        ? BT_WSTRING :
+        is_bond_type<T>::value      ? BondDataType::BT_STRUCT :
+        is_set_container<U>::value  ? BondDataType::BT_SET :
+        is_map_container<U>::value  ? BondDataType::BT_MAP :
+        is_list_container<U>::value ? BondDataType::BT_LIST :
+        is_string<U>::value         ? BondDataType::BT_STRING :
+        is_wstring<U>::value        ? BondDataType::BT_WSTRING :
                                       get_type_id<typename aliased_type<T>::type>::value;
 };
 

--- a/cpp/inc/bond/core/schema.h
+++ b/cpp/inc/bond/core/schema.h
@@ -55,7 +55,7 @@ inline RuntimeSchema RuntimeSchema::GetBaseSchema() const
     
 inline const StructDef& RuntimeSchema::GetStruct() const
 {
-    BOOST_ASSERT(type->id == BT_STRUCT);
+    BOOST_ASSERT(type->id == BondDataType::BT_STRUCT);
     return schema->structs[type->struct_def];
 }
 
@@ -134,7 +134,7 @@ namespace detail
         {
             // SchemaDef for unknown types: struct with no fields
             SchemaDef schema;
-            schema.root.id = BT_STRUCT;
+            schema.root.id = BondDataType::BT_STRUCT;
             schema.structs.resize(1);
             return schema;
         }

--- a/cpp/inc/bond/core/select_protocol.h
+++ b/cpp/inc/bond/core/select_protocol.h
@@ -32,7 +32,7 @@ inline std::pair<ProtocolType, bool> NextProtocol(
     const Transform&)
 {
     UnknownProtocolException();
-    return std::make_pair(MARSHALED_PROTOCOL, false);
+    return std::make_pair(ProtocolType::MARSHALED_PROTOCOL, false);
 }
 
 
@@ -68,7 +68,7 @@ inline std::pair<ProtocolType, bool> NextProtocol(
     const Transform&)
 {
     UnknownProtocolException(); 
-    return std::make_pair(MARSHALED_PROTOCOL, false);
+    return std::make_pair(ProtocolType::MARSHALED_PROTOCOL, false);
 }
 
 

--- a/cpp/inc/bond/core/value.h
+++ b/cpp/inc/bond/core/value.h
@@ -77,18 +77,18 @@ inline Skip(Reader& input, const RuntimeSchema& schema)
 {
     switch (schema.GetTypeId())
     {
-        case bond::BT_SET:
-        case bond::BT_LIST:
+        case bond::BondDataType::BT_SET:
+        case bond::BondDataType::BT_LIST:
         {
             return SkipContainer(
                 value<void, Reader&>(input, element_schema(schema), false), input);
         }
-        case bond::BT_MAP:
+        case bond::BondDataType::BT_MAP:
         {
             return SkipMap(key_schema(schema).GetTypeId(), 
                 value<void, Reader&>(input, element_schema(schema), false), input);
         }
-        case bond::BT_STRUCT:
+        case bond::BondDataType::BT_STRUCT:
         {
             return bonded<void, Reader&>(input, schema).Skip();
         }
@@ -539,18 +539,18 @@ public:
     {
         _skip = false;
 
-        if (_schema.GetTypeId() == bond::BT_STRUCT)
+        if (_schema.GetTypeId() == bond::BondDataType::BT_STRUCT)
         {
             Apply(transform, bonded<void, Reader>(_input, _schema));
         }
-        else if(_schema.GetTypeId() == bond::BT_MAP)
+        else if(_schema.GetTypeId() == bond::BondDataType::BT_MAP)
         {
             DeserializeMap(transform, key_schema(_schema).GetTypeId(),
                 value<void, Reader>(_input, element_schema(_schema), false), _input);
         }
         else
         {
-            BOOST_ASSERT(_schema.GetTypeId() == bond::BT_LIST || _schema.GetTypeId() == bond::BT_SET);
+            BOOST_ASSERT(_schema.GetTypeId() == bond::BondDataType::BT_LIST || _schema.GetTypeId() == bond::BondDataType::BT_SET);
 
             DeserializeContainer(transform, 
                 value<void, Reader>(_input, element_schema(_schema), false), _input);
@@ -732,10 +732,10 @@ inline DeserializeContainer(X& var, const T& element, Reader& input)
 
     switch (type)
     {
-        case bond::BT_SET:
-        case bond::BT_MAP:
-        case bond::BT_LIST:
-        case bond::BT_STRUCT:
+        case bond::BondDataType::BT_SET:
+        case bond::BondDataType::BT_MAP:
+        case bond::BondDataType::BT_LIST:
+        case bond::BondDataType::BT_STRUCT:
         {
             if (type == GetTypeId(element))
             {
@@ -792,10 +792,10 @@ inline DeserializeContainer(X& var, const T& element, Reader& input)
 
     switch (type)
     {
-        case bond::BT_SET:
-        case bond::BT_MAP:
-        case bond::BT_LIST:
-        case bond::BT_STRUCT:
+        case bond::BondDataType::BT_SET:
+        case bond::BondDataType::BT_MAP:
+        case bond::BondDataType::BT_LIST:
+        case bond::BondDataType::BT_STRUCT:
         {
             if (type == GetTypeId(element))
             {
@@ -899,10 +899,10 @@ inline DeserializeMap(X& var, BondDataType keyType, const T& element, Reader& in
 
     switch (type.second)
     {
-        case bond::BT_SET:
-        case bond::BT_MAP:
-        case bond::BT_LIST:
-        case bond::BT_STRUCT:
+        case bond::BondDataType::BT_SET:
+        case bond::BondDataType::BT_MAP:
+        case bond::BondDataType::BT_LIST:
+        case bond::BondDataType::BT_STRUCT:
         {
             if (type.second == GetTypeId(element))
             {
@@ -962,10 +962,10 @@ inline DeserializeMap(X& var, BondDataType keyType, const T& element, Reader& in
 
     switch (type.second)
     {
-        case bond::BT_SET:
-        case bond::BT_MAP:
-        case bond::BT_LIST:
-        case bond::BT_STRUCT:
+        case bond::BondDataType::BT_SET:
+        case bond::BondDataType::BT_MAP:
+        case bond::BondDataType::BT_LIST:
+        case bond::BondDataType::BT_STRUCT:
         {
             if (type.second == GetTypeId(element))
             {

--- a/cpp/inc/bond/protocol/compact_binary.h
+++ b/cpp/inc/bond/protocol/compact_binary.h
@@ -363,33 +363,33 @@ public:
     template <typename T>
     void Skip(const bonded<T, CompactBinaryReader&>&)
     {
-        SkipComplex(bond::BT_STRUCT);
+        SkipComplex(bond::BondDataType::BT_STRUCT);
     }
 
     void Skip(BondDataType type)
     {
         switch (type)
         {
-            case bond::BT_FLOAT:
+            case bond::BondDataType::BT_FLOAT:
                 _input.Skip(sizeof(float));
                 break;
 
-            case bond::BT_DOUBLE:
+            case bond::BondDataType::BT_DOUBLE:
                 _input.Skip(sizeof(double));
                 break;
 
-            case bond::BT_BOOL:
-            case bond::BT_UINT8:
-            case bond::BT_INT8:
+            case bond::BondDataType::BT_BOOL:
+            case bond::BondDataType::BT_UINT8:
+            case bond::BondDataType::BT_INT8:
                 _input.Skip(sizeof(uint8_t));
                 break;
 
-            case bond::BT_UINT64:
-            case bond::BT_UINT32:
-            case bond::BT_UINT16:
-            case bond::BT_INT64:
-            case bond::BT_INT32:
-            case bond::BT_INT16:
+            case bond::BondDataType::BT_UINT64:
+            case bond::BondDataType::BT_UINT32:
+            case bond::BondDataType::BT_UINT16:
+            case bond::BondDataType::BT_INT64:
+            case bond::BondDataType::BT_INT32:
+            case bond::BondDataType::BT_INT16:
             {
                 uint64_t value;
                 Read(value);
@@ -406,7 +406,7 @@ protected:
     {
         switch (type)
         {
-            case bond::BT_STRING:
+            case bond::BondDataType::BT_STRING:
             {
                 uint32_t length;
 
@@ -414,7 +414,7 @@ protected:
                 _input.Skip(length);
                 break;
             }
-            case bond::BT_WSTRING:
+            case bond::BondDataType::BT_WSTRING:
             {
                 uint32_t length;
 
@@ -422,8 +422,8 @@ protected:
                 _input.Skip(length * sizeof(uint16_t));
                 break;
             }
-            case bond::BT_SET:
-            case bond::BT_LIST:
+            case bond::BondDataType::BT_SET:
+            case bond::BondDataType::BT_LIST:
             {
                 BondDataType element_type;
                 uint32_t     size;
@@ -436,7 +436,7 @@ protected:
                 ReadContainerEnd();
                 break;
             }
-            case bond::BT_MAP:
+            case bond::BondDataType::BT_MAP:
             {
                 std::pair<BondDataType, BondDataType>   element_type;
                 uint32_t                                size;
@@ -450,7 +450,7 @@ protected:
                 ReadContainerEnd();
                 break;
             }
-            case bond::BT_STRUCT:
+            case bond::BondDataType::BT_STRUCT:
             {
                 if (v2 == _version)
                 {
@@ -466,7 +466,7 @@ protected:
                     BondDataType field_type;
 
                     for (ReadFieldBegin(field_type, id);
-                         field_type != bond::BT_STOP && field_type != bond::BT_STOP_BASE;
+                         field_type != bond::BondDataType::BT_STOP && field_type != bond::BondDataType::BT_STOP_BASE;
                          ReadFieldEnd(), ReadFieldBegin(field_type, id))
                     {
                         Skip(field_type);
@@ -474,7 +474,7 @@ protected:
 
                     ReadStructEnd();
 
-                    if (field_type == bond::BT_STOP)
+                    if (field_type == bond::BondDataType::BT_STOP)
                         break;
                 }
 
@@ -495,7 +495,7 @@ protected:
 };
 
 template <typename Buffer>
-const uint16_t CompactBinaryReader<Buffer>::magic = COMPACT_PROTOCOL;
+const uint16_t CompactBinaryReader<Buffer>::magic = ProtocolType::COMPACT_PROTOCOL;
 
 
 class OutputCounter;
@@ -577,11 +577,11 @@ public:
     {
         if (base)
         {
-            _output.Write(static_cast<uint8_t>(BT_STOP_BASE));
+            _output.Write(static_cast<uint8_t>(BondDataType::BT_STOP_BASE));
         }
         else
         {
-            _output.Write(static_cast<uint8_t>(BT_STOP));
+            _output.Write(static_cast<uint8_t>(BondDataType::BT_STOP));
             LengthEnd(_output);
         }
     }

--- a/cpp/inc/bond/protocol/compact_binary.h
+++ b/cpp/inc/bond/protocol/compact_binary.h
@@ -6,6 +6,7 @@
 #include "encoding.h"
 #include "detail/simple_array.h"
 #include <bond/core/bond_version.h>
+#include <bond/core/bond_const_enum.h>
 #include <bond/core/traits.h>
 #include <bond/stream/output_counter.h>
 #include <boost/call_traits.hpp>

--- a/cpp/inc/bond/protocol/detail/rapidjson_helper.h
+++ b/cpp/inc/bond/protocol/detail/rapidjson_helper.h
@@ -136,16 +136,16 @@ class JsonTypeMatching : boost::noncopyable
 {
 public:
     JsonTypeMatching(BondDataType type, BondDataType schema, bool is_enum)
-        : matchesObject(type == BT_STRUCT && type == schema),
-          matchesArray((type == BT_MAP || type == BT_LIST || type == BT_SET) && type == schema),
-          matchesNull(type == BT_LIST && type == schema),
-          matchesInt(type >= BT_INT8 && type <= BT_INT64),
-          matchesInt64(type == BT_INT64),
-          matchesUint(type >= BT_UINT8 && type <= BT_UINT64),
-          matchesUint64(type == BT_UINT64),
-          matchesNumber(type >= BT_FLOAT && type <= BT_DOUBLE),
-          matchesString(type == BT_STRING || type == BT_WSTRING || is_enum),
-          matchesBool(type == BT_BOOL)
+        : matchesObject(type == BondDataType::BT_STRUCT && type == schema),
+          matchesArray((type == BondDataType::BT_MAP || type == BondDataType::BT_LIST || type == BondDataType::BT_SET) && type == schema),
+          matchesNull(type == BondDataType::BT_LIST && type == schema),
+          matchesInt(type >= BondDataType::BT_INT8 && type <= BondDataType::BT_INT64),
+          matchesInt64(type == BondDataType::BT_INT64),
+          matchesUint(type >= BondDataType::BT_UINT8 && type <= BondDataType::BT_UINT64),
+          matchesUint64(type == BondDataType::BT_UINT64),
+          matchesNumber(type >= BondDataType::BT_FLOAT && type <= BondDataType::BT_DOUBLE),
+          matchesString(type == BondDataType::BT_STRING || type == BondDataType::BT_WSTRING || is_enum),
+          matchesBool(type == BondDataType::BT_BOOL)
     {}
 
 

--- a/cpp/inc/bond/protocol/fast_binary.h
+++ b/cpp/inc/bond/protocol/fast_binary.h
@@ -185,7 +185,7 @@ public:
     {
         ReadType(type);
 
-        if (type != BT_STOP && type != BT_STOP_BASE)
+        if (type != BondDataType::BT_STOP && type != BondDataType::BT_STOP_BASE)
             Read(id);
         else
             id = 0;
@@ -226,7 +226,7 @@ public:
     template <typename T>
     void Skip(const bonded<T, FastBinaryReader&>&)
     {
-        SkipComplex(BT_STRUCT);
+        SkipComplex(BondDataType::BT_STRUCT);
     }
 
 
@@ -234,32 +234,32 @@ public:
     {
         switch (type)
         {
-            case BT_BOOL:
-            case BT_UINT8:
-            case BT_INT8:
+            case BondDataType::BT_BOOL:
+            case BondDataType::BT_UINT8:
+            case BondDataType::BT_INT8:
                 _input.Skip(sizeof(uint8_t));
                 break;
 
-            case BT_UINT16:
-            case BT_INT16:
+            case BondDataType::BT_UINT16:
+            case BondDataType::BT_INT16:
                 _input.Skip(sizeof(uint16_t));
                 break;
 
-            case BT_UINT32:
-            case BT_INT32:
+            case BondDataType::BT_UINT32:
+            case BondDataType::BT_INT32:
                 _input.Skip(sizeof(uint32_t));
                 break;
 
-            case BT_UINT64:
-            case BT_INT64:
+            case BondDataType::BT_UINT64:
+            case BondDataType::BT_INT64:
                 _input.Skip(sizeof(uint64_t));
                 break;
 
-            case BT_FLOAT:
+            case BondDataType::BT_FLOAT:
                 _input.Skip(sizeof(float));
                 break;
 
-            case BT_DOUBLE:
+            case BondDataType::BT_DOUBLE:
                 _input.Skip(sizeof(double));
                 break;
 
@@ -282,7 +282,7 @@ protected:
     {
         switch (type)
         {
-            case BT_STRING:
+            case BondDataType::BT_STRING:
             {
                 uint32_t size = 0;
 
@@ -290,7 +290,7 @@ protected:
                 _input.Skip(size);
                 break;
             }
-            case BT_WSTRING:
+            case BondDataType::BT_WSTRING:
             {
                 uint32_t size = 0;
 
@@ -298,7 +298,7 @@ protected:
                 _input.Skip(size * sizeof(uint16_t));
                 break;
             }
-            case BT_STRUCT:
+            case BondDataType::BT_STRUCT:
             {
                 for(;;)
                 {
@@ -308,7 +308,7 @@ protected:
                     BondDataType field_type;
 
                     for (ReadFieldBegin(field_type, id);
-                            field_type != BT_STOP && field_type != BT_STOP_BASE;
+                            field_type != BondDataType::BT_STOP && field_type != BondDataType::BT_STOP_BASE;
                             ReadFieldEnd(), ReadFieldBegin(field_type, id))
                     {
                         Skip(field_type);
@@ -316,14 +316,14 @@ protected:
 
                     ReadStructEnd();
 
-                    if (field_type == BT_STOP)
+                    if (field_type == BondDataType::BT_STOP)
                         break;
                 }
 
                 break;
             }
-            case BT_SET:
-            case BT_LIST:
+            case BondDataType::BT_SET:
+            case BondDataType::BT_LIST:
             {
                 BondDataType element_type;
                 uint32_t size;
@@ -338,7 +338,7 @@ protected:
                 ReadContainerEnd();
                 break;
             }
-            case BT_MAP:
+            case BondDataType::BT_MAP:
             {
                 std::pair<BondDataType, BondDataType> element_type;
                 uint32_t size;
@@ -363,7 +363,7 @@ protected:
 };
 
 template <typename Buffer>
-const uint16_t FastBinaryReader<Buffer>::magic = FAST_PROTOCOL;
+const uint16_t FastBinaryReader<Buffer>::magic = ProtocolType::FAST_PROTOCOL;
 
 template <typename Buffer>
 const uint16_t FastBinaryReader<Buffer>::version = v1;
@@ -398,7 +398,7 @@ public:
 
     void WriteStructEnd(bool base = false)
     {
-        WriteType(base ? BT_STOP_BASE : BT_STOP);
+        WriteType(base ? BondDataType::BT_STOP_BASE : BondDataType::BT_STOP);
     }
 
     template <typename T>

--- a/cpp/inc/bond/protocol/simple_binary.h
+++ b/cpp/inc/bond/protocol/simple_binary.h
@@ -134,40 +134,40 @@ public:
     {
         switch (type)
         {
-            case BT_BOOL:
-            case BT_UINT8:
-            case BT_INT8:
+            case BondDataType::BT_BOOL:
+            case BondDataType::BT_UINT8:
+            case BondDataType::BT_INT8:
                 _input.Skip(sizeof(uint8_t));
                 break;
 
-            case BT_UINT16:
-            case BT_INT16:
+            case BondDataType::BT_UINT16:
+            case BondDataType::BT_INT16:
                 _input.Skip(sizeof(uint16_t));
                 break;
 
-            case BT_UINT32:
-            case BT_INT32:
+            case BondDataType::BT_UINT32:
+            case BondDataType::BT_INT32:
                 _input.Skip(sizeof(uint32_t));
                 break;
 
-            case BT_UINT64:
-            case BT_INT64:
+            case BondDataType::BT_UINT64:
+            case BondDataType::BT_INT64:
                 _input.Skip(sizeof(uint64_t));
                 break;
 
-            case BT_FLOAT:
+            case BondDataType::BT_FLOAT:
                 _input.Skip(sizeof(float));
                 break;
 
-            case BT_DOUBLE:
+            case BondDataType::BT_DOUBLE:
                 _input.Skip(sizeof(double));
                 break;
 
-            case BT_STRING:
+            case BondDataType::BT_STRING:
                 Skip<std::string>();
                 break;
 
-            case BT_WSTRING:
+            case BondDataType::BT_WSTRING:
                 Skip<std::wstring>();
                 break;
 
@@ -207,7 +207,7 @@ protected:
 
 
 template <typename Buffer>
-const uint16_t SimpleBinaryReader<Buffer>::magic = SIMPLE_PROTOCOL;
+const uint16_t SimpleBinaryReader<Buffer>::magic = ProtocolType::SIMPLE_PROTOCOL;
 
 
 /// @brief Writer for Simple Binary protocol

--- a/cpp/inc/bond/protocol/simple_binary.h
+++ b/cpp/inc/bond/protocol/simple_binary.h
@@ -6,6 +6,7 @@
 #include "encoding.h"
 #include <bond/core/traits.h>
 #include <bond/core/bond_version.h>
+#include <bond/core/bond_const_enum.h>
 #include <boost/call_traits.hpp>
 #include <boost/noncopyable.hpp>
 

--- a/cpp/inc/bond/protocol/simple_binary_impl.h
+++ b/cpp/inc/bond/protocol/simple_binary_impl.h
@@ -23,51 +23,51 @@ inline void SimpleBinaryWriter<BufferT>::WriteFieldOmitted(BondDataType type, ui
 
     switch (type)
     {
-        case BT_BOOL:
+        case BondDataType::BT_BOOL:
             Write(!!metadata.default_value.uint_value);
             break;
-        case BT_UINT8:
+        case BondDataType::BT_UINT8:
             Write(static_cast<uint8_t>(metadata.default_value.uint_value));
             break;
-        case BT_UINT16:
+        case BondDataType::BT_UINT16:
             Write(static_cast<uint16_t>(metadata.default_value.uint_value));
             break;
-        case BT_UINT32:
+        case BondDataType::BT_UINT32:
             Write(static_cast<uint32_t>(metadata.default_value.uint_value));
             break;
-        case BT_UINT64:
+        case BondDataType::BT_UINT64:
             Write(static_cast<uint64_t>(metadata.default_value.uint_value));
             break;
-        case BT_FLOAT:
+        case BondDataType::BT_FLOAT:
             Write(static_cast<float>(metadata.default_value.double_value));
             break;
-        case BT_DOUBLE:
+        case BondDataType::BT_DOUBLE:
             Write(metadata.default_value.double_value);
             break;
-        case BT_STRING:
+        case BondDataType::BT_STRING:
             Write(metadata.default_value.string_value);
             break;
-        case BT_STRUCT:
+        case BondDataType::BT_STRUCT:
             BOOST_ASSERT(false);
             break;
-        case BT_LIST:
-        case BT_SET:
-        case BT_MAP:
+        case BondDataType::BT_LIST:
+        case BondDataType::BT_SET:
+        case BondDataType::BT_MAP:
             WriteContainerBegin(0, type);
             break;
-        case BT_INT8:
+        case BondDataType::BT_INT8:
             Write(static_cast<int8_t>(metadata.default_value.int_value));
             break;
-        case BT_INT16:
+        case BondDataType::BT_INT16:
             Write(static_cast<int16_t>(metadata.default_value.int_value));
             break;
-        case BT_INT32:
+        case BondDataType::BT_INT32:
             Write(static_cast<int32_t>(metadata.default_value.int_value));
             break;
-        case BT_INT64:
+        case BondDataType::BT_INT64:
             Write(static_cast<int64_t>(metadata.default_value.int_value));
             break;
-        case BT_WSTRING:
+        case BondDataType::BT_WSTRING:
             Write(metadata.default_value.wstring_value);
             break;
         default:

--- a/cpp/inc/bond/protocol/simple_json_reader.h
+++ b/cpp/inc/bond/protocol/simple_json_reader.h
@@ -72,7 +72,7 @@ public:
         // matches JSON payload. If it doesn't, nothing horrible will happen, but
         // we might not indicate a required field missing for an int32 field if we 
         // mistake a string member with matching name for it.
-        return FindField(id, metadata, type, type == BT_INT32);
+        return FindField(id, metadata, type, type == BondDataType::BT_INT32);
     }
 
     const Field* FindField(uint16_t id, const Metadata& metadata, BondDataType type, bool is_enum);
@@ -171,7 +171,7 @@ private:
 
 
 template <typename Buffer>
-const uint16_t SimpleJsonReader<Buffer>::magic = SIMPLE_JSON_PROTOCOL;
+const uint16_t SimpleJsonReader<Buffer>::magic = ProtocolType::SIMPLE_JSON_PROTOCOL;
 
 // Disable fast pass-through optimization for Simple JSON
 template <typename Input, typename Output> struct

--- a/cpp/inc/bond/protocol/simple_json_writer.h
+++ b/cpp/inc/bond/protocol/simple_json_writer.h
@@ -291,43 +291,43 @@ public:
         {
             switch (type)
             {
-                case BT_BOOL:
+                case BondDataType::BT_BOOL:
                     Field(id, metadata, !!metadata.default_value.uint_value);
                     break;
-                case BT_UINT8:
-                case BT_UINT16:
-                case BT_UINT32:
-                case BT_UINT64:
+                case BondDataType::BT_UINT8:
+                case BondDataType::BT_UINT16:
+                case BondDataType::BT_UINT32:
+                case BondDataType::BT_UINT64:
                     Field(id, metadata, metadata.default_value.uint_value);
                     break;
-                case BT_FLOAT:
-                case BT_DOUBLE:
+                case BondDataType::BT_FLOAT:
+                case BondDataType::BT_DOUBLE:
                     Field(id, metadata, metadata.default_value.double_value);
                     break;
-                case BT_STRING:
+                case BondDataType::BT_STRING:
                     Field(id, metadata, metadata.default_value.string_value);
                     break;
-                case BT_STRUCT:
+                case BondDataType::BT_STRUCT:
                     BOOST_ASSERT(false);
                     break;
-                case BT_LIST:
-                case BT_SET:
+                case BondDataType::BT_LIST:
+                case BondDataType::BT_SET:
                     WriteName(detail::FieldName(metadata));
                     _output.WriteOpen('[');
                     _output.WriteClose(']');
                     break;
-                case BT_MAP:
+                case BondDataType::BT_MAP:
                     WriteName(detail::FieldName(metadata));
                     _output.WriteOpen('{');
                     _output.WriteClose('}');
                     break;
-                case BT_INT8:
-                case BT_INT16:
-                case BT_INT32:
-                case BT_INT64:
+                case BondDataType::BT_INT8:
+                case BondDataType::BT_INT16:
+                case BondDataType::BT_INT32:
+                case BondDataType::BT_INT64:
                     Field(id, metadata, metadata.default_value.int_value);
                     break;
-                case BT_WSTRING:
+                case BondDataType::BT_WSTRING:
                     Field(id, metadata, metadata.default_value.wstring_value);
                     break;
                 default:

--- a/cpp/test/core/blob_tests.cpp
+++ b/cpp/test/core/blob_tests.cpp
@@ -48,7 +48,7 @@ TEST_CASE_BEGIN(OutputBufferBlobs)
         std::vector<bond::blob> buffers;
         stream.GetBuffers(buffers);
         
-        if (Reader::magic == bond::SIMPLE_JSON_PROTOCOL)
+        if (Reader::magic == bond::ProtocolType::SIMPLE_JSON_PROTOCOL)
             UT_AssertAreEqual(1, buffers.size());
         else
             UT_AssertAreEqual(blobs.blobs.size() * 2 + 1, buffers.size());

--- a/cpp/test/core/protocol_test.cpp
+++ b/cpp/test/core/protocol_test.cpp
@@ -129,11 +129,11 @@ template <typename Buffer>
 void WritePass0(Buffer& pass0, uint16_t val0, int64_t val1)
 {
     pass0.WriteStructBegin(bond::Metadata(), false);
-    pass0.WriteFieldBegin(bond::BT_UINT16, 0);
+    pass0.WriteFieldBegin(bond::BondDataType::BT_UINT16, 0);
     pass0.Write(val0);
     pass0.WriteFieldEnd();
 
-    pass0.WriteFieldBegin(bond::BT_INT64, 1);
+    pass0.WriteFieldBegin(bond::BondDataType::BT_INT64, 1);
     pass0.Write(val1);
     pass0.WriteFieldEnd();
     pass0.WriteStructEnd();
@@ -144,11 +144,11 @@ template <typename Reader, typename Writer, typename Buffer>
 void TestReadStruct(Writer& output, Buffer& output_buffer, uint16_t val0, int64_t val1)
 {
     output.WriteStructBegin(bond::Metadata(), false);
-    output.WriteFieldBegin(bond::BT_UINT16, 0);
+    output.WriteFieldBegin(bond::BondDataType::BT_UINT16, 0);
     output.Write(val0);
     output.WriteFieldEnd();
 
-    output.WriteFieldBegin(bond::BT_INT64, 1);
+    output.WriteFieldBegin(bond::BondDataType::BT_INT64, 1);
     output.Write(val1);
     output.WriteFieldEnd();
     output.WriteStructEnd();
@@ -165,7 +165,7 @@ void TestReadStruct(Writer& output, Buffer& output_buffer, uint16_t val0, int64_
     input.ReadFieldBegin(type, id);
     input.Read(value0);
     input.ReadFieldEnd();
-    UT_AssertAreEqual(type, bond::BT_UINT16);
+    UT_AssertAreEqual(type, bond::BondDataType::BT_UINT16);
     UT_AssertAreEqual(id, 0);
     UT_AssertAreEqual(val0, value0);
 
@@ -173,7 +173,7 @@ void TestReadStruct(Writer& output, Buffer& output_buffer, uint16_t val0, int64_
     input.Read(value1);
     input.ReadFieldEnd();
     input.ReadStructEnd();
-    UT_AssertAreEqual(type, bond::BT_INT64);
+    UT_AssertAreEqual(type, bond::BondDataType::BT_INT64);
     UT_AssertAreEqual(id, 1);
     UT_AssertAreEqual(val1, value1);
 
@@ -181,7 +181,7 @@ void TestReadStruct(Writer& output, Buffer& output_buffer, uint16_t val0, int64_
     typename Reader::Buffer input_buffer2(output_buffer.GetBuffer());
     Reader input2(input_buffer2, 2);   
 
-    input2.Skip(bond::BT_STRUCT);
+    input2.Skip(bond::BondDataType::BT_STRUCT);
     UT_AssertIsTrue(input2.GetBuffer().IsEof());
 }
 

--- a/examples/cpp/core/bf/main.cpp
+++ b/examples/cpp/core/bf/main.cpp
@@ -9,7 +9,7 @@ using namespace bf;
 
 inline bool IsValidType(bond::BondDataType type)
 {
-    return type >= bond::BT_BOOL && type <= bond::BT_WSTRING;
+    return type >= bond::BondDataType::BT_BOOL && type <= bond::BondDataType::BT_WSTRING;
 }
 
 template <typename Reader>
@@ -26,16 +26,16 @@ bool TryProtocol(Reader reader, int confidence = 5)
 
         for (int i = 0; i < confidence; ++i, reader.ReadFieldEnd(), reader.ReadFieldBegin(type, id))
         {
-            if (type == bond::BT_STOP)
+            if (type == bond::BondDataType::BT_STOP)
                 break;
 
-            if (type == bond::BT_STOP_BASE)
+            if (type == bond::BondDataType::BT_STOP_BASE)
                 continue;
 
             if (!IsValidType(type))
                 return false;
 
-            if (type == bond::BT_SET || type == bond::BT_LIST)
+            if (type == bond::BondDataType::BT_SET || type == bond::BondDataType::BT_LIST)
             {
                 bond::BondDataType element_type;
 
@@ -45,7 +45,7 @@ bool TryProtocol(Reader reader, int confidence = 5)
                     return false;
             }
 
-            if (type == bond::BT_MAP)
+            if (type == bond::BondDataType::BT_MAP)
             {
                 std::pair<bond::BondDataType, bond::BondDataType> element_type;
 
@@ -76,9 +76,9 @@ Protocol Guess(InputFile input)
 
     input.Read(word);
 
-    if (word == bond::FAST_PROTOCOL
-     || word == bond::COMPACT_PROTOCOL
-     || word == bond::SIMPLE_PROTOCOL)
+    if (word == bond::ProtocolType::FAST_PROTOCOL
+     || word == bond::ProtocolType::COMPACT_PROTOCOL
+     || word == bond::ProtocolType::SIMPLE_PROTOCOL)
         return marshal;
 
     if (TryProtocol(mbp))

--- a/examples/cpp/core/import/import.cpp
+++ b/examples/cpp/core/import/import.cpp
@@ -17,7 +17,7 @@ int main()
     // is by default in include path for Bond projects. 
     Struct obj, obj2;
 
-    obj.type.id = bond::BT_STRING;
+    obj.type.id = bond::BondDataType::BT_STRING;
 
     bond::OutputBuffer output;
     bond::CompactBinaryWriter<bond::OutputBuffer> writer(output);


### PR DESCRIPTION
Use scoped syntax for BondDataType, Modifier, and ProtocolType, which are defined in bond.bond and bond_const.bond.
This does not change Bond to generated 'enum class ___' enums, nor does it require that you use the namespace when using the enums.

This puts Bond a step towards generating 'enum class' definitions as an option.  Plus, we've locally converted Bond over to generating 'enum class' definitions, and this will reduce the differences in our code from the stock bond.