### PR TITLE
[IDL Comm] Improve IDL for consistent naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ different versioning scheme, following the Haskell community's
 * C# NuGet version: major bump needed
 * C# Comm NuGet version: minor bump needed
 
+### IDL comm ###
+* Update IDL to conform to naming conventions.
+* Adjust IDL for changes made to Epoxy internals
+
 ### C++ ###
 * Generated enum types now have a `FromEnum` method that can be used to
   convert from an enum value to a string. Now generated enum types have all

--- a/compiler/src/Language/Bond/Codegen/Cs/Comm_cs.hs
+++ b/compiler/src/Language/Bond/Codegen/Cs/Comm_cs.hs
@@ -112,7 +112,8 @@ namespace #{csNamespace}
         public global::System.Threading.Tasks.Task<global::Bond.Comm.IMessage<#{getMessageResultTypeName}>> #{methodName}Async(global::Bond.Comm.IMessage<#{getMessageInputTypeName}> param, global::System.Threading.CancellationToken ct)
         {
             return m_connection.RequestResponseAsync<#{getMessageInputTypeName}, #{getMessageResultTypeName}>(
-                "#{getDeclTypeName idl s}.#{methodName}",
+                "#{getDeclTypeName idl s}",
+                "#{methodName}",
                 param,
                 ct);
         }|]
@@ -129,7 +130,8 @@ namespace #{csNamespace}
         public void #{methodName}Async(global::Bond.Comm.IMessage<#{getMessageInputTypeName}> param)
         {
             m_connection.FireEventAsync<#{getMessageInputTypeName}>(
-                "#{getDeclTypeName idl s}.#{methodName}",
+                "#{getDeclTypeName idl s}",
+                "#{methodName}",
                 param);
         }|]
           where

--- a/compiler/tests/generated/generic_service_proxies.cs
+++ b/compiler/tests/generated/generic_service_proxies.cs
@@ -34,7 +34,8 @@ namespace tests
         public global::System.Threading.Tasks.Task<global::Bond.Comm.IMessage<global::Bond.Void>> foo31Async(global::Bond.Comm.IMessage<Payload> param, global::System.Threading.CancellationToken ct)
         {
             return m_connection.RequestResponseAsync<Payload, global::Bond.Void>(
-                "tests.Foo.foo31",
+                "tests.Foo",
+                "foo31",
                 param,
                 ct);
         }
@@ -48,7 +49,8 @@ namespace tests
         public global::System.Threading.Tasks.Task<global::Bond.Comm.IMessage<Payload>> foo32Async(global::Bond.Comm.IMessage<global::Bond.Void> param, global::System.Threading.CancellationToken ct)
         {
             return m_connection.RequestResponseAsync<global::Bond.Void, Payload>(
-                "tests.Foo.foo32",
+                "tests.Foo",
+                "foo32",
                 param,
                 ct);
         }
@@ -62,7 +64,8 @@ namespace tests
         public global::System.Threading.Tasks.Task<global::Bond.Comm.IMessage<Payload>> foo33Async(global::Bond.Comm.IMessage<Payload> param, global::System.Threading.CancellationToken ct)
         {
             return m_connection.RequestResponseAsync<Payload, Payload>(
-                "tests.Foo.foo33",
+                "tests.Foo",
+                "foo33",
                 param,
                 ct);
         }

--- a/compiler/tests/generated/service_proxies.cs
+++ b/compiler/tests/generated/service_proxies.cs
@@ -34,7 +34,8 @@ namespace tests
         public void foo11Async(global::Bond.Comm.IMessage<global::Bond.Void> param)
         {
             m_connection.FireEventAsync<global::Bond.Void>(
-                "tests.Foo.foo11",
+                "tests.Foo",
+                "foo11",
                 param);
         }
 
@@ -47,7 +48,8 @@ namespace tests
         public void foo12Async(global::Bond.Comm.IMessage<global::Bond.Void> param)
         {
             m_connection.FireEventAsync<global::Bond.Void>(
-                "tests.Foo.foo12",
+                "tests.Foo",
+                "foo12",
                 param);
         }
 
@@ -60,7 +62,8 @@ namespace tests
         public void foo13Async(global::Bond.Comm.IMessage<BasicTypes> param)
         {
             m_connection.FireEventAsync<BasicTypes>(
-                "tests.Foo.foo13",
+                "tests.Foo",
+                "foo13",
                 param);
         }
 
@@ -73,7 +76,8 @@ namespace tests
         public void foo14Async(global::Bond.Comm.IMessage<dummy> param)
         {
             m_connection.FireEventAsync<dummy>(
-                "tests.Foo.foo14",
+                "tests.Foo",
+                "foo14",
                 param);
         }
 
@@ -86,7 +90,8 @@ namespace tests
         public global::System.Threading.Tasks.Task<global::Bond.Comm.IMessage<global::Bond.Void>> foo21Async(global::Bond.Comm.IMessage<global::Bond.Void> param, global::System.Threading.CancellationToken ct)
         {
             return m_connection.RequestResponseAsync<global::Bond.Void, global::Bond.Void>(
-                "tests.Foo.foo21",
+                "tests.Foo",
+                "foo21",
                 param,
                 ct);
         }
