### PR TITLE
[c#] Thread request IDs through to InternalServerErrors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ different versioning scheme, following the Haskell community's
   transport-specific subtypes.
 * Epoxy has a hook for performing custom host to IP address resolution. This
   is configured with `EpoxyTransportBuilder.SetResolver`.
+* Bond-generated Errors now give clients opaque GUIDs. These GUIDs can be
+  matched against emitted metrics for debugging.
 
 ## 4.2.1: 2016-06-02 ##
 

--- a/cs/src/comm/epoxy-transport/EpoxyConnection.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyConnection.cs
@@ -259,7 +259,7 @@ namespace Bond.Comm.Epoxy
 
             IBonded layerData = null;
             ILayerStack layerStack;
-            Error layerError = parentTransport.GetLayerStack(out layerStack);
+            Error layerError = parentTransport.GetLayerStack(requestMetrics.request_id, out layerStack);
 
             if (layerError == null)
             {
@@ -343,7 +343,7 @@ namespace Bond.Comm.Epoxy
 
             IBonded layerData =  null;
             ILayerStack layerStack;
-            Error layerError = parentTransport.GetLayerStack(out layerStack);
+            Error layerError = parentTransport.GetLayerStack(requestMetrics.request_id, out layerStack);
 
             if (layerError == null)
             {
@@ -726,7 +726,7 @@ namespace Bond.Comm.Epoxy
                 IBonded bondedLayerData = (layerData.Array == null) ? null : Unmarshal.From(layerData);
 
                 ILayerStack layerStack;
-                Error layerError = parentTransport.GetLayerStack(out layerStack);
+                Error layerError = parentTransport.GetLayerStack(requestMetrics.request_id, out layerStack);
 
                 if (layerError == null)
                 {
@@ -824,7 +824,7 @@ namespace Bond.Comm.Epoxy
 
                 IBonded bondedLayerData = (layerData.Array == null) ? null : Unmarshal.From(layerData);
                 ILayerStack layerStack;
-                Error layerError = parentTransport.GetLayerStack(out layerStack);
+                Error layerError = parentTransport.GetLayerStack(requestMetrics.request_id, out layerStack);
 
                 if (layerError == null)
                 {

--- a/cs/src/comm/epoxy-transport/EpoxyContexts.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyContexts.cs
@@ -5,7 +5,8 @@ namespace Bond.Comm.Epoxy
 {
     public class EpoxySendContext : SendContext
     {
-        public EpoxySendContext(EpoxyConnection connection)
+        public EpoxySendContext(EpoxyConnection connection, ConnectionMetrics connectionMetrics, RequestMetrics requestMetrics)
+            : base(connectionMetrics, requestMetrics)
         {
             Connection = connection;
         }
@@ -15,7 +16,8 @@ namespace Bond.Comm.Epoxy
 
     public class EpoxyReceiveContext : ReceiveContext
     {
-        public EpoxyReceiveContext(EpoxyConnection connection)
+        public EpoxyReceiveContext(EpoxyConnection connection, ConnectionMetrics connectionMetrics, RequestMetrics requestMetrics)
+            : base(connectionMetrics, requestMetrics)
         {
             Connection = connection;
         }

--- a/cs/src/comm/epoxy-transport/EpoxyListener.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyListener.cs
@@ -30,7 +30,7 @@ namespace Bond.Comm.Epoxy
         {
             this.parentTransport = parentTransport;
             listener = new TcpListener(listenEndpoint);
-            serviceHost = new ServiceHost(logger, metrics);
+            serviceHost = new ServiceHost(logger);
             connections = new HashSet<EpoxyConnection>();
             shutdownTokenSource = new CancellationTokenSource();
         }

--- a/cs/src/comm/epoxy-transport/EpoxyTransport.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyTransport.cs
@@ -89,11 +89,11 @@ namespace Bond.Comm.Epoxy
             metrics = new Metrics(metricsSink);
         }
 
-        public override Error GetLayerStack(out ILayerStack stack)
+        public override Error GetLayerStack(string uniqueId, out ILayerStack stack)
         {
             if (layerStackProvider != null)
             {
-                return layerStackProvider.GetLayerStack(out stack);
+                return layerStackProvider.GetLayerStack(uniqueId, out stack);
             }
             else
             {

--- a/cs/src/comm/interfaces/Connections.cs
+++ b/cs/src/comm/interfaces/Connections.cs
@@ -62,6 +62,10 @@ namespace Bond.Comm
     /// </summary>
     public abstract class Connection
     {
+        public readonly ConnectionMetrics ConnectionMetrics = Metrics.StartConnectionMetrics();
+
+        public string Id => ConnectionMetrics.connection_id;
+
         /// <summary>
         /// Starts an asynchronous operation to close a connection.
         /// </summary>

--- a/cs/src/comm/interfaces/Contexts.cs
+++ b/cs/src/comm/interfaces/Contexts.cs
@@ -8,6 +8,9 @@ namespace Bond.Comm
     /// </summary>
     public abstract class Context
     {
+        public readonly ConnectionMetrics ConnectionMetrics;
+        public readonly RequestMetrics RequestMetrics;
+
         /// <summary>
         /// The connection being used.
         /// </summary>
@@ -27,6 +30,12 @@ namespace Bond.Comm
         /// </para>
         /// </remarks>
         public abstract Connection Connection { get; }
+
+        protected Context(ConnectionMetrics connectionMetrics, RequestMetrics requestMetrics)
+        {
+            ConnectionMetrics = connectionMetrics;
+            RequestMetrics = requestMetrics;
+        }
     }
 
     /// <summary>
@@ -34,6 +43,9 @@ namespace Bond.Comm
     /// </summary>
     public abstract class SendContext : Context
     {
+
+        protected SendContext(ConnectionMetrics connectionMetrics, RequestMetrics requestMetrics)
+            : base(connectionMetrics, requestMetrics) {}
     }
 
     /// <summary>
@@ -41,5 +53,7 @@ namespace Bond.Comm
     /// </summary>
     public abstract class ReceiveContext : Context
     {
+        protected ReceiveContext(ConnectionMetrics connectionMetrics, RequestMetrics requestMetrics)
+            : base(connectionMetrics, requestMetrics) {}
     }
 }

--- a/cs/src/comm/interfaces/Errors.cs
+++ b/cs/src/comm/interfaces/Errors.cs
@@ -11,7 +11,12 @@ namespace Bond.Comm
         /// <summary>
         /// (Opaque) error message returned to client for server-side issues.
         /// </summary>
-        public static readonly string InternalErrorMessage = "The server has encounted an error";
+        public const string InternalErrorMessage = "The server has encounted an error";
+
+        /// <summary>
+        /// A unique ID for calls of MakeInternalServerError that are passed a null ID.
+        /// </summary>
+        private const string UniqueIdForNullId = "[4e2bec1b-42ca-482b-8895-b8586bc8f491]";
 
         /// <summary>
         /// Checks if an <see cref="Error" /> is an <see cref="InternalServerError"/>.
@@ -37,16 +42,17 @@ namespace Bond.Comm
         /// Creates an <see cref="InternalServerError"/> with the given message.
         /// </summary>
         /// <param name="message">An error message.</param>
+        /// <param name="uniqueId">The ID of the request that caused this error.</param>
         /// <returns>An InternalServerError representing the exception.</returns>
-        public static InternalServerError MakeInternalServerError(string message)
+        public static InternalServerError MakeInternalServerError(string message, string uniqueId)
         {
             var internalServerError = new InternalServerError
             {
-                error_code = (int)ErrorCode.InternalServerError,
-                unique_id = Guid.NewGuid().ToString("D")
+                error_code = (int) ErrorCode.InternalServerError,
+                unique_id = uniqueId ?? UniqueIdForNullId,
+                message = message ?? InternalErrorMessage
             };
-            
-            internalServerError.message = message ?? InternalErrorMessage;
+
 
             return internalServerError;
         }
@@ -55,17 +61,18 @@ namespace Bond.Comm
         /// Creates an <see cref="InternalServerError"/> from an exception.
         /// </summary>
         /// <param name="exception">An exception.</param>
+        /// <param name="uniqueId">The ID of the request that caused this error.</param>
         /// <param name="includeDetails">
         /// <c>true</c> if debugging details should be included; <c>false</c>
         /// to omit this potentailly sensitive information
         /// </param>
         /// <returns>An InternalServerError representing the exception.</returns>
-        public static InternalServerError MakeInternalServerError(Exception exception, bool includeDetails)
+        public static InternalServerError MakeInternalServerError(Exception exception, string uniqueId, bool includeDetails)
         {
             var internalServerError = new InternalServerError
             {
                 error_code = (int)ErrorCode.InternalServerError,
-                unique_id = Guid.NewGuid().ToString("D")
+                unique_id = uniqueId ?? UniqueIdForNullId
             };
 
             if (includeDetails && exception != null)
@@ -80,14 +87,14 @@ namespace Bond.Comm
 
                     foreach (var innerException in aggEx.InnerExceptions)
                     {
-                        var innerError = MakeInternalServerError(innerException, includeDetails);
+                        var innerError = MakeInternalServerError(innerException, uniqueId, includeDetails);
                         internalServerError.inner_errors.Add(new Bonded<InternalServerError>(innerError));
                     }
                 }
                 else if (exception.InnerException != null)
                 {
                     internalServerError.inner_errors = new List<IBonded<Error>>(1);
-                    var innerError = MakeInternalServerError(exception.InnerException, includeDetails);
+                    var innerError = MakeInternalServerError(exception.InnerException, uniqueId, includeDetails);
                     internalServerError.inner_errors.Add(new Bonded<InternalServerError>(innerError));
                 }
             }

--- a/cs/src/comm/interfaces/Errors.cs
+++ b/cs/src/comm/interfaces/Errors.cs
@@ -16,7 +16,7 @@ namespace Bond.Comm
         /// <summary>
         /// A unique ID for calls of MakeInternalServerError that are passed a null ID.
         /// </summary>
-        private const string UniqueIdForNullId = "[4e2bec1b-42ca-482b-8895-b8586bc8f491]";
+        private const string UniqueIdForNullId = "4e2bec1b-42ca-482b-8895-b8586bc8f491";
 
         /// <summary>
         /// Checks if an <see cref="Error" /> is an <see cref="InternalServerError"/>.
@@ -42,7 +42,9 @@ namespace Bond.Comm
         /// Creates an <see cref="InternalServerError"/> with the given message.
         /// </summary>
         /// <param name="message">An error message.</param>
-        /// <param name="uniqueId">The ID of the request that caused this error.</param>
+        /// <param name="uniqueId">The ID of the request that caused this error. This should not be null,
+        /// but if it is, the generated error will contain a fixed GUID (<see cref="UniqueIdForNullId"/>) to aid
+        /// in debugging.</param>
         /// <returns>An InternalServerError representing the exception.</returns>
         public static InternalServerError MakeInternalServerError(string message, string uniqueId)
         {
@@ -61,7 +63,9 @@ namespace Bond.Comm
         /// Creates an <see cref="InternalServerError"/> from an exception.
         /// </summary>
         /// <param name="exception">An exception.</param>
-        /// <param name="uniqueId">The ID of the request that caused this error.</param>
+        /// <param name="uniqueId">The ID of the request that caused this error. This should not be null,
+        /// but if it is, the generated error will contain a fixed GUID (<see cref="UniqueIdForNullId"/>) to aid
+        /// in debugging.</param>
         /// <param name="includeDetails">
         /// <c>true</c> if debugging details should be included; <c>false</c>
         /// to omit this potentailly sensitive information

--- a/cs/src/comm/interfaces/Errors.cs
+++ b/cs/src/comm/interfaces/Errors.cs
@@ -14,11 +14,6 @@ namespace Bond.Comm
         public const string InternalErrorMessage = "The server has encounted an error";
 
         /// <summary>
-        /// A unique ID for calls of MakeInternalServerError that are passed a null ID.
-        /// </summary>
-        private const string UniqueIdForNullId = "4e2bec1b-42ca-482b-8895-b8586bc8f491";
-
-        /// <summary>
         /// Checks if an <see cref="Error" /> is an <see cref="InternalServerError"/>.
         /// If it is, strips out all information except the <c>error_code</c> and
         /// <c>unique_id</c> and sets the message to <see cref="InternalErrorMessage"/>.
@@ -43,15 +38,14 @@ namespace Bond.Comm
         /// </summary>
         /// <param name="message">An error message.</param>
         /// <param name="uniqueId">The ID of the request that caused this error. This should not be null,
-        /// but if it is, the generated error will contain a fixed GUID (<see cref="UniqueIdForNullId"/>) to aid
-        /// in debugging.</param>
+        /// but if it is, the generated error will contain an empty string.</param>
         /// <returns>An InternalServerError representing the exception.</returns>
         public static InternalServerError MakeInternalServerError(string message, string uniqueId)
         {
             var internalServerError = new InternalServerError
             {
                 error_code = (int) ErrorCode.InternalServerError,
-                unique_id = uniqueId ?? UniqueIdForNullId,
+                unique_id = uniqueId ?? "",
                 message = message ?? InternalErrorMessage
             };
 
@@ -64,8 +58,7 @@ namespace Bond.Comm
         /// </summary>
         /// <param name="exception">An exception.</param>
         /// <param name="uniqueId">The ID of the request that caused this error. This should not be null,
-        /// but if it is, the generated error will contain a fixed GUID (<see cref="UniqueIdForNullId"/>) to aid
-        /// in debugging.</param>
+        /// but if it is, the generated error will contain an empty string.</param>
         /// <param name="includeDetails">
         /// <c>true</c> if debugging details should be included; <c>false</c>
         /// to omit this potentailly sensitive information
@@ -76,7 +69,7 @@ namespace Bond.Comm
             var internalServerError = new InternalServerError
             {
                 error_code = (int)ErrorCode.InternalServerError,
-                unique_id = uniqueId ?? UniqueIdForNullId
+                unique_id = uniqueId ?? ""
             };
 
             if (includeDetails && exception != null)

--- a/cs/src/comm/interfaces/ILayerStack.cs
+++ b/cs/src/comm/interfaces/ILayerStack.cs
@@ -45,8 +45,10 @@ namespace Bond.Comm
         /// <summary>
         /// Provide a layer stack instance.
         /// </summary>
+        /// <param name="uniqueId">A unique ID identifying the request or connection that triggered this call. Used in
+        /// layer-originated errors.</param>
         /// <param name="stack">The layer stack instance. May be null if an error occurred.</param>
         /// <returns>An error, or null if there is no error.</returns>
-        Error GetLayerStack(out ILayerStack stack);
+        Error GetLayerStack(string uniqueId, out ILayerStack stack);
     }
 }

--- a/cs/src/comm/interfaces/Listener.cs
+++ b/cs/src/comm/interfaces/Listener.cs
@@ -17,14 +17,6 @@ namespace Bond.Comm
         public readonly Connection Connection;
 
         /// <summary>
-        /// A Bond-generated unique identifier for this connection. If you need
-        /// to return an <see cref="Error"/>, give the client this identifier,
-        /// and you will be able to cross-reference it with Bond-generated log
-        /// messages.
-        /// </summary>
-        public string ConnectionId;
-
-        /// <summary>
         /// A value indicating whether the connection should be rejected.
         /// </summary>
         /// <remarks>
@@ -40,13 +32,9 @@ namespace Bond.Comm
         /// <param name="connection">
         /// The connection that was just established.
         /// </param>
-        /// <param name="connectionId">
-        /// The Bond-generated unique identifier for this connection.
-        /// </param>
-        public ConnectedEventArgs(Connection connection, string connectionId)
+        public ConnectedEventArgs(Connection connection)
         {
             Connection = connection;
-            ConnectionId = connectionId;
         }
     }
 
@@ -211,7 +199,7 @@ namespace Bond.Comm
                     catch (Exception ex)
                     {
                         logger.Site().Error(ex, "Exception in handler for connection {0}: {1}", args.Connection, ex.Message);
-                        args.DisconnectError = Errors.MakeInternalServerError(ex, args.ConnectionId, includeDetails: false);
+                        args.DisconnectError = Errors.MakeInternalServerError(ex, args.Connection.Id, includeDetails: false);
                     }
 
                     if (args.DisconnectError != null)

--- a/cs/src/comm/interfaces/Listener.cs
+++ b/cs/src/comm/interfaces/Listener.cs
@@ -17,6 +17,14 @@ namespace Bond.Comm
         public readonly Connection Connection;
 
         /// <summary>
+        /// A Bond-generated unique identifier for this connection. If you need
+        /// to return an <see cref="Error"/>, give the client this identifier,
+        /// and you will be able to cross-reference it with Bond-generated log
+        /// messages.
+        /// </summary>
+        public string ConnectionId;
+
+        /// <summary>
         /// A value indicating whether the connection should be rejected.
         /// </summary>
         /// <remarks>
@@ -32,9 +40,13 @@ namespace Bond.Comm
         /// <param name="connection">
         /// The connection that was just established.
         /// </param>
-        public ConnectedEventArgs(Connection connection)
+        /// <param name="connectionId">
+        /// The Bond-generated unique identifier for this connection.
+        /// </param>
+        public ConnectedEventArgs(Connection connection, string connectionId)
         {
             Connection = connection;
+            ConnectionId = connectionId;
         }
     }
 
@@ -199,7 +211,7 @@ namespace Bond.Comm
                     catch (Exception ex)
                     {
                         logger.Site().Error(ex, "Exception in handler for connection {0}: {1}", args.Connection, ex.Message);
-                        args.DisconnectError = Errors.MakeInternalServerError(ex, includeDetails: false);
+                        args.DisconnectError = Errors.MakeInternalServerError(ex, args.ConnectionId, includeDetails: false);
                     }
 
                     if (args.DisconnectError != null)

--- a/cs/src/comm/interfaces/Metrics.cs
+++ b/cs/src/comm/interfaces/Metrics.cs
@@ -48,10 +48,22 @@ namespace Bond.Comm
             return Guid.NewGuid().ToString();
         }
 
+        public static ConnectionMetrics StartConnectionMetrics()
+        {
+            return new ConnectionMetrics
+            {
+                connection_id = NewId()
+            };
+        }
+
+        public static void FinishConnectionMetrics(ConnectionMetrics connectionMetrics, Stopwatch duration)
+        {
+            connectionMetrics.duration_millis = duration.Elapsed.TotalMilliseconds;
+        }
 
         public static RequestMetrics StartRequestMetrics(ConnectionMetrics connectionMetrics)
         {
-            var requestMetrics = new RequestMetrics
+            return new RequestMetrics
             {
                 request_id = NewId(),
                 connection_id = connectionMetrics.connection_id,
@@ -59,12 +71,11 @@ namespace Bond.Comm
                 remote_endpoint = connectionMetrics.remote_endpoint,
                 error = null
             };
-            return requestMetrics;
         }
 
         public static void FinishRequestMetrics(RequestMetrics requestMetrics, Stopwatch totalTime)
         {
-            requestMetrics.total_time_millis = (float) totalTime.Elapsed.TotalMilliseconds;
+            requestMetrics.total_time_millis = totalTime.Elapsed.TotalMilliseconds;
         }
     }
 }

--- a/cs/src/comm/interfaces/Metrics.cs
+++ b/cs/src/comm/interfaces/Metrics.cs
@@ -3,6 +3,9 @@
 
 namespace Bond.Comm
 {
+    using System;
+    using System.Diagnostics;
+
     /// <summary>
     /// Receives metrics emitted by Transports. Supply an instance of <c>IMetricsSink</c> to a
     /// <see cref="TransportBuilder{TTransport}.SetMetricsSink"/> to register it with the
@@ -38,6 +41,30 @@ namespace Bond.Comm
         public void Emit(RequestMetrics metrics)
         {
             Sink?.Emit(metrics);
+        }
+
+        public static string NewId()
+        {
+            return Guid.NewGuid().ToString();
+        }
+
+
+        public static RequestMetrics StartRequestMetrics(ConnectionMetrics connectionMetrics)
+        {
+            var requestMetrics = new RequestMetrics
+            {
+                request_id = NewId(),
+                connection_id = connectionMetrics.connection_id,
+                local_endpoint = connectionMetrics.local_endpoint,
+                remote_endpoint = connectionMetrics.remote_endpoint,
+                error = null
+            };
+            return requestMetrics;
+        }
+
+        public static void FinishRequestMetrics(RequestMetrics requestMetrics, Stopwatch totalTime)
+        {
+            requestMetrics.total_time_millis = (float) totalTime.Elapsed.TotalMilliseconds;
         }
     }
 }

--- a/cs/src/comm/interfaces/Transport.cs
+++ b/cs/src/comm/interfaces/Transport.cs
@@ -73,9 +73,11 @@ namespace Bond.Comm
         /// <summary>
         /// Get a layer stack instance for this transport.
         /// </summary>
+        /// <param name="uniqueId">A unique ID identifying the request or connection that triggered this call. Used in
+        /// layer-originated errors.</param>
         /// <param name="stack">The layer stack instance. Will be null if an error is returned.</param>
         /// <returns>An error if one occurred, null otherwise.</returns>
-        public abstract Error GetLayerStack(out ILayerStack stack);
+        public abstract Error GetLayerStack(string uniqueId, out ILayerStack stack);
 
         /// <summary>
         /// Starts an asynchronous operation to connect to the specified

--- a/cs/src/comm/layers/LayerStack.cs
+++ b/cs/src/comm/layers/LayerStack.cs
@@ -61,7 +61,7 @@ namespace Bond.Comm.Layers
             if (context == null) { throw new ArgumentNullException(nameof(context)); }
 
             TLayerData realLayerData;
-            Error error = DeserializeLayerData(layerData, out realLayerData);
+            Error error = DeserializeLayerData(layerData, context.RequestMetrics.request_id, out realLayerData);
 
             if (error == null)
             {
@@ -86,7 +86,7 @@ namespace Bond.Comm.Layers
                 catch (Exception ex)
                 {
                     logger.Site().Error(ex, "While handling layer {0}", layerIndex);
-                    error = Errors.MakeInternalServerError(ex, includeDetails: true);
+                    error = Errors.MakeInternalServerError(ex, context.RequestMetrics.request_id, includeDetails: true);
                 }
             }
 
@@ -107,14 +107,14 @@ namespace Bond.Comm.Layers
                 catch (Exception ex)
                 {
                     logger.Site().Error(ex, "While handling layer {0}", layerIndex);
-                    error = Errors.MakeInternalServerError(ex, includeDetails: true);
+                    error = Errors.MakeInternalServerError(ex, context.RequestMetrics.request_id, includeDetails: true);
                 }
             }
 
             return error;
         }
 
