### PR TITLE
Provide serialization and deserialization of objects with only a RuntimeSchema

### DIFF
--- a/cs/src/core/Bond.csproj
+++ b/cs/src/core/Bond.csproj
@@ -74,7 +74,11 @@
     <Compile Include="Reflection.cs" />
     <Compile Include="Reflection40.cs" Condition="'$(TargetFrameworkVersion)' == 'v4.0'" />
     <Compile Include="Reflection45.cs" Condition="'$(TargetFrameworkVersion)' == 'v4.5'" />
+    <Compile Include="RuntimeBonded.cs" />
+    <Compile Include="RuntimeDeserializer.cs" />
+    <Compile Include="RuntimeObject.cs" />
     <Compile Include="RuntimeSchema.cs" />
+    <Compile Include="RuntimeSerializer.cs" />
     <Compile Include="Schema.cs" />
     <Compile Include="Serializer.cs" />
     <Compile Include="Transcoder.cs" />

--- a/cs/src/core/RuntimeBonded.cs
+++ b/cs/src/core/RuntimeBonded.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Bond
+{
+    using System;
+
+    /// <summary>
+    /// Interface representing bonded payload of unknown type
+    /// </summary>
+    public interface IRuntimeBonded
+    {
+        /// <summary>
+        /// Deserialize an object from the IRuntimeBonded instance
+        /// </summary>
+        /// <returns>Deserialized object</returns>
+        object Deserialize();
+    }
+
+    /// <summary>
+    /// Interface representing the schema type bonded&lt;T>
+    /// </summary>
+    /// <typeparam name="T">Type representing a Bond schema</typeparam>
+    public interface IRuntimeBonded<out T> : IRuntimeBonded
+    {
+        /// <summary>
+        /// Deserialize an object of type T from the IRuntimeBonded&lt;T> instance
+        /// </summary>
+        /// <returns>Deserialized object</returns>
+        new T Deserialize();
+    }
+
+    public class RuntimeBonded<T> : IRuntimeBonded<T>
+    {
+        private readonly Func<T> valueDeserializer;
+
+        public RuntimeBonded(T value)
+            : this(() => value)
+        {
+        }
+
+        public RuntimeBonded(Func<T> valueDeserializer)
+        {
+            this.valueDeserializer = valueDeserializer;
+        }
+
+        object IRuntimeBonded.Deserialize()
+        {
+            return Deserialize();
+        }
+
+        public T Deserialize()
+        {
+            return valueDeserializer();
+        }
+    }
+}