@@ -100,7 +105,8 @@ namespace tests
         public global::System.Threading.Tasks.Task<global::Bond.Comm.IMessage<global::Bond.Void>> foo22Async(global::Bond.Comm.IMessage<global::Bond.Void> param, global::System.Threading.CancellationToken ct)
         {
             return m_connection.RequestResponseAsync<global::Bond.Void, global::Bond.Void>(
-                "tests.Foo.foo22",
+                "tests.Foo",
+                "foo22",
                 param,
                 ct);
         }
@@ -114,7 +120,8 @@ namespace tests
         public global::System.Threading.Tasks.Task<global::Bond.Comm.IMessage<global::Bond.Void>> foo23Async(global::Bond.Comm.IMessage<BasicTypes> param, global::System.Threading.CancellationToken ct)
         {
             return m_connection.RequestResponseAsync<BasicTypes, global::Bond.Void>(
-                "tests.Foo.foo23",
+                "tests.Foo",
+                "foo23",
                 param,
                 ct);
         }
@@ -128,7 +135,8 @@ namespace tests
         public global::System.Threading.Tasks.Task<global::Bond.Comm.IMessage<global::Bond.Void>> foo24Async(global::Bond.Comm.IMessage<dummy> param, global::System.Threading.CancellationToken ct)
         {
             return m_connection.RequestResponseAsync<dummy, global::Bond.Void>(
-                "tests.Foo.foo24",
+                "tests.Foo",
+                "foo24",
                 param,
                 ct);
         }
@@ -142,7 +150,8 @@ namespace tests
         public global::System.Threading.Tasks.Task<global::Bond.Comm.IMessage<BasicTypes>> foo31Async(global::Bond.Comm.IMessage<global::Bond.Void> param, global::System.Threading.CancellationToken ct)
         {
             return m_connection.RequestResponseAsync<global::Bond.Void, BasicTypes>(
-                "tests.Foo.foo31",
+                "tests.Foo",
+                "foo31",
                 param,
                 ct);
         }
@@ -156,7 +165,8 @@ namespace tests
         public global::System.Threading.Tasks.Task<global::Bond.Comm.IMessage<BasicTypes>> foo32Async(global::Bond.Comm.IMessage<global::Bond.Void> param, global::System.Threading.CancellationToken ct)
         {
             return m_connection.RequestResponseAsync<global::Bond.Void, BasicTypes>(
-                "tests.Foo.foo32",
+                "tests.Foo",
+                "foo32",
                 param,
                 ct);
         }
@@ -170,7 +180,8 @@ namespace tests
         public global::System.Threading.Tasks.Task<global::Bond.Comm.IMessage<BasicTypes>> foo33Async(global::Bond.Comm.IMessage<BasicTypes> param, global::System.Threading.CancellationToken ct)
         {
             return m_connection.RequestResponseAsync<BasicTypes, BasicTypes>(
-                "tests.Foo.foo33",
+                "tests.Foo",
+                "foo33",
                 param,
                 ct);
         }
@@ -184,7 +195,8 @@ namespace tests
         public global::System.Threading.Tasks.Task<global::Bond.Comm.IMessage<BasicTypes>> foo34Async(global::Bond.Comm.IMessage<dummy> param, global::System.Threading.CancellationToken ct)
         {
             return m_connection.RequestResponseAsync<dummy, BasicTypes>(
-                "tests.Foo.foo34",
+                "tests.Foo",
+                "foo34",
                 param,
                 ct);
         }
@@ -198,7 +210,8 @@ namespace tests
         public global::System.Threading.Tasks.Task<global::Bond.Comm.IMessage<dummy>> foo41Async(global::Bond.Comm.IMessage<global::Bond.Void> param, global::System.Threading.CancellationToken ct)
         {
             return m_connection.RequestResponseAsync<global::Bond.Void, dummy>(
-                "tests.Foo.foo41",
+                "tests.Foo",
+                "foo41",
                 param,
                 ct);
         }
@@ -212,7 +225,8 @@ namespace tests
         public global::System.Threading.Tasks.Task<global::Bond.Comm.IMessage<dummy>> foo42Async(global::Bond.Comm.IMessage<global::Bond.Void> param, global::System.Threading.CancellationToken ct)
         {
             return m_connection.RequestResponseAsync<global::Bond.Void, dummy>(
-                "tests.Foo.foo42",
+                "tests.Foo",
+                "foo42",
                 param,
                 ct);
         }
@@ -226,7 +240,8 @@ namespace tests
         public global::System.Threading.Tasks.Task<global::Bond.Comm.IMessage<dummy>> foo43Async(global::Bond.Comm.IMessage<BasicTypes> param, global::System.Threading.CancellationToken ct)
         {
             return m_connection.RequestResponseAsync<BasicTypes, dummy>(
-                "tests.Foo.foo43",
+                "tests.Foo",
+                "foo43",
                 param,
                 ct);
         }
@@ -240,7 +255,8 @@ namespace tests
         public global::System.Threading.Tasks.Task<global::Bond.Comm.IMessage<dummy>> foo44Async(global::Bond.Comm.IMessage<dummy> param, global::System.Threading.CancellationToken ct)
         {
             return m_connection.RequestResponseAsync<dummy, dummy>(
-                "tests.Foo.foo44",
+                "tests.Foo",
+                "foo44",
                 param,
                 ct);
         }

