### PR TITLE
Fix AppVeyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -129,6 +129,7 @@
     build_script:
         - ps: >-
             $env:PreferredToolArchitecture = "x64"
+            
             $env:_IsNativeEnvironment = "true"
 
             if ($env:BOND_BUILD -eq "Doc") {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@
         BOND_TOKEN:
             secure: 30K3L1s8erWFnnS/Iyb2LP7kiGZBr/GzA24Y82mCsGMBjzSUyk7uV7MvZ3NepNvB
         matrix:
+            - BOND_BUILD: Doc
             - BOND_BUILD: Python
               BOND_VS: "Visual Studio 14 2015"
               BOND_VS_NUM: 14
@@ -34,7 +35,6 @@
             - BOND_BUILD: C#
               BOND_OUTPUT: Properties
               BOND_CONFIG: Debug
-            - BOND_BUILD: Doc
             - BOND_BUILD: C++
               BOND_VS: "Visual Studio 12 2013"
               BOND_VS_NUM: 12
@@ -65,10 +65,9 @@
             cabal update
 
             if ($env:BOND_BUILD -eq "Doc") {
-                
-                cabal install -v3 lifted-base-0.2.3.7
 
-                cabal install --verbose=0 pandoc
+                # Temp constraint until further investigation
+                cabal install --verbose=0 pandoc --constraint='lifted-base<=0.2.3.6'
 
                 choco install doxygen.install -y
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,7 +67,7 @@
             if ($env:BOND_BUILD -eq "Doc") {
 
                 # Temp constraint until further investigation
-                cabal install --verbose=0 pandoc --constraint='lifted-base<=0.2.3.6'
+                cabal install pandoc --constraint='lifted-base<=0.2.3.6'
 
                 choco install doxygen.install -y
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,18 +48,14 @@
         - ps: >-
             git submodule update --init
 
-            if ($env:BOND_BUILD -eq "Python") {
-
-                if ($env:BOND_BOOST -eq 56) {
-                    # Hard-coded Boost path as per https://www.appveyor.com/docs/installed-software#languages-libraries-frameworks
-                    $env:BOOST_ROOT = "C:/Libraries/boost"
-                    $env:BOOST_LIBRARYDIR = "C:/Libraries/boost/lib${env:BOND_ARCH}-msvc-${env:BOND_VS_NUM}.0"
-                }
-                else {
-                    $env:BOOST_ROOT = "C:/Libraries/boost_1_${env:BOND_BOOST}_0"
-                    $env:BOOST_LIBRARYDIR = "C:/Libraries/boost_1_${env:BOND_BOOST}_0/lib${env:BOND_ARCH}-msvc-${env:BOND_VS_NUM}.0"
-                }
-
+            if ($env:BOND_BOOST -eq 56) {
+                # Hard-coded Boost path per https://www.appveyor.com/docs/installed-software#languages-libraries-frameworks
+                $env:BOOST_ROOT = "C:/Libraries/boost"
+                $env:BOOST_LIBRARYDIR = "C:/Libraries/boost/lib${env:BOND_ARCH}-msvc-${env:BOND_VS_NUM}.0"
+            }
+            else {
+                $env:BOOST_ROOT = "C:/Libraries/boost_1_${env:BOND_BOOST}_0"
+                $env:BOOST_LIBRARYDIR = "C:/Libraries/boost_1_${env:BOND_BOOST}_0/lib${env:BOND_ARCH}-msvc-${env:BOND_VS_NUM}.0"
             }
 
             choco install haskellplatform -version 2014.2.0.0 -y
@@ -73,20 +69,6 @@
                 cabal install --verbose=0 pandoc
 
                 choco install doxygen.install -y
-
-            }
-
-            if ($env:BOND_BUILD -eq "C++") {
-
-                if ($env:BOND_BOOST -eq 56) {
-                    # Hard-coded Boost path as per https://www.appveyor.com/docs/installed-software#languages-libraries-frameworks
-                    $env:BOOST_ROOT = "C:/Libraries/boost"
-                    $env:BOOST_LIBRARYDIR = "C:/Libraries/boost/lib${env:BOND_ARCH}-msvc-${env:BOND_VS_NUM}.0"
-                }
-                else {
-                    $env:BOOST_ROOT = "C:/Libraries/boost_1_${env:BOND_BOOST}_0"
-                    $env:BOOST_LIBRARYDIR = "C:/Libraries/boost_1_${env:BOND_BOOST}_0/lib${env:BOND_ARCH}-msvc-${env:BOND_VS_NUM}.0"
-                }
 
             }
 
@@ -124,7 +106,7 @@
 
                 cd build
 
-                # Make sure we have Python27-64 before any other version; Python path as per https://www.appveyor.com/docs/installed-software#python
+                # Make sure we have Python27-64 before any other version; Python path per https://www.appveyor.com/docs/installed-software#python
                 if ($env:BOND_ARCH -eq 64) {
                     $env:Path = "C:\Python27-x64\scripts;C:\Python27-x64\;${env:Path}"
                 }
@@ -146,6 +128,9 @@
 
     build_script:
         - ps: >-
+            $env:PreferredToolArchitecture = "x64"
+            $env:_IsNativeEnvironment = "true"
+
             if ($env:BOND_BUILD -eq "Doc") {
 
                 cmake --build . --target documentation -- /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
@@ -184,9 +169,6 @@
             }
 
             if ($env:BOND_BUILD -eq "C++") {
-
-                $env:PreferredToolArchitecture = "x64"
-                $env:_IsNativeEnvironment = "true"
 
                 cmake --build . --target check -- /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,6 +65,8 @@
             cabal update
 
             if ($env:BOND_BUILD -eq "Doc") {
+                
+                cabal install -v3 lifted-base-0.2.3.7
 
                 cabal install --verbose=0 pandoc
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,9 +36,9 @@
               BOND_CONFIG: Debug
             - BOND_BUILD: Doc
             - BOND_BUILD: C++
-              BOND_VS: "Visual Studio 12 2013 Win64"
+              BOND_VS: "Visual Studio 12 2013"
               BOND_VS_NUM: 12
-              BOND_ARCH: 64
+              BOND_ARCH: 32
               BOND_BOOST: 56
             - BOND_BUILD: C#
               BOND_OUTPUT: Fields

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,9 +23,13 @@
         matrix:
             - BOND_BUILD: Python
               BOND_VS: "Visual Studio 14 2015"
+              BOND_VS_NUM: 14
+              BOND_ARCH: 32
               BOND_BOOST: 59
             - BOND_BUILD: C++
               BOND_VS: "Visual Studio 14 2015 Win64"
+              BOND_VS_NUM: 14
+              BOND_ARCH: 64
               BOND_BOOST: 59
             - BOND_BUILD: C#
               BOND_OUTPUT: Properties
@@ -33,7 +37,9 @@
             - BOND_BUILD: Doc
             - BOND_BUILD: C++
               BOND_VS: "Visual Studio 12 2013"
-              BOND_BOOST: 55
+              BOND_VS_NUM: 12
+              BOND_ARCH: 32
+              BOND_BOOST: 56
             - BOND_BUILD: C#
               BOND_OUTPUT: Fields
               BOND_CONFIG: Fields
@@ -44,19 +50,15 @@
 
             if ($env:BOND_BUILD -eq "Python") {
 
-                if (!(Test-Path boost.exe)) {
-
-                    echo "Downloading Boost 1.${env:BOND_BOOST} ..."
-
-                    Start-FileDownload "http://iweb.dl.sourceforge.net/project/boost/boost-binaries/1.${env:BOND_BOOST}.0/boost_1_${env:BOND_BOOST}_0-msvc-14.0-32.exe" -FileName boost.exe -Timeout 1200000
-
+                if ($env:BOND_BOOST -eq 56) {
+                    # Hard-coded Boost path as per https://www.appveyor.com/docs/installed-software#languages-libraries-frameworks
+                    $env:BOOST_ROOT = "C:/Libraries/boost"
+                    $env:BOOST_LIBRARYDIR = "C:/Libraries/boost/lib${env:BOND_ARCH}-msvc-${env:BOND_VS_NUM}.0"
                 }
-
-                .\boost.exe /DIR="${env:APPVEYOR_BUILD_FOLDER}\\boost_1_${env:BOND_BOOST}_0" /VERYSILENT
-
-                $env:BOOST_ROOT = "${env:APPVEYOR_BUILD_FOLDER}/boost_1_${env:BOND_BOOST}_0"
-
-                $env:BOOST_LIBRARYDIR = "${env:BOOST_ROOT}/lib32-msvc-14.0"
+                else {
+                    $env:BOOST_ROOT = "C:/Libraries/boost_1_${env:BOND_BOOST}_0"
+                    $env:BOOST_LIBRARYDIR = "C:/Libraries/boost_1_${env:BOND_BOOST}_0/lib${env:BOND_ARCH}-msvc-${env:BOND_VS_NUM}.0"
+                }
 
             }
 
@@ -76,19 +78,15 @@
 
             if ($env:BOND_BUILD -eq "C++") {
 
-                if (!(Test-Path boost.7z)) {
-
-                    echo "Downloading Boost 1.${env:BOND_BOOST} ..."
-
-                    Start-FileDownload "http://iweb.dl.sourceforge.net/project/boost/boost/1.${env:BOND_BOOST}.0/boost_1_${env:BOND_BOOST}_0.7z" -FileName boost.7z -Timeout 1200000
-
+                if ($env:BOND_BOOST -eq 56) {
+                    # Hard-coded Boost path as per https://www.appveyor.com/docs/installed-software#languages-libraries-frameworks
+                    $env:BOOST_ROOT = "C:/Libraries/boost"
+                    $env:BOOST_LIBRARYDIR = "C:/Libraries/boost/lib${env:BOND_ARCH}-msvc-${env:BOND_VS_NUM}.0"
                 }
-
-                echo "Extracting Boost..."
-
-                7z x boost.7z -y -o"${env:APPVEYOR_BUILD_FOLDER}" "boost_1_${env:BOND_BOOST}_0/boost" > $null
-
-                $env:BOOST_ROOT = "${env:APPVEYOR_BUILD_FOLDER}/boost_1_${env:BOND_BOOST}_0"
+                else {
+                    $env:BOOST_ROOT = "C:/Libraries/boost_1_${env:BOND_BOOST}_0"
+                    $env:BOOST_LIBRARYDIR = "C:/Libraries/boost_1_${env:BOND_BOOST}_0/lib${env:BOND_ARCH}-msvc-${env:BOND_VS_NUM}.0"
+                }
 
             }
 
@@ -97,8 +95,6 @@
     cache:
         - cs\packages -> cs\test\core\packages.config
         - compiler\.cabal-sandbox -> compiler\bond.cabal
-        - boost.7z
-        - boost.exe
 
     before_build:
         - ps: >-
@@ -127,6 +123,11 @@
                 mkdir build
 
                 cd build
+
+                # Make sure we have Python27-64 before any other version; Python path as per https://www.appveyor.com/docs/installed-software#python
+                if ($env:BOND_ARCH -eq 64) {
+                    $env:Path = "C:\Python27-x64\scripts;C:\Python27-x64\;${env:Path}"
+                }
 
                 cmake -G $env:BOND_VS ..
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,9 +36,9 @@
               BOND_CONFIG: Debug
             - BOND_BUILD: Doc
             - BOND_BUILD: C++
-              BOND_VS: "Visual Studio 12 2013"
+              BOND_VS: "Visual Studio 12 2013 Win64"
               BOND_VS_NUM: 12
-              BOND_ARCH: 32
+              BOND_ARCH: 64
               BOND_BOOST: 56
             - BOND_BUILD: C#
               BOND_OUTPUT: Fields
@@ -143,7 +143,6 @@
 
             }
 
-            $env:PreferredToolArchitecture = "x64"
 
     build_script:
         - ps: >-
@@ -185,6 +184,9 @@
             }
 
             if ($env:BOND_BUILD -eq "C++") {
+
+                $env:PreferredToolArchitecture = "x64"
+                $env:_IsNativeEnvironment = "true"
 
                 cmake --build . --target check -- /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -41,7 +41,7 @@ find_package (Boost 1.53.0
 
 message(STATUS "Boost Python Library: ${Boost_PYTHON_LIBRARY}")
 
-# make sure our CI runs fail when unit test dependencies are not found 
+# Make sure AppVeyor CI runs fail when unit test dependencies are not found 
 if (DEFINED ENV{APPVEYOR} AND ("$ENV{BOND_BUILD}" STREQUAL "C++"))
     if (NOT Boost_UNIT_TEST_FRAMEWORK_FOUND)
         message(FATAL_ERROR "Boost unit_test_framework not found")

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -41,6 +41,13 @@ find_package (Boost 1.53.0
 
 message(STATUS "Boost Python Library: ${Boost_PYTHON_LIBRARY}")
 
+# make sure our CI runs fail when unit test dependencies are not found 
+if (DEFINED ENV{APPVEYOR} AND ("$ENV{BOND_BUILD}" STREQUAL "C++"))
+    if (NOT Boost_UNIT_TEST_FRAMEWORK_FOUND)
+        message(FATAL_ERROR "Boost unit_test_framework not found")
+    endif()
+endif()
+
 # disable Boost auto-linking
 add_definitions (-DBOOST_ALL_NO_LIB)
 


### PR DESCRIPTION
- Use AppVeyor pre-installed Boost
- Run C++ unit tests
- Fail if Boot unit_test_framework is not found