--- a/cs/src/core/RuntimeDeserializer.cs
+++ b/cs/src/core/RuntimeDeserializer.cs
@@ -1,0 +1,671 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Bond
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using Bond.IO.Safe;
+    using Bond.Protocols;
+
+    /// <summary>
+    /// Deserializes <see cref="RuntimeObject"/>s from a protocol reader using only a runtime schema.
+    /// </summary>
+    public static class RuntimeDeserialize
+    {
+        /// <summary>
+        /// Deserializes a <see cref="RuntimeObject"/> from a tagged protocol reader using only a runtime schema.
+        /// </summary>
+        /// <param name="reader">The tagged protocol reader to read the object data from.</param>
+        /// <param name="schema">The schema to use when reading the object data.</param>
+        /// <returns>A <see cref="RuntimeObject"/> created from <paramref name="reader"/> and <paramref name="schema"/>.</returns>
+        public static RuntimeObject From(IClonableTaggedProtocolReader reader, RuntimeSchema schema)
+        {
+            return new RuntimeDeserializer(schema).Deserialize(reader);
+        }
+
+        /// <summary>
+        /// Deserializes a <see cref="RuntimeObject"/> from an untagged protocol reader using only a runtime schema.
+        /// </summary>
+        /// <param name="reader">The untagged protocol reader to read the object data from.</param>
+        /// <param name="schema">The schema to use when reading the object data.</param>
+        /// <returns>A <see cref="RuntimeObject"/> created from <paramref name="reader"/> and <paramref name="schema"/>.</returns>
+        public static RuntimeObject From(IClonableUntaggedProtocolReader reader, RuntimeSchema schema)
+        {
+            return new RuntimeDeserializer(schema).Deserialize(reader);
+        }
+    }
+
+    /// <summary>
+    /// Deserializes <see cref="RuntimeObject"/>s from a protocol reader using only a <see cref="RuntimeSchema"/>.
+    /// </summary>
+    public class RuntimeDeserializer
+    {
+        private readonly RuntimeSchema schema;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RuntimeDeserializer"/> class with a given schema.
+        /// </summary>
+        /// <param name="schema">The schema to use when deserializing objects.</param>
+        public RuntimeDeserializer(RuntimeSchema schema)
+        {
+            if (schema.SchemaDef.root.id != BondDataType.BT_STRUCT)
+            {
+                throw new ArgumentException("The root of the schema must be a struct (id == BT_STRUCT).",
+                    "schema");
+            }
+
+            this.schema = schema;
+        }
+
+        /// <summary>
+        /// Deserializes a <see cref="RuntimeObject"/> from a tagged protocol reader.
+        /// </summary>
+        /// <param name="reader">The tagged protocol reader to read object data from.</param>
+        /// <returns>A <see cref="RuntimeObject"/> created from <paramref name="reader"/>.</returns>
+        public RuntimeObject Deserialize(IClonableTaggedProtocolReader reader)
+        {
+            return ReadStruct(reader, schema.SchemaDef.root) ?? new RuntimeObject();
+        }
+
+        /// <summary>
+        /// Deserializes a <see cref="RuntimeObject"/> from an untagged protocol reader.
+        /// </summary>
+        /// <param name="reader">The untagged protocol reader to read object data from.</param>
+        /// <returns>A <see cref="RuntimeObject"/> created from <paramref name="reader"/>.</returns>
+        public RuntimeObject Deserialize(IClonableUntaggedProtocolReader reader)
+        {
+            return ReadStruct(reader, schema.SchemaDef.root) ?? new RuntimeObject();
+        }
+
+        private RuntimeObject ReadStruct(IClonableTaggedProtocolReader reader, TypeDef typeDef)
+        {
+            var result = new Lazy<RuntimeObject>(() => new RuntimeObject());
+
+            var structDefs = new Stack<StructDef>();
+            while (typeDef != null)
+            {
+                var structDef = schema.SchemaDef.structs[typeDef.struct_def];
+                structDefs.Push(structDef);
+                typeDef = structDef.base_def;
+            }
+
+            reader.ReadStructBegin();
+
+            while (structDefs.Any())
+            {
+                var structDef = structDefs.Pop();
+
+                bool isBaseStructDef = structDefs.Any();
+
+                if (isBaseStructDef)
+                {
+                    reader.ReadBaseBegin();
+                }
+
+                while (true)
+                {
+                    BondDataType actualType;
+                    ushort actualId;
+                    reader.ReadFieldBegin(out actualType, out actualId);
+
+                    if (actualType == BondDataType.BT_STOP || actualType == BondDataType.BT_STOP_BASE)
+                    {
+                        reader.ReadFieldEnd();
+                        break;
+                    }
+
+                    var field = structDef.fields.Single(x => x.id == actualId);
+                    object fieldValue = ReadFieldValue(reader, field.type, actualType);
+                    if (fieldValue != null
+                        || field.metadata.modifier == Modifier.Required
+                        || field.metadata.modifier == Modifier.RequiredOptional)
+                    {
+                        result.Value.Properties[field.metadata.name] = fieldValue;
+                    }
+
+                    reader.ReadFieldEnd();
+                }
+
+                if (isBaseStructDef)
+                {
+                    reader.ReadBaseEnd();
+                }
+            }
+
+            reader.ReadStructEnd();
+
+            return result.IsValueCreated ? result.Value : null;
+        }
+
+        private RuntimeObject ReadStruct(IClonableUntaggedProtocolReader reader, TypeDef typeDef)
+        {
+            var result = new Lazy<RuntimeObject>(() => new RuntimeObject());
+            
+            var structDefs = new Stack<StructDef>();
+            do
+            {
+                var structDef = schema.SchemaDef.structs[typeDef.struct_def];
+                structDefs.Push(structDef);
+                typeDef = structDef.base_def;
+            } while (typeDef != null);
+
+            do
+            {
+                var structDef = structDefs.Pop();
+
+                foreach (var field in structDef.fields)
+                {
+                    if (reader.ReadFieldOmitted())
+                    {
+                        if (field.type.bonded_type)
+                        {
+                            result.Value.Properties[field.metadata.name] = Activator.CreateInstance(
+                                typeof(Bonded<>).MakeGenericType(GetRuntimeType(field.type, false)),
+                                null);
+                        }
+                        else if (field.metadata.modifier == Modifier.Required
+                            || field.metadata.modifier == Modifier.RequiredOptional)
+                        {
+                            result.Value.Properties[field.metadata.name] = GetDefaultValue(field);
+                        }
+
+                        continue;
+                    }
+
+                    object fieldValue = ReadFieldValue(reader, field.type);
+                    if (fieldValue != null)
+                    {
+                        result.Value.Properties[field.metadata.name] = fieldValue;
+                    }
+                }
+            } while (structDefs.Any());
+
+            return result.IsValueCreated ? result.Value : null;
+        }
+
+        private object GetDefaultValue(FieldDef field)
+        {
+            if (field.metadata.default_value.nothing)
+            {
+                return null;
+            }
+
+            switch (field.type.id)
+            {
+                case BondDataType.BT_BOOL:
+                    return field.metadata.default_value.uint_value != 0;
+                case BondDataType.BT_DOUBLE:
+                    return field.metadata.default_value.double_value;
+                case BondDataType.BT_FLOAT:
+                    return (float)field.metadata.default_value.double_value;
+                case BondDataType.BT_INT16:
+                    return (short)field.metadata.default_value.int_value;
+                case BondDataType.BT_INT32:
+                    return (int)field.metadata.default_value.int_value;
+                case BondDataType.BT_INT64:
+                    return (long)field.metadata.default_value.int_value;
+                case BondDataType.BT_INT8:
+                    return (sbyte)field.metadata.default_value.int_value;
+                case BondDataType.BT_LIST:
+                case BondDataType.BT_MAP:
+                case BondDataType.BT_SET:
+                case BondDataType.BT_STRING:
+                case BondDataType.BT_STRUCT:
+                case BondDataType.BT_UINT16:
+                    return (ushort)field.metadata.default_value.uint_value;
+                case BondDataType.BT_UINT32:
+                    return (uint)field.metadata.default_value.uint_value;
+                case BondDataType.BT_UINT64:
+                    return (ulong)field.metadata.default_value.uint_value;
+                case BondDataType.BT_UINT8:
+                    return (byte)field.metadata.default_value.uint_value;
+                case BondDataType.BT_WSTRING:
+                    return field.metadata.default_value.wstring_value;
+            }
+
+            return null;
+        }
+
+        private IRuntimeBonded<RuntimeObject> ReadBondedStruct(IUntaggedProtocolReader reader, TypeDef typeDef)
+        {
+            int containerSize = (int)reader.ReadUInt32();
+            
+            var protocol = (ProtocolType)reader.ReadUInt16();
+            var version = reader.ReadUInt16();
+
+            // Subtract 2 bytes for protocol and 2 bytes for version
+            var bondedData = reader.ReadBytes(containerSize - 4);
+
+            switch (protocol)
+            {
+                case ProtocolType.COMPACT_PROTOCOL:
+                    return new RuntimeBonded<RuntimeObject>(
+                        new RuntimeDeserializer(schema).ReadStruct(
+                            new CompactBinaryReader<InputBuffer>(new InputBuffer(bondedData), version), typeDef));
+
+                case ProtocolType.FAST_PROTOCOL:
+                    return new RuntimeBonded<RuntimeObject>(
+                        new RuntimeDeserializer(schema).ReadStruct(
+                            new FastBinaryReader<InputBuffer>(new InputBuffer(bondedData), version), typeDef));
+
+                case ProtocolType.SIMPLE_PROTOCOL:
+                    return new RuntimeBonded<RuntimeObject>(
+                        new RuntimeDeserializer(schema).ReadStruct(
+                            new SimpleBinaryReader<InputBuffer>(new InputBuffer(bondedData), version), typeDef));
+
+                default:
+                    throw new InvalidDataException(string.Format("Unknown ProtocolType {0}", protocol));
+            }
+        }
+
+        private object ReadContainer(IClonableTaggedProtocolReader reader, TypeDef elementType)
+        {
+            int count;
+            BondDataType actualType;
+            reader.ReadContainerBegin(out count, out actualType);
+
+            if (count <= 0)
+            {
+                return null;
+            }
+
+            var itemType = GetRuntimeType(elementType);
+            var listType = typeof(List<>).MakeGenericType(itemType);
+            var addMethodType = typeof(ICollection<>).MakeGenericType(itemType);
+            
+            var list = new Lazy<object>(() => Activator.CreateInstance(listType));
+            var addMethod = addMethodType.FindMethod("Add", itemType);
+
+            for (int i = 0; i < count; i++)
+            {
+                var value = ReadFieldValue(reader, elementType, actualType);
+                if (value != null)
+                {
+                    addMethod.Invoke(list.Value, new[] { value });
+                }
+            }
+
+            reader.ReadContainerEnd();
+
+            return list.IsValueCreated ? list.Value : null;
+        }
+
+        private object ReadContainer(IClonableUntaggedProtocolReader reader, TypeDef elementType)
+        {
+            int count = reader.ReadContainerBegin();
+            if (count <= 0)
+            {
+                return null;
+            }
+
+            var itemType = GetRuntimeType(elementType);
+            var listType = typeof(List<>).MakeGenericType(itemType);
+            var addMethodType = typeof(ICollection<>).MakeGenericType(itemType);
+
+            var list = new Lazy<object>(() => Activator.CreateInstance(listType));
+            var addMethod = addMethodType.FindMethod("Add", itemType);
+
+            for (int i = 0; i < count; i++)
+            {
+                var value = ReadFieldValue(reader, elementType);
+                if (value != null)
+                {
+                    addMethod.Invoke(list.Value, new[] { value });
+                }
+            }
+
+            reader.ReadContainerEnd();
+
+            return list.IsValueCreated ? list.Value : null;
+        }
+
+        private object ReadMap(IClonableTaggedProtocolReader reader, TypeDef keyType, TypeDef valueType)
+        {
+            var keyRuntimeType = GetRuntimeType(keyType);
+            var valueRuntimeType = GetRuntimeType(valueType);
+            var dictionaryType = typeof(Dictionary<,>).MakeGenericType(keyRuntimeType, valueRuntimeType);
+            var addMethodType = typeof(IDictionary<,>).MakeGenericType(keyRuntimeType, valueRuntimeType);
+
+            var dictionary = new Lazy<object>(() => Activator.CreateInstance(dictionaryType));
+            var addMethod = addMethodType.FindMethod("Add", keyRuntimeType, valueRuntimeType);
+
+            int count;
+            BondDataType actualKeyType;
+            BondDataType actualValueType;
+            reader.ReadContainerBegin(out count, out actualKeyType, out actualValueType);
+
+            for (int i = 0; i < count; i++)
+            {
+                var key = ReadFieldValue(reader, keyType, actualKeyType);
+                var value = ReadFieldValue(reader, valueType, actualValueType);
+
+                addMethod.Invoke(dictionary.Value, new[] { key, value });
+            }
+
+            return dictionary.IsValueCreated ? dictionary.Value : null;
+        }
+
+        private object ReadMap(IClonableUntaggedProtocolReader reader, TypeDef keyType, TypeDef valueType)
+        {
+            var keyRuntimeType = GetRuntimeType(keyType);
+            var valueRuntimeType = GetRuntimeType(valueType);
+            var dictionaryType = typeof(Dictionary<,>).MakeGenericType(keyRuntimeType, valueRuntimeType);
+            var addMethodType = typeof(IDictionary<,>).MakeGenericType(keyRuntimeType, valueRuntimeType);
+
+            var dictionary = new Lazy<object>(() => Activator.CreateInstance(dictionaryType));
+            var addMethod = addMethodType.FindMethod("Add", keyRuntimeType, valueRuntimeType);
+
+            int count = reader.ReadContainerBegin();
+            
+            for (int i = 0; i < count; i++)
+            {
+                var key = ReadFieldValue(reader, keyType);
+                var value = ReadFieldValue(reader, valueType);
+
+                addMethod.Invoke(dictionary.Value, new[] { key, value });
+            }
+
+            return dictionary.IsValueCreated ? dictionary.Value : null;
+        }
+
+        private object ReadFieldValue(IClonableTaggedProtocolReader reader, TypeDef fieldType,
+            BondDataType actualType)
+        {
+            switch (actualType)
+            {
+                case BondDataType.BT_BOOL:
+                    {
+                        return reader.ReadBool();
+                    }
+                case BondDataType.BT_INT8:
+                    {
+                        return reader.ReadInt8();
+                    }
+                case BondDataType.BT_UINT8:
+                    {
+                        return reader.ReadUInt8();
+                    }
+                case BondDataType.BT_INT16:
+                    {
+                        return reader.ReadInt16();
+                    }
+                case BondDataType.BT_UINT16:
+                    {
+                        return reader.ReadUInt16();
+                    }
+                case BondDataType.BT_INT32:
+                    {
+                        return reader.ReadInt32();
+                    }
+                case BondDataType.BT_UINT32:
+                    {
+                        return reader.ReadUInt32();
+                    }
+                case BondDataType.BT_INT64:
+                    {
+                        return reader.ReadInt64();
+                    }
+                case BondDataType.BT_UINT64:
+                    {
+                        return reader.ReadUInt64();
+                    }
+                case BondDataType.BT_FLOAT:
+                    {
+                        return reader.ReadFloat();
+                    }
+                case BondDataType.BT_DOUBLE:
+                    {
+                        return reader.ReadDouble();
+                    }
+                case BondDataType.BT_STRING:
+                    {
+                        return reader.ReadString();
+                    }
+                case BondDataType.BT_WSTRING:
+                    {
+                        return reader.ReadWString();
+                    }
+                case BondDataType.BT_LIST:
+                case BondDataType.BT_SET:
+                    {
+                        if (fieldType.bonded_type)
+                        {
+                            var readerClone = reader.Clone();
+
+                            int itemCount;
+                            BondDataType itemType;
+                            reader.ReadContainerBegin(out itemCount, out itemType);
+                            for (int i = 0; i < itemCount; i++)
+                            {
+                                reader.Skip(itemType);
+                            }
+                            reader.ReadContainerEnd();
+
+                            return CreateRuntimeBonded(() => ReadContainer(readerClone, fieldType.element));
+                        }
+
+                        return ReadContainer(reader, fieldType.element);
+                    }
+                case BondDataType.BT_MAP:
+                    {
+                        if (fieldType.bonded_type)
+                        {
+                            var readerClone = reader.Clone();
+
+                            int itemCount;
+                            BondDataType actualKeyType;
+                            BondDataType actualValueType;
+                            reader.ReadContainerBegin(out itemCount, out actualKeyType, out actualValueType);
+                            for (int i = 0; i < itemCount; i++)
+                            {
+                                reader.Skip(actualKeyType);
+                                reader.Skip(actualValueType);
+                            }
+                            reader.ReadContainerEnd();
+
+                            return CreateRuntimeBonded(() => ReadMap(readerClone, fieldType.key, fieldType.element));
+                        }
+
+                        return ReadMap(reader, fieldType.key, fieldType.element);
+                    }
+                case BondDataType.BT_STRUCT:
+                    {
+                        if (fieldType.bonded_type)
+                        {
+                            var readerClone = reader.Clone();
+
+                            reader.Skip(actualType);
+
+                            return CreateRuntimeBonded(() => ReadStruct(readerClone, fieldType));
+                        }
+
+                        return ReadStruct(reader, fieldType);
+                    }
+                case BondDataType.BT_UNAVAILABLE:
+                default:
+                    return fieldType.bonded_type ? new RuntimeBonded<object>(null) : null;
+            }
+        }
+
+        private object ReadFieldValue(IClonableUntaggedProtocolReader reader, TypeDef fieldType)
+        {
+            switch (fieldType.id)
+            {
+                case BondDataType.BT_BOOL:
+                    return reader.ReadBool();
+                case BondDataType.BT_INT8:
+                    return reader.ReadInt8();
+                case BondDataType.BT_UINT8:
+                    return reader.ReadUInt8();
+                case BondDataType.BT_INT16:
+                    return reader.ReadInt16();
+                case BondDataType.BT_UINT16:
+                    return reader.ReadUInt16();
+                case BondDataType.BT_INT32:
+                    return reader.ReadInt32();
+                case BondDataType.BT_UINT32:
+                    return reader.ReadUInt32();
+                case BondDataType.BT_INT64:
+                    return reader.ReadInt64();
+                case BondDataType.BT_UINT64:
+                    return reader.ReadUInt64();
+                case BondDataType.BT_FLOAT:
+                    return reader.ReadFloat();
+                case BondDataType.BT_DOUBLE:
+                    return reader.ReadDouble();
+                case BondDataType.BT_STRING:
+                    return reader.ReadString();
+                case BondDataType.BT_WSTRING:
+                    return reader.ReadWString();
+                case BondDataType.BT_LIST:
+                case BondDataType.BT_SET:
+                    {
+                        if (fieldType.bonded_type)
+                        {
+                            var readerClone = reader.Clone();
+                            
+                            int itemCount = reader.ReadContainerBegin();
+                            for (int i = 0; i < itemCount; i++)
+                            {
+                                switch (fieldType.element.id)
+                                {
+                                    case BondDataType.BT_STRING:
+                                        reader.SkipString();
+                                        break;
+                                    default:
+                                        throw new NotImplementedException();
+                                }
+                            }
+                            reader.ReadContainerEnd();
+
+                            return CreateRuntimeBonded(() => ReadContainer(readerClone, fieldType.element));
+                        }
+
+                        return ReadContainer(reader, fieldType.element);
+                    }
+                case BondDataType.BT_MAP:
+                    {
+                        if (fieldType.bonded_type)
+                        {
+                            var readerClone = reader.Clone();
+
+                            int itemCount = reader.ReadContainerBegin();
+                            for (int i = 0; i < itemCount; i++)
+                            {
+                                switch (fieldType.key.id)
+                                {
+                                    case BondDataType.BT_STRING:
+                                        reader.SkipString();
+                                        break;
+                                    default:
+                                        throw new NotImplementedException();
+                                }
+
+                                switch (fieldType.element.id)
+                                {
+                                    case BondDataType.BT_STRING:
+                                        reader.SkipString();
+                                        break;
+                                    default:
+                                        throw new NotImplementedException();
+                                }
+                            }
+
+                            return CreateRuntimeBonded(() => ReadMap(readerClone, fieldType.key, fieldType.element));
+                        }
+
+                        return ReadMap(reader, fieldType.key, fieldType.element);
+                    }
+                case BondDataType.BT_STRUCT:
+                    {
+                        if (fieldType.bonded_type)
+                        {
+                            var readerClone = reader.Clone();
+
+                            int structSize = (int)reader.ReadUInt32();
+                            reader.SkipBytes(structSize);
+                            
+                            return ReadBondedStruct(readerClone, fieldType);
+                        }
+
+                        return ReadStruct(reader, fieldType);
+                    }
+                case BondDataType.BT_UNAVAILABLE:
+                default:
+                    return fieldType.bonded_type ? new RuntimeBonded<object>(null) : null;
+            }
+        }
+
+        private static Type GetRuntimeType(TypeDef elementType, bool shouldWrapBonded = false)
+        {
+            Type runtimeType;
+
+            switch (elementType.id)
+            {
+                case BondDataType.BT_BOOL:
+                    runtimeType = typeof(bool);
+                    break;
+                case BondDataType.BT_INT8:
+                    runtimeType = typeof(sbyte);
+                    break;
+                case BondDataType.BT_UINT8:
+                    runtimeType = typeof(byte);
+                    break;
+                case BondDataType.BT_INT16:
+                    runtimeType = typeof(short);
+                    break;
+                case BondDataType.BT_UINT16:
+                    runtimeType = typeof(ushort);
+                    break;
+                case BondDataType.BT_INT32:
+                    runtimeType = typeof(int);
+                    break;
+                case BondDataType.BT_UINT32:
+                    runtimeType = typeof(uint);
+                    break;
+                case BondDataType.BT_INT64:
+                    runtimeType = typeof(long);
+                    break;
+                case BondDataType.BT_UINT64:
+                    runtimeType = typeof(ulong);
+                    break;
+                case BondDataType.BT_FLOAT:
+                    runtimeType = typeof(float);
+                    break;
+                case BondDataType.BT_DOUBLE:
+                    runtimeType = typeof(double);
+                    break;
+                case BondDataType.BT_STRING:
+                case BondDataType.BT_WSTRING:
+                    runtimeType = typeof(string);
+                    break;
+                case BondDataType.BT_LIST:
+                case BondDataType.BT_SET:
+                    runtimeType = typeof(List<>).MakeGenericType(GetRuntimeType(elementType.element));
+                    break;
+                case BondDataType.BT_MAP:
+                    runtimeType = typeof(Dictionary<,>).MakeGenericType(
+                        GetRuntimeType(elementType.key), GetRuntimeType(elementType.element));
+                    break;
+                case BondDataType.BT_STRUCT:
+                    runtimeType = typeof(RuntimeObject);
+                    break;
+                case BondDataType.BT_UNAVAILABLE:
+                default:
+                    throw new ArgumentException("No type is available for the given bond data type.");
+            }
+
+            return elementType.bonded_type && shouldWrapBonded
+                ? typeof(IRuntimeBonded<>).MakeGenericType(runtimeType)
+                : runtimeType;
+        }
+        
+        private static object CreateRuntimeBonded<T>(Func<T> valueDeserializer)
+        {
+            return Activator.CreateInstance(typeof(RuntimeBonded<T>), valueDeserializer);
+        }
+    }
+}