--- a/cs/src/comm/epoxy-transport/EpoxyProtocol.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyProtocol.cs
@@ -471,9 +471,9 @@ namespace Bond.Comm.Epoxy
 
             switch (headers.message_type)
             {
-                case EpoxyMessageType.Request:
-                case EpoxyMessageType.Response:
-                case EpoxyMessageType.Event:
+                case EpoxyMessageType.REQUEST:
+                case EpoxyMessageType.RESPONSE:
+                case EpoxyMessageType.EVENT:
                     return ClassifyState.ValidFrame;
 
                 default:
@@ -493,15 +493,15 @@ namespace Bond.Comm.Epoxy
 
             switch (headers.message_type)
             {
-                case EpoxyMessageType.Request:
+                case EpoxyMessageType.REQUEST:
                     disposition = FrameDisposition.DeliverRequestToService;
                     return ClassifyState.ClassifiedValidFrame;
 
-                case EpoxyMessageType.Response:
+                case EpoxyMessageType.RESPONSE:
                     disposition = FrameDisposition.DeliverResponseToProxy;
                     return ClassifyState.ClassifiedValidFrame;
 
-                case EpoxyMessageType.Event:
+                case EpoxyMessageType.EVENT:
                     disposition = FrameDisposition.DeliverEventToService;
                     return ClassifyState.ClassifiedValidFrame;
 

--- a/cs/src/comm/epoxy-transport/ResponseMap.cs
+++ b/cs/src/comm/epoxy-transport/ResponseMap.cs
@@ -19,7 +19,7 @@ namespace Bond.Comm.Epoxy
         /// The <see cref="ErrorCode"/> that is used in the <see cref="Error"/>
         /// response when the ResponseMap has been shutdown.
         /// </summary>
-        public static readonly ErrorCode ShutDownErrorCode = ErrorCode.ConnectionShutDown;
+        public static readonly ErrorCode ShutDownErrorCode = ErrorCode.CONNECTION_SHUT_DOWN;
         const string ShutdownMessage = "Connection has already been shutdown";
 
         static readonly Lazy<IMessage>  alreadyShutdownResponse = new Lazy<IMessage>(InitAlreadyShutdownResponse, LazyThreadSafetyMode.PublicationOnly);

--- a/cs/src/comm/interfaces/Connections.cs
+++ b/cs/src/comm/interfaces/Connections.cs
@@ -18,9 +18,12 @@ namespace Bond.Comm
         /// </summary>
         /// <typeparam name="TRequest">The type of the request.</typeparam>
         /// <typeparam name="TResponse">The type of the response.</typeparam>
-        /// <param name="methodName">
-        /// The fully qualified name in the Bond namespace of the method to
+        /// <param name="serviceName">
+        /// The fully qualified name in the Bond namespace of the service to
         /// invoke.
+        /// </param>
+        /// <param name="methodName">
+        /// The name of the method to invoke within the indicated service.
         /// </param>
         /// <param name="message">The message to send.</param>
         /// <param name="ct">
@@ -30,7 +33,8 @@ namespace Bond.Comm
         /// A task that represents the result of invoking the method. This is
         /// usually the response to the method, but may be an error.
         /// </returns>
-        Task<IMessage<TResponse>> RequestResponseAsync<TRequest, TResponse>(string methodName, IMessage<TRequest> message, CancellationToken ct);
+        Task<IMessage<TResponse>> RequestResponseAsync<TRequest, TResponse>(string serviceName, string methodName,
+                                                                            IMessage<TRequest> message, CancellationToken ct);
     }
 
     /// <summary>
@@ -43,9 +47,12 @@ namespace Bond.Comm
         /// Starts an asynchronous operation to invoke an event method.
         /// </summary>
         /// <typeparam name="TPayload">The type of the event.</typeparam>
-        /// <param name="methodName">
-        /// The fully qualified name in the Bond namespace of the method to
+        /// <param name="serviceName">
+        /// The fully qualified name in the Bond namespace of the service to
         /// invoke.
+        /// </param>
+        /// <param name="methodName">
+        /// The name of the method to invoke within the indicated service.
         /// </param>
         /// <param name="message">The message to send.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
@@ -54,7 +61,7 @@ namespace Bond.Comm
         /// task may represent an error if there was a local error sending the
         /// message.
         /// </remarks>
-        Task FireEventAsync<TPayload>(string methodName, IMessage<TPayload> message);
+        Task FireEventAsync<TPayload>(string serviceName, string methodName, IMessage<TPayload> message);
     }
 
     /// <summary>

