### PR TITLE
[epoxy] Add support for custom resolution of host names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,9 +66,12 @@ different versioning scheme, following the Haskell community's
   * `Log.DropBelow` added to automatically ignore some levels of logging.
   * The `ILogHandle.Handle` method is now provided a pre-formatted string
     instead of a format string and its arguments.
-* Transport is now parameterized with Connection and Listener implementations.
-  This eliminates the need to cast the results of transport.ConnectToAsync() and
-  transport.MakeListener() to transport-specific subtypes.
+* Transport is now parameterized with Connection and Listener
+  implementations. This eliminates the need to cast the results of
+  transport.ConnectToAsync() and transport.MakeListener() to
+  transport-specific subtypes.
+* Epoxy has a hook for performing custom host to IP address resolution. This
+  is configured with `EpoxyTransportBuilder.SetResolver`.
 
 ## 4.2.1: 2016-06-02 ##
 

--- a/cs/src/comm/epoxy-transport/EpoxyExceptions.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyExceptions.cs
@@ -5,6 +5,14 @@ namespace Bond.Comm.Epoxy
 {
     using System;
 
+    public class EpoxyFailedToResolveException : TransportException
+    {
+        public EpoxyFailedToResolveException(string message, Exception innerException = null)
+            : base(message, innerException)
+        {
+        }
+    }
+
     public class EpoxyProtocolErrorException : TransportException
     {
         public EpoxyProtocolErrorException(

--- a/cs/src/comm/epoxy-transport/EpoxyTransport.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyTransport.cs
@@ -15,6 +15,18 @@ namespace Bond.Comm.Epoxy
     {
         Func<string, Task<IPAddress>> resolver;
 
+        /// <summary>
+        /// Sets a customer host resolver.
+        /// </summary>
+        /// <param name="resolver">
+        /// The host resolver to use. May be <c>null</c>, in which case DNS
+        /// resolution will be used.
+        /// </param>
+        /// <returns>The builder.</returns>
+        /// <remarks>
+        /// A resolver takes a string host name and turns it into one
+        /// <see cref="IPAddress"/> however it sees fit.
+        /// </remarks>
         public EpoxyTransportBuilder SetResolver(Func<string, Task<IPAddress>> resolver)
         {
             this.resolver = resolver;

--- a/cs/src/comm/epoxy-transport/EpoxyTransport.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyTransport.cs
@@ -246,10 +246,6 @@ namespace Bond.Comm.Epoxy
             {
                 throw new EpoxyFailedToResolveException($"Failed to resolve [{host}] due to DNS error", ex);
             }
-            catch (Exception ex) when(ex is ArgumentOutOfRangeException || ex is ArgumentException)
-            {
-                throw new EpoxyFailedToResolveException($"Could not parse [{host}]", ex);
-            }
 
             // TODO: IPv6 support
             IPAddress ipAddr = ipAddresses.FirstOrDefault(addr => addr.AddressFamily == AddressFamily.InterNetwork);

--- a/cs/src/comm/epoxy-transport/EpoxyTransport.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyTransport.cs
@@ -150,25 +150,27 @@ namespace Bond.Comm.Epoxy
         {
             logger.Site().Information("Connecting to {0}.", endpoint);
 
+            IPAddress ipAddress;
+
             try
             {
-                IPAddress ipAddress = await resolver(endpoint.Host);
-
-                var socket = MakeClientSocket();
-                await Task.Factory.FromAsync(
-                    socket.BeginConnect, socket.EndConnect, ipAddress, endpoint.Port,
-                    state: null);
-
-                // TODO: keep these in some master collection for shutdown
-                var connection = EpoxyConnection.MakeClientConnection(this, socket, logger, metrics);
-                await connection.StartAsync();
-                return connection;
+                ipAddress = await resolver(endpoint.Host);
             }
             catch (EpoxyFailedToResolveException ex)
             {
                 logger.Site().Error(ex, "Failed to resolve {0}: {1}", endpoint, ex.Message);
                 throw;
             }
+
+            var socket = MakeClientSocket();
+            await Task.Factory.FromAsync(
+                socket.BeginConnect, socket.EndConnect, ipAddress, endpoint.Port,
+                state: null);
+
+            // TODO: keep these in some master collection for shutdown
+            var connection = EpoxyConnection.MakeClientConnection(this, socket, logger, metrics);
+            await connection.StartAsync();
+            return connection;
         }
 
         public async Task<EpoxyConnection> ConnectToAsync(Endpoint endpoint)

--- a/cs/src/comm/epoxy-transport/epoxy-transport.csproj
+++ b/cs/src/comm/epoxy-transport/epoxy-transport.csproj
@@ -19,9 +19,9 @@
     <Compile Include="properties\AssemblyInfo.cs" />
     <Compile Include="EpoxyConnection.cs" />
     <Compile Include="EpoxyContexts.cs" />
+    <Compile Include="EpoxyExceptions.cs" />
     <Compile Include="EpoxyListener.cs" />
     <Compile Include="EpoxyProtocol.cs" />
-    <Compile Include="EpoxyProtocolErrorException.cs" />
     <Compile Include="EpoxyTransport.cs" />
     <BondCodegen Include="EpoxyTransport.bond">
       <Options>--namespace=bond.comm=Bond.Comm --namespace=bond.comm.epoxy=Bond.Comm.Epoxy</Options>


### PR DESCRIPTION
* Default resolver uses DNS
* Custom resolvers can be provided via
  `EpoxyTransportBuilder.SetResolver`