-        private Error DeserializeLayerData(IBonded layerData, out TLayerData realLayerData)
+        private Error DeserializeLayerData(IBonded layerData, string uniqueId, out TLayerData realLayerData)
         {
             Error error = null;
             if (layerData == null)
@@ -130,7 +130,7 @@ namespace Bond.Comm.Layers
                 catch (Exception ex)
                 {
                     logger.Site().Error(ex, "Unmarshaling layer data threw exception");
-                    error = Errors.MakeInternalServerError(ex, includeDetails: true);
+                    error = Errors.MakeInternalServerError(ex, uniqueId, includeDetails: true);
                     realLayerData = new TLayerData();
                 }
             }
@@ -230,7 +230,7 @@ namespace Bond.Comm.Layers
                     layers[i] = layerProviders[i].GetLayer();
                     if (layers[i] == null)
                     {
-                        result = Errors.MakeInternalServerError($"Layer provider {i} produced null layer");
+                        result = Errors.MakeInternalServerError($"Layer provider {i} produced null layer", null);
                         logger.Site().Error(result.message);
                         layers = null;
                         break;
@@ -239,7 +239,7 @@ namespace Bond.Comm.Layers
                 catch (Exception ex)
                 {
                     logger.Site().Error(ex, "Layer provider {0} threw exception", i);
-                    result = Errors.MakeInternalServerError(ex, includeDetails: true);
+                    result = Errors.MakeInternalServerError(ex, null, includeDetails: true);
                     layers = null;
                     break;
                 }

--- a/cs/src/comm/layers/LayerStack.cs
+++ b/cs/src/comm/layers/LayerStack.cs
@@ -173,28 +173,22 @@ namespace Bond.Comm.Layers
             }
 
             this.layerProviders = layerProviders;