--- a/cs/src/core/RuntimeObject.cs
+++ b/cs/src/core/RuntimeObject.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Bond
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Represents an object created using a <see cref="RuntimeSchema"/> object without a corresponding .NET type.
+    /// </summary>
+    [Schema]
+    public class RuntimeObject
+    {
+        private readonly Dictionary<string, object> _properties = new Dictionary<string, object>();
+
+        /// <summary>
+        /// Gets a dictionary containing properties of this object.
+        /// </summary>
+        public Dictionary<string, object> Properties
+        {
+            get { return _properties; }
+        }
+    }
+}

--- a/cs/src/core/RuntimeSerializer.cs
+++ b/cs/src/core/RuntimeSerializer.cs
@@ -1,0 +1,246 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Bond
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Bond.IO;
+    using Bond.IO.Safe;
+    using Bond.Protocols;
+
+    /// <summary>
+    /// Serializes <see cref="RuntimeObject"/>s to a protocol writer using only a runtime schema.
+    /// </summary>
+    public static class RuntimeSerialize
+    {
+        /// <summary>
+        /// Serializes a <see cref="RuntimeObject"/> to a protocol writer using only a runtime schema.
+        /// </summary>
+        /// <param name="writer">The protocol writer to write the object data to.</param>
+        /// <param name="schema">The schema to use when writing the object data.</param>
+        /// <param name="obj">The object to serialize.</param>
+        public static void To(IProtocolWriter writer, RuntimeSchema schema, RuntimeObject obj)
+        {
+            new RuntimeSerializer(schema).Serialize(writer, obj);
+        }
+    }
+
+    /// <summary>
+    /// Serializes <see cref="RuntimeObject"/>s to a protocol writer using only a runtime schema.
+    /// </summary>
+    public class RuntimeSerializer
+    {
+        private readonly RuntimeSchema schema;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RuntimeSerializer"/> class with a given runtime schema.
+        /// </summary>
+        /// <param name="schema">The schema to use when serializing objects.</param>
+        public RuntimeSerializer(RuntimeSchema schema)
+        {
+            this.schema = schema;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="RuntimeObject"/> to a protocol writer.
+        /// </summary>
+        /// <param name="writer">The protocol writer to write object data to.</param>
+        /// <param name="obj">The object to serialize.</param>
+        public void Serialize(IProtocolWriter writer, RuntimeObject obj)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException("obj");
+            }
+
+            WriteStruct(writer, obj, schema.SchemaDef.root);
+        }
+
+        private void WriteStruct(IProtocolWriter writer, RuntimeObject obj, TypeDef structType)
+        {
+            var topLevelStructDef = schema.SchemaDef.structs[structType.struct_def];
+
+            var structDefs = new Stack<StructDef>();
+            while (structType != null)
+            {
+                var structDef = schema.SchemaDef.structs[structType.struct_def];
+                structDefs.Push(structDef);
+                structType = structDef.base_def;
+            }
+
+            writer.WriteStructBegin(topLevelStructDef.metadata);
+
+            while (structDefs.Any())
+            {
+                var structDef = structDefs.Pop();
+
+                bool isBaseStructDef = structDefs.Any();
+
+                if (isBaseStructDef)
+                {
+                    writer.WriteBaseBegin(structDef.metadata);
+                }
+
+                foreach (var field in structDef.fields)
+                {
+                    WriteField(writer, obj, field);
+                }
+
+                if (isBaseStructDef)
+                {
+                    writer.WriteBaseEnd();
+                }
+            }
+
+            writer.WriteStructEnd();
+        }
+
+        private void WriteField(IProtocolWriter writer, RuntimeObject obj, FieldDef field)
+        {
+            bool fieldExists = obj != null && obj.Properties.ContainsKey(field.metadata.name);
+
+            if (!fieldExists && field.type.id != BondDataType.BT_STRUCT)
+            {
+                writer.WriteFieldOmitted(field.type.id, field.id, field.metadata);
+                return;
+            }
+
+            object value = fieldExists ? obj.Properties[field.metadata.name] : null;
+
+            if (field.type.bonded_type)
+            {
+                if (value is IRuntimeBonded)
+                {
+                    value = ((IRuntimeBonded)value).Deserialize();
+
+                    writer.WriteFieldBegin(field.type.id, field.id, field.metadata);
+
+                    // All bonded fields appear to always be serialized using the CompactBinary format
+                    if (writer.GetType().GetGenericTypeDefinition() == typeof(CompactBinaryWriter<>))
+                    {
+                        // If the writer is already using CompactBinary, just write the bonded data
+                        WriteValue(writer, value, field.type);
+                    }
+                    else
+                    {
+                        // If the writer is not already using CompactBinary, serialize the bonded field value using
+                        // CompactBinary then write it as a byte array.
+                        var bondedBuffer = new OutputBuffer();
+                        var bondedWriter = new CompactBinaryWriter<OutputBuffer>(bondedBuffer);
+
+                        bondedWriter.WriteVersion();
+                        WriteValue(bondedWriter, value, field.type);
+
+                        writer.WriteUInt32((uint)bondedBuffer.Data.Count);
+                        writer.WriteBytes(bondedBuffer.Data);
+                    }
+
+                    writer.WriteFieldEnd();
+                }
+            }
+            else
+            {
+                if (value == null && field.type.id != BondDataType.BT_STRUCT)
+                {
+                    writer.WriteFieldOmitted(field.type.id, field.id, field.metadata);
+                }
+                else
+                {
+                    writer.WriteFieldBegin(field.type.id, field.id, field.metadata);
+
+                    WriteValue(writer, value, field.type);
+
+                    writer.WriteFieldEnd();
+                }
+            }
+        }
+
+        private void WriteValue(IProtocolWriter writer, object obj, TypeDef fieldType)
+        {
+            switch (fieldType.id)
+            {
+                case BondDataType.BT_BOOL:
+                    writer.WriteBool((bool)obj);
+                    break;
+                case BondDataType.BT_INT8:
+                    writer.WriteInt8((sbyte)obj);
+                    break;
+                case BondDataType.BT_UINT8:
+                    writer.WriteUInt8((byte)obj);
+                    break;
+                case BondDataType.BT_INT16:
+                    writer.WriteInt16((short)obj);
+                    break;
+                case BondDataType.BT_UINT16:
+                    writer.WriteUInt16((ushort)obj);
+                    break;
+                case BondDataType.BT_INT32:
+                    writer.WriteInt32((int)obj);
+                    break;
+                case BondDataType.BT_UINT32:
+                    writer.WriteUInt32((uint)obj);
+                    break;
+                case BondDataType.BT_INT64:
+                    writer.WriteInt64((long)obj);
+                    break;
+                case BondDataType.BT_UINT64:
+                    writer.WriteUInt64((ulong)obj);
+                    break;
+                case BondDataType.BT_FLOAT:
+                    writer.WriteFloat((float)obj);
+                    break;
+                case BondDataType.BT_DOUBLE:
+                    writer.WriteDouble((double)obj);
+                    break;
+                case BondDataType.BT_STRING:
+                    writer.WriteString((string)obj);
+                    break;
+                case BondDataType.BT_WSTRING:
+                    writer.WriteWString((string)obj);
+                    break;
+                case BondDataType.BT_LIST:
+                case BondDataType.BT_SET:
+                    WriteContainer(writer, obj, fieldType.element);
+                    break;
+                case BondDataType.BT_MAP:
+                    WriteMap(writer, obj, fieldType.key, fieldType.element);
+                    break;
+                case BondDataType.BT_STRUCT:
+                    WriteStruct(writer, (RuntimeObject)obj, fieldType);
+                    break;
+            }
+        }
+
+        private void WriteContainer(IProtocolWriter writer, object value, TypeDef elementType)
+        {
+            var list = (ICollection)value;
+
+            writer.WriteContainerBegin(list.Count, elementType.id);
+
+            foreach (object item in list)
+            {
+                WriteValue(writer, item, elementType);
+            }
+
+            writer.WriteContainerEnd();
+        }
+
+        private void WriteMap(IProtocolWriter writer, object value, TypeDef keyType, TypeDef valueType)
+        {
+            var dictionary = (IDictionary)value;
+
+            writer.WriteContainerBegin(dictionary.Count, keyType.id, valueType.id);
+
+            foreach (object key in dictionary.Keys)
+            {
+                WriteValue(writer, key, keyType);
+                WriteValue(writer, dictionary[key], valueType);
+            }
+
+            writer.WriteContainerEnd();
+        }
+    }
+}

