### PR TITLE
Add C# example to demonstrate storing Guid as a binary blob.

### DIFF
--- a/examples/cs/core/guid/guid.csproj
+++ b/examples/cs/core/guid/guid.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>guid</RootNamespace>
     <AssemblyName>guid</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <BondOptions>--using="guid=System.Guid"</BondOptions>
+    <BondOptions>--using="guid=System.Guid" --using="guid_bin=System.Guid"</BondOptions>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/examples/cs/core/guid/program.cs
+++ b/examples/cs/core/guid/program.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Diagnostics;
+    using System.IO;
     using Bond;
     using Bond.Protocols;
     using Bond.IO.Unsafe;
@@ -26,14 +27,36 @@
 
         public static Guid Convert(ArraySegment<byte> value, Guid unused)
         {
-            var bits = new byte[16];
-            Buffer.BlockCopy(value.Array, value.Offset, bits, 0, 16);
-            return new Guid(bits);
+            if (value.Count != 16)
+            {
+                throw new InvalidDataException("value must be of length 16");
+            }
+
+            byte[] array = value.Array;
+            int offset = value.Offset;
+
+            int a =
+                  ((int)array[offset + 3] << 24)
+                | ((int)array[offset + 2] << 16)
+                | ((int)array[offset + 1] << 8)
+                | array[offset];
+            short b = (short)(((int)array[offset + 5] << 8) | array[offset + 4]);
+            short c = (short)(((int)array[offset + 7] << 8) | array[offset + 6]);
+
+            return new Guid(a, b, c,
+                array[offset+ 8],
+                array[offset+ 9],
+                array[offset+ 10],
+                array[offset+ 11],
+                array[offset+ 12],
+                array[offset+ 13],
+                array[offset+ 14],
+                array[offset+ 15]);
         }
 
         public static ArraySegment<byte> Convert(Guid value, ArraySegment<byte> unused)
         {
-            return new ArraySegment<byte>(value.ToByteArray(), 0, 16);
+            return new ArraySegment<byte>(value.ToByteArray());
         }
 
         #endregion

--- a/examples/cs/core/guid/program.cs
+++ b/examples/cs/core/guid/program.cs
@@ -8,6 +8,8 @@
 
     public static class BondTypeAliasConverter
     {
+        #region Guid-string conversion
+
         public static Guid Convert(string value, Guid unused)
         {
             return new Guid(value);
@@ -17,6 +19,24 @@
         {
             return value.ToString();
         }
+
+        #endregion
+
+        #region Guid-blob conversion
+
+        public static Guid Convert(ArraySegment<byte> value, Guid unused)
+        {
+            var bits = new byte[16];
+            Buffer.BlockCopy(value.Array, value.Offset, bits, 0, 16);
+            return new Guid(bits);
+        }
+
+        public static ArraySegment<byte> Convert(Guid value, ArraySegment<byte> unused)
+        {
+            return new ArraySegment<byte>(value.ToByteArray(), 0, 16);
+        }
+
+        #endregion
     }
 
     static class Program
@@ -25,7 +45,8 @@
         {
             var src = new Example
             {
-                id = new Guid("{DC37ECC5-9E39-49C9-931B-51138D648262}")
+                id = new Guid("{DC37ECC5-9E39-49C9-931B-51138D648262}"),
+                id_bin = new Guid("{0F5F6768-1608-4D5C-A11D-B176D0D792B5}"),
             };
 
             var output = new OutputBuffer();
@@ -38,6 +59,7 @@
 
             var dst = Deserialize<Example>.From(reader);
             Debug.Assert(dst.id == src.id);
+            Debug.Assert(dst.id_bin == src.id_bin);
         }
     }
 }

--- a/examples/cs/core/guid/schema.bond
+++ b/examples/cs/core/guid/schema.bond
@@ -1,8 +1,13 @@
 ﻿namespace Examples
 
+// Two flavors of storing guid are demonstrated here:
+// the first using string, and the second using binary blob.
+
 using guid = string;
+using guid_bin = blob;
 
 struct Example
 {
     0: guid id;
+    1: guid_bin id_bin;
 }


### PR DESCRIPTION
Useful for those who prefer storing Guid in a more compact form.