### PR TITLE
[epoxy] Add basic IDN support to conn. strings

### DIFF
--- a/cs/src/comm/epoxy-transport/EpoxyTransport.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyTransport.cs
@@ -132,7 +132,7 @@ namespace Bond.Comm.Epoxy
                 return null;
             }
 
-            return new Endpoint(uri.Host, port);
+            return new Endpoint(uri.DnsSafeHost, port);
         }
 
         public override async Task<EpoxyConnection> ConnectToAsync(string address, CancellationToken ct)


### PR DESCRIPTION
Use `Uri.DnsSafeHost`, which can be configured at an application level
to return Punycode-encoded ACEs.

.NET 4.6 includes `Uri.IdnHost`, which is always Punycode-encoded if
needed, but Mono doesn't yet support that, so we can't use it.