-
-            ILayer<TLayerData>[] layers;
-            Error error = GetNewLayers(out layers);
-
-            if (error == null)
+            ILayer<TLayerData>[] layers = new ILayer<TLayerData>[layerProviders.Length];
+            for (var i = 0; i < layerProviders.Length; i++)
             {
-                bool stateless = layers.All(layer => layer is IStatelessLayer<TLayerData>);
-
-                if (stateless)
-                {
-                    cachedLayerStack = new LayerStack<TLayerData>(logger, layers);
-                }
+                layers[i] = layerProviders[i].GetLayer();
             }
-            else
+
+            bool stateless = layers.All(layer => layer is IStatelessLayer<TLayerData>);
+            if (stateless)
             {
-                throw new InvalidOperationException(error.message);
+                cachedLayerStack = new LayerStack<TLayerData>(logger, layers);
             }
 
             this.logger = logger;
         }
 
-        public Error GetLayerStack(out ILayerStack stack)
+        public Error GetLayerStack(string uniqueId, out ILayerStack stack)
         {
             Error error = null;
 
@@ -204,48 +198,33 @@ namespace Bond.Comm.Layers
             }
             else
             {
-                ILayer<TLayerData>[] layers;
-                error = GetNewLayers(out layers);
-                if (error == null)
+                var layers = new ILayer<TLayerData>[layerProviders.Length];
+                for (int i = 0; i < layerProviders.Length; i++)
                 {
-                    stack = new LayerStack<TLayerData>(logger, layers);
-                }
-                else
-                {
-                    stack = null;
-                }
-            }
-
-            return error;
-        }
-
-        Error GetNewLayers(out ILayer<TLayerData>[] layers)
-        {
-            layers = new ILayer<TLayerData>[layerProviders.Length];
-            Error result = null;
-            for (int i = 0; i < layerProviders.Length; i++)
-            {
-                try
-                {
-                    layers[i] = layerProviders[i].GetLayer();
-                    if (layers[i] == null)
+                    try
                     {
-                        result = Errors.MakeInternalServerError($"Layer provider {i} produced null layer", null);
-                        logger.Site().Error(result.message);
+                        layers[i] = layerProviders[i].GetLayer();
+                        if (layers[i] == null)
+                        {
+                            error = Errors.MakeInternalServerError($"Layer provider {i} produced null layer", uniqueId);
+                            logger.Site().Error(error.message);
+                            layers = null;
+                            break;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Site().Error(ex, "Layer provider {0} threw exception", i);
+                        error = Errors.MakeInternalServerError(ex, uniqueId, includeDetails: true);
                         layers = null;
                         break;
                     }
                 }
-                catch (Exception ex)
-                {
-                    logger.Site().Error(ex, "Layer provider {0} threw exception", i);
-                    result = Errors.MakeInternalServerError(ex, null, includeDetails: true);
-                    layers = null;
-                    break;
-                }
+
+                stack = error == null ? new LayerStack<TLayerData>(logger, layers) : null;
             }
 
-            return result;
+            return error;
         }
     }
 }

