### PR TITLE
[comm] Switch Error to only have one inner_error

### DIFF
--- a/cs/test/comm/Interfaces/ErrorsTests.cs
+++ b/cs/test/comm/Interfaces/ErrorsTests.cs
@@ -21,7 +21,7 @@ namespace UnitTest.Interfaces
             Assert.IsNotEmpty(error.unique_id);
             Assert.That(error.message, Is.Not.StringContaining(ex.Message));
             Assert.IsEmpty(error.server_stack_trace);
-            Assert.IsEmpty(error.inner_errors);
+            Assert.IsNull(error.inner_error);
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace UnitTest.Interfaces
             Assert.IsNotEmpty(error.unique_id);
             Assert.IsNotEmpty(error.message);
             Assert.IsEmpty(error.server_stack_trace);
-            Assert.IsEmpty(error.inner_errors);
+            Assert.IsNull(error.inner_error);
         }
 
         [Test]
@@ -50,7 +50,7 @@ namespace UnitTest.Interfaces
 
             Assert.AreEqual((int)ErrorCode.InternalServerError, cleansedInternalError.error_code);
             Assert.AreEqual(Errors.InternalErrorMessage, cleansedInternalError.message);
-            Assert.IsEmpty(cleansedInternalError.inner_errors);
+            Assert.IsNull(cleansedInternalError.inner_error);
             Assert.AreEqual(savedID, cleansedInternalError.unique_id);
             Assert.IsEmpty(cleansedInternalError.server_stack_trace);
         }
@@ -76,7 +76,7 @@ namespace UnitTest.Interfaces
             Assert.IsNotEmpty(error.unique_id);
             Assert.That(error.message, Is.StringContaining(ex.Message));
             Assert.IsNotEmpty(error.server_stack_trace);
-            Assert.AreEqual(1, error.inner_errors.Count);
+            Assert.IsNotNull(error.inner_error);
         }
 
         [Test]
@@ -90,7 +90,12 @@ namespace UnitTest.Interfaces
             Assert.IsNotEmpty(error.unique_id);
             Assert.That(error.message, Is.StringContaining(aggEx.Message));
             Assert.IsNotEmpty(error.server_stack_trace);
-            Assert.AreEqual(2, error.inner_errors.Count);
+            Assert.IsNotNull(error.inner_error);
+
+            var aggError = error.inner_error.Deserialize<AggregateError>();
+            Assert.AreEqual((int)ErrorCode.MultipleErrorsOccured, aggError.error_code);
+            Assert.That(aggError.message, Is.StringMatching("One or more errors occured"));
+            Assert.AreEqual(2, aggError.inner_errors.Count);
         }
 
         private static Exception GenerateException(Exception ex)

--- a/idl/bond/comm/comm.bond
+++ b/idl/bond/comm/comm.bond
@@ -13,11 +13,12 @@ enum MessageType
 enum ErrorCode
 {
     OK = 0x0;
-    InternalServerError = 0xA0BD0000;
+    InternalServerError = 0xA0BD0000; // Error is an InternalServerError
     MethodNotFound = 0xA0BD0001;
     InvalidInvocation = 0xA0BD0002;
     TransportError = 0xA0BD0003;
     ConnectionShutDown = 0xA0BD0004;
+    MultipleErrorsOccured = 0xA0BD0005; // Error is an AggregateError
 }
 
 enum ConnectionShutdownReason
@@ -35,13 +36,18 @@ struct Error
 {
     0: required int32 error_code;
     1: string message;
-    2: vector<bonded<Error>> inner_errors;
+    2: nullable<bonded<Error>> inner_error;
 }
 
 struct InternalServerError : Error
 {
     0: string unique_id;
     1: string server_stack_trace;
+}
+
+struct AggregateError : Error
+{
+    0: vector<bonded<Error>> inner_errors;
 }
 
 struct ConnectionMetrics


### PR DESCRIPTION
Error now has a `nullable<bonded<Error>> inner_error` field. If multiple
errors need to be represented, the `AggregateError` struct and its error
code, `MultipleErrorsOccured`, can be used to collect these up.