--- a/cs/src/comm/interfaces/Errors.cs
+++ b/cs/src/comm/interfaces/Errors.cs
@@ -44,8 +44,8 @@ namespace Bond.Comm
         {
             var internalServerError = new InternalServerError
             {
-                error_code = (int) ErrorCode.InternalServerError,
-                unique_id = uniqueId ?? "",
+                error_code = (int) ErrorCode.INTERNAL_SERVER_ERROR,
+                unique_id = uniqueId ?? string.Empty,
                 message = message ?? InternalErrorMessage
             };
 
@@ -68,8 +68,8 @@ namespace Bond.Comm
         {
             var internalServerError = new InternalServerError
             {
-                error_code = (int)ErrorCode.InternalServerError,
-                unique_id = uniqueId ?? ""
+                error_code = (int)ErrorCode.INTERNAL_SERVER_ERROR,
+                unique_id = uniqueId ?? string.Empty
             };
 
             if (includeDetails && exception != null)
@@ -82,7 +82,7 @@ namespace Bond.Comm
                 {
                     var aggregateError = new AggregateError
                     {
-                        error_code = (int) ErrorCode.MultipleErrorsOccured,
+                        error_code = (int) ErrorCode.MULTIPLE_ERRORS_OCCURRED,
                         message = "One or more errors occured",
                         inner_errors = new List<IBonded<Error>>(aggEx.InnerExceptions.Count)
                     };

--- a/cs/src/comm/interfaces/Listener.cs
+++ b/cs/src/comm/interfaces/Listener.cs
@@ -133,7 +133,7 @@ namespace Bond.Comm
         /// <remarks>
         /// After a service has been removed, the listener will cease directing
         /// messages to its methods and will respond with a
-        /// <see cref="ErrorCode.MethodNotFound"/> error.
+        /// <see cref="ErrorCode.METHOD_NOT_FOUND"/> error.
         /// </remarks>
         public abstract void RemoveService<T>(T service) where T : IService;
 

--- a/cs/src/comm/simpleinmem-transport/SimpleInMemTransport.bond
+++ b/cs/src/comm/simpleinmem-transport/SimpleInMemTransport.bond
@@ -5,14 +5,15 @@ namespace bond.comm.simpleinmem;
 
 enum SimpleInMemMessageType
 {
-    Request = 1;
-    Response = 2;
-    Event = 3;
+    REQUEST = 1;
+    RESPONSE = 2;
+    EVENT = 3;
 }
 
 struct SimpleInMemHeaders
 {
     0: uint64 conversation_id;
-    1: required SimpleInMemMessageType message_type = Request;
-    2: string method_name;
+    1: required SimpleInMemMessageType message_type = REQUEST;
+    2: string service_name;
+    3: string method_name;
 }

--- a/cs/test/comm/Epoxy/EpoxyConnectionTests.cs
+++ b/cs/test/comm/Epoxy/EpoxyConnectionTests.cs
@@ -23,7 +23,7 @@ namespace UnitTest.Epoxy
 
         private static readonly Error AnyDetails = new Error
         {
-            error_code = (int) ErrorCode.MethodNotFound,
+            error_code = (int) ErrorCode.METHOD_NOT_FOUND,
             message = "This is some error message"
         };
 
@@ -97,7 +97,7 @@ namespace UnitTest.Epoxy
             IMessage<SomePayload> anyPayload = Message.FromPayload(new SomePayload());
             Task<IMessage<SomePayload>> responseTask = connection
                 .RequestResponseAsync<SomePayload, SomePayload>(
-                    "TestService.NeverRespond", anyPayload, CancellationToken.None);
+                    "TestService", "NeverRespond", anyPayload, CancellationToken.None);
 
             await connection.StopAsync();
 
@@ -105,7 +105,7 @@ namespace UnitTest.Epoxy
 
             Assert.IsTrue(response.IsError);
             Error err = response.Error.Deserialize();
-            Assert.AreEqual((int)ErrorCode.ConnectionShutDown, err.error_code);
+            Assert.AreEqual((int)ErrorCode.CONNECTION_SHUT_DOWN, err.error_code);
         }
 
         class TestServiceNeverResponds : IService

--- a/cs/test/comm/Epoxy/EpoxyProtocolTests.cs
+++ b/cs/test/comm/Epoxy/EpoxyProtocolTests.cs
@@ -19,33 +19,38 @@ namespace UnitTest.Epoxy
     {
         private const uint GoodRequestId = 1;
         private const uint GoodResponseId = 1;
+        private const string GoodService = "MyService";
         private const string GoodMethod = "ShaveYaks";
         private const ProtocolErrorCode MeaninglessErrorCode = ProtocolErrorCode.GENERIC_ERROR;
         private static readonly IMessage<Dummy> meaninglessPayload = new Message<Dummy>(new Dummy());
-        private static readonly IMessage meaninglessError = Message.FromError(new InternalServerError() { error_code = (int)ErrorCode.InternalServerError, message = "Meaningless message"});
+        private static readonly IMessage meaninglessError = Message.FromError(new InternalServerError() { error_code = (int)ErrorCode.INTERNAL_SERVER_ERROR, message = "Meaningless message"});
         private static readonly ArraySegment<byte> emptyLayerData = new ArraySegment<byte>();
         private static ArraySegment<byte> goodLayerData;
 
         private static readonly EpoxyHeaders goodRequestHeaders = new EpoxyHeaders
         {
+            service_name = GoodService,
             method_name = GoodMethod,
-            message_type = EpoxyMessageType.Request,
+            message_type = EpoxyMessageType.REQUEST,
             conversation_id = GoodRequestId
         };
         private static readonly EpoxyHeaders goodResponseHeaders = new EpoxyHeaders
         {
+            service_name = GoodService,
             method_name = GoodMethod,
-            message_type = EpoxyMessageType.Response,
+            message_type = EpoxyMessageType.RESPONSE,
             conversation_id = GoodResponseId
         };
         private static readonly EpoxyHeaders goodEventHeaders = new EpoxyHeaders
         {
+            service_name = GoodService,
             method_name = GoodMethod,
-            message_type = EpoxyMessageType.Event,
+            message_type = EpoxyMessageType.EVENT,
             conversation_id = GoodRequestId
         };
         private static readonly EpoxyHeaders unknownTypeHeaders = new EpoxyHeaders
         {
+            service_name = GoodService,
             method_name = GoodMethod,
             message_type = (EpoxyMessageType)(-100),
             conversation_id = GoodRequestId
@@ -85,17 +90,17 @@ namespace UnitTest.Epoxy
 
             // Good frames, from which we can pull good framelets to build bad frames.
             goodRequestFrame = EpoxyConnection.MessageToFrame(
-                GoodRequestId, GoodMethod, EpoxyMessageType.Request, meaninglessPayload, null, LoggerTests.BlackHole);
+                GoodRequestId, GoodService, GoodMethod, EpoxyMessageType.REQUEST, meaninglessPayload, null, LoggerTests.BlackHole);
             goodRequestLayerDataFrame = EpoxyConnection.MessageToFrame(
-                GoodRequestId, GoodMethod, EpoxyMessageType.Request, meaninglessPayload, goodLayerObject, LoggerTests.BlackHole);
+                GoodRequestId, GoodService, GoodMethod, EpoxyMessageType.REQUEST, meaninglessPayload, goodLayerObject, LoggerTests.BlackHole);
 
             goodResponseFrame = EpoxyConnection.MessageToFrame(
-                GoodResponseId, GoodMethod, EpoxyMessageType.Response, meaninglessPayload, null, LoggerTests.BlackHole);
+                GoodResponseId, GoodService, GoodMethod, EpoxyMessageType.RESPONSE, meaninglessPayload, null, LoggerTests.BlackHole);
             goodErrorResponseFrame = EpoxyConnection.MessageToFrame(
-                GoodResponseId, GoodMethod, EpoxyMessageType.Response, meaninglessError, null, LoggerTests.BlackHole);
+                GoodResponseId, GoodService, GoodMethod, EpoxyMessageType.RESPONSE, meaninglessError, null, LoggerTests.BlackHole);
 
             goodEventFrame = EpoxyConnection.MessageToFrame(
-                GoodRequestId, GoodMethod, EpoxyMessageType.Event, meaninglessPayload, null, LoggerTests.BlackHole);
+                GoodRequestId, GoodService, GoodMethod, EpoxyMessageType.EVENT, meaninglessPayload, null, LoggerTests.BlackHole);
 
             configFrame = EpoxyConnection.MakeConfigFrame(LoggerTests.BlackHole);
             protocolErrorFrame = EpoxyConnection.MakeProtocolErrorFrame(MeaninglessErrorCode, null, LoggerTests.BlackHole);