--- a/cs/test/core/Core.csproj
+++ b/cs/test/core/Core.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <BuildFramework Condition="'$(Configuration)' == 'Net40'">net40</BuildFramework>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Fields|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;NET45;BOND_LIST_INTERFACES</DefineConstants>
+  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath32)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath32)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\build\Common.Internal.props" />
   <PropertyGroup>
@@ -43,6 +46,9 @@
     <Compile Include="Partial.cs" />
     <Compile Include="properties\AssemblyInfo.cs" />
     <Compile Include="Random.cs" />
+    <Compile Include="RuntimeBondedTests.cs" />
+    <Compile Include="RuntimeDeserializerTests.cs" />
+    <Compile Include="RuntimeSerializerTests.cs" />
     <Compile Include="SerializationTests.cs" />
     <Compile Include="SerializerGeneratorFactoryTests.cs" />
     <Compile Include="GenericsTests.cs" />

--- a/cs/test/core/RuntimeBondedTests.cs
+++ b/cs/test/core/RuntimeBondedTests.cs
@@ -1,0 +1,74 @@
+﻿namespace UnitTest
+{
+    using System.Threading;
+    using Bond;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class RuntimeBondedTests
+    {
+        [Test]
+        public void Deserialize_ReturnsSameObjectWhenObjectIsProvided()
+        {
+            object expected = new object();
+
+            var target = new RuntimeBonded<object>(expected);
+
+            object actual = target.Deserialize();
+
+            Assert.AreSame(expected, actual);
+        }
+
+        [Test]
+        public void Deserialize_CallsValueDeserializerFuncOnceWhenCalledOnce()
+        {
+            object expected = new object();
+            int valueDeserializerFuncCallCount = 0;
+
+            var target = new RuntimeBonded<object>(() =>
+            {
+                Interlocked.Increment(ref valueDeserializerFuncCallCount);
+
+                return expected;
+            });
+
+            target.Deserialize();
+
+            Assert.AreEqual(1, valueDeserializerFuncCallCount);
+        }
+
+        [Test]
+        public void Deserialize_CallsValueDeserializerFuncTwiceWhenCalledTwice()
+        {
+            object expected = new object();
+            int valueDeserializerFuncCallCount = 0;
+
+            var target = new RuntimeBonded<object>(() =>
+            {
+                Interlocked.Increment(ref valueDeserializerFuncCallCount);
+
+                return expected;
+            });
+
+            target.Deserialize();
+            target.Deserialize();
+
+            Assert.AreEqual(2, valueDeserializerFuncCallCount);
+        }
+
+        [Test]
+        public void Deserialize_ReturnsSameObjectReturnedByValueDeserializerFunc()
+        {
+            object expected = new object();
+
+            var target = new RuntimeBonded<object>(() =>
+            {
+                return expected;
+            });
+
+            var actual = target.Deserialize();
+
+            Assert.AreSame(expected, actual);
+        }
+    }
+}

