### PR TITLE
[epoxy] Add IPv6 support

### DIFF
--- a/cs/src/comm/epoxy-transport/EpoxyTransport.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyTransport.cs
@@ -162,7 +162,7 @@ namespace Bond.Comm.Epoxy
                 throw;
             }
 
-            var socket = MakeClientSocket();
+            var socket = MakeClientSocket(ipAddress);
             await Task.Factory.FromAsync(
                 socket.BeginConnect, socket.EndConnect, ipAddress, endpoint.Port,
                 state: null);
@@ -249,20 +249,17 @@ namespace Bond.Comm.Epoxy
                 throw new EpoxyFailedToResolveException($"Failed to resolve [{host}] due to DNS error", ex);
             }
 
-            // TODO: IPv6 support
-            IPAddress ipAddr = ipAddresses.FirstOrDefault(addr => addr.AddressFamily == AddressFamily.InterNetwork);
-
-            if (ipAddr == null)
+            if (ipAddresses.Length < 1)
             {
                 throw new EpoxyFailedToResolveException($"Could not resolve [{host}] to a supported IP address.");
             }
 
-            return ipAddr;
+            return ipAddresses[0];
         }
 
-        private Socket MakeClientSocket()
+        private Socket MakeClientSocket(IPAddress remoteIpAddress)
         {
-            return new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            return new Socket(remoteIpAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
         }
     }
 }

--- a/cs/test/comm/Epoxy/EpoxyTransportTests.cs
+++ b/cs/test/comm/Epoxy/EpoxyTransportTests.cs
@@ -603,5 +603,23 @@ namespace UnitTest.Epoxy
             Assert.That(exception.Message, Is.StringContaining("registered as invalid type"));
         }
 
+        [Test]
+        public async Task IPv6Listener_RequestReply_PayloadResponse()
+        {
+            var transport = new EpoxyTransportBuilder().Construct();
+            listener = transport.MakeListener(new IPEndPoint(IPAddress.IPv6Loopback, EpoxyTransport.DefaultPort));
+            listener.AddService(new DummyTestService());
+            await listener.StartAsync();
+
+            EpoxyConnection conn = await transport.ConnectToAsync("epoxy://[::1]");
+            var proxy = new DummyTestProxy<EpoxyConnection>(conn);
+            var request = new Dummy { int_value = 100 };
+
+            IMessage<Dummy> response = await proxy.ReqRspMethodAsync(request);
+            Assert.IsFalse(response.IsError);
+            Assert.AreEqual(101, response.Payload.Deserialize().int_value);
+
+            await transport.StopAsync();
+        }
     }
 }


### PR DESCRIPTION
* Both listeners and connections can be made to IPv6 addresses now.
* Default resolver no longer prefers IPv4 addresses. It just uses the first
  address returned.