@@ -196,8 +201,9 @@ namespace UnitTest.Epoxy
             Assert.AreEqual(EpoxyProtocol.ClassifyState.ExpectOptionalLayerData, after);
             Assert.NotNull(headers);
             Assert.AreEqual(GoodRequestId, headers.conversation_id);
+            Assert.AreEqual(GoodService, headers.service_name);
             Assert.AreEqual(GoodMethod, headers.method_name);
-            Assert.AreEqual(EpoxyMessageType.Request, headers.message_type);
+            Assert.AreEqual(EpoxyMessageType.REQUEST, headers.message_type);
             Assert.Null(errorCode);
 
             after = EpoxyProtocol.TransitionExpectEpoxyHeaders(
@@ -206,8 +212,9 @@ namespace UnitTest.Epoxy
             Assert.AreEqual(EpoxyProtocol.ClassifyState.ExpectOptionalLayerData, after);
             Assert.NotNull(headers);
             Assert.AreEqual(GoodRequestId, headers.conversation_id);
+            Assert.AreEqual(GoodService, headers.service_name);
             Assert.AreEqual(GoodMethod, headers.method_name);
-            Assert.AreEqual(EpoxyMessageType.Request, headers.message_type);
+            Assert.AreEqual(EpoxyMessageType.REQUEST, headers.message_type);
             Assert.Null(errorCode);
         }
 
@@ -549,6 +556,7 @@ namespace UnitTest.Epoxy
         {
             Assert.AreEqual(expected.conversation_id, actual.conversation_id);
             Assert.AreEqual(expected.message_type, actual.message_type);
+            Assert.AreEqual(expected.service_name, actual.service_name);
             Assert.AreEqual(expected.method_name, actual.method_name);
         }
 

--- a/cs/test/comm/Epoxy/EpoxyTestBase.cs
+++ b/cs/test/comm/Epoxy/EpoxyTestBase.cs
@@ -108,7 +108,7 @@ namespace UnitTest.Epoxy
             {
                 var error = new Error
                 {
-                    error_code = (int) ErrorCode.InternalServerError,
+                    error_code = (int) ErrorCode.INTERNAL_SERVER_ERROR,
                 };
 
                 return Task.FromResult<IMessage>(Message.FromError(error));

--- a/cs/test/comm/Epoxy/ResponseMapTests.cs
+++ b/cs/test/comm/Epoxy/ResponseMapTests.cs
@@ -67,7 +67,7 @@ namespace UnitTest.Epoxy
             IMessage response = await responseTask;
             Assert.IsTrue(response.IsError);
             Error err = response.Error.Deserialize();
-            Assert.AreEqual((int)ErrorCode.ConnectionShutDown, err.error_code);
+            Assert.AreEqual((int)ErrorCode.CONNECTION_SHUT_DOWN, err.error_code);
         }
 
         [Test]
