### PR TITLE
Add ability to customize default implementation of bonded<T> in C#

### DIFF
--- a/cs/src/core/Clone.cs
+++ b/cs/src/core/Clone.cs
@@ -37,30 +37,58 @@ namespace Bond
     public class Cloner<SourceT>
     {
         readonly Func<object, object>[] clone;
-        
+
+        /// <summary>
+        /// Create a cloner that makes clones of the same type SourceT as source objects.
+        /// </summary>
+        public Cloner()
+            : this(typeof(SourceT))
+        {}
+
         /// <summary>
         /// Create a cloner that makes clones of the specified type.
         /// </summary>
         /// <param name="type">type of clone object, may be different than source object</param>
         public Cloner(Type type)
+            : this(type, (IParser) null)
+        {}
+
+        /// <summary>
+        /// Create a cloner that makes clones of the specified type.
+        /// </summary>
+        /// <param name="type">type of clone object, may be different than source object</param>
+        /// <param name="parser">Custom <see cref="IParser"/> instance</param>
+        public Cloner(Type type, IParser parser)
         {
-            clone = Generate(type, new DeserializerTransform<object>(
-                (o, i) => clone[i](o)));
+            clone = Generate(type,
+                             new DeserializerTransform<object>((o, i) => clone[i](o)),
+                             parser);
         }
+
+        /// <summary>
+        /// Create a cloner that makes clones of the specified type.
+        /// </summary>
+        /// <param name="type">type of clone object, may be different than source object</param>
+        /// /// <param name="factory">factory implementing IFactory interface</param>
+        public Cloner(Type type, IFactory factory)
+            : this(type, null, factory)
+        {}
 
         /// <summary>
         /// Create a cloner that uses specified factory and makes clones of the specified type.
         /// </summary>
         /// <param name="type">type of clone object, may be different than source object</param>
+        /// <param name="parser">Custom <see cref="IParser"/> instance</param>
         /// <param name="factory">factory implementing IFactory interface</param>
-        public Cloner(Type type, IFactory factory)
+        public Cloner(Type type, IParser parser, IFactory factory)
         {
-            clone = Generate(type, 
-                new DeserializerTransform<object>(
-                    (o, i) => clone[i](o),
-                    true,
-                    (t1, t2) => factory.CreateObject(t1, t2),
-                    (t1, t2, count) => factory.CreateContainer(t1, t2, count)));
+            clone = Generate(type,
+                             new DeserializerTransform<object>(
+                                 (o, i) => clone[i](o),
+                                 true,
+                                 (t1, t2) => factory.CreateObject(t1, t2),
+                                 (t1, t2, count) => factory.CreateContainer(t1, t2, count)),
+                             parser);
         }
 
         /// <summary>
@@ -69,19 +97,23 @@ namespace Bond
         /// <param name="type">type of clone object, may be different than source object</param>
         /// <param name="factory">factory delegate returning expressions to create objects</param>
         public Cloner(Type type, Factory factory)
-        {
-            clone = Generate(type,
-                new DeserializerTransform<object>(
-                    (o, i) => clone[i](o),
-                    factory));
-        }
+            : this(type, null, factory)
+        {}
 
         /// <summary>
-        /// Create a cloner that makes clones of the same type SourceT as source objects.
+        /// Create a cloner that uses specified factory and makes clones of the specified type.
         /// </summary>
-        public Cloner()
-            : this(typeof(SourceT))
-        {}
+        /// <param name="type">type of clone object, may be different than source object</param>
+        /// <param name="parser">Custom IParser instance</param>
+        /// <param name="factory">factory delegate returning expressions to create objects</param>
+        public Cloner(Type type, IParser parser, Factory factory)
+        {
+            clone = Generate(type,
+                             new DeserializerTransform<object>(
+                                 (o, i) => clone[i](o),
+                                 factory),
+                             parser);
+        }
 
         /// <summary>
         /// Clone the source object into an object of type T.
@@ -94,9 +126,10 @@ namespace Bond
             return (T)clone[0](source);
         }
 
-        static Func<object, object>[] Generate(Type type, DeserializerTransform<object> transform)
+        static Func<object, object>[] Generate(Type type, DeserializerTransform<object> transform, IParser parser)
         {
-            var parser = new ObjectParser(typeof(SourceT));
+            parser = parser ?? new ObjectParser(typeof(SourceT));
+            
             return transform.Generate(parser, type).Select(lambda => lambda.Compile()).ToArray();
         }
     }

--- a/cs/src/core/Clone.cs
+++ b/cs/src/core/Clone.cs
@@ -19,9 +19,9 @@ namespace Bond
         }
 
         /// <summary>
-        /// Create an instance of type T by deep cloning properties/fields of a source object of type SourceT.
+        /// Create an instance of type <typeparamref name="T"/> by deep cloning properties/fields of a source object of type <typeparamref name="SourceT"/>.
         /// </summary>
-        /// <typeparam name="SourceT">type representing a source schema compatible with schema T</typeparam>
+        /// <typeparam name="SourceT">type representing a source schema compatible with schema <typeparamref name="T"/></typeparam>
         /// <param name="source">source object to create a clone from</param>
         /// <returns></returns>
         public static T From<SourceT>(SourceT source)
@@ -31,7 +31,7 @@ namespace Bond
     }
 
     /// <summary>
-    /// Utility for cloning objects of type SourceT.
+    /// Utility for cloning objects of type <typeparamref name="SourceT"/>.
     /// </summary>
     /// <typeparam name="SourceT">type representing a Bond schema</typeparam>
     public class Cloner<SourceT>
@@ -39,7 +39,7 @@ namespace Bond
         readonly Func<object, object>[] clone;
 
         /// <summary>
-        /// Create a cloner that makes clones of the same type SourceT as source objects.
+        /// Create a cloner that makes clones of the same type <typeparamref name="SourceT"/> as source objects.
         /// </summary>
         public Cloner()
             : this(typeof(SourceT))
@@ -69,7 +69,7 @@ namespace Bond
         /// Create a cloner that makes clones of the specified type.
         /// </summary>
         /// <param name="type">type of clone object, may be different than source object</param>
-        /// /// <param name="factory">factory implementing IFactory interface</param>
+        /// /// <param name="factory">factory implementing <see cref="IFactory"/> interface</param>
         public Cloner(Type type, IFactory factory)
             : this(type, null, factory)
         {}
