### PR TITLE
[gbc] Fully qualify names in generated C++ swap()s.

### DIFF
--- a/compiler/src/Language/Bond/Codegen/Cpp/Types_h.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Types_h.hs
@@ -146,13 +146,13 @@ namespace std
         #{initMetadata}
     };
 
-    #{template}inline void swap(#{structName}& left, #{structName}& right)
+    #{template}inline void swap(#{qualifiedStructName}& left, #{qualifiedStructName}& right)
     {
         left.swap(right);
     }|]
       where
         template = CPP.template s
-        structName = CPP.structName s
+        qualifiedStructName = [lt|#{getDeclTypeName cpp s}#{CPP.structParams s}|]
 
         otherParam = if hasOnlyMetaFields then mempty else [lt| other|]
         hasOnlyMetaFields = not (any (not . getAny . metaField) structFields) && isNothing structBase

--- a/compiler/tests/generated/alias_key_types.h
+++ b/compiler/tests/generated/alias_key_types.h
@@ -79,7 +79,7 @@ namespace test
         }
     };
 
-    inline void swap(foo& left, foo& right)
+    inline void swap(::test::foo& left, ::test::foo& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/alias_with_allocator_types.h
+++ b/compiler/tests/generated/alias_with_allocator_types.h
@@ -132,7 +132,7 @@ namespace test
         }
     };
 
-    inline void swap(foo& left, foo& right)
+    inline void swap(::test::foo& left, ::test::foo& right)
     {
         left.swap(right);
     }
@@ -203,7 +203,7 @@ namespace test
         }
     };
 
-    inline void swap(withFoo& left, withFoo& right)
+    inline void swap(::test::withFoo& left, ::test::withFoo& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/aliases_types.h
+++ b/compiler/tests/generated/aliases_types.h
@@ -77,7 +77,7 @@ namespace tests
     };
 
     template <typename T>
-    inline void swap(Foo<T>& left, Foo<T>& right)
+    inline void swap(::tests::Foo<T>& left, ::tests::Foo<T>& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/allocator/alias_key_types.h
+++ b/compiler/tests/generated/allocator/alias_key_types.h
@@ -86,7 +86,7 @@ namespace test
         }
     };
 
-    inline void swap(foo& left, foo& right)
+    inline void swap(::test::foo& left, ::test::foo& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/allocator/aliases_types.h
+++ b/compiler/tests/generated/allocator/aliases_types.h
@@ -83,7 +83,7 @@ namespace tests
     };
 
     template <typename T>
-    inline void swap(Foo<T>& left, Foo<T>& right)
+    inline void swap(::tests::Foo<T>& left, ::tests::Foo<T>& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/allocator/attributes_types.h
+++ b/compiler/tests/generated/allocator/attributes_types.h
@@ -141,7 +141,7 @@ namespace tests
         }
     };
 
-    inline void swap(Foo& left, Foo& right)
+    inline void swap(::tests::Foo& left, ::tests::Foo& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/allocator/basic_types_types.h
+++ b/compiler/tests/generated/allocator/basic_types_types.h
@@ -156,7 +156,7 @@ namespace tests
         }
     };
 
-    inline void swap(BasicTypes& left, BasicTypes& right)
+    inline void swap(::tests::BasicTypes& left, ::tests::BasicTypes& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/allocator/bond_meta_types.h
+++ b/compiler/tests/generated/allocator/bond_meta_types.h
@@ -92,7 +92,7 @@ namespace bondmeta
         }
     };
 
-    inline void swap(HasMetaFields& left, HasMetaFields& right)
+    inline void swap(::deprecated::bondmeta::HasMetaFields& left, ::deprecated::bondmeta::HasMetaFields& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/allocator/complex_types_types.h
+++ b/compiler/tests/generated/allocator/complex_types_types.h
@@ -78,7 +78,7 @@ namespace tests
         }
     };
 
-    inline void swap(Foo& left, Foo& right)
+    inline void swap(::tests::Foo& left, ::tests::Foo& right)
     {
         left.swap(right);
     }
@@ -175,7 +175,7 @@ namespace tests
         }
     };
 
-    inline void swap(ComplexTypes& left, ComplexTypes& right)
+    inline void swap(::tests::ComplexTypes& left, ::tests::ComplexTypes& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/allocator/defaults_types.h
+++ b/compiler/tests/generated/allocator/defaults_types.h
@@ -348,7 +348,7 @@ namespace tests
         }
     };
 
-    inline void swap(Foo& left, Foo& right)
+    inline void swap(::tests::Foo& left, ::tests::Foo& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/allocator/field_modifiers_types.h
+++ b/compiler/tests/generated/allocator/field_modifiers_types.h
@@ -94,7 +94,7 @@ namespace tests
         }
     };
 
-    inline void swap(Foo& left, Foo& right)
+    inline void swap(::tests::Foo& left, ::tests::Foo& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/allocator/generics_types.h
+++ b/compiler/tests/generated/allocator/generics_types.h
@@ -89,7 +89,7 @@ namespace tests
     };
 
     template <typename T1, typename T2>
