### PR TITLE
[c# comm] Remove error code from EpoxyHeaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,11 +37,12 @@ different versioning scheme, following the Haskell community's
   [Issue #161 re-opened](https://github.com/Microsoft/bond/issues/161)
 
 ### C# Comm ###
-
 * `EpoxyListeners` can now be configured to require clients to authenticate
   themselves with a certificate. This is configured via the
   `clientCertificateRequired` parameter when creating an
   `EpoxyServerTlsConfig`.
+* Internals of the Epoxy protocol cleaned up. See the
+  [updated wire format specification](https://microsoft.github.io/bond/manual/bond_comm_epoxy_wire.html).
 
 ## 4.3.0: 2016-08-23 ##
 
@@ -164,7 +165,7 @@ different versioning scheme, following the Haskell community's
   * Bond.Compiler.CSharp: contains `gbc` and C# MSBuild targets. No longer
     do you have to consume Bond.CSharp (which pulls in all of the rest of
     Bond) just to get codegen.
-  
+
 ### C# Comm ###
 
 * Initial preview release of the

--- a/cs/src/comm/epoxy-transport/EpoxyConnection.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyConnection.cs
@@ -160,7 +160,7 @@ namespace Bond.Comm.Epoxy
             return $"{nameof(EpoxyConnection)}(local: {LocalEndPoint}, remote: {RemoteEndPoint})";
         }
 
-        internal static Frame MessageToFrame(ulong conversationId, string methodName, PayloadType type, IMessage message, IBonded layerData, Logger logger)
+        internal static Frame MessageToFrame(ulong conversationId, string methodName, EpoxyMessageType type, IMessage message, IBonded layerData, Logger logger)
         {
             var frame = new Frame(logger);
 
@@ -168,18 +168,9 @@ namespace Bond.Comm.Epoxy
                 var headers = new EpoxyHeaders
                 {
                     conversation_id = conversationId,
-                    payload_type = type,
+                    message_type = type,
                     method_name = methodName ?? string.Empty, // method_name is not nullable
                 };
-
-                if (message.IsError)
-                {
-                    headers.error_code = message.Error.Deserialize<Error>().error_code;
-                }
-                else
-                {
-                    headers.error_code = (int)ErrorCode.OK;
-                }
 
                 const int initialHeaderBufferSize = 150;
                 var outputBuffer = new OutputBuffer(initialHeaderBufferSize);
@@ -200,15 +191,16 @@ namespace Bond.Comm.Epoxy
             }
 
             {
-                var userData = message.IsError ? (IBonded)message.Error : (IBonded)message.RawPayload;
+                FrameletType frameletType = message.IsError ? FrameletType.ErrorData : FrameletType.PayloadData;
+                IBonded userData = message.IsError ? message.Error : message.RawPayload;
 
-                const int initialPayloadBufferSize = 1024;
-                var outputBuffer = new OutputBuffer(initialPayloadBufferSize);
+                const int initialMessageBufferSize = 1024;
+                var outputBuffer = new OutputBuffer(initialMessageBufferSize);
                 var compactWriter = new CompactBinaryWriter<OutputBuffer>(outputBuffer);
                 compactWriter.WriteVersion();
                 userData.Serialize(compactWriter);
 
-                frame.Add(new Framelet(FrameletType.PayloadData, outputBuffer.Data));
+                frame.Add(new Framelet(frameletType, outputBuffer.Data));
             }
 
             return frame;
@@ -266,7 +258,7 @@ namespace Bond.Comm.Epoxy
                 return Message.FromError(layerError);
             }
 
-            var frame = MessageToFrame(conversationId, methodName, PayloadType.Request, request, layerData, logger);
+            var frame = MessageToFrame(conversationId, methodName, EpoxyMessageType.Request, request, layerData, logger);
 
             logger.Site().Debug("{0} Sending request {1}/{2}.", this, conversationId, methodName);
             var responseTask = responseMap.Add(conversationId, layerStack);
@@ -318,7 +310,7 @@ namespace Bond.Comm.Epoxy
                 response = Message.FromError(Errors.CleanseInternalServerError(layerError));
             }
 
-            var frame = MessageToFrame(conversationId, null, PayloadType.Response, response, layerData, logger);
+            var frame = MessageToFrame(conversationId, null, EpoxyMessageType.Response, response, layerData, logger);
             logger.Site().Debug("{0} Sending reply for conversation ID {1}.", this, conversationId);
 
             bool wasSent = await SendFrameAsync(frame);