@@ -79,7 +79,7 @@ namespace Bond
         /// </summary>
         /// <param name="type">type of clone object, may be different than source object</param>
         /// <param name="parser">Custom <see cref="IParser"/> instance</param>
-        /// <param name="factory">factory implementing IFactory interface</param>
+        /// <param name="factory">factory implementing <see cref="IFactory"/> interface</param>
         public Cloner(Type type, IParser parser, IFactory factory)
         {
             clone = Generate(type,
@@ -104,7 +104,7 @@ namespace Bond
         /// Create a cloner that uses specified factory and makes clones of the specified type.
         /// </summary>
         /// <param name="type">type of clone object, may be different than source object</param>
-        /// <param name="parser">Custom IParser instance</param>
+        /// <param name="parser">Custom <see cref="IParser"/> instance</param>
         /// <param name="factory">factory delegate returning expressions to create objects</param>
         public Cloner(Type type, IParser parser, Factory factory)
         {
@@ -116,11 +116,11 @@ namespace Bond
         }
 
         /// <summary>
-        /// Clone the source object into an object of type T.
+        /// Clone the source object into an object of type <typeparamref name="T"/>.
         /// </summary>
-        /// <typeparam name="T">type of result, must be the same as types specified during Cloner construction</typeparam>
+        /// <typeparam name="T">type of result, must be the same as types specified during <see cref="Cloner{SourceT}" /> construction</typeparam>
         /// <param name="source">source object to be cloned</param>
-        /// <returns>clone of the source object projected on type T</returns>
+        /// <returns>clone of the source object projected on type <typeparamref name="T"/></returns>
         public T Clone<T>(SourceT source)
         {
             return (T)clone[0](source);

--- a/cs/src/core/Deserializer.cs
+++ b/cs/src/core/Deserializer.cs
@@ -109,11 +109,35 @@ namespace Bond
         /// Create a deserializer instance for specified type, using a custom object factory
         /// </summary>
         /// <param name="type">Type representing a Bond schema</param>
+        /// <param name="parser">Custom IParser instance</param>
+        /// <param name="factory">Factory providing expressions to create objects during deserialization</param>
+        /// <param name="inlineNested">Inline nested types if possible (optimizes for reduction of execution time
+        /// at the expense of initialization time and memory)</param>
+        public Deserializer(Type type, IParser parser, IFactory factory, bool inlineNested)
+            : this(type, parser, factory, null, inlineNested)
+        { }
+
+        /// <summary>
+        /// Create a deserializer instance for specified type, using a custom object factory
+        /// </summary>
+        /// <param name="type">Type representing a Bond schema</param>
         /// <param name="factory">Factory providing expressions to create objects during deserialization</param>
         /// <param name="inlineNested">Inline nested types if possible (optimizes for reduction of execution time
         /// at the expense of initialization time and memory)</param>
         public Deserializer(Type type, Factory factory, bool inlineNested)
             : this(type, ParserFactory<R>.Create(type), null, factory, inlineNested)
+        { }
+
+        /// <summary>
+        /// Create a deserializer instance for specified type, using a custom object factory
+        /// </summary>
+        /// <param name="type">Type representing a Bond schema</param>
+        /// <param name="parser">Custom IParser instance</param>
+        /// <param name="factory">Factory providing expressions to create objects during deserialization</param>
+        /// <param name="inlineNested">Inline nested types if possible (optimizes for reduction of execution time
+        /// at the expense of initialization time and memory)</param>
+        public Deserializer(Type type, IParser parser, Factory factory, bool inlineNested)
+            : this(type, parser, null, factory, inlineNested)
         { }
 
         /// <summary>

--- a/cs/src/core/Deserializer.cs
+++ b/cs/src/core/Deserializer.cs
@@ -11,7 +11,7 @@ namespace Bond
     using Bond.IO;
 
     /// <summary>
-    /// Deserialize objects of type T
+    /// Deserialize objects of type <typeparamref name="T"/>
     /// </summary>
     /// <typeparam name="T">Type representing a Bond schema</typeparam>
     public static class Deserialize<T>
@@ -22,7 +22,7 @@ namespace Bond
         }
 
         /// <summary>
-        /// Deserialize an object of type T from a payload
+        /// Deserialize an object of type <typeparamref name="T"/> from a payload
         /// </summary>
         /// <typeparam name="R">Protocol reader</typeparam>
         /// <param name="reader">Protocol reader representing payload</param>
@@ -34,7 +34,7 @@ namespace Bond
     }
 
     /// <summary>
-    /// Deserializer for a protocol reader R
+    /// Deserializer for a protocol reader <typeparamref name="R"/>
     /// </summary>
     /// <typeparam name="R">Protocol reader</typeparam>
     public class Deserializer<R>
@@ -109,7 +109,7 @@ namespace Bond
         /// Create a deserializer instance for specified type, using a custom object factory
         /// </summary>
         /// <param name="type">Type representing a Bond schema</param>
-        /// <param name="parser">Custom IParser instance</param>
+        /// <param name="parser">Custom <see cref="IParser"/> instance</param>
         /// <param name="factory">Factory providing expressions to create objects during deserialization</param>
         /// <param name="inlineNested">Inline nested types if possible (optimizes for reduction of execution time
         /// at the expense of initialization time and memory)</param>
@@ -132,7 +132,7 @@ namespace Bond
         /// Create a deserializer instance for specified type, using a custom object factory
         /// </summary>
         /// <param name="type">Type representing a Bond schema</param>
-        /// <param name="parser">Custom IParser instance</param>
+        /// <param name="parser">Custom <see cref="IParser"/> instance</param>
         /// <param name="factory">Factory providing expressions to create objects during deserialization</param>
         /// <param name="inlineNested">Inline nested types if possible (optimizes for reduction of execution time
         /// at the expense of initialization time and memory)</param>
@@ -198,7 +198,7 @@ namespace Bond
         }
 
         /// <summary>
-        /// Deserialize an object of type T from a payload
+        /// Deserialize an object of type <typeparamref name="T"/> from a payload
         /// </summary>
         /// <typeparam name="T">Type representing a Bond schema</typeparam>
         /// <param name="reader">Protocol reader representing the payload</param>
