### PR TITLE
Bring C++ and C# serialization examples in sync

### DIFF
--- a/examples/cpp/core/serialization/serialization.cpp
+++ b/examples/cpp/core/serialization/serialization.cpp
@@ -8,38 +8,39 @@ using namespace examples::serialization;
 
 int main()
 {
-    Struct obj, obj2;
+    Struct obj;
 
     obj.n = 0x1000;
     obj.str = "test";
     obj.items.push_back(3.14);
     obj.items.push_back(0);
 
-    // bond::OutputBuffer implements Bond output stream interface on top of
+    // bond::OutputBuffer implements the Bond output stream interface on top of
     // a series of memory buffers.
     bond::OutputBuffer output;
-    
-    // Use Compact Binary protocol for encoding; the data will be written to
+
+    // Use the Compact Binary protocol for encoding; the data will be written to
     // the OutputBuffer which will allocate memory as needed.
     bond::CompactBinaryWriter<bond::OutputBuffer> writer(output);
 
     // Serialize the object
     Serialize(obj, writer);
 
-    // At this point the OutputBuffer contains serialized representation of the
-    // object.  Depending on the size, serialized data may be spread across one
-    // or more memory blocks. Application can get all these blocks using
-    // GetBuffers method, or merge them into a single block using GetBuffer
-    // method.
+    // At this point the OutputBuffer contains a serialized representation of
+    // the object. Depending on the size, the serialized data may be spread
+    // across one or more memory blocks. Applications can get all these blocks
+    // using the GetBuffers method, or merge them into a single block using
+    // GetBuffer method.
     bond::blob data = output.GetBuffer();
 
-    // Use Compact Binary protocol for decoding (the same protocol that was used
-    // for encoding) and InputBuffer which implements input stream interface on
-    // top of a memory blob.
+    // Use the Compact Binary protocol for decoding (the same protocol that was
+    // used for encoding) and InputBuffer which implements the input stream
+    // interface on top of a memory blob.
     bond::CompactBinaryReader<bond::InputBuffer> reader(data);
-    
+
     // De-serialize the object
+    Struct obj2;
     Deserialize(reader, obj2);
 
-    return 0;    
+    return 0;
 }

--- a/examples/cs/core/serialization/program.cs
+++ b/examples/cs/core/serialization/program.cs
@@ -1,33 +1,48 @@
 ﻿namespace Examples
 {
+    using System.Collections.Generic;
     using System.Diagnostics;
     using Bond;
     using Bond.Protocols;
     using Bond.IO.Unsafe;
 
+    using examples.serialization;
+
     static class Program
     {
         static void Main()
         {
-            var src = new Example
+            var obj = new Struct
             {
-                Name = "FooBar",
-                Constants = {  3.14, 6.28 }
+                n = 0x1000,
+                str = "test",
+                items = new List<double> { 3.14, 0}
             };
 
+            // OutputBuffer implements the Bond output stream interface on top
+            // of a memory buffer.
             var output = new OutputBuffer();
+            // Use the Compact Binary protocol for encoding; the data will be
+            // written to the OutputBuffer which will allocate memory as needed.
             var writer = new CompactBinaryWriter<OutputBuffer>(output);
 
             // The first calls to Serialize.To and Deserialize<T>.From can take
-            // a relatively long time because they generate the de/serializer 
-            // for a given type and protocol.
-            Serialize.To(writer, src);
+            // a relatively long time because they generate the
+            // serializer/deserializer for a given type, protocol, and stream.
+            // See the serializer example for a way to control this.
+            Serialize.To(writer, obj);
 
+            // At this point the OutputBuffer contains a serialized
+            // representation of the object.
+
+            // Use the Compact Binary protocol for decoding (the same protocol
+            // that was used for encoding) and InputBuffer which implements the
+            // input stream interface on top of a memory blob.
             var input = new InputBuffer(output.Data);
             var reader = new CompactBinaryReader<InputBuffer>(input);
 
-            var dst = Deserialize<Example>.From(reader);
-            Debug.Assert(Comparer.Equal(src, dst));
+            var obj2 = Deserialize<Struct>.From(reader);
+            Debug.Assert(Comparer.Equal(obj, obj2));
         }
     }
 }

--- a/examples/cs/core/serialization/schema.bond
+++ b/examples/cs/core/serialization/schema.bond
@@ -1,7 +1,8 @@
-﻿namespace Examples
+﻿namespace examples.serialization
 
-struct Example
+struct Struct
 {
-    0: string Name;
-    1: vector<double> Constants;
+    0: uint32          n;
+    1: string          str;
+    2: vector<double>  items;
 }

--- a/examples/cs/core/serialization/serialization.csproj
+++ b/examples/cs/core/serialization/serialization.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\..\..\cs\build\nuget\Bond.CSharp.props" />
@@ -27,7 +27,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-  </PropertyGroup>   
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -47,13 +47,13 @@
   <ItemGroup>
     <Reference Include="Attributes">
       <HintPath>$(BOND_BINARY_PATH)\net45\Bond.Attributes.dll</HintPath>
-    </Reference>    
+    </Reference>
     <Reference Include="Bond">
       <HintPath>$(BOND_BINARY_PATH)\net45\Bond.dll</HintPath>
-    </Reference>    
+    </Reference>
     <Reference Include="Bond.IO">
       <HintPath>$(BOND_BINARY_PATH)\net45\Bond.IO.dll</HintPath>
-    </Reference>    
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(BOND_PATH)\build\nuget\Bond.CSharp.targets" />


### PR DESCRIPTION
Both examples now use the same schema and populate the object with the same
values.