### PR TITLE
Relax the upper bound of Newtonsoft Json dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ different versioning scheme, following the Haskell community's
 
 ### C# ###
 
+* Bond can now be used with Newtonsoft.Json >= 7.0.1 and < 10
 * Runtime SchemaDef now includes information about whether BT_LIST fields
   are nullable or blobs.
   [Issue #161](https://github.com/Microsoft/bond/issues/161)

--- a/cs/nuget/bond.runtime.csharp.nuspec
+++ b/cs/nuget/bond.runtime.csharp.nuspec
@@ -22,7 +22,7 @@
         <copyright>Copyright (c) Microsoft</copyright>
         <tags>Bond .NET C# serialization</tags>
         <dependencies>
-            <dependency id="Newtonsoft.Json" version="7.0.1" />
+            <dependency id="Newtonsoft.Json" version="[7.0.1,10)" />
             <dependency id="Bond.Core.CSharp" version ="[$version$]"/>
         </dependencies>
     </metadata>


### PR DESCRIPTION
- Bond can now be used with Newtonsoft.Json >= 7.0.1 and < 10
- Closes issue https://github.com/Microsoft/bond/issues/212