### PR TITLE
Undo Bond.Runtime's limit to Newtonsoft.Json < 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ different versioning scheme, following the Haskell community's
   consumers of serialized SchemaDef. We plan to restore this field in the
   future.
   [Issue #161 re-opened](https://github.com/Microsoft/bond/issues/161)
+* The Bond.Runtime NuGet package no longer artificially limits
+  Newtonsoft.Json to versions before 10.
+  [Issue #212](https://github.com/Microsoft/bond/issues/212)
 
 ### C# Comm ###
 * `EpoxyListeners` can now be configured to require clients to authenticate

--- a/cs/nuget/bond.runtime.csharp.nuspec
+++ b/cs/nuget/bond.runtime.csharp.nuspec
@@ -22,7 +22,7 @@
         <copyright>Copyright (c) Microsoft</copyright>
         <tags>Bond .NET C# serialization</tags>
         <dependencies>
-            <dependency id="Newtonsoft.Json" version="[7.0.1,10)" />
+            <dependency id="Newtonsoft.Json" version="7.0.1" />
             <dependency id="Bond.Core.CSharp" version ="[$version$]"/>
         </dependencies>
     </metadata>


### PR DESCRIPTION
The Bond.Runtime NuGet package again only specifies a lower bound on its
Newtonsoft.JSON dependency. This reverts commit
e2be0bf3ec12e97555cf6204dc56cb8b6a4985f4, which artificially limited the
upper bound to < 10. The previous behavior did not limit Bond.Runtime to
only working with Newtonsoft.Json 7.0.1. _However_, the default behavior
of NuGet (since 2.8) is to install the _lowest_ version of a package
that satisfied the constraints. This behavior can be overridden when a
package is installed, but that decision needs to be made by the consumer
of Bond.Runtime.

Closes https://github.com/Microsoft/bond/issues/212