### PR TITLE
CMake improvements for stand-alone builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,20 +3,6 @@ project (bond)
 
 cmake_policy (SET CMP0022 NEW)
 
-set(BOND_GBC_PATH
-    CACHE
-    FILEPATH
-    "Optional path to the gbc executable to use. If set, this gbc will be used when generating code from .bond files. If not set, then gbc will be built (and the Haskell toolchain will need to be present on the machine) and the gbc tests will be run.")
-
-if (BOND_GBC_PATH)
-    if(EXISTS ${BOND_GBC_PATH})
-        set (GBC_EXECUTABLE ${BOND_GBC_PATH})
-        MESSAGE (STATUS "GBC Executable found: " ${GBC_EXECUTABLE})
-    else()
-        MESSAGE (FATAL_ERROR "GBC Executable defined by BOND_GBC_PATH does not exists at " ${BOND_GBC_PATH})
-    endif()
-endif()
-
 set (CMAKE_MODULE_PATH
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake
     ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/cmake-modules)
@@ -39,16 +25,13 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -C ${CMAKE_CFG_INTDIR} --
 
 if (NOT BOND_GBC_PATH)
     add_subfolder (compiler "compiler")
+    add_dependencies (check gbc-tests)
 endif()
 
 add_subdirectory (cpp)
 add_subfolder (doc "doc")
 add_python_subdirectory (python)
 add_subdirectory (examples)
-
-if (NOT BOND_GBC_PATH)
-    add_dependencies (check gbc-tests)
-endif()
 
 install (DIRECTORY
     cpp/inc/bond
@@ -61,7 +44,7 @@ install (EXPORT bond
     DESTINATION lib/bond
     EXPORT_LINK_INTERFACE_LIBRARIES)
 
-# if BOND_GBC_PATH is set we must copy over the gbc.exe to the install location
+# if BOND_GBC_PATH is set we must copy over that gbc to the install location
 if (BOND_GBC_PATH)
     install (FILES
         ${BOND_GBC_PATH}

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -1,5 +1,20 @@
 include (Compiler)
 
+set (BOND_GBC_PATH_DESCRIPTION
+     "Optional path to the gbc executable to use. If set, this gbc will be used when generating code from .bond files. If not set, then gbc will be built (and the Haskell toolchain will need to be present on the machine) and the gbc tests will be run.")
+
+find_program (BOND_GBC_PATH "gbc"
+    HINTS ENV BOND_GBC_PATH
+    DOC ${BOND_GBC_PATH_DESCRIPTION}
+    # We don't really want to pull gbc from the system path. If someone
+    # wants to do that, they'll need to set BOND_GBC_PATH instead.
+    NO_SYSTEM_ENVIRONMENT_PATH)
+
+if (BOND_GBC_PATH)
+    set (GBC_EXECUTABLE ${BOND_GBC_PATH})
+    message (STATUS "Existing GBC executable found: '${GBC_EXECUTABLE}'")
+endif()
+
 if (MSVC)
     # disable MSVC warnings
     add_compile_options (/bigobj /FIbond/core/warning.h /W4 /WX)
@@ -41,7 +56,7 @@ find_package (Boost 1.53.0
 
 message(STATUS "Boost Python Library: ${Boost_PYTHON_LIBRARY}")
 
-# Make sure AppVeyor CI runs fail when unit test dependencies are not found 
+# Make sure AppVeyor CI runs fail when unit test dependencies are not found
 if (DEFINED ENV{APPVEYOR} AND ("$ENV{BOND_BUILD}" STREQUAL "C++"))
     if (NOT Boost_UNIT_TEST_FRAMEWORK_FOUND)
         message(FATAL_ERROR "Boost unit_test_framework not found")
@@ -70,4 +85,3 @@ include_directories (
     ${BOND_GENERATED}
     ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/rapidjson/include)
-

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -85,3 +85,7 @@ include_directories (
     ${BOND_GENERATED}
     ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/rapidjson/include)
+
+set (BOND_LIBRARIES_ONLY
+    "FALSE"
+    CACHE BOOL "If TRUE, then only build the Bond library files, skipping any tools. gbc will still be built if it cannot be found, however, as gbc is needed to build the libraries.")

--- a/examples/cpp/core/bf/CMakeLists.txt
+++ b/examples/cpp/core/bf/CMakeLists.txt
@@ -1,10 +1,18 @@
-add_bond_executable (bf cmd_arg.bond main.cpp)
+if (BOND_LIBRARIES_ONLY)
+  set (bf_EXCLUDE "EXCLUDE_FROM_ALL")
+else ()
+  set (bf_EXCLUDE "")
+endif ()
+
+add_bond_executable (bf ${bf_EXCLUDE} cmd_arg.bond main.cpp)
+target_use_cxx11 (bf)
+
+if (NOT BOND_LIBRARIES_ONLY)
+  # bf was excluded from the all target, so it cannot be installed
+  install (TARGETS bf DESTINATION bin)
+endif()
 
 add_dependencies (check bf)
-
-install (TARGETS bf DESTINATION bin)
-
-target_use_cxx11 (bf)
 
 add_test (
     NAME bf


### PR DESCRIPTION
Improves the Bond CMake build to make it easier to build the minimum amount needed to consume Bond in a C++ project.
* Improve logic to locate a pre-compiled gbc
* Add ability to request that just the libraries be built and no additional tools (like bf)