--- a/cs/test/core/RuntimeDeserializerTests.cs
+++ b/cs/test/core/RuntimeDeserializerTests.cs
@@ -362,7 +362,20 @@
 
             foreach (string propertyName in actual.Properties.Keys)
             {
-                var expectedValue = expected.GetType().GetProperty(propertyName).GetValue(expected, null);
+                object expectedValue;
+
+                // The bond field could be created as either a property or field in the C# class
+                var propertyInfo = expected.GetType().GetProperty(propertyName);
+                if (propertyInfo != null)
+                {
+                    expectedValue = propertyInfo.GetValue(expected, null);
+                }
+                else
+                {
+                    var fieldInfo = expected.GetType().GetField(propertyName);
+                    expectedValue = fieldInfo.GetValue(expected);
+                }
+
                 var actualValue = actual.Properties[propertyName];
 
                 VerifyObjectsMatch(propertyName, expectedValue, actualValue);

--- a/cs/test/core/RuntimeDeserializerTests.cs
+++ b/cs/test/core/RuntimeDeserializerTests.cs
@@ -1,0 +1,591 @@
+﻿namespace UnitTest
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Bond;
+    using Bond.IO.Safe;
+    using Bond.Protocols;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class RuntimeDeserializerTests
+    {
+        [Test]
+        public void Deserialize_DeserializesScalarTypesCorrectlyWhenEverythingIsPopulated()
+        {
+            var expected = new BasicTypes
+            {
+                _bool = true,
+                _str = "String",
+                _wstr = "WideString",
+                _uint64 = ulong.MaxValue - 6464,
+                _uint16 = ushort.MaxValue - 1616,
+                _uint32 = uint.MaxValue - 3232,
+                _uint8 = byte.MaxValue - 88,
+                _int8 = sbyte.MaxValue - 8,
+                _int16 = short.MaxValue - 16,
+                _int32 = int.MaxValue - 32,
+                _int64 = long.MaxValue - 64,
+                _double = double.MaxValue / 22,
+                _float = float.MaxValue / 2,
+                _enum1 = EnumType1.EnumValue4,
+                dt = DateTime.UtcNow,
+            };
+
+            TestRuntimeDeserialization(expected);
+        }
+
+        [Test]
+        public void Deserialize_DeserializesScalarTypesCorrectlyWhenOnlySomePropertiesArePopulated()
+        {
+            var expected = new BasicTypes
+            {
+                _str = "String",
+                _uint32 = uint.MaxValue - 3232,
+                _uint8 = byte.MaxValue - 88,
+                _int16 = short.MaxValue - 16,
+                _int64 = long.MaxValue - 64,
+                _double = double.MaxValue / 22,
+                _float = float.MaxValue / 2,
+                _enum1 = EnumType1.EnumValue4,
+                dt = DateTime.UtcNow,
+            };
+
+            TestRuntimeDeserialization(expected);
+        }
+
+        [Test]
+        public void Deserialize_DeserializesNestedTypes()
+        {
+            var expected = new Nested
+            {
+                basic = new BasicTypes
+                {
+                    _str = "Basic",
+                },
+                nested = new Nested1
+                {
+                    basic1 = new BasicTypes { _str = "Basic1" },
+                    basic2 = new BasicTypes { _str = "Basic2" },
+                    guid = new GUID { Data1 = 101, Data2 = 202, Data3 = 303, Data4 = 404 },
+                },
+            };
+
+            TestRuntimeDeserialization(expected);
+        }
+
+        [Test]
+        public void Deserialize_DeserializesBondedProperties()
+        {
+            var expected = new StructWithBonded
+            {
+                field = new Bonded<Nested>(new Nested
+                {
+                    basic = new BasicTypes
+                    {
+                        _str = "Bonded field.basic._str",
+                    },
+                    nested = new Nested1
+                    {
+                        guid = new GUID { Data1 = 1, Data2 = 22, Data3 = 333, Data4 = 4444 },
+                    },
+                }),
+            };
+
+            TestRuntimeDeserialization(expected);
+        }
+
+        [Test]
+        public void Deserialize_DeserializesListProperties()
+        {
+            var expected = new StructWithByteLists
+            {
+                b = new List<sbyte> { 1 },
+#if BOND_LIST_INTERFACES
+                lb = new List<IList<sbyte>> { new List<sbyte> { 21, 22 }, new List<sbyte> { 23, 24 } },
+#else
+                lb = new List<List<sbyte>> { new List<sbyte> { 21, 22 }, new List<sbyte> { 23, 24 } },
+#endif
+                nb = new List<sbyte>(),
+            };
+
+            TestRuntimeDeserialization(expected);
+        }
+
+        [Test]
+        public void Deserialize_DeserializesMapProperties()
+        {
+            var expected = new Maps
+            {
+                _bool = new Dictionary<string, bool> { { "trueValue", true }, {"falseValue", false } },
+                _str = new Dictionary<string, string> { { "stringValue", "Abc123" } },
+            };
+
+            TestRuntimeDeserialization(expected);
+        }
+
+        [Test]
+        public void Deserialize_DeserializesNullablePropertiesWhenNotNull()
+        {
+            var expected = new NullableBasicTypes
+            {
+                _bool = true,
+                _str = "str value",
+                _wstr = "wstr value",
+                _int8 = -8,
+                _int16 = -16,
+                _int32 = -32,
+                _int64 = -64,
+                _uint8 = 8,
+                _uint16 = 16,
+                _uint32 = 32,
+                _uint64 = 64,
+                _double = 2468.10,
+                _float = 1234.5f,
+                _enum1 = EnumType1.EnumValue3,
+                dt = DateTime.UtcNow,
+            };
+
+            TestRuntimeDeserialization(expected);
+        }
+
+        [Test]
+        public void Deserialize_DeserializesNullablePropertiesWhenNull()
+        {
+            var expected = new NullableBasicTypes
+            {
+                _bool = null,
+                _str = null,
+                _wstr = null,
+                _int8 = null,
+                _int16 = null,
+                _int32 = null,
+                _int64 = null,
+                _uint8 = null,
+                _uint16 = null,
+                _uint32 = null,
+                _uint64 = null,
+                _double = null,
+                _float = null,
+                _enum1 = null,
+                dt = null,
+            };
+
+            TestRuntimeDeserialization(expected);
+        }
+
+        [Test]
+        public void Deserialize_DeserializesGenerics()
+        {
+            var expected = new Generics
+            {
+                sb = new GenericScalar<bool>
+                {
+                    field = true,
+                    vectorField = new List<bool> { true, false },
+                    listGeneric = new LinkedList<GenericScalar<bool>>(
+                        new[]
+                        {
+                            new GenericScalar<bool>
+                            {
+                                field = true,
+                                vectorField = new List<bool> { false, true },
+                                nullableField = true,
+                                mapField = new Dictionary<bool,bool> { { true, false }, { false, true } },
+                            }
+                        }
+                        ),
+                    nullableField = true,
+                    mapField = new Dictionary<bool, bool> { { true, true }, { false, false } },
+                },
+                ci32 = new GenericClass<HashSet<int>>
+                {
+                    field = new HashSet<int> { 101 },
+                    vectorField = new List<HashSet<int>> { new HashSet<int> { 201 } },
+                    listGeneric = new LinkedList<GenericClass<HashSet<int>>>(
+                        new[]
+                        {
+                            new GenericClass<HashSet<int>>
+                            {
+                                field = new HashSet<int> { 301 },
+                                vectorField = new List<HashSet<int>> { new HashSet<int> { 302 } },
+                                nullableField = new HashSet<int> { 303 },
+                                mapField = new Dictionary<string,HashSet<int>>
+                                {
+                                    { "304", new HashSet<int> { 304 } }
+                                },
+                            }
+                        }),
+                    nullableField = new HashSet<int> { 401 },
+                    mapField = new Dictionary<string, HashSet<int>> { { "501", new HashSet<int> { 601 } } },
+                },
+                cbt = new GenericClass<BasicTypes>
+                {
+                    field = new BasicTypes
+                    {
+                        _enum1 = EnumType1.EnumValue1,
+                    },
+                },
+            };
+
+            TestRuntimeDeserialization(expected);
+        }
+
+        [Test]
+        public void Deserialize_DeserializesFieldsFromBaseType()
+        {
+            var expected = new DerivedWithMeta
+            {
+                a = "ValueFromBaseClass",
+                b = "ValueFromSubClass",
+            };
+
+            TestRuntimeDeserialization(expected);
+        }
+
+        private static void TestRuntimeDeserialization<T>(T expected)
+        {
+            TestWithRuntimeDeserializerCompact(expected);
+            TestWithRuntimeDeserializerSimple(expected);
+        }
+
+        private static ArraySegment<byte> SerializeCompact<T>(T original)
+        {
+            var serializer = new Serializer<CompactBinaryWriter<OutputBuffer>>(typeof(T));
+
+            var output = new OutputBuffer();
+            var writer = new CompactBinaryWriter<OutputBuffer>(output);
+
+            serializer.Serialize(original, writer);
+
+            return output.Data;
+        }
+
+        private static ArraySegment<byte> SerializeFast<T>(T original)
+        {
+            var serializer = new Serializer<FastBinaryWriter<OutputBuffer>>(typeof(T));
+
+            var output = new OutputBuffer();
+            var writer = new FastBinaryWriter<OutputBuffer>(output);
+
+            serializer.Serialize(original, writer);
+
+            return output.Data;
+        }
+
+        private static ArraySegment<byte> SerializeSimple<T>(T original)
+        {
+            var serializer = new Serializer<SimpleBinaryWriter<OutputBuffer>>(typeof(T));
+
+            var output = new OutputBuffer();
+            var writer = new SimpleBinaryWriter<OutputBuffer>(output);
+
+            serializer.Serialize(original, writer);
+
+            return output.Data;
+        }
+
+        private static void TestWithRuntimeDeserializerCompact<T>(T original)
+        {
+            var serializer = new Serializer<CompactBinaryWriter<OutputBuffer>>(typeof(T));
+
+            var output = new OutputBuffer();
+            var writer = new CompactBinaryWriter<OutputBuffer>(output);
+
+            serializer.Serialize(original, writer);
+
+            var input = new InputBuffer(output.Data);
+            var reader = new CompactBinaryReader<InputBuffer>(input);
+            var expected = Deserialize<T>.From(reader);
+
+            var runtimeDeserializer = new RuntimeDeserializer(Schema<T>.RuntimeSchema);
+
+            var runtimeInput = new InputBuffer(output.Data);
+            var runtimeReader = new CompactBinaryReader<InputBuffer>(runtimeInput);
+
+            var actual = runtimeDeserializer.Deserialize(runtimeReader);
+
+            VerifyStructsMatch(expected, actual);
+        }
+
+        private static void TestWithRuntimeDeserializerFast<T>(T original)
+        {
+            var serializer = new Serializer<FastBinaryWriter<OutputBuffer>>(typeof(T));
+
+            var output = new OutputBuffer();
+            var writer = new FastBinaryWriter<OutputBuffer>(output);
+
+            serializer.Serialize(original, writer);
+
+            var input = new InputBuffer(output.Data);
+            var reader = new FastBinaryReader<InputBuffer>(input);
+            var expected = Deserialize<T>.From(reader);
+
+            var runtimeDeserializer = new RuntimeDeserializer(Schema<T>.RuntimeSchema);
+
+            var runtimeInput = new InputBuffer(output.Data);
+            var runtimeReader = new FastBinaryReader<InputBuffer>(runtimeInput);
+
+            var actual = runtimeDeserializer.Deserialize(runtimeReader);
+
+            VerifyStructsMatch(expected, actual);
+        }
+
+        private static void TestWithRuntimeDeserializerSimple<T>(T original)
+        {
+            var serializer = new Serializer<SimpleBinaryWriter<OutputBuffer>>(typeof(T));
+
+            var output = new OutputBuffer();
+            var writer = new SimpleBinaryWriter<OutputBuffer>(output);
+
+            serializer.Serialize(original, writer);
+
+            var input = new InputBuffer(output.Data);
+            var reader = new SimpleBinaryReader<InputBuffer>(input);
+            var expected = Deserialize<T>.From(reader);
+
+            var runtimeDeserializer = new RuntimeDeserializer(Schema<T>.RuntimeSchema);
+
+            var runtimeInput = new InputBuffer(output.Data);
+            var runtimeReader = new SimpleBinaryReader<InputBuffer>(runtimeInput);
+
+            var actual = runtimeDeserializer.Deserialize(runtimeReader);
+
+            VerifyStructsMatch(expected, actual);
+        }
+
+        private static void VerifyStructsMatch(object expected, RuntimeObject actual)
+        {
+            var propertiesVerified = new List<string>();
+
+            foreach (string propertyName in actual.Properties.Keys)
+            {
+                var expectedValue = expected.GetType().GetProperty(propertyName).GetValue(expected, null);
+                var actualValue = actual.Properties[propertyName];
+
+                VerifyObjectsMatch(propertyName, expectedValue, actualValue);
+
+                propertiesVerified.Add(propertyName);
+            }
+        }
+
+        private static void VerifyObjectsMatch(string propertyName, object expectedValue, object actualValue)
+        {
+            if (expectedValue == null && actualValue == null)
+            {
+                return;
+            }
+
+            if (expectedValue == null || actualValue == null)
+            {
+                Assert.Fail(string.Format(
+                    "Expected and actual values of the {0} property do not match. One of them is null.",
+                    propertyName));
+            }
+
+            if (ImplementsInterface(actualValue, typeof(IRuntimeBonded<>)))
+            {
+                if (!ImplementsInterface(expectedValue, typeof(IBonded<>)))
+                {
+                    Assert.Fail("The actual value is bonded, but the expected value is not.");
+                }
+
+                expectedValue = ((IBonded<object>)expectedValue).Deserialize();
+                actualValue = ((IRuntimeBonded)actualValue).Deserialize();
+            }
+
+            if (ImplementsDictionaryInterface(actualValue))
+            {
+                if (!ImplementsDictionaryInterface(expectedValue))
+                {
+                    Assert.Fail("The actual value is a dictionary, but the expected value is not.");
+                }
+
+                var expectedDictionary = GetAsDictionary(expectedValue);
+                var actualDictionary = GetAsDictionary(actualValue);
+
+                Assert.AreEqual(expectedDictionary.Count, actualDictionary.Count);
+                foreach (object key in expectedDictionary.Keys)
+                {
+                    VerifyObjectsMatch(string.Format("{0}[{1}]", propertyName, key), expectedDictionary[key],
+                        actualDictionary[key]);
+                }
+            }
+            else if (ImplementsCollectionInterface(actualValue))
+            {
+                var actualList = GetAsList(actualValue);
+
+                if (!ImplementsCollectionInterface(expectedValue))
+                {
+                    switch (actualList.Count)
+                    {
+                        case 0:
+                            VerifyObjectsMatch(propertyName, expectedValue, null);
+                            return;
+                        case 1:
+                            VerifyObjectsMatch(propertyName, expectedValue, actualList[0]);
+                            return;
+                        default:
+                            Assert.Fail("The actual value is a list, but the expected value is not.");
+                            break;
+                    }
+                }
+
+                var expectedList = GetAsList(expectedValue);
+
+                Assert.AreEqual(expectedList.Count, actualList.Count);
+
+                for (int i = 0; i < expectedList.Count; i++)
+                {
+                    VerifyObjectsMatch(string.Format("{0}[{1}]", propertyName, i), expectedList[i], actualList[i]);
+                }
+            }
+            else if (actualValue is RuntimeObject)
+            {
+                VerifyStructsMatch(expectedValue, (RuntimeObject)actualValue);
+            }
+            else
+            {
+                VerifyScalarValuesMatch(expectedValue, actualValue);
+            }
+        }
+
+        private static bool ImplementsInterface(object actualValue, Type genericTypeDefinition)
+        {
+            if (genericTypeDefinition.IsGenericType)
+            {
+                genericTypeDefinition = genericTypeDefinition.GetGenericTypeDefinition();
+            }
+
+            return actualValue.GetType()
+                .GetInterfaces()
+                .Select(x => x.IsGenericType ? x.GetGenericTypeDefinition() : x)
+                .Any(x => x == genericTypeDefinition);
+        }
+
+        private static bool ImplementsCollectionInterface(object actualValue)
+        {
+            return ImplementsInterface(actualValue, typeof(ICollection))
+                || ImplementsInterface(actualValue, typeof(ICollection<>));
+        }
+
+        private static bool ImplementsDictionaryInterface(object actualValue)
+        {
+            return ImplementsInterface(actualValue, typeof(IDictionary))
+                || ImplementsInterface(actualValue, typeof(IDictionary<,>));
+        }
+
+        private static IList GetAsList(object actualValue)
+        {
+            if (ImplementsInterface(actualValue, typeof(ICollection)))
+            {
+                return new ArrayList((ICollection)actualValue);
+            }
+
+            if (ImplementsInterface(actualValue, typeof(IEnumerable)))
+            {
+                var list = new ArrayList();
+
+                foreach (object obj in (IEnumerable)actualValue)
+                {
+                    list.Add(obj);
+                }
+
+                return list;
+            }
+
+            throw new ArgumentException("The object does not implement a known collection interface.");
+        }
+
+        private static IDictionary GetAsDictionary(object actualValue)
+        {
+            if (actualValue is IDictionary)
+            {
+                return (IDictionary)actualValue;
+            }
+
+            if (ImplementsInterface(actualValue, typeof(IEnumerable)))
+            {
+                var hashtable = new Hashtable();
+
+                var keyProperty = typeof(KeyValuePair<,>).GetProperty("Key");
+                var valueProperty = typeof(KeyValuePair<,>).GetProperty("Value");
+
+                foreach (var kvp in (IEnumerable)actualValue)
+                {
+                    hashtable.Add(keyProperty.GetValue(kvp, null), valueProperty.GetValue(kvp, null));
+                }
+
+                return hashtable;
+            }
+
+            throw new ArgumentException("The object does not implement a known dictionary interface.");
+        }
+
+        private static void VerifyScalarValuesMatch(object expectedValue, object actualValue)
+        {
+            if (actualValue.GetType() == typeof(bool))
+            {
+                Assert.AreEqual((bool)expectedValue, (bool)actualValue);
+            }
+            else if (actualValue.GetType() == typeof(sbyte))
+            {
+                Assert.AreEqual((sbyte)expectedValue, (sbyte)actualValue);
+            }
+            else if (actualValue.GetType() == typeof(short))
+            {
+                Assert.AreEqual((short)expectedValue, (short)actualValue);
+            }
+            else if (actualValue.GetType() == typeof(int)
+                || expectedValue.GetType().IsEnum)
+            {
+                Assert.AreEqual((int)expectedValue, (int)actualValue);
+            }
+            else if (actualValue.GetType() == typeof(long))
+            {
+                if (expectedValue.GetType() == typeof(DateTime))
+                {
+                    Assert.AreEqual(((DateTime)expectedValue).Ticks, (long)actualValue);
+                }
+                else
+                {
+                    Assert.AreEqual((long)expectedValue, (long)actualValue);
+                }
+            }
+            else if (actualValue.GetType() == typeof(byte))
+            {
+                Assert.AreEqual((byte)expectedValue, (byte)actualValue);
+            }
+            else if (actualValue.GetType() == typeof(ushort))
+            {
+                Assert.AreEqual((ushort)expectedValue, (ushort)actualValue);
+            }
+            else if (actualValue.GetType() == typeof(uint))
+            {
+                Assert.AreEqual((uint)expectedValue, (uint)actualValue);
+            }
+            else if (actualValue.GetType() == typeof(ulong))
+            {
+                Assert.AreEqual((ulong)expectedValue, (ulong)actualValue);
+            }
+            else if (actualValue.GetType() == typeof(float))
+            {
+                Assert.AreEqual((float)expectedValue, (float)actualValue);
+            }
+            else if (actualValue.GetType() == typeof(double))
+            {
+                Assert.AreEqual((double)expectedValue, (double)actualValue);
+            }
+            else if (actualValue.GetType() == typeof(string))
+            {
+                Assert.AreEqual((string)expectedValue, (string)actualValue);
+            }
+            else
+            {
+                Assert.AreEqual(expectedValue.ToString(), actualValue.ToString());
+            }
+        }
+    }
+}

