### PR TITLE
Make accept failures in EpoxyListener non-fatal

### DIFF
--- a/cs/src/comm/epoxy-transport/EpoxyListener.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyListener.cs
@@ -114,7 +114,7 @@ namespace Bond.Comm.Epoxy
                 }
                 catch (SocketException ex)
                 {
-                    Log.Site().Fatal(ex, "Accept failed with error {0}.", ex.SocketErrorCode);
+                    Log.Site().Error(ex, "Accept failed with error {0}.", ex.SocketErrorCode);
 
                     ShutdownSocketSafe(socket);
                 }


### PR DESCRIPTION
We anticipate that sometimes we won't be able to accept a connection, so
such a case should be logged as a regular error instead of a fatal (so
take the process down) error.