@@ -84,7 +84,7 @@ namespace UnitTest.Epoxy
             var response = await responseTask;
             Assert.IsTrue(response.IsError);
             Error err = response.Error.Deserialize();
-            Assert.AreEqual((int)ErrorCode.ConnectionShutDown, err.error_code);
+            Assert.AreEqual((int)ErrorCode.CONNECTION_SHUT_DOWN, err.error_code);
         }
 
         [Test]

--- a/cs/test/comm/Interfaces/ErrorsTests.cs
+++ b/cs/test/comm/Interfaces/ErrorsTests.cs
@@ -17,7 +17,7 @@ namespace UnitTest.Interfaces
 
             InternalServerError error = Errors.MakeInternalServerError(ex, "some ID", includeDetails: false);
 
-            Assert.AreEqual((int)ErrorCode.InternalServerError, error.error_code);
+            Assert.AreEqual((int)ErrorCode.INTERNAL_SERVER_ERROR, error.error_code);
             Assert.IsNotEmpty(error.unique_id);
             Assert.That(error.message, Is.Not.StringContaining(ex.Message));
             Assert.IsEmpty(error.server_stack_trace);
@@ -28,7 +28,7 @@ namespace UnitTest.Interfaces
         public void MakeInternalServerError_NullExIncludeDetails_GenericErrorReturned()
         {
             InternalServerError error = Errors.MakeInternalServerError(exception: null, uniqueId: "some ID", includeDetails: true);
-            Assert.AreEqual((int)ErrorCode.InternalServerError, error.error_code);
+            Assert.AreEqual((int)ErrorCode.INTERNAL_SERVER_ERROR, error.error_code);
             Assert.IsNotEmpty(error.unique_id);
             Assert.IsNotEmpty(error.message);
             Assert.IsEmpty(error.server_stack_trace);
@@ -48,7 +48,7 @@ namespace UnitTest.Interfaces
             InternalServerError cleansedInternalError = cleansedError as InternalServerError;
             Assert.NotNull(cleansedInternalError);
 
-            Assert.AreEqual((int)ErrorCode.InternalServerError, cleansedInternalError.error_code);
+            Assert.AreEqual((int)ErrorCode.INTERNAL_SERVER_ERROR, cleansedInternalError.error_code);
             Assert.AreEqual(Errors.InternalErrorMessage, cleansedInternalError.message);
             Assert.IsNull(cleansedInternalError.inner_error);
             Assert.AreEqual(savedID, cleansedInternalError.unique_id);
@@ -58,11 +58,11 @@ namespace UnitTest.Interfaces
         [Test]
         public void CleanseInternalServerError_WithOtherError()
         {
-            Error error = new Error { error_code = (int)ErrorCode.TransportError, message = "message" };
+            Error error = new Error { error_code = (int)ErrorCode.TRANSPORT_ERROR, message = "message" };
 
             Error cleansedError = Errors.CleanseInternalServerError(error);
             Assert.NotNull(cleansedError);
-            Assert.AreEqual((int)ErrorCode.TransportError, cleansedError.error_code);
+            Assert.AreEqual((int)ErrorCode.TRANSPORT_ERROR, cleansedError.error_code);
             Assert.AreEqual("message", cleansedError.message);
         }
 
@@ -72,7 +72,7 @@ namespace UnitTest.Interfaces
             var ex = GenerateException(new Exception("this is some message", GenerateException<InvalidOperationException>()));
             InternalServerError error = Errors.MakeInternalServerError(ex, "some ID", includeDetails: true);
 
-            Assert.AreEqual((int)ErrorCode.InternalServerError, error.error_code);
+            Assert.AreEqual((int)ErrorCode.INTERNAL_SERVER_ERROR, error.error_code);
             Assert.IsNotEmpty(error.unique_id);
             Assert.That(error.message, Is.StringContaining(ex.Message));
             Assert.IsNotEmpty(error.server_stack_trace);
@@ -86,14 +86,14 @@ namespace UnitTest.Interfaces
             var aggEx = GenerateException(new AggregateException("this is some message", innerExceptions));
             InternalServerError error = Errors.MakeInternalServerError(aggEx, "some ID", includeDetails: true);
 
-            Assert.AreEqual((int)ErrorCode.InternalServerError, error.error_code);
+            Assert.AreEqual((int)ErrorCode.INTERNAL_SERVER_ERROR, error.error_code);
             Assert.IsNotEmpty(error.unique_id);
             Assert.That(error.message, Is.StringContaining(aggEx.Message));
             Assert.IsNotEmpty(error.server_stack_trace);
             Assert.IsNotNull(error.inner_error);
 
             var aggError = error.inner_error.Deserialize<AggregateError>();
-            Assert.AreEqual((int)ErrorCode.MultipleErrorsOccured, aggError.error_code);
+            Assert.AreEqual((int)ErrorCode.MULTIPLE_ERRORS_OCCURRED, aggError.error_code);
             Assert.That(aggError.message, Is.StringMatching("One or more errors occured"));
             Assert.AreEqual(2, aggError.inner_errors.Count);
         }

--- a/cs/test/comm/Layers/LayerStackTests.cs
+++ b/cs/test/comm/Layers/LayerStackTests.cs
@@ -44,7 +44,7 @@ namespace UnitTest.Layers
             Assert.IsNull(error);
 
             IBonded layerData;