@@ -231,11 +231,13 @@ namespace Bond
     public static class Deserializer
     {
         /// <summary>
-        /// Deserialize an object from an IBonded&lt;T> instance using a specific deserializer
+        /// Deserialize an object from an <see cref="IBonded{T}"/> instance using a specific deserializer
         /// </summary>
-        /// <param name="deserializer">Deserializer to be used to deserialize IBonded&lt;T> payload</param>
-        /// <param name="bonded">IBonded&lt;T> instance representing payload</param>
-        /// <remarks>Implemented as an extension method to avoid ICloneable&lt;R> constraint on Deserializer&lt;R></remarks>
+        /// <typeparam name="R">Protocol reader</typeparam>
+        /// <typeparam name="T">Type of source object in the bonded</typeparam>
+        /// <param name="deserializer">Deserializer to be used to deserialize <see cref="IBonded{T}"/> payload</param>
+        /// <param name="bonded"><see cref="IBonded{T}"/> instance representing payload</param>
+        /// <remarks>Implemented as an extension method to avoid <see cref="ICloneable{R}"/> constraint on <see cref="Deserializer{R}"/></remarks>
         /// <returns>Deserialized object</returns>
         public static T Deserialize<T, R>(this Deserializer<R> deserializer, IBonded<T> bonded)
             where R : ICloneable<R>

--- a/cs/src/core/Serializer.cs
+++ b/cs/src/core/Serializer.cs
@@ -66,16 +66,31 @@ namespace Bond
         /// Create a serializer for specified type
         /// </summary>
         /// <param name="type">Type representing a Bond schema</param>
-        public Serializer(Type type) : this(type, inlineNested: true) { }
+        public Serializer(Type type) : this(type, null, inlineNested: true) { }
+
+        /// <summary>
+        /// Create a serializer for specified type
+        /// </summary>
+        /// <param name="type">Type representing a Bond schema</param>
+        /// <param name="parser">Custom IParser instance</param>
+        public Serializer(Type type, IParser parser) : this(type, parser, inlineNested: true) { }
 
         /// <summary>
         /// Create a serializer for specified type
         /// </summary>
         /// <param name="type">Type representing a Bond schema</param>
         /// <param name="inlineNested">Indicates whether nested struct serialization code may be inlined</param>
-        public Serializer(Type type, bool inlineNested)
+        public Serializer(Type type, bool inlineNested) : this(type, null, inlineNested) { }
+
+        /// <summary>
+        /// Create a serializer for specified type
+        /// </summary>
+        /// <param name="type">Type representing a Bond schema</param>
+        /// <param name="parser">Custom IParser instance</param>
+        /// <param name="inlineNested">Indicates whether nested struct serialization code may be inlined</param>
+        public Serializer(Type type, IParser parser, bool inlineNested)
         {
-            var parser = new ObjectParser(type);
+            parser = parser ?? new ObjectParser(type);
             serialize = SerializerGeneratorFactory<object, W>.Create(
                     (o, w, i) => serialize[i](o, w), type, inlineNested)
                 .Generate(parser)

--- a/cs/src/core/Serializer.cs
+++ b/cs/src/core/Serializer.cs
@@ -19,7 +19,7 @@ namespace Bond
         }
 
         /// <summary>
-        /// Serialize object of type T to protocol writer of type W
+        /// Serialize object of type <typeparamref name="T"/> to protocol writer of type <typeparamref name="W"/>
         /// </summary>
         /// <typeparam name="W">Protocol writer</typeparam>
         /// <typeparam name="T">Type representing a Bond schema</typeparam>
@@ -31,23 +31,23 @@ namespace Bond
         }
 
         /// <summary>
-        /// Serialize IBonded&lt;T> to protocol writer of type W
+        /// Serialize <see cref="IBonded{T}" /> to protocol writer of type <typeparamref name="W"/>
         /// </summary>
         /// <typeparam name="W">Protocol writer</typeparam>
         /// <typeparam name="T">Type representing a Bond schema</typeparam>
         /// <param name="writer">Writer instance</param>
-        /// <param name="bonded">IBonded instance</param>
+        /// <param name="bonded"><see cref="IBonded"/> instance</param>
         public static void To<W, T>(W writer, IBonded<T> bonded)
         {
             bonded.Serialize(writer);
         }
 
         /// <summary>
-        /// Serialize IBonded to protocol writer of type W
+        /// Serialize <see cref="IBonded"/> to protocol writer of type <typeparamref name="W"/>
         /// </summary>
         /// <typeparam name="W">Protocol writer</typeparam>
         /// <param name="writer">Writer instance</param>
-        /// <param name="bonded">IBonded instance</param>
+        /// <param name="bonded"><see cref="IBonded"/> instance</param>
         public static void To<W>(W writer, IBonded bonded)
         {
             bonded.Serialize(writer);
@@ -55,7 +55,7 @@ namespace Bond
     }
 
     /// <summary>
-    /// Serializer for protocol writer W
+    /// Serializer for protocol writer <typeparamref name="W"/>
     /// </summary>
     /// <typeparam name="W">Protocol writer</typeparam>
     public class Serializer<W>
@@ -72,7 +72,7 @@ namespace Bond
         /// Create a serializer for specified type
         /// </summary>
         /// <param name="type">Type representing a Bond schema</param>
-        /// <param name="parser">Custom IParser instance</param>
+        /// <param name="parser">Custom <see cref="IParser"/> instance</param>
         public Serializer(Type type, IParser parser) : this(type, parser, inlineNested: true) { }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace Bond
         /// Create a serializer for specified type
         /// </summary>
         /// <param name="type">Type representing a Bond schema</param>
-        /// <param name="parser">Custom IParser instance</param>
+        /// <param name="parser">Custom <see cref="IParser"/> instance</param>
         /// <param name="inlineNested">Indicates whether nested struct serialization code may be inlined</param>
         public Serializer(Type type, IParser parser, bool inlineNested)
         {
@@ -98,12 +98,12 @@ namespace Bond
         }
 
         /// <summary>
-        /// Serialize object using protocol writer of type W
+        /// Serialize object using protocol writer of type <typeparamref name="W"/>
         /// </summary>
         /// <param name="obj">Object to serialize</param>
         /// <param name="writer">Writer instance</param>
         /// <remarks>