@@ -350,7 +342,7 @@ namespace Bond.Comm.Epoxy
                 return;
             }
 
-            var frame = MessageToFrame(conversationId, methodName, PayloadType.Event, message, layerData, logger);
+            var frame = MessageToFrame(conversationId, methodName, EpoxyMessageType.Event, message, layerData, logger);
 
             logger.Site().Debug("{0} Sending event {1}/{2}.", this, conversationId, methodName);
 
@@ -593,13 +585,12 @@ namespace Bond.Comm.Epoxy
                     return State.Disconnecting;
                 }
 
-
                 var result = EpoxyProtocol.Classify(frame, logger);
                 switch (result.Disposition)
                 {
                     case EpoxyProtocol.FrameDisposition.DeliverRequestToService:
                     {
-                        State? nextState = DispatchRequest(result.Headers, result.Payload, result.LayerData);
+                        State? nextState = DispatchRequest(result.Headers, result.MessageData, result.LayerData);
                         if (nextState.HasValue)
                         {
                             return nextState.Value;
@@ -612,11 +603,11 @@ namespace Bond.Comm.Epoxy
                     }
 
                     case EpoxyProtocol.FrameDisposition.DeliverResponseToProxy:
-                        DispatchResponse(result.Headers, result.Payload, result.LayerData);
+                        DispatchResponse(result.Headers, result.MessageData, result.LayerData);
                         break;
 
                     case EpoxyProtocol.FrameDisposition.DeliverEventToService:
-                        DispatchEvent(result.Headers, result.Payload, result.LayerData);
+                        DispatchEvent(result.Headers, result.MessageData, result.LayerData);
                         break;
 
                     case EpoxyProtocol.FrameDisposition.SendProtocolError:
@@ -698,49 +689,54 @@ namespace Bond.Comm.Epoxy
             metrics.Emit(ConnectionMetrics);
         }
 
-        private State? DispatchRequest(EpoxyHeaders headers, ArraySegment<byte> payload, ArraySegment<byte> layerData)
+        private State? DispatchRequest(EpoxyHeaders headers, EpoxyProtocol.MessageData messageData, ArraySegment<byte> layerData)
         {
-            if (headers.error_code != (int)ErrorCode.OK)
-            {
-                logger.Site().Error("{0} Received request with a non-zero error code. Conversation ID: {1}",
-                    this, headers.conversation_id);
-                protocolError = ProtocolErrorCode.PROTOCOL_VIOLATED;
-                return State.SendProtocolError;
-            }
-
             Task.Run(async () =>
             {
                 var totalTime = Stopwatch.StartNew();
                 var requestMetrics = Metrics.StartRequestMetrics(ConnectionMetrics);
                 var receiveContext = new EpoxyReceiveContext(this, ConnectionMetrics, requestMetrics);
 
-                IMessage request = Message.FromPayload(Unmarshal.From(payload));
-                IBonded bondedLayerData = (layerData.Array == null) ? null : Unmarshal.From(layerData);
-
-                ILayerStack layerStack;
-                Error layerError = parentTransport.GetLayerStack(requestMetrics.request_id, out layerStack);
-
-                if (layerError == null)
-                {
-                    layerError = LayerStackUtils.ProcessOnReceive(
-                            layerStack, MessageType.Request, receiveContext, bondedLayerData, logger);
-                }
-
+                ILayerStack layerStack = null; // CHWARR TODO: is not giving layers a chance on this response okay?
                 IMessage result;
 
-                if (layerError == null)
+                if (messageData.IsError)
                 {
-                    result = await serviceHost.DispatchRequest(headers.method_name, receiveContext, request);
+                    logger.Site().Error("{0} Received request with an error message. Only payload messages are allowed. Conversation ID: {1}",
+                        this, headers.conversation_id);
+                    result = Message.FromError(new Error
+                    {
+                        error_code = (int)ErrorCode.InvalidInvocation,
+                        message = "Received request with an error message"
+                    });
                 }
                 else
                 {
-                    logger.Site().Error("{0} Receiving request {1}/{2} failed due to layer error (Code: {3}, Message: {4}).",
-                        this, headers.conversation_id, headers.method_name,
-                        layerError.error_code, layerError.message);
+                    IMessage request = Message.FromPayload(Unmarshal.From(messageData.Data));
+                    IBonded bondedLayerData = (layerData.Array == null) ? null : Unmarshal.From(layerData);
 
-                    // Set layer error as result of this Bond method call and do not dispatch to method.
-                    // Since this error will be returned to client, cleanse out internal server error details, if any.
-                    result = Message.FromError(Errors.CleanseInternalServerError(layerError));
+                    Error layerError = parentTransport.GetLayerStack(requestMetrics.request_id, out layerStack);
+
+                    if (layerError == null)
+                    {
+                        layerError = LayerStackUtils.ProcessOnReceive(
+                            layerStack, MessageType.Request, receiveContext, bondedLayerData, logger);
+                    }
+
+                    if (layerError == null)
+                    {
+                        result = await serviceHost.DispatchRequest(headers.method_name, receiveContext, request);
+                    }
+                    else
+                    {
+                        logger.Site().Error("{0} Receiving request {1}/{2} failed due to layer error (Code: {3}, Message: {4}).",
+                            this, headers.conversation_id, headers.method_name,
+                            layerError.error_code, layerError.message);
+
+                        // Set layer error as result of this Bond method call and do not dispatch to method.
+                        // Since this error will be returned to client, cleanse out internal server error details, if any.
+                        result = Message.FromError(Errors.CleanseInternalServerError(layerError));
+                    }
                 }
 
                 await SendReplyAsync(headers.conversation_id, result, layerStack, requestMetrics);
@@ -752,17 +748,11 @@ namespace Bond.Comm.Epoxy
             return null;
         }
 
-        private void DispatchResponse(EpoxyHeaders headers, ArraySegment<byte> payload, ArraySegment<byte> layerData)
+        private void DispatchResponse(EpoxyHeaders headers, EpoxyProtocol.MessageData messageData, ArraySegment<byte> layerData)
         {
-            IMessage response;
-            if (headers.error_code != (int)ErrorCode.OK)
-            {
-                response = Message.FromError(Unmarshal<Error>.From(payload));
-            }
-            else
-            {
-                response = Message.FromPayload(Unmarshal.From(payload));
-            }
+            IMessage response = messageData.IsError
+                ? Message.FromError(Unmarshal<Error>.From(messageData.Data))
+                : Message.FromPayload(Unmarshal.From(messageData.Data));
 
             TaskCompletionSource<IMessage> tcs = responseMap.TakeTaskCompletionSource(headers.conversation_id);
             if (tcs == null)
@@ -798,18 +788,18 @@ namespace Bond.Comm.Epoxy
             });
         }
 
-        private void DispatchEvent(EpoxyHeaders headers, ArraySegment<byte> payload, ArraySegment<byte> layerData)
+        private void DispatchEvent(EpoxyHeaders headers, EpoxyProtocol.MessageData messageData, ArraySegment<byte> layerData)
         {
-            if (headers.error_code != (int)ErrorCode.OK)
+            if (messageData.IsError)
             {
-                logger.Site().Error("{0} Received event with a non-zero error code. Conversation ID: {1}",
+                logger.Site().Error("{0} Received event with an error message. Only payload messages are allowed. Conversation ID: {1}",
                     this, headers.conversation_id);
                 return;
             }
 
             Task.Run(async () =>
             {
-                IMessage request = Message.FromPayload(Unmarshal.From(payload));
+                IMessage request = Message.FromPayload(Unmarshal.From(messageData.Data));
                 var totalTime = Stopwatch.StartNew();
                 var requestMetrics = Metrics.StartRequestMetrics(ConnectionMetrics);
                 var receiveContext = new EpoxyReceiveContext(this, ConnectionMetrics, requestMetrics);

--- a/cs/src/comm/epoxy-transport/EpoxyConnection.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyConnection.cs
@@ -697,7 +697,7 @@ namespace Bond.Comm.Epoxy
                 var requestMetrics = Metrics.StartRequestMetrics(ConnectionMetrics);
                 var receiveContext = new EpoxyReceiveContext(this, ConnectionMetrics, requestMetrics);
 
-                ILayerStack layerStack = null; // CHWARR TODO: is not giving layers a chance on this response okay?
+                ILayerStack layerStack = null;
                 IMessage result;
 
                 if (messageData.IsError)

--- a/cs/src/comm/epoxy-transport/EpoxyProtocol.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyProtocol.cs
@@ -35,7 +35,7 @@ namespace Bond.Comm.Epoxy
             /// The frame was a valid Event.
             /// </summary>
             DeliverEventToService,
-            
+
             /// <summary>
             /// The frame is a valid Config frame and needs to be handled.
             /// </summary>

--- a/cs/src/comm/epoxy-transport/EpoxyProtocol.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyProtocol.cs
@@ -385,7 +385,7 @@ namespace Bond.Comm.Epoxy
 
             if (frame.Count < 2)
             {
-                logger.Site().Error("Frame had headers but no message.");
+                logger.Site().Error("Frame had headers but no message data.");
                 errorCode = ProtocolErrorCode.MALFORMED_DATA;
                 return ClassifyState.MalformedFrame;
             }
@@ -416,7 +416,7 @@ namespace Bond.Comm.Epoxy
             int messageDataIndex = (layerData.Array == null ? 1 : 2);
             if (messageDataIndex >= frame.Count)
             {
-                logger.Site().Error("Frame had headers but no message.");
+                logger.Site().Error("Frame had headers but no message data.");
                 errorCode = ProtocolErrorCode.MALFORMED_DATA;
                 return ClassifyState.MalformedFrame;
             }
@@ -424,7 +424,7 @@ namespace Bond.Comm.Epoxy
             var framelet = frame.Framelets[messageDataIndex];
             if (framelet.Type != FrameletType.PayloadData && framelet.Type != FrameletType.ErrorData)
             {
-                logger.Site().Error("Frame had headers but no message framelet. Unexpected framelet type {0}", (int)framelet.Type);
+                logger.Site().Error("Frame had headers but no message data. Unexpected framelet type {0}", (int)framelet.Type);
                 errorCode = ProtocolErrorCode.MALFORMED_DATA;
                 return ClassifyState.MalformedFrame;
             }

--- a/cs/src/comm/epoxy-transport/Frame.cs
+++ b/cs/src/comm/epoxy-transport/Frame.cs
@@ -13,11 +13,12 @@ namespace Bond.Comm.Epoxy
 
     internal enum FrameletType
     {
-        EpoxyConfig = 0x4743,
-        EpoxyHeaders = 0x5248,
-        LayerData = 0x594C,
-        PayloadData = 0x5444,
-        ProtocolError = 0x5245,
+        EpoxyConfig = 0x4743,           // "GC"
+        EpoxyHeaders = 0x5248,          // "RH"
+        ErrorData = 0x4445,             // "DE"
+        LayerData = 0x594C,             // "YL"
+        PayloadData = 0x4450,           // "DP"
+        ProtocolError = 0x5245,         // "RE"
     }
 
     internal struct Framelet
@@ -28,6 +29,7 @@ namespace Bond.Comm.Epoxy
             {
                 case FrameletType.EpoxyConfig:
                 case FrameletType.EpoxyHeaders:
+                case FrameletType.ErrorData:
                 case FrameletType.LayerData:
                 case FrameletType.PayloadData:
                 case FrameletType.ProtocolError:
@@ -48,10 +50,12 @@ namespace Bond.Comm.Epoxy
 
         public static bool IsKnownType(UInt16 value)
         {
-            return value == (UInt16)FrameletType.LayerData
-                | value == (UInt16)FrameletType.PayloadData
-                | value == (UInt16)FrameletType.EpoxyHeaders
+            return false
                 | value == (UInt16)FrameletType.EpoxyConfig
+                | value == (UInt16)FrameletType.EpoxyHeaders
+                | value == (UInt16)FrameletType.ErrorData
+                | value == (UInt16)FrameletType.LayerData
+                | value == (UInt16)FrameletType.PayloadData
                 | value == (UInt16)FrameletType.ProtocolError;
         }
 
@@ -61,7 +65,7 @@ namespace Bond.Comm.Epoxy
 
     internal class Frame
     {
-        // most frames will have at most three framelets: EpoxyHeaders, LayerData, PayloadData
+        // most frames will have at most three framelets: EpoxyHeaders, LayerData, PayloadData/ErrorData
         private const int DefaultFrameCount = 3;
 
         private readonly List<Framelet> framelets;
@@ -96,7 +100,7 @@ namespace Bond.Comm.Epoxy
 
             try
             {
-                // add space for framelet type, length of payload, and actual payload content
+                // add space for framelet type, length of message, and actual message content
                 TotalSize = checked(TotalSize + sizeof(UInt16) + sizeof(UInt32) + framelet.Contents.Count);
                 framelets.Add(framelet);
             }

--- a/cs/src/comm/epoxy-transport/Frame.cs
+++ b/cs/src/comm/epoxy-transport/Frame.cs
@@ -50,13 +50,12 @@ namespace Bond.Comm.Epoxy
 
         public static bool IsKnownType(UInt16 value)
         {
-            return false
-                | value == (UInt16)FrameletType.EpoxyConfig
-                | value == (UInt16)FrameletType.EpoxyHeaders
-                | value == (UInt16)FrameletType.ErrorData
-                | value == (UInt16)FrameletType.LayerData
-                | value == (UInt16)FrameletType.PayloadData
-                | value == (UInt16)FrameletType.ProtocolError;
+            return value == (UInt16) FrameletType.EpoxyConfig
+                   || value == (UInt16) FrameletType.EpoxyHeaders
+                   || value == (UInt16) FrameletType.ErrorData
+                   || value == (UInt16) FrameletType.LayerData
+                   || value == (UInt16) FrameletType.PayloadData
+                   || value == (UInt16) FrameletType.ProtocolError;
         }
 
         public FrameletType Type { get; }

--- a/cs/src/comm/interfaces/Message.cs
+++ b/cs/src/comm/interfaces/Message.cs
@@ -10,7 +10,8 @@ namespace Bond.Comm
     /// Interface representing a message of an unknown payload type.
     /// </summary>
     /// <remarks>
-    /// A message can contain either a payload or an <see cref="Bond.Comm.Error"/>.
+    /// A message can contain either a payload or an error, represented by
+    /// <see cref="Bond.Comm.Error"/>.
     /// </remarks>
     public interface IMessage
     {
@@ -18,23 +19,23 @@ namespace Bond.Comm
         /// Gets the payload as a <see cref="IBonded"/> value.
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        /// Thrown when the message contains an Error and not a payload.
+        /// Thrown when the message contains an error and not a payload.
         /// </exception>
         IBonded RawPayload { get; }
 
         /// <summary>
-        /// Gets the Error, if any.
+        /// Gets the error, if any.
         /// </summary>
         /// <remarks>
-        /// If the message has a payload and no Error, <c>null</c> is returned.
+        /// If the message has a payload and no error, <c>null</c> is returned.
         /// </remarks>
         IBonded<Error> Error { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the message contains an Error.
+        /// Gets a value indicating whether the message contains an error.
         /// </summary>
         /// <remarks>
-        /// If a message does not contain an Error, it contains a payload.
+        /// If a message does not contain an error, it contains a payload.
         /// </remarks>
         bool IsError { get; }
 
@@ -55,7 +56,8 @@ namespace Bond.Comm
     /// </summary>
     /// <typeparam name="T">The type of the message payload.</typeparam>
     /// <remarks>
-    /// A message can contain either a payload or an <see cref="Bond.Comm.Error"/>.
+    /// A message can contain either a payload or an error, represented by
+    /// <see cref="Bond.Comm.Error"/>.
     /// </remarks>
     public interface IMessage<out T> : IMessage
     {
@@ -64,7 +66,7 @@ namespace Bond.Comm
         /// value.
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        /// Thrown when the message contains an Error and not a payload.
+        /// Thrown when the message contains an error and not a payload.
         /// </exception>
         IBonded<T> Payload { get; }
     }
@@ -92,10 +94,10 @@ namespace Bond.Comm
             error = null;
         }
 
-        // To create an Error Message, use Message.FromError<TPayload>() or Message.FromError().
+        // To create an error Message, use Message.FromError<TPayload>() or Message.FromError().
         //
         // This ctor is internal so that a non-error Message<Error> can be created. If this were
-        // public, then new Message<Error>(SomeError) would resolve to this ctor, creating an Error
+        // public, then new Message<Error>(SomeError) would resolve to this ctor, creating an error
         // message, instead of to the generic ctor. We need new Message<Error>(SomeError) to resolve
         // to the generic ctor to create a non-error Message.
         internal Message(IBonded<Error> error)
@@ -161,13 +163,13 @@ namespace Bond.Comm
         }
 
         /// <summary>
-        /// Creates an Error message from the given Error.
+        /// Creates an error message from the given Error.
         /// </summary>
         /// <typeparam name="TPayload">
         /// The type of the message payload
         /// </typeparam>
         /// <param name="err">The Error for the message.</param>
-        /// <returns>An Error message of the given payload type.</returns>
+        /// <returns>An error message of the given payload type.</returns>
         public static IMessage<TPayload> FromError<TPayload>(Error err)
         {
             if (err == null)
@@ -179,13 +181,13 @@ namespace Bond.Comm
         }
 
         /// <summary>
-        /// Creates an Error message from the given Error.
+        /// Creates an error message from the given Error.
         /// </summary>
         /// <typeparam name="TPayload">
         /// The type of the message payload.
         /// </typeparam>
         /// <param name="err">The Error for the message.</param>
-        /// <returns>An Error message of the given payload type.</returns>
+        /// <returns>An error message of the given payload type.</returns>
         public static IMessage<TPayload> FromError<TPayload>(IBonded<Error> err)
         {
             if (err == null)
@@ -197,10 +199,10 @@ namespace Bond.Comm
         }
 
         /// <summary>
-        /// Creates an Error message from the given error.
+        /// Creates an error message from the given error.
         /// </summary>
         /// <param name="err">The Error for the message.</param>
-        /// <returns>An Error message of unknown payload type.</returns>
+        /// <returns>An error message of unknown payload type.</returns>
         public static IMessage FromError(Error err)
         {
             if (err == null)
@@ -212,10 +214,10 @@ namespace Bond.Comm
         }
 
         /// <summary>
-        /// Creates an Error message from the given Error.
+        /// Creates an error message from the given Error.
         /// </summary>
         /// <param name="err">The Error for the message.</param>
-        /// <returns>An Error message of unknown payload type.</returns>
+        /// <returns>An error message of unknown payload type.</returns>
         public static IMessage FromError(IBonded<Error> err)
         {
             if (err == null)
@@ -243,7 +245,7 @@ namespace Bond.Comm
             {
                 if (IsError)
                 {
-                    throw new InvalidOperationException("The Payload of this message cannot be accessed, as this message contains an Error.");
+                    throw new InvalidOperationException("The Payload of this message cannot be accessed, as this message contains an error.");
                 }
 
                 Debug.Assert(payload != null);

--- a/cs/src/comm/simpleinmem-transport/Processor/BatchProcessor.cs
+++ b/cs/src/comm/simpleinmem-transport/Processor/BatchProcessor.cs
@@ -41,23 +41,23 @@ namespace Bond.Comm.SimpleInMem.Processor
                     break;
                 }
 
-                switch(payload.headers.payload_type)
+                switch(payload.headers.message_type)
                 {
-                    case PayloadType.Event:
+                    case SimpleInMemMessageType.Event:
                         Task.Run(() => DispatchEvent(payload));
                         break;
 
-                    case PayloadType.Request:
+                    case SimpleInMemMessageType.Request:
                         Task.Run(() => DispatchRequest(payload, writeQueue));
                         break;
 
-                    case PayloadType.Response:
+                    case SimpleInMemMessageType.Response:
                         Task.Run(() => DispatchResponse(payload));
                         break;
 
                     default:
-                        logger.Site().Error("Unsupported Payload type: [{0}], for conversation id: {1}.",
-                                         payload.headers.payload_type, payload.headers.conversation_id);
+                        logger.Site().Error("Unsupported message type: [{0}], for conversation id: {1}.",
+                                         payload.headers.message_type, payload.headers.conversation_id);
                         break;
                 }
 
@@ -125,7 +125,7 @@ namespace Bond.Comm.SimpleInMem.Processor
                 response = Message.FromError(Errors.CleanseInternalServerError(layerError));
             }
 
-            var payload = Util.NewPayLoad(conversationId, PayloadType.Response, layerData, response, taskSource);
+            var payload = Util.NewPayLoad(conversationId, SimpleInMemMessageType.Response, layerData, response, taskSource);
             queue.Enqueue(payload);
         }
 

--- a/cs/src/comm/simpleinmem-transport/Processor/Util.cs
+++ b/cs/src/comm/simpleinmem-transport/Processor/Util.cs
@@ -10,13 +10,17 @@ namespace Bond.Comm.SimpleInMem.Processor
 
     internal static class Util
     {
-        internal static InMemFrame NewPayLoad(ulong conversationId, PayloadType payloadType, IBonded layerData,
-                                                IMessage message, TaskCompletionSource<IMessage> taskSource)
+        internal static InMemFrame NewPayLoad(
+            ulong conversationId,
+            SimpleInMemMessageType messageType,
+            IBonded layerData,
+            IMessage message,
+            TaskCompletionSource<IMessage> taskSource)
         {
             var headers = new SimpleInMemHeaders
             {
                 conversation_id = conversationId,
-                payload_type = payloadType
+                message_type = messageType
             };
 
             var payload = new InMemFrame

--- a/cs/src/comm/simpleinmem-transport/SimpleInMemConnection.cs
+++ b/cs/src/comm/simpleinmem-transport/SimpleInMemConnection.cs
@@ -214,7 +214,7 @@ namespace Bond.Comm.SimpleInMem
 
             // Pass the layer stack instance as state in response task completion source.
             var responseCompletionSource = new TaskCompletionSource<IMessage>(layerStack);
-            var payload = Util.NewPayLoad(conversationId, PayloadType.Request, layerData, request, responseCompletionSource);
+            var payload = Util.NewPayLoad(conversationId, SimpleInMemMessageType.Request, layerData, request, responseCompletionSource);
             payload.headers.method_name = methodName;
             writeQueue.Enqueue(payload);
 
@@ -243,7 +243,7 @@ namespace Bond.Comm.SimpleInMem
                 return;
             }
 
-            var payload = Util.NewPayLoad(conversationId, PayloadType.Event, layerData, message, null);
+            var payload = Util.NewPayLoad(conversationId, SimpleInMemMessageType.Event, layerData, message, null);
             payload.headers.method_name = methodName;
             writeQueue.Enqueue(payload);
         }

--- a/cs/src/comm/simpleinmem-transport/SimpleInMemTransport.bond
+++ b/cs/src/comm/simpleinmem-transport/SimpleInMemTransport.bond
@@ -3,7 +3,7 @@
 
 namespace bond.comm.simpleinmem;
 
-enum PayloadType
+enum SimpleInMemMessageType
 {
     Request = 1;
     Response = 2;
@@ -13,6 +13,6 @@ enum PayloadType
 struct SimpleInMemHeaders
 {
     0: uint64 conversation_id;
-    1: required PayloadType payload_type = Request;
+    1: required SimpleInMemMessageType message_type = Request;
     2: string method_name;
 }

--- a/cs/test/comm/Epoxy/EpoxyProtocolTests.cs
+++ b/cs/test/comm/Epoxy/EpoxyProtocolTests.cs
@@ -21,7 +21,7 @@ namespace UnitTest.Epoxy
         private const uint GoodResponseId = 1;
         private const string GoodMethod = "ShaveYaks";
         private const ProtocolErrorCode MeaninglessErrorCode = ProtocolErrorCode.GENERIC_ERROR;
-        private static readonly IMessage<Dummy> meaninglessMessage = new Message<Dummy>(new Dummy());
+        private static readonly IMessage<Dummy> meaninglessPayload = new Message<Dummy>(new Dummy());
         private static readonly IMessage meaninglessError = Message.FromError(new InternalServerError() { error_code = (int)ErrorCode.InternalServerError, message = "Meaningless message"});
         private static readonly ArraySegment<byte> emptyLayerData = new ArraySegment<byte>();
         private static ArraySegment<byte> goodLayerData;
@@ -85,17 +85,17 @@ namespace UnitTest.Epoxy
 
             // Good frames, from which we can pull good framelets to build bad frames.
             goodRequestFrame = EpoxyConnection.MessageToFrame(
-                GoodRequestId, GoodMethod, EpoxyMessageType.Request, meaninglessMessage, null, LoggerTests.BlackHole);
+                GoodRequestId, GoodMethod, EpoxyMessageType.Request, meaninglessPayload, null, LoggerTests.BlackHole);
             goodRequestLayerDataFrame = EpoxyConnection.MessageToFrame(
-                GoodRequestId, GoodMethod, EpoxyMessageType.Request, meaninglessMessage, goodLayerObject, LoggerTests.BlackHole);
+                GoodRequestId, GoodMethod, EpoxyMessageType.Request, meaninglessPayload, goodLayerObject, LoggerTests.BlackHole);
 
             goodResponseFrame = EpoxyConnection.MessageToFrame(
-                GoodResponseId, GoodMethod, EpoxyMessageType.Response, meaninglessMessage, null, LoggerTests.BlackHole);
+                GoodResponseId, GoodMethod, EpoxyMessageType.Response, meaninglessPayload, null, LoggerTests.BlackHole);
             goodErrorResponseFrame = EpoxyConnection.MessageToFrame(
                 GoodResponseId, GoodMethod, EpoxyMessageType.Response, meaninglessError, null, LoggerTests.BlackHole);
 
             goodEventFrame = EpoxyConnection.MessageToFrame(
-                GoodRequestId, GoodMethod, EpoxyMessageType.Event, meaninglessMessage, null, LoggerTests.BlackHole);
+                GoodRequestId, GoodMethod, EpoxyMessageType.Event, meaninglessPayload, null, LoggerTests.BlackHole);
 
             configFrame = EpoxyConnection.MakeConfigFrame(LoggerTests.BlackHole);
             protocolErrorFrame = EpoxyConnection.MakeProtocolErrorFrame(MeaninglessErrorCode, null, LoggerTests.BlackHole);
@@ -289,6 +289,7 @@ namespace UnitTest.Epoxy
                 EpoxyProtocol.ClassifyState.ExpectMessageData, goodRequestFrame, goodRequestHeaders, emptyLayerData,
                 ref  message, ref errorCode, LoggerTests.BlackHole);
             Assert.AreEqual(EpoxyProtocol.ClassifyState.ExpectEndOfFrame, after);
+            Assert.IsFalse(message.IsError);
             Assert.NotNull(message.Data.Array);
             Assert.Null(errorCode);
 
@@ -296,6 +297,7 @@ namespace UnitTest.Epoxy
                 EpoxyProtocol.ClassifyState.ExpectMessageData, goodRequestLayerDataFrame, goodRequestHeaders, goodLayerData,
                 ref  message, ref errorCode, LoggerTests.BlackHole);
             Assert.AreEqual(EpoxyProtocol.ClassifyState.ExpectEndOfFrame, after);
+            Assert.IsFalse(message.IsError);
             Assert.NotNull(message.Data.Array);
             Assert.Null(errorCode);
         }