-            error = stack.OnSend(MessageType.Request, sendContext, out layerData);
+            error = stack.OnSend(MessageType.REQUEST, sendContext, out layerData);
 
             Assert.IsNull(error);
             Assert.IsNotNull(layerData);
@@ -69,7 +69,7 @@ namespace UnitTest.Layers
             Error error = stackProvider.GetLayerStack(null, out stack);
             Assert.IsNull(error);
 
-            error = stack.OnReceive(MessageType.Request, receiveContext, CreateBondedTestData(initialReceiveValue));
+            error = stack.OnReceive(MessageType.REQUEST, receiveContext, CreateBondedTestData(initialReceiveValue));
 
             Assert.IsNull(error);
             Assert.AreEqual(2, testList.Count);
@@ -83,9 +83,9 @@ namespace UnitTest.Layers
             var stack = new LayerStack<Dummy>(LoggerTests.BlackHole, new TestLayer_AlwaysThrows());
 
             IBonded layerData;
-            Error error = stack.OnSend(MessageType.Request, sendContext, out layerData);
+            Error error = stack.OnSend(MessageType.REQUEST, sendContext, out layerData);
             Assert.IsNotNull(error);
-            Assert.AreEqual((int)ErrorCode.InternalServerError, error.error_code);
+            Assert.AreEqual((int)ErrorCode.INTERNAL_SERVER_ERROR, error.error_code);
         }
 
         [Test]
@@ -93,9 +93,9 @@ namespace UnitTest.Layers
         {
             var stack = new LayerStack<Dummy>(LoggerTests.BlackHole, new TestLayer_AlwaysThrows());
 
-            Error error = stack.OnReceive(MessageType.Request, receiveContext, CreateBondedTestData(initialReceiveValue));
+            Error error = stack.OnReceive(MessageType.REQUEST, receiveContext, CreateBondedTestData(initialReceiveValue));
             Assert.IsNotNull(error);
-            Assert.AreEqual((int)ErrorCode.InternalServerError, error.error_code);
+            Assert.AreEqual((int)ErrorCode.INTERNAL_SERVER_ERROR, error.error_code);
         }
 
         public void LayerStackProvider_BadCtorArguments_Throw()

--- a/cs/test/core/JsonParsingTests.cs
+++ b/cs/test/core/JsonParsingTests.cs
@@ -214,7 +214,7 @@ World", target._str);
 
             var target = ParseJson<BasicTypes>(json);
 
-            Assert.AreEqual(string.Empty, target._str);
+            Assert.IsEmpty(target._str);
             Assert.IsTrue(target._bool);
             Assert.AreEqual(13.2, target._double);
         }

--- a/cs/test/core/XmlTests.cs
+++ b/cs/test/core/XmlTests.cs
@@ -178,7 +178,7 @@ World</_str>
 
             var target = ParseXml<BasicTypes>(xml);
 
-            Assert.AreEqual(string.Empty, target._str);
+            Assert.IsEmpty(target._str);
             Assert.IsTrue(target._bool);
             Assert.AreEqual(13.2, target._double);
         }

--- a/doc/src/bond_comm_epoxy_wire.md
+++ b/doc/src/bond_comm_epoxy_wire.md
@@ -284,16 +284,17 @@ various messaging patterns.
 
     enum EpoxyMessageType
     {
-        Request = 1;
-        Response = 2;
-        Event = 3;
+        REQUEST = 1;
+        RESPONSE = 2;
+        EVENT = 3;
     }
 
     struct EpoxyHeaders
     {
         0: uint64 conversation_id;
         1: required EpoxyMessageType message_type;
-        2: string method_name;
+        2: string service_name;
+        3: string method_name;
     }
 
 ### Conversation ID ###
@@ -346,17 +347,24 @@ connection for over 580 years before exhausting its conversation IDs. In
 practice, the `CONVERSATION_IDS_EXHAUSTED` error should never be
 encountered.
 
+### Service name ###
+
+The `serice_name` field is the name of the service that is being invoked.
+
+The `service_name` field must be set to a UTF-8 encoded string (without a
+BOM) that is the fully-qualified service name. Namespace elements are separated
+by the period character ('.', ASCII 0x2E). May be empty string if the message
+type does not require a service name.
+
+Example: `root_namespace.child_namespace.some_service`
+
 ### Method name ###
 
-The `method_name` field is the name of the service and it's method being
-invoked.
+The `method_name` field is the name of the method on the service that is being
+invoked. It is also a UTF-8 encoded string (without a BOM). May be empty string
+if the message type does not require a method name.
 
-The `method_name` field must be set to a UTF-8 encoded string (without a
-BOM) that is the concatenation of the fully-qualified service name with the
-method name. Namespace elements are separated by the period character ('.',
-ASCII 0x2E), as is the service name from the method name.
-
-Example: `root_namespace.child_namespace.some_service.some_method`
+Example: `SomeMethod`
 
 ### Message type ###
 

--- a/doc/src/bond_comm_epoxy_wire.md
+++ b/doc/src/bond_comm_epoxy_wire.md
@@ -349,20 +349,22 @@ encountered.
 
 ### Service name ###
 