-        /// The object must be of type used to create the Serializer, otherwise behavior is undefined
+        /// The object must be of type used to create the <see cref="Serializer{W}"/>, otherwise behavior is undefined
         /// </remarks>
         public void Serialize(object obj, W writer)
         {

--- a/cs/src/core/Transcoder.cs
+++ b/cs/src/core/Transcoder.cs
@@ -68,17 +68,35 @@ namespace Bond
         /// </summary>
         /// <param name="schema">Payload schema, required for transcoding from untagged protocols</param>
         public Transcoder(RuntimeSchema schema)
-        {
-            transcode = Generate(schema);
-        }
+            : this(schema, null)
+        {}
 
         /// <summary>
         /// Create a transcoder for payloads with specified compile-time schema
         /// </summary>
         /// <param name="type">Type representing a Bond schema</param>
         public Transcoder(Type type)
+            : this(type, null)
+        {}
+
+        /// <summary>
+        /// Create a transcoder for payloads with specified runtime schema
+        /// </summary>
+        /// <param name="schema">Payload schema, required for transcoding from untagged protocols</param>
+        /// <param name="parser">Custom IParser instance</param>
+        public Transcoder(RuntimeSchema schema, IParser parser)
         {
-            transcode = Generate(type);
+            transcode = Generate(schema, parser);
+        }
+
+        /// <summary>
+        /// Create a transcoder for payloads with specified compile-time schema
+        /// </summary>
+        /// <param name="type">Type representing a Bond schema</param>
+        /// <param name="parser">Custom IParser instance</param>
+        public Transcoder(Type type, IParser parser)
+        {
+            transcode = Generate(type, parser);
         }
 
         // Create a transcoder
@@ -96,9 +114,9 @@ namespace Bond
             transcode[0](reader, writer);
         }
 
-        Action<R, W>[] Generate<S>(S schema)
+        Action<R, W>[] Generate<S>(S schema, IParser parser)
         {
-            var parser = ParserFactory<R>.Create(schema);
+            parser = parser ?? ParserFactory<R>.Create(schema);
             return SerializerGeneratorFactory<R, W>.Create(
                     (r, w, i) => transcode[i](r, w), schema)
                 .Generate(parser)

--- a/cs/src/core/Transcoder.cs
+++ b/cs/src/core/Transcoder.cs
@@ -18,7 +18,7 @@ namespace Bond
         }
 
         /// <summary>
-        /// Transcode data from protocol reader R to protocol writer W
+        /// Transcode data from protocol reader <typeparamref name="R"/> to protocol writer <typeparamref name="W"/>
         /// </summary>
         /// <typeparam name="R">Protocol reader</typeparam>
         /// <typeparam name="W">Protocol writer</typeparam>
@@ -31,7 +31,7 @@ namespace Bond
     }
 
     /// <summary>
-    /// Transcode payload from one protocol into another using compile-time schema T
+    /// Transcode payload from one protocol into another using compile-time schema <typeparamref name="T"/>
     /// </summary>
     /// <typeparam name="T">Type representing a Bond schema</typeparam>
     public static class Transcode<T>
@@ -42,7 +42,7 @@ namespace Bond
         }
 
         /// <summary>
-        /// Transcode data from protocol reader R to protocol writer W
+        /// Transcode data from protocol reader <typeparamref name="R"/> to protocol writer <typeparamref name="W"/>
         /// </summary>
         /// <typeparam name="R">Protocol reader</typeparam>
         /// <typeparam name="W">Protocol writer</typeparam>
@@ -55,7 +55,7 @@ namespace Bond
     }
 
     /// <summary>
-    /// Transcoder from protocol reader R to protocol writer W
+    /// Transcoder from protocol reader <typeparamref name="R"/> to protocol writer <typeparamref name="W"/>
     /// </summary>
     /// <typeparam name="R">Protocol reader</typeparam>
     /// <typeparam name="W">Protocol writer</typeparam>
@@ -83,7 +83,7 @@ namespace Bond
         /// Create a transcoder for payloads with specified runtime schema
         /// </summary>
         /// <param name="schema">Payload schema, required for transcoding from untagged protocols</param>