--- a/cs/test/comm/Epoxy/FrameTests.cs
+++ b/cs/test/comm/Epoxy/FrameTests.cs
@@ -28,8 +28,9 @@ namespace UnitTest.Epoxy
             {
                 new { EnumMember = FrameletType.EpoxyConfig, ExpectedValue = 0x4743 },
                 new { EnumMember = FrameletType.EpoxyHeaders, ExpectedValue = 0x5248 },
+                new { EnumMember = FrameletType.ErrorData, ExpectedValue = 0x4445 },
                 new { EnumMember = FrameletType.LayerData, ExpectedValue = 0x594C },
-                new { EnumMember = FrameletType.PayloadData, ExpectedValue = 0x5444 },
+                new { EnumMember = FrameletType.PayloadData, ExpectedValue = 0x4450 },
                 new { EnumMember = FrameletType.ProtocolError, ExpectedValue = 0x5245 },
             };
 

--- a/cs/test/comm/Interfaces/MessageTests.cs
+++ b/cs/test/comm/Interfaces/MessageTests.cs
@@ -216,14 +216,6 @@ namespace UnitTest.Interfaces
         }
 
         [Test]
-        public void FromError_ZeroErrorCode_Throws()
-        {
-            var zeroErrorCode = new Error {error_code = 0};
-            Assert.Throws<ArgumentException>(() => Message.FromError<SomePayload>(zeroErrorCode));
-            Assert.Throws<ArgumentException>(() => Message.FromError(zeroErrorCode));
-        }
-
-        [Test]
         public void Message_ConvertToMessageT_Works()
         {
             IBonded typelessBonded = new Bonded<SomeDerivedPayload>(AnyDerivedPayload);

--- a/idl/bond/comm/comm.bond
+++ b/idl/bond/comm/comm.bond
@@ -12,7 +12,6 @@ enum MessageType
 
 enum ErrorCode
 {
-    OK = 0x0;
     InternalServerError = 0xA0BD0000; // Error is an InternalServerError
     MethodNotFound = 0xA0BD0001;
     InvalidInvocation = 0xA0BD0002;

--- a/idl/bond/comm/epoxy_transport.bond
+++ b/idl/bond/comm/epoxy_transport.bond
@@ -9,7 +9,7 @@ struct EpoxyConfig
 {
 }
 
-enum PayloadType
+enum EpoxyMessageType
 {
     Request = 1;
     Response = 2;
@@ -19,9 +19,8 @@ enum PayloadType
 struct EpoxyHeaders
 {
     0: uint64 conversation_id;
-    1: required PayloadType payload_type = Request;
+    1: required EpoxyMessageType message_type = Request;
     2: string method_name;
-    3: int32 error_code;
 }
 
 enum ProtocolErrorCode


### PR DESCRIPTION
Indicate transmission of an Error using a new framelet instead. In
addition, remove ErrorCode.OK and rename Epoxy's PayloadType to
EpoxyMessageType.

Left to do:
- [x] Update SimpleInMemTransport like we did Epoxy

@chadwalters, @tstein: please review, as you've already seen some parts of this change elsewhere.