--- a/cs/test/core/RuntimeSerializerTests.cs
+++ b/cs/test/core/RuntimeSerializerTests.cs
@@ -1,0 +1,418 @@
+﻿namespace UnitTest
+{
+    using System;
+    using System.Collections.Generic;
+    using Bond;
+    using Bond.IO.Safe;
+    using Bond.Protocols;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class RuntimeSerializerTests
+    {
+        [Test]
+        public void Serialize_SerializesScalarTypesCorrectlyWhenEverythingIsPopulated()
+        {
+            var original = new BasicTypes
+            {
+                _bool = true,
+                _str = "String",
+                _wstr = "WideString",
+                _uint64 = ulong.MaxValue - 6464,
+                _uint16 = ushort.MaxValue - 1616,
+                _uint32 = uint.MaxValue - 3232,
+                _uint8 = byte.MaxValue - 88,
+                _int8 = sbyte.MaxValue - 8,
+                _int16 = short.MaxValue - 16,
+                _int32 = int.MaxValue - 32,
+                _int64 = long.MaxValue - 64,
+                _double = double.MaxValue / 22,
+                _float = float.MaxValue / 2,
+                _enum1 = EnumType1.EnumValue4,
+                dt = DateTime.UtcNow,
+            };
+
+            TestRuntimeSerialization(original);
+        }
+
+        [Test]
+        public void Serialize_SerializesScalarTypesCorrectlyWhenOnlySomePropertiesArePopulated()
+        {
+            var original = new BasicTypes
+            {
+                _str = "String",
+                _uint32 = uint.MaxValue - 3232,
+                _uint8 = byte.MaxValue - 88,
+                _int16 = short.MaxValue - 16,
+                _int64 = long.MaxValue - 64,
+                _double = double.MaxValue / 22,
+                _float = float.MaxValue / 2,
+                _enum1 = EnumType1.EnumValue4,
+                dt = DateTime.UtcNow,
+            };
+
+            TestRuntimeSerializerDataCompact(original);
+            TestRuntimeSerializerDataSimple(original);
+        }
+
+        [Test]
+        public void Serialize_SerializesDefaultValuesCorrectly()
+        {
+            var original = new BasicTypes();
+
+            TestRuntimeSerializerDataCompact(original);
+            TestRuntimeSerializerDataSimple(original);
+        }
+
+        [Test]
+        public void Serialize_SerializesNestedTypesCorrectly()
+        {
+            var original = new Nested
+            {
+                basic = new BasicTypes
+                {
+                    _str = "Basic",
+                },
+                nested = new Nested1
+                {
+                    basic1 = new BasicTypes { _str = "Basic1" },
+                    basic2 = new BasicTypes { _str = "Basic2" },
+                    guid = new GUID { Data1 = 101, Data2 = 202, Data3 = 303, Data4 = 404 },
+                },
+            };
+
+            TestRuntimeSerializerDataCompact(original);
+            TestRuntimeSerializerDataSimple(original);
+        }
+
+        [Test]
+        public void Serialize_SerializesBondedPropertiesCorrectly()
+        {
+            var original = new StructWithBonded
+            {
+                field = new Bonded<Nested>(new Nested
+                {
+                    basic = new BasicTypes
+                    {
+                        _str = "Bonded field.basic._str",
+                    },
+                    nested = new Nested1
+                    {
+                        guid = new GUID { Data1 = 1, Data2 = 22, Data3 = 333, Data4 = 4444 },
+                    },
+                }),
+            };
+
+            TestRuntimeSerializerDataCompact(original);
+            TestRuntimeSerializerDataSimple(original);
+        }
+
+        [Test]
+        public void Serialize_SerializesListPropertiesCorrectly()
+        {
+            var original = new StructWithByteLists
+            {
+                b = new List<sbyte> { 1 },
+#if BOND_LIST_INTERFACES
+                lb = new List<IList<sbyte>> { new List<sbyte> { 21, 22 }, new List<sbyte> { 23, 24 } },
+#else
+                lb = new List<List<sbyte>> { new List<sbyte> { 21, 22 }, new List<sbyte> { 23, 24 } },
+#endif
+            };
+
+            TestRuntimeSerializerDataCompact(original);
+            TestRuntimeSerializerDataSimple(original);
+        }
+
+        [Test]
+        public void Serialize_SerializesMapPropertiesCorrectly()
+        {
+            var original = new Maps
+            {
+                _bool = new Dictionary<string, bool> { { "trueValue", true }, { "falseValue", false } },
+                _str = new Dictionary<string, string> { { "stringValue", "Abc123" } },
+            };
+
+            TestRuntimeSerializerDataCompact(original);
+            TestRuntimeSerializerDataSimple(original);
+        }
+
+        [Test]
+        public void Serialize_SerializesNullablePropertiesCorrectlyWhenNotNull()
+        {
+            var original = new NullableBasicTypes
+            {
+                _bool = true,
+                _str = "str value",
+                _wstr = "wstr value",
+                _int8 = -8,
+                _int16 = -16,
+                _int32 = -32,
+                _int64 = -64,
+                _uint8 = 8,
+                _uint16 = 16,
+                _uint32 = 32,
+                _uint64 = 64,
+                _double = 2468.10,
+                _float = 1234.5f,
+                _enum1 = EnumType1.EnumValue3,
+                dt = DateTime.UtcNow,
+            };
+
+            TestRuntimeSerializerDataCompact(original);
+            TestRuntimeSerializerDataSimple(original);
+        }
+
+        [Test]
+        public void Serialize_SerializesNullablePropertiesCorrectlyWhenNull()
+        {
+            var original = new NullableBasicTypes
+            {
+                _bool = null,
+                _str = null,
+                _wstr = null,
+                _int8 = null,
+                _int16 = null,
+                _int32 = null,
+                _int64 = null,
+                _uint8 = null,
+                _uint16 = null,
+                _uint32 = null,
+                _uint64 = null,
+                _double = null,
+                _float = null,
+                _enum1 = null,
+                dt = null,
+            };
+
+            TestRuntimeSerializerDataCompact(original);
+            TestRuntimeSerializerDataSimple(original);
+        }
+
+        [Test]
+        public void Serialize_SerializesGenericsCorrectly()
+        {
+            var original = new Generics
+            {
+                sb = new GenericScalar<bool>
+                {
+                    field = true,
+                    vectorField = new List<bool> { true, false },
+                    listGeneric = new LinkedList<GenericScalar<bool>>(
+                        new[]
+                        {
+                            new GenericScalar<bool>
+                            {
+                                field = true,
+                                vectorField = new List<bool> { false, true },
+                                nullableField = true,
+                                mapField = new Dictionary<bool,bool> { { true, false }, { false, true } },
+                            }
+                        }
+                        ),
+                    nullableField = true,
+                    mapField = new Dictionary<bool, bool> { { true, true }, { false, false } },
+                },
+                ci32 = new GenericClass<HashSet<int>>
+                {
+                    field = new HashSet<int> { 101 },
+                    vectorField = new List<HashSet<int>> { new HashSet<int> { 201 } },
+                    listGeneric = new LinkedList<GenericClass<HashSet<int>>>(
+                        new[]
+                        {
+                            new GenericClass<HashSet<int>>
+                            {
+                                field = new HashSet<int> { 301 },
+                                vectorField = new List<HashSet<int>> { new HashSet<int> { 302 } },
+                                nullableField = new HashSet<int> { 303 },
+                                mapField = new Dictionary<string,HashSet<int>>
+                                {
+                                    { "304", new HashSet<int> { 304 } }
+                                },
+                            }
+                        }),
+                    nullableField = new HashSet<int> { 401 },
+                    mapField = new Dictionary<string, HashSet<int>> { { "501", new HashSet<int> { 601 } } },
+                },
+            };
+
+            TestRuntimeSerializerDataCompact(original);
+            TestRuntimeSerializerDataSimple(original);
+        }
+
+        [Test]
+        public void Serialize_SerializesFieldsFromBaseTypeCorrectly()
+        {
+            var original = new DerivedWithMeta
+            {
+                a = "ValueFromBaseClass",
+                b = "ValueFromSubClass",
+            };
+
+            TestRuntimeSerializerDataCompact(original);
+            TestRuntimeSerializerDataSimple(original);
+        }
+
+        [Test]
+        public void Serialize_SerializesOptionalFieldsCorrectly()
+        {
+            var original = new WithOptional
+            {
+                field = 3,
+                fieldWithDefault = 4,
+            };
+
+            TestRuntimeSerializerDataCompact(original);
+            TestRuntimeSerializerDataSimple(original);
+        }
+
+        [Test]
+        public void Serialize_SerializesOptionalAliasedFieldsCorrectly()
+        {
+            var original = new WithOptionalAliased
+            {
+                field = DateTime.UtcNow,
+                fieldWithDefault = DateTime.UtcNow,
+            };
+
+            TestRuntimeSerializerDataCompact(original);
+            TestRuntimeSerializerDataSimple(original);
+        }
+
+        [Test]
+        public void Serialize_SerializesOptionalNullableFieldsCorrectly()
+        {
+            var original = new WithOptionalNullable
+            {
+                field = 3,
+                fieldWithDefault = 4,
+            };
+
+            TestRuntimeSerializerDataCompact(original);
+            TestRuntimeSerializerDataSimple(original);
+        }
+
+        [Test]
+        public void Serialize_SerializesOptionalNullableAliasedFieldsCorrectly()
+        {
+            var original = new WithOptionalNullableAliased
+            {
+                field = DateTime.UtcNow,
+                fieldWithDefault = DateTime.UtcNow,
+            };
+
+            TestRuntimeSerializerDataCompact(original);
+            TestRuntimeSerializerDataSimple(original);
+        }
+
+        private static void TestRuntimeSerialization<T>(T original)
+        {
+            TestRuntimeSerializerDataCompact(original);
+            TestRuntimeSerializerDataFast(original);
+            TestRuntimeSerializerDataSimple(original);
+        }
+
+        private static void TestRuntimeSerializerDataCompact<T>(T obj)
+        {
+            var serializer = new Serializer<CompactBinaryWriter<OutputBuffer>>(typeof(T));
+
+            var output = new OutputBuffer();
+            var writer = new CompactBinaryWriter<OutputBuffer>(output);
+
+            serializer.Serialize(obj, writer);
+
+            var runtimeObj = DeserializeCompactWithRuntimeDeserializer<T>(output.Data);
+
+            var runtimeSerializer = new RuntimeSerializer(Schema<T>.RuntimeSchema);
+
+            var runtimeOutput = new OutputBuffer();
+            var runtimeWriter = new CompactBinaryWriter<OutputBuffer>(runtimeOutput);
+
+            runtimeSerializer.Serialize(runtimeWriter, runtimeObj);
+
+            VerifyDataMatches(output.Data, runtimeOutput.Data);
+        }
+
+        private static void TestRuntimeSerializerDataFast<T>(T obj)
+        {
+            var serializer = new Serializer<FastBinaryWriter<OutputBuffer>>(typeof(T));
+
+            var output = new OutputBuffer();
+            var writer = new FastBinaryWriter<OutputBuffer>(output);
+
+            serializer.Serialize(obj, writer);
+
+            var runtimeObj = DeserializeFastWithRuntimeDeserializer<T>(output.Data);
+
+            var runtimeSerializer = new RuntimeSerializer(Schema<T>.RuntimeSchema);
+
+            var runtimeOutput = new OutputBuffer();
+            var runtimeWriter = new FastBinaryWriter<OutputBuffer>(runtimeOutput);
+
+            runtimeSerializer.Serialize(runtimeWriter, runtimeObj);
+
+            VerifyDataMatches(output.Data, runtimeOutput.Data);
+        }
+
+        private static void TestRuntimeSerializerDataSimple<T>(T obj)
+        {
+            var serializer = new Serializer<SimpleBinaryWriter<OutputBuffer>>(typeof(T));
+
+            var output = new OutputBuffer();
+            var writer = new SimpleBinaryWriter<OutputBuffer>(output);
+
+            serializer.Serialize(obj, writer);
+
+            var runtimeObj = DeserializeSimpleWithRuntimeDeserializer<T>(output.Data);
+
+            var runtimeSerializer = new RuntimeSerializer(Schema<T>.RuntimeSchema);
+
+            var runtimeOutput = new OutputBuffer();
+            var runtimeWriter = new SimpleBinaryWriter<OutputBuffer>(runtimeOutput);
+
+            runtimeSerializer.Serialize(runtimeWriter, runtimeObj);
+
+            VerifyDataMatches(output.Data, runtimeOutput.Data);
+        }
+
+        private static RuntimeObject DeserializeCompactWithRuntimeDeserializer<T>(ArraySegment<byte> data)
+        {
+            var deserializer = new Bond.RuntimeDeserializer(Schema<T>.RuntimeSchema);
+
+            var input = new InputBuffer(data);
+            var reader = new CompactBinaryReader<InputBuffer>(input);
+
+            return deserializer.Deserialize(reader);
+        }
+
+        private static RuntimeObject DeserializeFastWithRuntimeDeserializer<T>(ArraySegment<byte> data)
+        {
+            var deserializer = new Bond.RuntimeDeserializer(Schema<T>.RuntimeSchema);
+
+            var input = new InputBuffer(data);
+            var reader = new FastBinaryReader<InputBuffer>(input);
+
+            return deserializer.Deserialize(reader);
+        }
+
+        private static RuntimeObject DeserializeSimpleWithRuntimeDeserializer<T>(ArraySegment<byte> data)
+        {
+            var deserializer = new Bond.RuntimeDeserializer(Schema<T>.RuntimeSchema);
+
+            var input = new InputBuffer(data);
+            var reader = new SimpleBinaryReader<InputBuffer>(input);
+
+            return deserializer.Deserialize(reader);
+        }
+
+        private static void VerifyDataMatches(ArraySegment<byte> data, ArraySegment<byte> runtimeData)
+        {
+            Assert.AreEqual(data.Count, runtimeData.Count);
+
+            for (int i = 0; i < data.Count; i++)
+            {
+                Assert.AreEqual(data.Array[i], runtimeData.Array[i]);
+            }
+        }
+    }
+}