--- a/cs/src/comm/simpleinmem-transport/Processor/BatchProcessor.cs
+++ b/cs/src/comm/simpleinmem-transport/Processor/BatchProcessor.cs
@@ -69,7 +69,8 @@ namespace Bond.Comm.SimpleInMem.Processor
         private async void DispatchRequest(InMemFrame payload,
                                            InMemFrameQueue queue)
         {
-            var receiveContext = new SimpleInMemReceiveContext(connection);
+            var requestMetrics = Metrics.StartRequestMetrics(connection.ConnectionMetrics);
+            var receiveContext = new SimpleInMemReceiveContext(connection, connection.ConnectionMetrics, requestMetrics);
             var headers = payload.headers;
             var layerData = payload.layerData;
             var message = payload.message;
@@ -87,7 +88,7 @@ namespace Bond.Comm.SimpleInMem.Processor
 
             if (layerError == null)
             {
-                response = await serviceHost.DispatchRequest(headers.method_name, receiveContext, message, connection.ConnectionMetrics);
+                response = await serviceHost.DispatchRequest(headers.method_name, receiveContext, message);
             }
             else
             {
@@ -107,7 +108,8 @@ namespace Bond.Comm.SimpleInMem.Processor
                                 ILayerStack layerStack,
                                 InMemFrameQueue queue)
         {
-            var sendContext = new SimpleInMemSendContext(connection);
+            var requestMetrics = Metrics.StartRequestMetrics(connection.ConnectionMetrics);
+            var sendContext = new SimpleInMemSendContext(connection, connection.ConnectionMetrics, requestMetrics);
             IBonded layerData = null;
 
             Error layerError = LayerStackUtils.ProcessOnSend(layerStack, MessageType.Response, sendContext, out layerData, logger);
@@ -129,7 +131,8 @@ namespace Bond.Comm.SimpleInMem.Processor
 
         private void DispatchResponse(InMemFrame payload)
         {
-            var receiveContext = new SimpleInMemReceiveContext(connection);
+            var requestMetrics = Metrics.StartRequestMetrics(connection.ConnectionMetrics);
+            var receiveContext = new SimpleInMemReceiveContext(connection, connection.ConnectionMetrics, requestMetrics);
             var headers = payload.headers;
             var layerData = payload.layerData;
             var message = payload.message;
@@ -151,7 +154,8 @@ namespace Bond.Comm.SimpleInMem.Processor
 
         private async void DispatchEvent(InMemFrame payload)
         {
-            var receiveContext = new SimpleInMemReceiveContext(connection);
+            var requestMetrics = Metrics.StartRequestMetrics(connection.ConnectionMetrics);
+            var receiveContext = new SimpleInMemReceiveContext(connection, connection.ConnectionMetrics, requestMetrics);
             var headers = payload.headers;
             var layerData = payload.layerData;
             var message = payload.message;
@@ -171,8 +175,7 @@ namespace Bond.Comm.SimpleInMem.Processor
                 return;
             }
 
-            await serviceHost.DispatchEvent(
-                    headers.method_name, receiveContext, message, connection.ConnectionMetrics);
+            await serviceHost.DispatchEvent(headers.method_name, receiveContext, message);
         }
     }
 }

--- a/cs/src/comm/simpleinmem-transport/Processor/BatchProcessor.cs
+++ b/cs/src/comm/simpleinmem-transport/Processor/BatchProcessor.cs
@@ -77,7 +77,7 @@ namespace Bond.Comm.SimpleInMem.Processor
             var taskSource = payload.outstandingRequest;
 
             ILayerStack layerStack;