-    inline void swap(Foo<T1, T2>& left, Foo<T1, T2>& right)
+    inline void swap(::tests::Foo<T1, T2>& left, ::tests::Foo<T1, T2>& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/allocator/inheritance_types.h
+++ b/compiler/tests/generated/allocator/inheritance_types.h
@@ -82,7 +82,7 @@ namespace tests
         }
     };
 
-    inline void swap(Base& left, Base& right)
+    inline void swap(::tests::Base& left, ::tests::Base& right)
     {
         left.swap(right);
     }
@@ -155,7 +155,7 @@ namespace tests
         }
     };
 
-    inline void swap(Foo& left, Foo& right)
+    inline void swap(::tests::Foo& left, ::tests::Foo& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/allocator/maybe_blob_types.h
+++ b/compiler/tests/generated/allocator/maybe_blob_types.h
@@ -80,7 +80,7 @@ namespace tests
         }
     };
 
-    inline void swap(Foo& left, Foo& right)
+    inline void swap(::tests::Foo& left, ::tests::Foo& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/attributes_types.h
+++ b/compiler/tests/generated/attributes_types.h
@@ -135,7 +135,7 @@ namespace tests
         }
     };
 
-    inline void swap(Foo& left, Foo& right)
+    inline void swap(::tests::Foo& left, ::tests::Foo& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/basic_types_types.h
+++ b/compiler/tests/generated/basic_types_types.h
@@ -138,7 +138,7 @@ namespace tests
         }
     };
 
-    inline void swap(BasicTypes& left, BasicTypes& right)
+    inline void swap(::tests::BasicTypes& left, ::tests::BasicTypes& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/bond_meta_types.h
+++ b/compiler/tests/generated/bond_meta_types.h
@@ -84,7 +84,7 @@ namespace bondmeta
         }
     };
 
-    inline void swap(HasMetaFields& left, HasMetaFields& right)
+    inline void swap(::deprecated::bondmeta::HasMetaFields& left, ::deprecated::bondmeta::HasMetaFields& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/complex_types_types.h
+++ b/compiler/tests/generated/complex_types_types.h
@@ -73,7 +73,7 @@ namespace tests
         }
     };
 
-    inline void swap(Foo& left, Foo& right)
+    inline void swap(::tests::Foo& left, ::tests::Foo& right)
     {
         left.swap(right);
     }
@@ -159,7 +159,7 @@ namespace tests
         }
     };
 
-    inline void swap(ComplexTypes& left, ComplexTypes& right)
+    inline void swap(::tests::ComplexTypes& left, ::tests::ComplexTypes& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/custom_alias_with_allocator_types.h
+++ b/compiler/tests/generated/custom_alias_with_allocator_types.h
@@ -137,7 +137,7 @@ namespace test
         }
     };
 
-    inline void swap(foo& left, foo& right)
+    inline void swap(::test::foo& left, ::test::foo& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/custom_alias_without_allocator_types.h
+++ b/compiler/tests/generated/custom_alias_without_allocator_types.h
@@ -137,7 +137,7 @@ namespace test
         }
     };
 
-    inline void swap(foo& left, foo& right)
+    inline void swap(::test::foo& left, ::test::foo& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/defaults_types.h
+++ b/compiler/tests/generated/defaults_types.h
@@ -307,7 +307,7 @@ namespace tests
         }
     };
 
-    inline void swap(Foo& left, Foo& right)
+    inline void swap(::tests::Foo& left, ::tests::Foo& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/field_modifiers_types.h
+++ b/compiler/tests/generated/field_modifiers_types.h
@@ -86,7 +86,7 @@ namespace tests
         }
     };
 
-    inline void swap(Foo& left, Foo& right)
+    inline void swap(::tests::Foo& left, ::tests::Foo& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/generics_types.h
+++ b/compiler/tests/generated/generics_types.h
@@ -82,7 +82,7 @@ namespace tests
     };
 
     template <typename T1, typename T2>
-    inline void swap(Foo<T1, T2>& left, Foo<T1, T2>& right)
+    inline void swap(::tests::Foo<T1, T2>& left, ::tests::Foo<T1, T2>& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/inheritance_types.h
+++ b/compiler/tests/generated/inheritance_types.h
@@ -76,7 +76,7 @@ namespace tests
         }
     };
 
-    inline void swap(Base& left, Base& right)
+    inline void swap(::tests::Base& left, ::tests::Base& right)
     {
         left.swap(right);
     }
@@ -142,7 +142,7 @@ namespace tests
         }
     };
 
-    inline void swap(Foo& left, Foo& right)
+    inline void swap(::tests::Foo& left, ::tests::Foo& right)
     {
         left.swap(right);
     }

--- a/compiler/tests/generated/maybe_blob_types.h
+++ b/compiler/tests/generated/maybe_blob_types.h
@@ -75,7 +75,7 @@ namespace tests
         }
     };
 
-    inline void swap(Foo& left, Foo& right)
+    inline void swap(::tests::Foo& left, ::tests::Foo& right)
     {
         left.swap(right);
     }


### PR DESCRIPTION
This fixes another bit of invalid C++ generated when a bondfile contains a struct and an enum value with the same name.

Previously: #202, #204 