--- a/cs/test/core/SerializationTests.cs
+++ b/cs/test/core/SerializationTests.cs
@@ -413,6 +413,48 @@
             Assert.IsNotNull(new EnsureSpacesInPathsWork());
         }
 
+        [Test]
+        public void OptionalAndNullable()
+        {
+            TestSerialization<WithOptional>();
+            TestSerialization<WithOptionalAliased>();
+            TestSerialization<WithOptionalNullable>();
+            TestSerialization<WithOptionalNullableAliased>();
+            TestSerialization<InheritsWithOptional>();
+            TestSerialization<InheritsWithOptionalAliased>();
+            TestSerialization<InheritsWithOptionalNullable>();
+            TestSerialization<InheritsWithOptionalNullableAliased>();
+        }
+
+        [Test]
+        public void TestCreateSerializer()
+        {
+            var serializer = new Serializer<
+                Bond.Protocols.CompactBinaryWriter<
+                    Bond.IO.Unsafe.OutputBuffer>>(typeof(WithOptional));
+            serializer = new Serializer<
+                Bond.Protocols.CompactBinaryWriter<
+                    Bond.IO.Unsafe.OutputBuffer>>(typeof(WithOptionalAliased));
+            serializer = new Serializer<
+                Bond.Protocols.CompactBinaryWriter<
+                    Bond.IO.Unsafe.OutputBuffer>>(typeof(WithOptionalNullable));
+            serializer = new Serializer<
+                Bond.Protocols.CompactBinaryWriter<
+                    Bond.IO.Unsafe.OutputBuffer>>(typeof(WithOptionalNullableAliased));
+            serializer = new Serializer<
+                Bond.Protocols.CompactBinaryWriter<
+                    Bond.IO.Unsafe.OutputBuffer>>(typeof(InheritsWithOptional));
+            serializer = new Serializer<
+                Bond.Protocols.CompactBinaryWriter<
+                    Bond.IO.Unsafe.OutputBuffer>>(typeof(InheritsWithOptionalAliased));
+            serializer = new Serializer<
+                Bond.Protocols.CompactBinaryWriter<
+                    Bond.IO.Unsafe.OutputBuffer>>(typeof(InheritsWithOptionalNullable));
+            serializer = new Serializer<
+                Bond.Protocols.CompactBinaryWriter<
+                    Bond.IO.Unsafe.OutputBuffer>>(typeof(InheritsWithOptionalNullableAliased));
+        }
+
         void TestTypePromotion<From, To>()
         {
             TestFieldSerialization<From, To>();

--- a/cs/test/core/UnitTest.bond
+++ b/cs/test/core/UnitTest.bond
@@ -715,3 +715,43 @@ struct WithConflictingMeta
     2: string fullName = "Bar";
     3: bond_meta::full_name meta;
 }