-The `serice_name` field is the name of the service that is being invoked.
+The `service_name` field is the name of the service that is being invoked.
 
 The `service_name` field must be set to a UTF-8 encoded string (without a
-BOM) that is the fully-qualified service name. Namespace elements are separated
-by the period character ('.', ASCII 0x2E). May be empty string if the message
-type does not require a service name.
+BOM) that is the fully-qualified service name. Namespace elements are
+separated by the period character ('.', ASCII 0x2E). May be the empty string
+if the message type does not require a service name.
 
 Example: `root_namespace.child_namespace.some_service`
 
 ### Method name ###
 
-The `method_name` field is the name of the method on the service that is being
-invoked. It is also a UTF-8 encoded string (without a BOM). May be empty string
-if the message type does not require a method name.
+The `method_name` field is the name of the method on the service that is
+being invoked.
+
+It is also a UTF-8 encoded string (without a BOM). May be the
+empty string if the message type does not require a method name.
 
 Example: `SomeMethod`
 

--- a/examples/cs/comm/metrics/ConsoleMetricsSink.cs
+++ b/examples/cs/comm/metrics/ConsoleMetricsSink.cs
@@ -24,6 +24,7 @@ namespace Bond.Examples.Metrics
             sb.Append($"\trequest ID: {metrics.request_id}\n");
             sb.Append($"\tconnection ID: {metrics.connection_id}\n");
             sb.Append($"\tendpoints: {metrics.local_endpoint} <-> {metrics.remote_endpoint}\n");
+            sb.Append($"\tservice: {metrics.service_name}\n");
             sb.Append($"\tmethod: {metrics.method_name}\n");
             sb.Append($"\ttotal millis: {metrics.total_time_millis}\n");
             sb.Append($"\tservice millis: {metrics.service_method_time_millis}\n");

--- a/idl/bond/comm/comm.bond
+++ b/idl/bond/comm/comm.bond
@@ -5,30 +5,30 @@ namespace bond.comm;
 
 enum MessageType
 {
-    Request = 0;
-    Response = 1;
-    Event = 2;
+    REQUEST = 0;
+    RESPONSE = 1;
+    EVENT = 2;
 }
 
 enum ErrorCode
 {
-    InternalServerError = 0xA0BD0000; // Error is an InternalServerError
-    MethodNotFound = 0xA0BD0001;
-    InvalidInvocation = 0xA0BD0002;
-    TransportError = 0xA0BD0003;
-    ConnectionShutDown = 0xA0BD0004;
-    MultipleErrorsOccured = 0xA0BD0005; // Error is an AggregateError
+    INTERNAL_SERVER_ERROR = 0xA0BD0000; // Error is an InternalServerError
+    METHOD_NOT_FOUND = 0xA0BD0001;
+    INVALID_INVOCATION = 0xA0BD0002;
+    TRANSPORT_ERROR = 0xA0BD0003;
+    CONNECTION_SHUT_DOWN = 0xA0BD0004;
+    MULTIPLE_ERRORS_OCCURRED = 0xA0BD0005; // Error is an AggregateError
 }
 
 enum ConnectionShutdownReason
 {
-    Unknown = 0x0;
-    ClientGraceful = 0x1;
-    ServerGraceful = 0x2;
-    ClientProtocolError = 0x3;
-    BondInternalError = 0x4;
-    ServiceInternalError = 0x5;
-    NetworkError = 0x6;
+    UNKNOWN= 0x0;
+    CLIENT_GRACEFUL = 0x1;
+    SERVER_GRACEFUL = 0x2;
+    CLIENT_PROTOCOL_ERROR = 0x3;
+    BOND_INTERNAL_ERROR = 0x4;
+    SERVICE_INTERNAL_ERROR = 0x5;
+    NETWORK_ERROR = 0x6;
 }
 
 struct Error
@@ -54,7 +54,7 @@ struct ConnectionMetrics
     0: string connection_id;
     1: string local_endpoint;
     2: string remote_endpoint;
-    3: ConnectionShutdownReason shutdown_reason = Unknown;
+    3: ConnectionShutdownReason shutdown_reason = UNKNOWN;
     4: double duration_millis;
 }
 
@@ -62,10 +62,11 @@ struct RequestMetrics
 {
     0: string request_id;
     1: string connection_id;
-    2: string method_name;
-    3: string local_endpoint;
-    4: string remote_endpoint;
-    5: nullable<InternalServerError> error;
-    6: double total_time_millis;
-    7: double service_method_time_millis;
+    2: string service_name;
+    3: string method_name;
+    4: string local_endpoint;
+    5: string remote_endpoint;
+    6: nullable<InternalServerError> error;
+    7: double total_time_millis;
+    8: double service_method_time_millis;
 }

--- a/idl/bond/comm/epoxy_transport.bond
+++ b/idl/bond/comm/epoxy_transport.bond
@@ -11,16 +11,17 @@ struct EpoxyConfig
 
 enum EpoxyMessageType
 {
-    Request = 1;
-    Response = 2;
-    Event = 3;
+    REQUEST = 1;
+    RESPONSE = 2;
+    EVENT = 3;
 }
 
 struct EpoxyHeaders
 {
     0: uint64 conversation_id;
-    1: required EpoxyMessageType message_type = Request;
-    2: string method_name;
+    1: required EpoxyMessageType message_type = REQUEST;
+    2: string service_name;
+    3: string method_name;
 }
 
 enum ProtocolErrorCode


### PR DESCRIPTION
Conform to predominant IDL naming convention. Also pass service and method
names as separate strings. Minor fixups on empty string usage in C#.