### PR TITLE
Don't download and embed images for C# docs

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -99,7 +99,7 @@ if (Haskell_PANDOC_EXECUTABLE AND Doxygen_EXECUTABLE)
 
     add_pandoc_markdown (src/bond_cs.md
         CODE "cs,numberLines"
-        OPTIONS --self-contained --table-of-contents
+        OPTIONS --table-of-contents
         OUTPUT_DIR manual)
 
     add_pandoc_markdown (src/reference_index.md


### PR DESCRIPTION
With the `--self-contained` flag to Pandoc, we were downloading the
NuGet version badges at build time and embedding them in the generated
HTML as data URIs. We actually want those to be fetched anew each time
someone renders the page so they see the latest version, not the version
that was current when the page was generated.

This should also get rid of the build failures we were seeing when
shields.io was down.