+
+struct WithOptional
+{
+    1: optional int64 field;
+    2: optional int64 fieldWithDefault = nothing;
+}
+
+struct WithOptionalAliased
+{
+    1: optional DateTime field;
+    2: optional DateTime fieldWithDefault = nothing;
+}
+
+struct WithOptionalNullable
+{
+    1: optional nullable<int64> field;
+    2: optional nullable<int64> fieldWithDefault = nothing;
+}
+
+struct WithOptionalNullableAliased
+{
+    1: optional nullable<DateTime> field;
+    2: optional nullable<DateTime> fieldWithDefault = nothing;
+}
+
+struct InheritsWithOptional : WithOptional
+{
+}
+
+struct InheritsWithOptionalAliased : WithOptionalAliased
+{
+}
+
+struct InheritsWithOptionalNullable : WithOptionalNullable
+{
+}
+
+struct InheritsWithOptionalNullableAliased : WithOptionalNullableAliased
+{
+}

--- a/cs/test/core/Util.cs
+++ b/cs/test/core/Util.cs
@@ -772,7 +772,16 @@ namespace UnitTest
             });
 
             // Simple doesn't support omitting fields
-            if (typeof(From) != typeof(Nothing) && typeof(From) != typeof(GenericsWithNothing))
+            if (typeof(From) != typeof(Nothing)
+                && typeof(From) != typeof(GenericsWithNothing)
+                && typeof(From) != typeof(WithOptional)
+                && typeof(From) != typeof(WithOptionalAliased)
+                && typeof(From) != typeof(WithOptionalNullable)
+                && typeof(From) != typeof(WithOptionalNullableAliased)
+                && typeof(From) != typeof(InheritsWithOptional)
+                && typeof(From) != typeof(InheritsWithOptionalAliased)
+                && typeof(From) != typeof(InheritsWithOptionalNullable)
+                && typeof(From) != typeof(InheritsWithOptionalNullableAliased))
             {
                 streamRoundtrip(SerializeSP, DeserializeSP<From, To>);
                 memoryRoundtrip(SerializeSP, DeserializeSafeSP<From, To>);


### PR DESCRIPTION
This includes the addition of RuntimeSerializer and RuntimeDeserializer, which use a new RuntimeObject type (instead of actual .NET types) to represent bond structs. That allows bond data to be serialized/deserialized using just a RuntimeSchema, without a corresponding .NET type.

Unit tests were added to verify that RuntimeDeserializer deserializes values that are the same as Deserializer, and that RuntimeSerializer serializes the exact same bytes as Serializer.