-        /// <param name="parser">Custom IParser instance</param>
+        /// <param name="parser">Custom <see cref="IParser"/> instance</param>
         public Transcoder(RuntimeSchema schema, IParser parser)
         {
             transcode = Generate(schema, parser);
@@ -93,7 +93,7 @@ namespace Bond
         /// Create a transcoder for payloads with specified compile-time schema
         /// </summary>
         /// <param name="type">Type representing a Bond schema</param>
-        /// <param name="parser">Custom IParser instance</param>
+        /// <param name="parser">Custom <see cref="IParser"/> instance</param>
         public Transcoder(Type type, IParser parser)
         {
             transcode = Generate(type, parser);

--- a/cs/src/core/expressions/ObjectParser.cs
+++ b/cs/src/core/expressions/ObjectParser.cs
@@ -11,6 +11,14 @@ namespace Bond.Expressions
     using System.Linq.Expressions;
     using System.Reflection;
 
+    /// <summary>
+    /// Creates expression of type <see cref="IBonded{T}"/> given a object type and value.
+    /// </summary>
+    /// <param name="objectType">Type of value stored in IBonded</param>
+    /// <param name="value">Expression representing the value to be stored in the bonded instance.</param>
+    /// <returns>Expression representing creation of bonded with the specified value.</returns>
+    public delegate Expression InstanceBondedFactory(Type objectType, Expression value);
+
     public class ObjectParser : IParser
     {
         static readonly MethodInfo moveNext = Reflection.MethodInfoOf((IEnumerator e) => e.MoveNext());
@@ -22,19 +30,26 @@ namespace Bond.Expressions
         readonly Type schemaType;
         readonly Type objectType;
         readonly int hierarchyDepth;
+        readonly InstanceBondedFactory bondedFactory;
 
         public ObjectParser(Type type)
+            : this(type, null)
+        {}
+
+        public ObjectParser(Type type, InstanceBondedFactory bondedFactory)
         {
             typeAlias = new TypeAlias(type);
             value = objParam = Expression.Parameter(typeof(object), "obj");
             objectType = schemaType = type;
             hierarchyDepth = type.GetHierarchyDepth();
+            this.bondedFactory = bondedFactory ?? NewBonded;
         }
 
         ObjectParser(ObjectParser that, Expression value, Type schemaType)
         {
             typeAlias = that.typeAlias;
             objParam = that.objParam;
+            bondedFactory = that.bondedFactory;
             this.value = value;
             this.schemaType = schemaType;
             objectType = value.Type;
@@ -182,11 +197,9 @@ namespace Bond.Expressions
             {
                 return handler(value);
             }
-            
-            var bondedType = typeof(Bonded<>).MakeGenericType(objectType);
-            var bondedCtor = bondedType.GetConstructor(objectType);
 
-            return handler(Expression.New(bondedCtor, value));
+            var newBonded = bondedFactory(objectType, value);
+            return handler(newBonded);
         }
 
         public Expression Blob(Expression count)
@@ -215,6 +228,12 @@ namespace Bond.Expressions
         public override int GetHashCode()
         {
             return schemaType.GetHashCode();
+        }
+
+        static Expression NewBonded(Type objectType, Expression value)
+        {
+            var ctor = typeof(Bonded<>).MakeGenericType(objectType).GetConstructor(objectType);
+            return Expression.New(ctor, value);
         }
 
         static Expression ContainerCount(Expression container)

--- a/cs/src/core/expressions/ObjectParser.cs
+++ b/cs/src/core/expressions/ObjectParser.cs
@@ -14,10 +14,10 @@ namespace Bond.Expressions
     /// <summary>
     /// Creates expression of type <see cref="IBonded{T}"/> given a object type and value.
     /// </summary>
-    /// <param name="objectType">Type of value stored in IBonded</param>
+    /// <param name="objectType">Type of object to be stored in <see cref="IBonded"/></param>
     /// <param name="value">Expression representing the value to be stored in the bonded instance.</param>
     /// <returns>Expression representing creation of bonded with the specified value.</returns>
-    public delegate Expression InstanceBondedFactory(Type objectType, Expression value);
+    public delegate Expression ObjectBondedFactory(Type objectType, Expression value);
 
     public class ObjectParser : IParser
     {
@@ -30,13 +30,13 @@ namespace Bond.Expressions
         readonly Type schemaType;
         readonly Type objectType;
         readonly int hierarchyDepth;
-        readonly InstanceBondedFactory bondedFactory;
+        readonly ObjectBondedFactory bondedFactory;
 
         public ObjectParser(Type type)
             : this(type, null)
         {}
 
-        public ObjectParser(Type type, InstanceBondedFactory bondedFactory)
+        public ObjectParser(Type type, ObjectBondedFactory bondedFactory)
         {
             typeAlias = new TypeAlias(type);
             value = objParam = Expression.Parameter(typeof(object), "obj");

--- a/cs/src/core/expressions/TaggedParser.cs
+++ b/cs/src/core/expressions/TaggedParser.cs
@@ -14,20 +14,31 @@ namespace Bond.Expressions
         delegate Expression TypeHandlerRuntime(Expression type);
 
         readonly TaggedReader<R> reader = new TaggedReader<R>();
+        readonly PayloadBondedFactory bondedFactory;
         readonly TaggedParser<R> baseParser;
         readonly TaggedParser<R> fieldParser;
         readonly bool isBase;
 
         public TaggedParser(RuntimeSchema schema)
-        {
-            isBase = false;
-            baseParser = new TaggedParser<R>(this, isBase: true);
-            fieldParser = this;
-        }
+            : this(schema, null)
+        { }
+
+        public TaggedParser(RuntimeSchema schema, PayloadBondedFactory bondedFactory)
+            : this(bondedFactory)
+        { }
 
         public TaggedParser(Type type)
+            : this(type, null)
+        { }
+
+        public TaggedParser(Type type, PayloadBondedFactory bondedFactory)
+            : this(bondedFactory)
+        { }
+
+        private TaggedParser(PayloadBondedFactory bondedFactory)
         {
             isBase = false;
+            this.bondedFactory = bondedFactory ?? NewBonded;
             baseParser = new TaggedParser<R>(this, isBase: true);
             fieldParser = this;
         }
@@ -35,6 +46,7 @@ namespace Bond.Expressions
         TaggedParser(TaggedParser<R> that, bool isBase)
         {
             this.isBase = isBase;
+            bondedFactory = that.bondedFactory;
             reader = that.reader;
             baseParser = this;
             fieldParser = that;
@@ -166,16 +178,22 @@ namespace Bond.Expressions
 
         public Expression Bonded(ValueHandler handler)
         {
-            var bondedCtor = typeof(BondedVoid<>).MakeGenericType(typeof(R)).GetConstructor(typeof(R));
+            var newBonded = bondedFactory(reader.Param, Expression.Constant(RuntimeSchema.Empty));
 
             return Expression.Block(
-                handler(Expression.New(bondedCtor, reader.Param)),
+                handler(newBonded),
                 reader.Skip(Expression.Constant(BondDataType.BT_STRUCT)));
         }
 
         public Expression Skip(Expression type)
         {
             return reader.Skip(type);
+        }
+
+        static Expression NewBonded(Expression reader, Expression schema)
+        {
+            var ctor = typeof(BondedVoid<>).MakeGenericType(reader.Type).GetConstructor(reader.Type);
+            return Expression.New(ctor, reader);
         }
 
         static Expression MatchOrCompatible(Expression valueType, BondDataType? expectedType, TypeHandlerRuntime handler)

--- a/cs/test/core/Core.csproj
+++ b/cs/test/core/Core.csproj
@@ -35,6 +35,7 @@
     <Compile Include="BondClass.cs" />
     <Compile Include="BondedTests.cs" />
     <Compile Include="CloningTests.cs" />
+    <Compile Include="CustomBondedTests.cs" />
     <Compile Include="EnumString.cs" />
     <Compile Include="Equal.cs" />
     <Compile Include="InterfaceTests.cs" />

--- a/cs/test/core/CustomBondedTests.cs
+++ b/cs/test/core/CustomBondedTests.cs
@@ -127,17 +127,17 @@ namespace UnitTest
 
                 public T Deserialize()
                 {
-                    return CustomTransformFactory.Default.Cloner<TActual, T>().Clone<T>(instance);
+                    return CustomTransformFactory.Instance.Cloner<TActual, T>().Clone<T>(instance);
                 }
 
                 public void Serialize<W>(W writer)
                 {
-                    CustomTransformFactory.Default.Serializer<W, TActual>().Serialize(instance, writer);
+                    CustomTransformFactory.Instance.Serializer<W, TActual>().Serialize(instance, writer);
                 }
 
                 public U Deserialize<U>()
                 {
-                    return CustomTransformFactory.Default.Cloner<TActual, U>().Clone<U>(instance);
+                    return CustomTransformFactory.Instance.Cloner<TActual, U>().Clone<U>(instance);
                 }
 
                 IBonded<U> IBonded.Convert<U>()
@@ -187,12 +187,12 @@ namespace UnitTest
 
             public void Serialize<W>(W writer)
             {
-                CustomTransformFactory.Default.Transcoder<R, W>(schema).Transcode(reader.Clone(), writer);
+                CustomTransformFactory.Instance.Transcoder<R, W>(schema).Transcode(reader.Clone(), writer);
             }
 
             public U Deserialize<U>()
             {
-                return CustomTransformFactory.Default.Deserializer<R, U>(schema).Deserialize<U>(reader.Clone());
+                return CustomTransformFactory.Instance.Deserializer<R, U>(schema).Deserialize<U>(reader.Clone());
             }
 
             IBonded<U> IBonded.Convert<U>()
@@ -220,12 +220,12 @@ namespace UnitTest
 
             public void Serialize<W>(W writer)
             {
-                CustomTransformFactory.Default.Transcoder<R, W>(schema).Transcode(reader.Clone(), writer);
+                CustomTransformFactory.Instance.Transcoder<R, W>(schema).Transcode(reader.Clone(), writer);
             }
 
             public U Deserialize<U>()
             {
-                return CustomTransformFactory.Default.Deserializer<R, U>(schema).Deserialize<U>(reader.Clone());
+                return CustomTransformFactory.Instance.Deserializer<R, U>(schema).Deserialize<U>(reader.Clone());
             }
 
             IBonded<U> IBonded.Convert<U>()
@@ -239,7 +239,7 @@ namespace UnitTest
         /// </summary>
         private class CustomTransformFactory
         {
-            public static readonly CustomTransformFactory Default = new CustomTransformFactory();
+            public static readonly CustomTransformFactory Instance = new CustomTransformFactory();
 
             private CustomTransformFactory() { }
 
@@ -308,11 +308,11 @@ namespace UnitTest
             
             var buffer = new OutputBuffer();
             var writer = new CompactBinaryWriter<OutputBuffer>(buffer);
-            CustomTransformFactory.Default.Serializer<CompactBinaryWriter<OutputBuffer>, X>().Serialize(x, writer);
+            CustomTransformFactory.Instance.Serializer<CompactBinaryWriter<OutputBuffer>, X>().Serialize(x, writer);
             
             var inputStream = new InputBuffer(buffer.Data);
             var reader = new CompactBinaryReader<InputBuffer>(inputStream);
-            var x1 = CustomTransformFactory.Default.Deserializer<CompactBinaryReader<InputBuffer>, X>(RuntimeSchema.Empty).Deserialize<X>(reader);
+            var x1 = CustomTransformFactory.Instance.Deserializer<CompactBinaryReader<InputBuffer>, X>(RuntimeSchema.Empty).Deserialize<X>(reader);
 
             Assert.That(x1, Is.Not.Null);
             Assert.That(x1.bonded_Y, Is.InstanceOf<CustomBonded<Y, CompactBinaryReader<InputBuffer>>>());
@@ -329,7 +329,7 @@ namespace UnitTest
             var x = new X();
             x.bonded_Y = CustomBonded<Y>.From(y);
 
-            var x1 = CustomTransformFactory.Default.Cloner<X, X>().Clone<X>(x);
+            var x1 = CustomTransformFactory.Instance.Cloner<X, X>().Clone<X>(x);
 
             Assert.That(x1, Is.Not.Null);
             Assert.That(x1.bonded_Y.Value.FullName, Is.EqualTo("CustomBondedTests.YDerived"));

--- a/cs/test/core/CustomBondedTests.cs
+++ b/cs/test/core/CustomBondedTests.cs
@@ -245,12 +245,12 @@ namespace UnitTest
 
             public Cloner<TSource> Cloner<TSource, T>()
             {
-                return new Cloner<TSource>(typeof(T), new ObjectParser(typeof(TSource), InstanceBondedFactory), Factory);
+                return new Cloner<TSource>(typeof(T), new ObjectParser(typeof(TSource), ObjectBondedFactory), Factory);
             }
 
             public Serializer<W> Serializer<W, T>()
             {
-                return new Serializer<W>(typeof(T), new ObjectParser(typeof(T), InstanceBondedFactory), false);
+                return new Serializer<W>(typeof(T), new ObjectParser(typeof(T), ObjectBondedFactory), false);
             }
 
             public Deserializer<R> Deserializer<R, T>(RuntimeSchema schema)
@@ -262,7 +262,7 @@ namespace UnitTest
                 return new Deserializer<R>(typeof(T), parser, Factory, false);
             }
 
-            private static Expression InstanceBondedFactory(Type objectType, Expression value)
+            private static Expression ObjectBondedFactory(Type objectType, Expression value)
             {
                 var method = typeof(CustomBonded<>).MakeGenericType(objectType).GetMethod("From", new[] {value.Type});
 

--- a/cs/test/core/CustomBondedTests.cs
+++ b/cs/test/core/CustomBondedTests.cs
@@ -1,0 +1,339 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace UnitTest
+{
+    using System;
+    using System.Linq.Expressions;
+    using System.Reflection;
+    using System.Threading;
+    using Bond;
+    using Bond.Expressions;
+    using Bond.IO;
+    using Bond.IO.Unsafe;
+    using Bond.Protocols;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class CustomBondedTests
+    {
+        #region Schemas
+
+        [Schema]
+        public class X
+        {
+            public X()
+                : this("CustomBondedTests.X", "X")
+            {
+            }
+
+            protected X(string fullName, string name)
+            {
+                bonded_Y = CustomBonded<Y>.Empty;
+            }
+
+            [Bond.Id(0), Bond.Type(typeof (Bond.Tag.bonded<Y>))]
+            public CustomBonded<Y> bonded_Y { get; set; }
+        }
+
+        [Schema]
+        public class Y
+        {
+            public Y()
+                : this("CustomBondedTests.Y", "Y")
+            {
+            }
+
+            protected Y(string fullName, string name)
+            {
+                FullName = fullName;
+            }
+
+            [Bond.Id(0), Bond.Type(typeof (string))]
+            public string FullName { get; set; }
+        }
+
+        [Schema]
+        public class YDerived : Y
+        {
+            public YDerived()
+                : this("CustomBondedTests.YDerived", "YDerived")
+            {
+            }
+
+            protected YDerived(string fullName, string name)
+                : base(fullName, name)
+            {
+                Z = CustomBonded<Z>.From(Bond.GenericFactory.Create<Z>());
+            }
+
+            [Bond.Id(1), Bond.Type(typeof (Bond.Tag.bonded<Z>))]
+            public CustomBonded<Z> Z { get; set; }
+        }
+
+        [Schema]
+        public class Z
+        {
+            public Z()
+                : this("CustomBondedTests.Z", "Z")
+            {
+            }
+
+            protected Z(string fullName, string name)
+            {
+                FullName = fullName;
+            }
+
+            [Bond.Id(0)]
+            public string FullName { get; set; }
+
+            [Bond.Id(1)]
+            public int Value { get; set; }
+        }
+
+        #endregion
+
+        public abstract class CustomBonded<T>
+        {
+            public abstract T Value { get; }
+
+            public abstract CustomBonded<U> Convert<U>();
+
+            public static CustomBonded<T> Empty
+            {
+                get { return CustomBondedPoly<T, T>.Empty; }
+            }
+
+            public static CustomBonded<T> From<TActual>(TActual instance)
+            {
+                return new CustomBondedPoly<T,TActual>(instance);
+            }
+
+            internal class CustomBondedPoly<T, TActual> : CustomBonded<T>, IBonded<T>
+            {
+                public new static readonly CustomBonded<T> Empty = new CustomBondedPoly<T, TActual>(GenericFactory.Create<TActual>());
+
+                private readonly TActual instance;
+
+                public CustomBondedPoly(TActual instance)
+                {
+                    this.instance = instance;
+                }
+
+                public override T Value
+                {
+                    get { return Deserialize(); }
+                }
+
+                public T Deserialize()
+                {
+                    return CustomTransformFactory.Default.Cloner<TActual, T>().Clone<T>(instance);
+                }
+
+                public void Serialize<W>(W writer)
+                {
+                    CustomTransformFactory.Default.Serializer<W, TActual>().Serialize(instance, writer);
+                }
+
+                public U Deserialize<U>()
+                {
+                    return CustomTransformFactory.Default.Cloner<TActual, U>().Clone<U>(instance);
+                }
+
+                IBonded<U> IBonded.Convert<U>()
+                {
+                    return this as IBonded<U>;
+                }
+
+                public override CustomBonded<U> Convert<U>()
+                {
+                    return new CustomBondedPoly<U, TActual>(instance);
+                }
+            }
+        }
+
+        internal class CustomBonded<T, R> : CustomBonded<T>, IBonded<T> 
+            where R : ICloneable<R>
+        {
+            private readonly R reader;
+            private readonly RuntimeSchema schema;
+            private readonly Lazy<T> value;
+
+            public CustomBonded(R reader)
+            {
+                this.reader = reader.Clone();
+                this.schema = RuntimeSchema.Empty;
+
+                this.value = new Lazy<T>(this.Deserialize<T>, LazyThreadSafetyMode.ExecutionAndPublication);
+            }
+
+            public CustomBonded(R reader, RuntimeSchema schema)
+            {
+                this.reader = reader.Clone();
+                this.schema = schema;
+
+                this.value = new Lazy<T>(this.Deserialize<T>, LazyThreadSafetyMode.ExecutionAndPublication);
+            }
+
+            public override T Value
+            {
+                get { return value.Value; }
+            }
+
+            public T Deserialize()
+            {
+                return Deserialize<T>();
+            }
+
+            public void Serialize<W>(W writer)
+            {
+                CustomTransformFactory.Default.Transcoder<R, W>(schema).Transcode(reader.Clone(), writer);
+            }
+
+            public U Deserialize<U>()
+            {
+                return CustomTransformFactory.Default.Deserializer<R, U>(schema).Deserialize<U>(reader.Clone());
+            }
+
+            IBonded<U> IBonded.Convert<U>()
+            {
+                return (IBonded<U>) Convert<U>();
+            }
+
+            public override CustomBonded<U> Convert<U>()
+            {
+                return new CustomBonded<U, R>(reader, schema);
+            }
+        }
+
+        internal class CustomBondedVoid<R> : IBonded
+            where R : ICloneable<R>
+        {
+            private readonly R reader;
+            private readonly RuntimeSchema schema;
+
+            public CustomBondedVoid(R reader, RuntimeSchema schema)
+            {
+                this.reader = reader.Clone();
+                this.schema = schema;
+            }
+
+            public void Serialize<W>(W writer)
+            {
+                CustomTransformFactory.Default.Transcoder<R, W>(schema).Transcode(reader.Clone(), writer);
+            }
+
+            public U Deserialize<U>()
+            {
+                return CustomTransformFactory.Default.Deserializer<R, U>(schema).Deserialize<U>(reader.Clone());
+            }
+
+            IBonded<U> IBonded.Convert<U>()
+            {
+                return new CustomBonded<U, R>(reader, schema);
+            }
+        }
+
+        /// <summary>
+        ///     Custom ITransformFactory for making Deserializer work.
+        /// </summary>
+        private class CustomTransformFactory
+        {
+            public static readonly CustomTransformFactory Default = new CustomTransformFactory();
+
+            private CustomTransformFactory() { }
+
+            public Cloner<TSource> Cloner<TSource, T>()
+            {
+                return new Cloner<TSource>(typeof(T), new ObjectParser(typeof(TSource), InstanceBondedFactory), Factory);
+            }
+
+            public Serializer<W> Serializer<W, T>()
+            {
+                return new Serializer<W>(typeof(T), new ObjectParser(typeof(T), InstanceBondedFactory), false);
+            }
+
+            public Deserializer<R> Deserializer<R, T>(RuntimeSchema schema)
+            {
+                var parser = schema.HasValue
+                                 ? ParserFactory<R>.Create(schema, PayloadBondedFactory)
+                                 : ParserFactory<R>.Create(typeof(T), PayloadBondedFactory);
+
+                return new Deserializer<R>(typeof(T), parser, Factory, false);
+            }
+
+            private static Expression InstanceBondedFactory(Type objectType, Expression value)
+            {
+                var method = typeof(CustomBonded<>).MakeGenericType(objectType).GetMethod("From", new[] {value.Type});
+
+                return Expression.Call(method, value);
+            }
+
+            private static Expression PayloadBondedFactory(Expression reader, Expression schema)
+            {
+                var ctor = typeof(CustomBondedVoid<>).MakeGenericType(reader.Type).GetConstructor(BindingFlags.Instance | BindingFlags.Public, null, new [] { reader.Type, schema.Type }, null);
+                return Expression.New(ctor, reader, schema);
+            }
+
+            public Transcoder<R, W> Transcoder<R, W>(RuntimeSchema schema)
+            {
+                return new Transcoder<R, W>(schema, ParserFactory<R>.Create(schema, PayloadBondedFactory));
+            }
+
+            private static Expression Factory(Type type, Type schemaType, params Expression[] arguments)
+            {
+                if (type.IsGenericType)
+                {
+                    var typeDefinition = type.GetGenericTypeDefinition();
+                    if (typeDefinition == typeof(CustomBonded<>))
+                    {
+                        var arg = arguments[0]; // CustomBondedVoid<R>
+                        var bondedConvert = typeof(IBonded).GetMethod("Convert").MakeGenericMethod(type.GetGenericArguments());
+
+                        return Expression.ConvertChecked(Expression.Call(arg, bondedConvert), type);
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        [Test]
+        public void SupportSettingCustomFactory_RoundTrip()
+        {
+            var y = new YDerived();
+            y.Z = CustomBonded<Z>.From(new Z {Value = 42});
+            var x = new X();
+            x.bonded_Y = CustomBonded<Y>.From(y);
+            
+            var buffer = new OutputBuffer();
+            var writer = new CompactBinaryWriter<OutputBuffer>(buffer);
+            CustomTransformFactory.Default.Serializer<CompactBinaryWriter<OutputBuffer>, X>().Serialize(x, writer);
+            
+            var inputStream = new InputBuffer(buffer.Data);
+            var reader = new CompactBinaryReader<InputBuffer>(inputStream);
+            var x1 = CustomTransformFactory.Default.Deserializer<CompactBinaryReader<InputBuffer>, X>(RuntimeSchema.Empty).Deserialize<X>(reader);
+
+            Assert.That(x1, Is.Not.Null);
+            Assert.That(x1.bonded_Y, Is.InstanceOf<CustomBonded<Y, CompactBinaryReader<InputBuffer>>>());
+            Assert.That(x1.bonded_Y.Value.FullName, Is.EqualTo("CustomBondedTests.YDerived"));
+            Assert.That(x1.bonded_Y.Convert<YDerived>().Value.Z.Value.Value, Is.EqualTo(42));
+            
+        }
+
+        [Test]
+        public void SupportSettingCustomFactory_Clone()
+        {
+            var y = new YDerived();
+            y.Z = CustomBonded<Z>.From(new Z { Value = 42 });
+            var x = new X();
+            x.bonded_Y = CustomBonded<Y>.From(y);
+
+            var x1 = CustomTransformFactory.Default.Cloner<X, X>().Clone<X>(x);
+
+            Assert.That(x1, Is.Not.Null);
+            Assert.That(x1.bonded_Y.Value.FullName, Is.EqualTo("CustomBondedTests.YDerived"));
+            Assert.That(x1.bonded_Y.Convert<YDerived>().Value.Z.Value.Value, Is.EqualTo(42));
+        }
+    }
+}

--- a/doc/src/bond_cs.md
+++ b/doc/src/bond_cs.md
@@ -573,12 +573,12 @@ during deserialization.
 
 Standard implementations of `Bonded<T>` and `Bonded<T,R>` always use default
 `Serializer/Deserializer/Cloner/Transcoder`. In order to customize this behavior,
-user can pass custom `InstanceBondedFactory` or `PayloadBondedFactory` delegates
+user can pass custom `ObjectBondedFactory` or `PayloadBondedFactory` delegates
 as parameters to `ObjectParser` or `ParserFactory<R>.Create()`:
 
     // create serializer for schema type T and protocol reader W
     // using custom InstanceBondedFactory
-    new Serializer<W>(typeof(T), new ObjectParser(typeof(T), CustomInstanceBondedFactory), ...); 
+    new Serializer<W>(typeof(T), new ObjectParser(typeof(T), CustomObjectBondedFactory), ...); 
 
     // create deserializer for schema type T and protocol reader R
     // using custom PayloadBondedFactory 

--- a/doc/src/bond_cs.md
+++ b/doc/src/bond_cs.md
@@ -571,6 +571,19 @@ payload represented by a protocol reader `R`. The former is usually used by
 producers to initialize `bonded<T>` values, the latter is implicitly used 
 during deserialization.
 
+Standard implementations of `Bonded<T>` and `Bonded<T,R>` always use default
+`Serializer/Deserializer/Cloner/Transcoder`. In order to customize this behavior,
+user can pass custom `InstanceBondedFactory` or `PayloadBondedFactory` delegates
+as parameters to `ObjectParser` or `ParserFactory<R>.Create()`:
+
+    // create serializer for schema type T and protocol reader W
+    // using custom InstanceBondedFactory
+    new Serializer<W>(typeof(T), new ObjectParser(typeof(T), CustomInstanceBondedFactory), ...); 
+
+    // create deserializer for schema type T and protocol reader R
+    // using custom PayloadBondedFactory 
+    new Deserializer<R>(typeof(T), ParserFactory<R>.Create(typeof(T), CustomPayloadBondedFactory), ...);
+
 Lazy deserialization
 --------------------
 

--- a/doc/src/bond_cs.md
+++ b/doc/src/bond_cs.md
@@ -571,9 +571,8 @@ payload represented by a protocol reader `R`. The former is usually used by
 producers to initialize `bonded<T>` values, the latter is implicitly used 
 during deserialization.
 
-Standard implementations of `Bonded<T>` and `Bonded<T,R>` always use default
-`Serializer/Deserializer/Cloner/Transcoder`. In order to customize this behavior,
-user can pass custom `ObjectBondedFactory` or `PayloadBondedFactory` delegates
+The standard implementations always use default implementations of `Serializer/Deserializer/Cloner/Transcoder`. 
+In order to customize this behavior, the user can pass custom `ObjectBondedFactory` or `PayloadBondedFactory` delegates
 as parameters to `ObjectParser` or `ParserFactory<R>.Create()`:
 
     // create serializer for schema type T and protocol reader W


### PR DESCRIPTION
Add ability to specify custom implementations of `bonded<T>` given:
- instance of `T`
- pair of reader and `RuntimeSchema`

Fixes the inability to support custom `Serializer/Deserializer/Cloner/Transcoder` within `bonded<T>`