-            Error layerError = transport.GetLayerStack(out layerStack);
+            Error layerError = transport.GetLayerStack(requestMetrics.request_id, out layerStack);
 
             if (layerError == null)
             {
@@ -161,7 +161,7 @@ namespace Bond.Comm.SimpleInMem.Processor
             var message = payload.message;
 
             ILayerStack layerStack;
-            Error layerError = transport.GetLayerStack(out layerStack);
+            Error layerError = transport.GetLayerStack(requestMetrics.request_id, out layerStack);
 
             if (layerError == null)
             {

--- a/cs/src/comm/simpleinmem-transport/SimpleInMemConnection.cs
+++ b/cs/src/comm/simpleinmem-transport/SimpleInMemConnection.cs
@@ -29,7 +29,6 @@ namespace Bond.Comm.SimpleInMem
 
     public class SimpleInMemConnection : Connection, IRequestResponseConnection, IEventConnection
     {
-        private readonly Guid connectionId;
         private readonly ConnectionType connectionType;
         private readonly SimpleInMemListener parentListener;
         private readonly ServiceHost serviceHost;
@@ -42,8 +41,6 @@ namespace Bond.Comm.SimpleInMem
         private object stateLock = new object();
         private readonly Logger logger;
         private readonly Metrics metrics;
-
-        public ConnectionMetrics ConnectionMetrics { get; } = new ConnectionMetrics();
 
         internal SimpleInMemConnection(
             SimpleInMemListener parentListener, ConnectionType connectionType,
@@ -59,12 +56,10 @@ namespace Bond.Comm.SimpleInMem
             this.serviceHost = serviceHost;
             this.transport = transport;
             writeQueue = new InMemFrameQueue();
-            connectionId = Guid.NewGuid();
 
             // start at -1 or 0 so the first conversation ID is 1 or 2.
             prevConversationId = (connectionType == ConnectionType.Client) ? -1 : 0;
             state = CnxState.Created;
-            ConnectionMetrics.connection_id = connectionId.ToString();
 
             this.logger = logger;
             this.metrics = metrics;
@@ -83,14 +78,6 @@ namespace Bond.Comm.SimpleInMem
             get
             {
                 return connectionType;
-            }
-        }
-
-        public Guid Id
-        {
-            get
-            {
-                return connectionId;
             }
         }
 
@@ -128,7 +115,7 @@ namespace Bond.Comm.SimpleInMem
 
         public override string ToString()
         {
-            return $"{nameof(SimpleInMemConnection)}({connectionId})";
+            return $"{nameof(SimpleInMemConnection)}({Id})";
         }
 
         public override Task StopAsync()

--- a/cs/src/comm/simpleinmem-transport/SimpleInMemConnection.cs
+++ b/cs/src/comm/simpleinmem-transport/SimpleInMemConnection.cs
@@ -198,7 +198,7 @@ namespace Bond.Comm.SimpleInMem
 
             IBonded layerData = null;
             ILayerStack layerStack;
-            Error layerError = transport.GetLayerStack(out layerStack);
+            Error layerError = transport.GetLayerStack(requestMetrics.request_id, out layerStack);
 
             if (layerError == null)
             {
@@ -229,7 +229,7 @@ namespace Bond.Comm.SimpleInMem
             var sendContext = new SimpleInMemSendContext(this, ConnectionMetrics, requestMetrics);
             IBonded layerData = null;
             ILayerStack layerStack;
-            Error layerError = transport.GetLayerStack(out layerStack);
+            Error layerError = transport.GetLayerStack(requestMetrics.request_id, out layerStack);
 
             if (layerError == null)
             {

--- a/cs/src/comm/simpleinmem-transport/SimpleInMemConnection.cs
+++ b/cs/src/comm/simpleinmem-transport/SimpleInMemConnection.cs
@@ -204,9 +204,10 @@ namespace Bond.Comm.SimpleInMem
 
         private Task<IMessage> SendRequestAsync(string methodName, IMessage request)
         {
+            var requestMetrics = Metrics.StartRequestMetrics(ConnectionMetrics);
             var conversationId = AllocateNextConversationId();
 
-            var sendContext = new SimpleInMemSendContext(this);
+            var sendContext = new SimpleInMemSendContext(this, ConnectionMetrics, requestMetrics);
 
             IBonded layerData = null;
             ILayerStack layerStack;
@@ -235,9 +236,10 @@ namespace Bond.Comm.SimpleInMem
 
         private void SendEventAsync(string methodName, IMessage message)
         {
+            var requestMetrics = Metrics.StartRequestMetrics(ConnectionMetrics);
             var conversationId = AllocateNextConversationId();
 
-            var sendContext = new SimpleInMemSendContext(this);
+            var sendContext = new SimpleInMemSendContext(this, ConnectionMetrics, requestMetrics);
             IBonded layerData = null;
             ILayerStack layerStack;
             Error layerError = transport.GetLayerStack(out layerStack);

--- a/cs/src/comm/simpleinmem-transport/SimpleInMemContexts.cs
+++ b/cs/src/comm/simpleinmem-transport/SimpleInMemContexts.cs
@@ -5,7 +5,8 @@ namespace Bond.Comm.SimpleInMem
 {
     public class SimpleInMemSendContext : SendContext
     {
-        public SimpleInMemSendContext(SimpleInMemConnection connection)
+        public SimpleInMemSendContext(SimpleInMemConnection connection, ConnectionMetrics connectionMetrics, RequestMetrics requestMetrics)
+            : base(connectionMetrics, requestMetrics)
         {
             Connection = connection;
         }
@@ -15,7 +16,8 @@ namespace Bond.Comm.SimpleInMem
 
     public class SimpleInMemReceiveContext : ReceiveContext
     {
-        public SimpleInMemReceiveContext(SimpleInMemConnection connection)
+        public SimpleInMemReceiveContext(SimpleInMemConnection connection, ConnectionMetrics connectionMetrics, RequestMetrics requestMetrics)
+            : base(connectionMetrics, requestMetrics)
         {
             Connection = connection;
         }

--- a/cs/src/comm/simpleinmem-transport/SimpleInMemListener.cs
+++ b/cs/src/comm/simpleinmem-transport/SimpleInMemListener.cs
@@ -167,7 +167,7 @@ namespace Bond.Comm.SimpleInMem
         private void Add(ConnectionPair connectionPair)
         {
             var client = connectionPair.Client;
-            var connectedEventArgs = new ConnectedEventArgs(client, connectionPair.Server.ConnectionMetrics.connection_id);
+            var connectedEventArgs = new ConnectedEventArgs(client);
             Error error = OnConnected(connectedEventArgs);
 
             if (error != null)

--- a/cs/src/comm/simpleinmem-transport/SimpleInMemListener.cs
+++ b/cs/src/comm/simpleinmem-transport/SimpleInMemListener.cs
@@ -35,7 +35,7 @@ namespace Bond.Comm.SimpleInMem
             if (string.IsNullOrEmpty(address)) throw new ArgumentException(nameof(address));
 
             this.address = address;
-            serviceHost = new ServiceHost(logger, metrics);
+            serviceHost = new ServiceHost(logger);
             this.transport = transport;
             connectionPairs = new Dictionary<Guid, ConnectionPair>();
             logname = $"{nameof(SimpleInMemListener)}({this.address})";
@@ -155,7 +155,7 @@ namespace Bond.Comm.SimpleInMem
 
         internal ConnectionPair CreateConnectionPair()
         {
-            var clientConnection = new SimpleInMemConnection(this, ConnectionType.Client, new ServiceHost(logger, metrics),
+            var clientConnection = new SimpleInMemConnection(this, ConnectionType.Client, new ServiceHost(logger),
                 transport, logger, metrics);
             var serverConnection = new SimpleInMemConnection(this, ConnectionType.Server, serviceHost, transport, logger, metrics);
             var connectionPair = SimpleInMemConnection.Pair(clientConnection, serverConnection);
@@ -167,7 +167,7 @@ namespace Bond.Comm.SimpleInMem
         private void Add(ConnectionPair connectionPair)
         {
             var client = connectionPair.Client;
-            var connectedEventArgs = new ConnectedEventArgs(client);
+            var connectedEventArgs = new ConnectedEventArgs(client, connectionPair.Server.ConnectionMetrics.connection_id);
             Error error = OnConnected(connectedEventArgs);
 
             if (error != null)

--- a/cs/src/comm/simpleinmem-transport/SimpleInMemTransport.cs
+++ b/cs/src/comm/simpleinmem-transport/SimpleInMemTransport.cs
@@ -32,11 +32,11 @@ namespace Bond.Comm.SimpleInMem
             this.metrics = metrics;
         }
 
-        public override Error GetLayerStack(out ILayerStack stack)
+        public override Error GetLayerStack(string uniqueId, out ILayerStack stack)
         {
             if (layerStackProvider != null)
             {
-                return layerStackProvider.GetLayerStack(out stack);
+                return layerStackProvider.GetLayerStack(uniqueId, out stack);
             }
             else
             {

--- a/cs/test/comm/Interfaces/ErrorsTests.cs
+++ b/cs/test/comm/Interfaces/ErrorsTests.cs
@@ -15,7 +15,7 @@ namespace UnitTest.Interfaces
         {
             var ex = new InvalidOperationException("You can't do that.");
 
-            InternalServerError error = Errors.MakeInternalServerError(ex, null, includeDetails: false);
+            InternalServerError error = Errors.MakeInternalServerError(ex, "some ID", includeDetails: false);
 
             Assert.AreEqual((int)ErrorCode.InternalServerError, error.error_code);
             Assert.IsNotEmpty(error.unique_id);
@@ -27,7 +27,7 @@ namespace UnitTest.Interfaces
         [Test]
         public void MakeInternalServerError_NullExIncludeDetails_GenericErrorReturned()
         {
-            InternalServerError error = Errors.MakeInternalServerError(exception: null, uniqueId: null, includeDetails: true);
+            InternalServerError error = Errors.MakeInternalServerError(exception: null, uniqueId: "some ID", includeDetails: true);
             Assert.AreEqual((int)ErrorCode.InternalServerError, error.error_code);
             Assert.IsNotEmpty(error.unique_id);
             Assert.IsNotEmpty(error.message);
@@ -39,7 +39,7 @@ namespace UnitTest.Interfaces
         public void CleanseInternalServerError_WithInternalServerError()
         {
             InternalServerError originalInternalError =
-                Errors.MakeInternalServerError(GenerateException<InvalidOperationException>(), null, includeDetails: true);
+                Errors.MakeInternalServerError(GenerateException<InvalidOperationException>(), "some ID", includeDetails: true);
 
             string savedID = originalInternalError.unique_id;
 
@@ -70,7 +70,7 @@ namespace UnitTest.Interfaces
         public void MakeInternalServerError_ExIncludeDetails_HasStackAndInnerExceptions()
         {
             var ex = GenerateException(new Exception("this is some message", GenerateException<InvalidOperationException>()));
-            InternalServerError error = Errors.MakeInternalServerError(ex, null, includeDetails: true);
+            InternalServerError error = Errors.MakeInternalServerError(ex, "some ID", includeDetails: true);
 
             Assert.AreEqual((int)ErrorCode.InternalServerError, error.error_code);
             Assert.IsNotEmpty(error.unique_id);
@@ -84,7 +84,7 @@ namespace UnitTest.Interfaces
         {
             var innerExceptions = new[] { GenerateException<ArgumentException>(), GenerateException<InvalidOperationException>() };
             var aggEx = GenerateException(new AggregateException("this is some message", innerExceptions));
-            InternalServerError error = Errors.MakeInternalServerError(aggEx, null, includeDetails: true);
+            InternalServerError error = Errors.MakeInternalServerError(aggEx, "some ID", includeDetails: true);
 
             Assert.AreEqual((int)ErrorCode.InternalServerError, error.error_code);
             Assert.IsNotEmpty(error.unique_id);

--- a/cs/test/comm/Interfaces/ErrorsTests.cs
+++ b/cs/test/comm/Interfaces/ErrorsTests.cs
@@ -15,7 +15,7 @@ namespace UnitTest.Interfaces
         {
             var ex = new InvalidOperationException("You can't do that.");
 
-            InternalServerError error = Errors.MakeInternalServerError(ex, includeDetails: false);
+            InternalServerError error = Errors.MakeInternalServerError(ex, null, includeDetails: false);
 
             Assert.AreEqual((int)ErrorCode.InternalServerError, error.error_code);
             Assert.IsNotEmpty(error.unique_id);
@@ -27,7 +27,7 @@ namespace UnitTest.Interfaces
         [Test]
         public void MakeInternalServerError_NullExIncludeDetails_GenericErrorReturned()
         {
-            InternalServerError error = Errors.MakeInternalServerError(exception: null, includeDetails: true);
+            InternalServerError error = Errors.MakeInternalServerError(exception: null, uniqueId: null, includeDetails: true);
             Assert.AreEqual((int)ErrorCode.InternalServerError, error.error_code);
             Assert.IsNotEmpty(error.unique_id);
             Assert.IsNotEmpty(error.message);
@@ -39,7 +39,7 @@ namespace UnitTest.Interfaces
         public void CleanseInternalServerError_WithInternalServerError()
         {
             InternalServerError originalInternalError =
-                Errors.MakeInternalServerError(GenerateException<InvalidOperationException>(), includeDetails: true);
+                Errors.MakeInternalServerError(GenerateException<InvalidOperationException>(), null, includeDetails: true);
 
             string savedID = originalInternalError.unique_id;
 
@@ -70,7 +70,7 @@ namespace UnitTest.Interfaces
         public void MakeInternalServerError_ExIncludeDetails_HasStackAndInnerExceptions()
         {
             var ex = GenerateException(new Exception("this is some message", GenerateException<InvalidOperationException>()));
-            InternalServerError error = Errors.MakeInternalServerError(ex, includeDetails: true);
+            InternalServerError error = Errors.MakeInternalServerError(ex, null, includeDetails: true);
 
             Assert.AreEqual((int)ErrorCode.InternalServerError, error.error_code);
             Assert.IsNotEmpty(error.unique_id);
@@ -84,7 +84,7 @@ namespace UnitTest.Interfaces
         {
             var innerExceptions = new[] { GenerateException<ArgumentException>(), GenerateException<InvalidOperationException>() };
             var aggEx = GenerateException(new AggregateException("this is some message", innerExceptions));
-            InternalServerError error = Errors.MakeInternalServerError(aggEx, includeDetails: true);
+            InternalServerError error = Errors.MakeInternalServerError(aggEx, null, includeDetails: true);
 
             Assert.AreEqual((int)ErrorCode.InternalServerError, error.error_code);
             Assert.IsNotEmpty(error.unique_id);

--- a/cs/test/comm/Interfaces/ListenerTests.cs
+++ b/cs/test/comm/Interfaces/ListenerTests.cs
@@ -14,7 +14,7 @@ namespace UnitTest.Interfaces
         [Test]
         public void Connected_NoSubscribedEvents_Works()
         {
-            new TestListener(LoggerTests.BlackHole).Test_OnConnected(new ConnectedEventArgs(null));
+            new TestListener(LoggerTests.BlackHole).Test_OnConnected(new ConnectedEventArgs(null, null));
         }
 
         [Test]
@@ -51,7 +51,7 @@ namespace UnitTest.Interfaces
                 args.DisconnectError = event3Error;
             };
 
-            var cea = new ConnectedEventArgs(null);
+            var cea = new ConnectedEventArgs(null, null);
             listener.Test_OnConnected(cea);
 
             Assert.IsTrue(event1Called);

--- a/cs/test/comm/Interfaces/ListenerTests.cs
+++ b/cs/test/comm/Interfaces/ListenerTests.cs
@@ -14,7 +14,7 @@ namespace UnitTest.Interfaces
         [Test]
         public void Connected_NoSubscribedEvents_Works()
         {
-            new TestListener(LoggerTests.BlackHole).Test_OnConnected(new ConnectedEventArgs(null, null));
+            new TestListener(LoggerTests.BlackHole).Test_OnConnected(new ConnectedEventArgs(null));
         }
 
         [Test]
@@ -51,7 +51,7 @@ namespace UnitTest.Interfaces
                 args.DisconnectError = event3Error;
             };
 
-            var cea = new ConnectedEventArgs(null, null);
+            var cea = new ConnectedEventArgs(null);
             listener.Test_OnConnected(cea);
 
             Assert.IsTrue(event1Called);

--- a/cs/test/comm/Interfaces/LoggerTests.cs
+++ b/cs/test/comm/Interfaces/LoggerTests.cs
@@ -20,14 +20,14 @@ namespace UnitTest.Interfaces
             public LogSeverity? LastMessageSeverity;
             public string LastMessage;
             public Exception LastException;
-            public int MessagesHandled;
+            public int MessagesReceived;
 
             public void Log(string message, LogSeverity severity, Exception exception)
             {
                 LastMessageSeverity = severity;
                 LastMessage = message;
                 LastException = exception;
-                MessagesHandled++;
+                MessagesReceived++;
             }
 
             public void Clear()
@@ -140,7 +140,7 @@ namespace UnitTest.Interfaces
                 Assert.AreEqual(severity, sink.LastMessageSeverity);
                 StringAssert.Contains(message, sink.LastMessage);
                 Assert.IsNull(sink.LastException);
-                Assert.AreEqual(messagesLogged + 1, sink.MessagesHandled);
+                Assert.AreEqual(messagesLogged + 1, sink.MessagesReceived);
                 messagesLogged++;
                 sink.Clear();
 
@@ -153,7 +153,7 @@ namespace UnitTest.Interfaces
                 StringAssert.Contains(message, sink.LastMessage);
                 Assert.NotNull(sink.LastException);
                 Assert.AreEqual(severity, ((TestException)sink.LastException).Severity);
-                Assert.AreEqual(messagesLogged + 1, sink.MessagesHandled);
+                Assert.AreEqual(messagesLogged + 1, sink.MessagesReceived);
                 messagesLogged++;
                 sink.Clear();
             }
@@ -164,7 +164,7 @@ namespace UnitTest.Interfaces
         {
             logger = new Logger(sink, includeDebug: false);
 
-            var messagesHandled = sink.MessagesHandled;
+            var messagesHandled = sink.MessagesReceived;
             // Assumes allSeverities is sorted.
             foreach (var severity in allSeverities)
             {
@@ -174,14 +174,14 @@ namespace UnitTest.Interfaces
                 {
                     Assert.Null(sink.LastMessage);
                     Assert.Null(sink.LastMessageSeverity);
-                    Assert.AreEqual(messagesHandled, sink.MessagesHandled);
+                    Assert.AreEqual(messagesHandled, sink.MessagesReceived);
                 }
                 else
                 {
                     StringAssert.Contains(message, sink.LastMessage);
                     Assert.AreEqual(severity, sink.LastMessageSeverity);
-                    Assert.AreEqual(messagesHandled + 1, sink.MessagesHandled);
-                    messagesHandled = sink.MessagesHandled;
+                    Assert.AreEqual(messagesHandled + 1, sink.MessagesReceived);
+                    messagesHandled = sink.MessagesReceived;
                 }
             }
         }
@@ -210,7 +210,7 @@ namespace UnitTest.Interfaces
             StringAssert.Contains(formatted, sink.LastMessage);
             StringAssert.Contains(messageReturned, sink.LastMessage);
             Assert.IsNull(sink.LastException);
-            Assert.AreEqual(messagesLogged + 1, sink.MessagesHandled);
+            Assert.AreEqual(messagesLogged + 1, sink.MessagesReceived);
             messagesLogged++;
             sink.Clear();
 
@@ -224,7 +224,7 @@ namespace UnitTest.Interfaces
             StringAssert.Contains(messageReturned, sink.LastMessage);
             Assert.NotNull(sink.LastException);
             Assert.AreEqual(LogSeverity.Fatal, ((TestException)sink.LastException).Severity);
-            Assert.AreEqual(messagesLogged + 1, sink.MessagesHandled);
+            Assert.AreEqual(messagesLogged + 1, sink.MessagesReceived);
         }
 
         [Test]

--- a/cs/test/comm/Interfaces/MetricsTests.cs
+++ b/cs/test/comm/Interfaces/MetricsTests.cs
@@ -3,12 +3,162 @@
 
 namespace UnitTest.Interfaces
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
     using Bond.Comm;
+    using Bond.Comm.Epoxy;
     using NUnit.Framework;
+    using UnitTest.Comm;
 
     [TestFixture]
     class MetricsTests
     {
         public static readonly Metrics BlackHole = new Metrics(null);
+
+        // Metrics emission does not necessarily happen before the client gets control back from
+        // a request or connection shutdown. There's nothing to block on that would guarantee this.
+        internal static readonly Action WaitForMetrics = () => Thread.Sleep(25);
+
+        private class TestMetricsSink : IMetricsSink
+        {
+            public ConnectionMetrics LastConnectionMetrics;
+            public RequestMetrics LastRequestMetrics;
+            public int ConnectionMetricsReceived;
+            public int RequestMetricsReceived;
+
+            public void Emit(ConnectionMetrics metrics)
+            {
+                LastConnectionMetrics = metrics;
+                ConnectionMetricsReceived++;
+            }
+
+            public void Emit(RequestMetrics metrics)
+            {
+                LastRequestMetrics = metrics;
+                RequestMetricsReceived++;
+            }
+        }
+
+        [Test]
+        public void Server_Request_MetricsAreEmitted()
+        {
+            Server_MetricsAreEmitted(MessageType.Request);
+        }
+
+        [Test]
+        public void Server_Event_MetricsAreEmitted()
+        {
+            Server_MetricsAreEmitted(MessageType.Event);
+        }
+
+        private async void Server_MetricsAreEmitted(MessageType messageType)
+        {
+            // There are several invariants around metrics that involve cross-request and cross-connection state.
+            // Bring up a service, connect to it several times, and make several requests each time.
+
+            Action<DummyTestProxy<EpoxyConnection>> doRpc;
+            switch (messageType)
+            {
+                case MessageType.Request:
+                    doRpc = async proxy => await proxy.ReqRspMethodAsync(new Dummy());
+                    break;
+                case MessageType.Event:
+                    doRpc = proxy => proxy.EventMethodAsync(new Dummy());
+                    break;
+                default:
+                    throw new ArgumentException(nameof(messageType));
+            }
+
+
+            var metricsSink = new TestMetricsSink();
+            var serverTransport = new EpoxyTransportBuilder().SetMetricsSink(metricsSink).Construct();
+            var listener = serverTransport.MakeListener("127.0.0.1");
+            listener.AddService(new DummyTestService());
+            await listener.StartAsync();
+            var serverEndpoint = listener.ListenEndpoint.ToString();
+
+            var connectionsSeen = 0;
+            var requestsSeen = 0;
+            var connectionIdsSeen = new HashSet<string>();
+            var requestIdsSeen = new HashSet<string>();
+
+            for (var i = 0; i < 3; i++)
+            {
+                var clientTransport = new EpoxyTransportBuilder().Construct();
+                var clientConn = await clientTransport.ConnectToAsync("epoxy://127.0.0.1");
+                var clientEndpoint = clientConn.LocalEndPoint.ToString();
+                var proxy = new DummyTestProxy<EpoxyConnection>(clientConn);
+
+                string currentConnectionId = null;
+                for (var j = 0; j < 3; j++)
+                {
+                    doRpc(proxy);
+                    WaitForMetrics();
+
+                    Assert.AreEqual(requestsSeen + 1, metricsSink.RequestMetricsReceived,
+                        "Did not get a RequestMetrics.");
+                    Assert.NotNull(metricsSink.LastRequestMetrics);
+                    var requestMetrics = metricsSink.LastRequestMetrics;
+
+                    // The new RequestMetrics should have non-empty unique IDs. The request ID should be unique
+                    // and the connection ID should match that of any requests previously made on this connection.
+                    Assert.NotNull(requestMetrics.request_id);
+                    Assert.AreNotEqual("", requestMetrics.request_id);
+                    Assert.NotNull(requestMetrics.connection_id);
+                    Assert.AreNotEqual("", requestMetrics.connection_id);
+                    CollectionAssert.DoesNotContain(requestIdsSeen, requestMetrics.request_id,
+                        "Got two RequestMetrics with the same request ID.");
+                    requestIdsSeen.Add(requestMetrics.request_id);
+                    if (currentConnectionId == null)
+                    {
+                        currentConnectionId = requestMetrics.connection_id;
+                    }
+                    else
+                    {
+                        Assert.AreEqual(currentConnectionId, requestMetrics.connection_id,
+                            "Got two different connection IDs in RequestMetrics for the same connection.");
+                    }
+
+                    Assert.AreEqual(serverEndpoint, requestMetrics.local_endpoint);
+                    Assert.AreEqual(clientEndpoint, requestMetrics.remote_endpoint);
+                    Assert.AreEqual("unittest.comm.DummyTest.ReqRspMethod", requestMetrics.method_name);
+                    Assert.Null(requestMetrics.error);
+
+                    Assert.Greater(requestMetrics.total_time_millis, 0.0);
+                    Assert.Greater(requestMetrics.service_method_time_millis, 0.0);
+                    Assert.Greater(requestMetrics.total_time_millis, requestMetrics.service_method_time_millis);
+
+                    requestsSeen++;
+                }
+
+                // We're still connected, so there shouldn't be any new connection metrics.
+                Assert.AreEqual(connectionsSeen, metricsSink.ConnectionMetricsReceived);
+
+                await clientConn.StopAsync();
+                WaitForMetrics();
+
+                Assert.AreEqual(connectionsSeen + 1, metricsSink.ConnectionMetricsReceived);
+                Assert.NotNull(metricsSink.LastConnectionMetrics);
+                var connectionMetrics = metricsSink.LastConnectionMetrics;
+
+                Assert.NotNull(connectionMetrics.connection_id);
+                Assert.AreNotEqual("", connectionMetrics.connection_id);
+                // The connection ID in the new ConnectionMetrics must match the one seen by the requests.
+                Assert.AreEqual(currentConnectionId, connectionMetrics.connection_id,
+                    "Got a different connection IDs in ConnectionMetrics and this connection's RequestMetrics.");
+                CollectionAssert.DoesNotContain(connectionIdsSeen, connectionMetrics.connection_id,
+                    "Got two different ConnectionMetrics with the same connection ID.");
+                connectionIdsSeen.Add(connectionMetrics.connection_id);
+
+                Assert.AreEqual(serverEndpoint, connectionMetrics.local_endpoint);
+                Assert.AreEqual(clientEndpoint, connectionMetrics.remote_endpoint);
+                Assert.Greater(connectionMetrics.duration_millis, 0.0);
+
+                connectionsSeen++;
+            }
+
+            await listener.StopAsync();
+        }
     }
 }

--- a/cs/test/comm/Layers/LayerStackTests.cs
+++ b/cs/test/comm/Layers/LayerStackTests.cs
@@ -151,6 +151,8 @@ namespace UnitTest.Layers
 
     class TestSendContext : SendContext
     {
+        public TestSendContext() : base(new ConnectionMetrics(), new RequestMetrics()) { }
+
         public override Connection Connection
         {
             get
@@ -162,6 +164,8 @@ namespace UnitTest.Layers
 
     class TestReceiveContext : ReceiveContext
     {
+        public TestReceiveContext() : base(new ConnectionMetrics(), new RequestMetrics()) { }
+
         public override Connection Connection
         {
             get
@@ -356,6 +360,7 @@ namespace UnitTest.Layers
     public class TestLayerStackProvider_Fails : ILayerStackProvider
     {
         public static string InternalDetails = "Internal details";
+        public static string UniqueId = "Unique ID";
         uint failAfterGets;
 
         public TestLayerStackProvider_Fails(uint failAfterGets)
@@ -368,7 +373,7 @@ namespace UnitTest.Layers
             if (failAfterGets == 0)
             {
                 layerStack = null;
-                return Errors.MakeInternalServerError(InternalDetails);
+                return Errors.MakeInternalServerError(InternalDetails, UniqueId);
             }
             else
             {

--- a/cs/test/comm/Layers/LayerStackTests.cs
+++ b/cs/test/comm/Layers/LayerStackTests.cs
@@ -40,7 +40,7 @@ namespace UnitTest.Layers
             var testLayer2 = new TestLayer_Append("bar", testList);
             var stackProvider = new LayerStackProvider<Dummy>(LoggerTests.BlackHole, testLayer1, testLayer2);
             ILayerStack stack;
-            Error error = stackProvider.GetLayerStack(out stack);
+            Error error = stackProvider.GetLayerStack(null, out stack);
             Assert.IsNull(error);
 
             IBonded layerData;
@@ -66,7 +66,7 @@ namespace UnitTest.Layers
             var testLayer2 = new TestLayer_Append("bar", testList);
             var stackProvider = new LayerStackProvider<Dummy>(LoggerTests.BlackHole, testLayer1, testLayer2);
             ILayerStack stack;
-            Error error = stackProvider.GetLayerStack(out stack);
+            Error error = stackProvider.GetLayerStack(null, out stack);
             Assert.IsNull(error);
 
             error = stack.OnReceive(MessageType.Request, receiveContext, CreateBondedTestData(initialReceiveValue));
@@ -114,10 +114,10 @@ namespace UnitTest.Layers
         {
             var provider = new LayerStackProvider<Dummy>(LoggerTests.BlackHole, new TestLayer_AlwaysThrows(), new TestLayer_AlwaysThrows());
             ILayerStack stack;
-            Error error = provider.GetLayerStack(out stack);
+            Error error = provider.GetLayerStack(null, out stack);
             Assert.IsNull(error);
             ILayerStack stack2;
-            error = provider.GetLayerStack(out stack2);
+            error = provider.GetLayerStack(null, out stack2);
             Assert.IsNull(error);
             Assert.AreSame(stack, stack2);
         }
@@ -130,10 +130,10 @@ namespace UnitTest.Layers
                                                          new TestLayerProvider_StatefulAppend("foo"),
                                                          new TestLayer_AlwaysThrows());
             ILayerStack stack;
-            Error error = provider.GetLayerStack(out stack);
+            Error error = provider.GetLayerStack(null, out stack);
             Assert.IsNull(error);
             ILayerStack stack2;
-            error = provider.GetLayerStack(out stack2);
+            error = provider.GetLayerStack(null, out stack2);
             Assert.IsNull(error);
             Assert.AreNotSame(stack, stack2);
         }
@@ -360,7 +360,6 @@ namespace UnitTest.Layers
     public class TestLayerStackProvider_Fails : ILayerStackProvider
     {
         public static string InternalDetails = "Internal details";
-        public static string UniqueId = "Unique ID";
         uint failAfterGets;
 
         public TestLayerStackProvider_Fails(uint failAfterGets)
@@ -368,12 +367,12 @@ namespace UnitTest.Layers
             this.failAfterGets = failAfterGets;
         }
 
-        public Error GetLayerStack(out ILayerStack layerStack)
+        public Error GetLayerStack(string uniqueId, out ILayerStack layerStack)
         {
             if (failAfterGets == 0)
             {
                 layerStack = null;
-                return Errors.MakeInternalServerError(InternalDetails, UniqueId);
+                return Errors.MakeInternalServerError(InternalDetails, uniqueId);
             }
             else
             {


### PR DESCRIPTION
The internal consequences of this change are somewhat widespread. I've made RequestMetrics creation and emission the responsibility of Connections, rather than the ServiceHost, and I've added both flavors of metrics the base Context structure, with the immediate intent to make them visible to Layers.

This change also includes an end-to-end metrics test for requests and events. We still need a similar test to make sure valid metrics are emitted in various error cases, but this diff is uncomfortably large as it is.