### PR TITLE
[c#] Fix metrics tests.

### DIFF
--- a/cs/test/comm/Interfaces/ServiceIsolationTests.cs
+++ b/cs/test/comm/Interfaces/ServiceIsolationTests.cs
@@ -85,7 +85,7 @@ namespace UnitTest.Interfaces
         }
 
         [Test]
-        public async void IsolatedLoggingAndMetrics()
+        public async Task IsolatedLoggingAndMetrics()
         {
             // Create two services on their own transports with separate ILogSinks and IMetricsSinks.
             // Create one client for each service on separate transports so they don't log or emit metrics.


### PR DESCRIPTION
Previously, the tests were failing, but the failure exceptions were getting
swallowed by an async void function. Additionally, this increases the length of
the pause for metrics to settle.