### PR TITLE
[c++] Refine noexcept specifications

### DIFF
--- a/cpp/inc/bond/core/nullable.h
+++ b/cpp/inc/bond/core/nullable.h
@@ -477,16 +477,15 @@ public:
 #ifndef BOND_NO_CXX11_RVALUE_REFERENCES
     explicit
     nullable(value_type&& value,
-             const allocator_type& alloc = allocator_type()) BOND_NOEXCEPT_IF(
-                 bond::is_nothrow_move_constructible<Allocator>::value
-                 && bond::is_nothrow_move_constructible<real_pointer>::value)
+             const allocator_type& alloc = allocator_type())
         : Allocator(alloc),
           _value(new_value(std::move(value)))
     {}
 
     nullable(nullable&& src) BOND_NOEXCEPT_IF(
         bond::is_nothrow_move_constructible<Allocator>::value
-        && bond::is_nothrow_move_constructible<real_pointer>::value)
+        && bond::is_nothrow_move_constructible<real_pointer>::value
+        && BOND_NOEXCEPT(src._value = real_pointer()))
         : Allocator(std::move(src.base())),
           _value(std::move(src._value))
     {
@@ -499,8 +498,7 @@ public:
         return *this;
     }
 
-    void set(value_type&& value) BOND_NOEXCEPT_IF(
-        bond::is_nothrow_move_constructible<real_pointer>::value)
+    void set(value_type&& value)
     {
         if (empty())
             _value = new_value(std::move(value));

--- a/cpp/inc/bond/core/traits.h
+++ b/cpp/inc/bond/core/traits.h
@@ -5,6 +5,7 @@
 
 #include "config.h"
 #include "scalar_interface.h"
+#include <boost/type_traits/has_nothrow_copy.hpp>
 #include <boost/utility/enable_if.hpp>
 
 #ifndef BOND_NO_CXX11_HDR_TYPE_TRAITS
@@ -40,6 +41,13 @@ using BOND_TYPE_TRAITS_NAMESPACE::remove_reference;
 using BOND_TYPE_TRAITS_NAMESPACE::true_type;
 
 #undef BOND_TYPE_TRAITS_NAMESPACE
+
+// version of is_nothrow_copy_constructible/has_nothrow_copy_constructor
+// that works across C++03 and C++11 and later: we just delegate to boost,
+// but use the modern name and put it in the bond namespace
+template <typename T>
+struct is_nothrow_copy_constructible : boost::has_nothrow_copy_constructor<T> {};
+
 
 // is_signed_int
 template <typename T> struct
@@ -94,13 +102,13 @@ is_protocol_same<Reader<I>, Writer<O> >
 
 // For protocols that have multiple versions, specialize this template
 template <typename Reader> struct
-protocol_has_multiple_versions 
+protocol_has_multiple_versions
     : false_type {};
 
 
-// ... and overload this function. 
+// ... and overload this function.
 template <typename Reader, typename Writer>
-inline 
+inline
 bool is_protocol_version_same(const Reader&, const Writer&)
 {
     return true;
@@ -128,12 +136,12 @@ get_protocol_writer<Reader<I>, OutputStream>
 };
 
 
-template <typename T, T> struct 
+template <typename T, T> struct
 check_method
     : true_type {};
 
 
-template <typename Reader, typename Unused = void> struct 
+template <typename Reader, typename Unused = void> struct
 uses_marshaled_bonded;
 
 
@@ -144,4 +152,3 @@ is_type_alias
 
 
 } // namespace bond
-

--- a/cpp/inc/bond/core/value.h
+++ b/cpp/inc/bond/core/value.h
@@ -181,7 +181,7 @@ public:
 
 #ifndef BOND_NO_CXX11_RVALUE_REFERENCES
     value_common(value_common&& rhs) BOND_NOEXCEPT_IF(
-        bond::is_nothrow_move_constructible<Reader>::value)
+        bond::is_nothrow_copy_constructible<Reader>::value)
         : _input(rhs._input),
           _skip(std::move(rhs._skip))
     {


### PR DESCRIPTION
* nullable's move constructors and set member function sometimes invoke
  new_value, which may perform an allocation that may throw.
* value_common's move constructor copies the input Reader, so it needs
  to be conditionally noexcept on being able to make a copy.