### PR TITLE
[C# Comm] Remove logger from LayerStackProvider

### DIFF
--- a/cs/src/comm/epoxy-transport/EpoxyTransport.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyTransport.cs
@@ -156,7 +156,7 @@ namespace Bond.Comm.Epoxy
         {
             if (layerStackProvider != null)
             {
-                return layerStackProvider.GetLayerStack(uniqueId, out stack);
+                return layerStackProvider.GetLayerStack(uniqueId, out stack, logger);
             }
             else
             {

--- a/cs/src/comm/interfaces/ILayer.cs
+++ b/cs/src/comm/interfaces/ILayer.cs
@@ -19,6 +19,7 @@ namespace Bond.Comm
         /// <summary>
         /// Take action on sending of a message.
         /// </summary>
+        /// <param name="logger">The logger</param>
         /// <param name="messageType">The type of message</param>
         /// <param name="context">The send context</param>
         /// <param name="layerData">The layer data for this layer</param>
@@ -28,11 +29,12 @@ namespace Bond.Comm
         /// If this method throws, the exception will be caught and converted into an error.
         /// Errors returned from layers for request-response methods will replace the response.
         /// </remarks>
-        Error OnSend(MessageType messageType, SendContext context, TLayerData layerData);
+        Error OnSend(Logger logger, MessageType messageType, SendContext context, TLayerData layerData);
 
         /// <summary>
         /// Take action on receipt of a message.
         /// </summary>
+        /// <param name="logger">The logger</param>
         /// <param name="messageType">The type of message</param>
         /// <param name="context">The receive context</param>
         /// <param name="layerData">The layer data for this layer</param>
@@ -42,7 +44,7 @@ namespace Bond.Comm
         /// If this method throws, the exception will be caught and converted into an error.
         /// Errors returned from layers for request-response methods will replace the response.
         /// </remarks>
-        Error OnReceive(MessageType messageType, ReceiveContext context, TLayerData layerData);
+        Error OnReceive(Logger logger, MessageType messageType, ReceiveContext context, TLayerData layerData);
     }
 
     /// <summary>

--- a/cs/src/comm/interfaces/ILayer.cs
+++ b/cs/src/comm/interfaces/ILayer.cs
@@ -19,32 +19,32 @@ namespace Bond.Comm
         /// <summary>
         /// Take action on sending of a message.
         /// </summary>
-        /// <param name="logger">The logger</param>
         /// <param name="messageType">The type of message</param>
         /// <param name="context">The send context</param>
         /// <param name="layerData">The layer data for this layer</param>
+        /// <param name="logger">The logger</param>
         /// <returns>An error if something went wrong; null otherwise </returns>
         /// <remarks>
         /// Layers may not interact with the message payload itself so it is not provided.
         /// If this method throws, the exception will be caught and converted into an error.
         /// Errors returned from layers for request-response methods will replace the response.
         /// </remarks>
-        Error OnSend(Logger logger, MessageType messageType, SendContext context, TLayerData layerData);
+        Error OnSend(MessageType messageType, SendContext context, TLayerData layerData, Logger logger);
 
         /// <summary>
         /// Take action on receipt of a message.
         /// </summary>
-        /// <param name="logger">The logger</param>
         /// <param name="messageType">The type of message</param>
         /// <param name="context">The receive context</param>
         /// <param name="layerData">The layer data for this layer</param>
+        /// <param name="logger">The logger</param>
         /// <returns>An error if something went wrong; null otherwise </returns>
         /// <remarks>
         /// Layers may not interact with the message payload itself so it is not provided.
         /// If this method throws, the exception will be caught and converted into an error.
         /// Errors returned from layers for request-response methods will replace the response.
         /// </remarks>
-        Error OnReceive(Logger logger, MessageType messageType, ReceiveContext context, TLayerData layerData);
+        Error OnReceive(MessageType messageType, ReceiveContext context, TLayerData layerData, Logger logger);
     }
 
     /// <summary>

--- a/cs/src/comm/interfaces/ILayerStack.cs
+++ b/cs/src/comm/interfaces/ILayerStack.cs
@@ -15,11 +15,12 @@ namespace Bond.Comm
         /// <param name="messageType">The type of message</param>
         /// <param name="context">The send context. May not be null.</param>
         /// <param name="layerData">The layer data for this layer, provided as an instance in an <see cref="IBonded"/> ready to be serialized</param>
+        /// <param name="logger">The logger</param>
         /// <returns>An error, or null if there is no error.</returns>
         /// <remarks>
         /// In general, the layer is not expected to interact with the message payload itself.
         /// </remarks>
-        Error OnSend(MessageType messageType, SendContext context, out IBonded layerData);
+        Error OnSend(MessageType messageType, SendContext context, out IBonded layerData, Logger logger);
 
         /// <summary>
         /// Take action on receipt of a message, by invoking a stack of layers (in reverse order).
@@ -27,11 +28,12 @@ namespace Bond.Comm
         /// <param name="messageType">The type of message</param>
         /// <param name="context">The receive context. May not be null.</param>
         /// <param name="layerData">The layer data for this layer, provided as an <see cref="IBonded"/> to be deserialized</param>
+        /// <param name="logger">The logger</param>
         /// <returns>An error, or null if there is no error.</returns>
         /// <remarks>
         /// In general, the layer is not expected to interact with the message payload itself.
         /// </remarks>
-        Error OnReceive(MessageType messageType, ReceiveContext context, IBonded layerData);
+        Error OnReceive(MessageType messageType, ReceiveContext context, IBonded layerData, Logger logger);
     }
 
     /// <summary>
@@ -48,7 +50,8 @@ namespace Bond.Comm
         /// <param name="uniqueId">A unique ID identifying the request or connection that triggered this call. Used in
         /// layer-originated errors.</param>
         /// <param name="stack">The layer stack instance. May be null if an error occurred.</param>
+        /// <param name="logger">The logger</param>
         /// <returns>An error, or null if there is no error.</returns>
-        Error GetLayerStack(string uniqueId, out ILayerStack stack);
+        Error GetLayerStack(string uniqueId, out ILayerStack stack, Logger logger);
     }
 }

--- a/cs/src/comm/layers/LayerStack.cs
+++ b/cs/src/comm/layers/LayerStack.cs
@@ -79,7 +79,7 @@ namespace Bond.Comm.Layers
             {
                 try
                 {
-                    error = layers[layerIndex].OnSend(logger, messageType, context, layerData);
+                    error = layers[layerIndex].OnSend(messageType, context, layerData, logger);
                 }
                 catch (Exception ex)
                 {
@@ -100,7 +100,7 @@ namespace Bond.Comm.Layers
             {
                 try
                 {
-                    error = layers[layerIndex].OnReceive(logger, messageType, context, layerData);
+                    error = layers[layerIndex].OnReceive(messageType, context, layerData, logger);
                 }
                 catch (Exception ex)
                 {

--- a/cs/src/comm/layers/LayerStack.cs
+++ b/cs/src/comm/layers/LayerStack.cs
@@ -6,6 +6,7 @@ namespace Bond.Comm.Layers
     using System;
     using System.Diagnostics;
     using System.Linq;
+    using System.Threading;
 
     /// <summary>
     /// Concrete layer stack implementation. The layer stack encapsulates
@@ -19,14 +20,12 @@ namespace Bond.Comm.Layers
     public class LayerStack<TLayerData> : ILayerStack where TLayerData : class, new()
     {
         readonly ILayer<TLayerData>[] layers;
-        readonly Logger logger;
 
         /// <summary>
         /// Construct a layer stack instance from a set of layers.
         /// </summary>
-        /// <param name="logger"></param>
         /// <param name="layers">Layers for this stack. Must be at least one and all must not be null.</param>
-        public LayerStack(Logger logger, params ILayer<TLayerData>[] layers)
+        public LayerStack(params ILayer<TLayerData>[] layers)
         {
             if ((layers == null) || (layers.Length == 0)) { throw new ArgumentException("At least one layer must be provided"); }
 
@@ -39,15 +38,14 @@ namespace Bond.Comm.Layers
             }
 
             this.layers = layers;
-            this.logger = logger;
         }
 
-        public Error OnSend(MessageType messageType, SendContext context, out IBonded layerData)
+        public Error OnSend(MessageType messageType, SendContext context, out IBonded layerData, Logger logger)
         {
             if (context == null) { throw new ArgumentNullException(nameof(context)); }
 
             var realLayerData = new TLayerData();
-            var error = OnSendImpl(messageType, context, realLayerData);
+            var error = OnSendImpl(messageType, context, realLayerData, logger);
             layerData = (error == null
                             ? (IBonded<TLayerData>)new Bonded<TLayerData>(realLayerData)
                             : null);
@@ -56,23 +54,23 @@ namespace Bond.Comm.Layers
             return error;
         }
 
-        public Error OnReceive(MessageType messageType, ReceiveContext context, IBonded layerData)
+        public Error OnReceive(MessageType messageType, ReceiveContext context, IBonded layerData, Logger logger)
         {
             if (context == null) { throw new ArgumentNullException(nameof(context)); }
 
             TLayerData realLayerData;
-            Error error = DeserializeLayerData(layerData, context.RequestMetrics.request_id, out realLayerData);
+            Error error = DeserializeLayerData(layerData, context.RequestMetrics.request_id, out realLayerData, logger);
 
             if (error == null)
             {
                 Debug.Assert(realLayerData != null);
-                error = OnReceiveImpl(messageType, context, realLayerData);
+                error = OnReceiveImpl(messageType, context, realLayerData, logger);
             }
 
             return error;
         }
 
-        private Error OnSendImpl(MessageType messageType, SendContext context, TLayerData layerData)
+        private Error OnSendImpl(MessageType messageType, SendContext context, TLayerData layerData, Logger logger)
         {
             Error error = null;
 
@@ -81,7 +79,7 @@ namespace Bond.Comm.Layers
             {
                 try
                 {
-                    error = layers[layerIndex].OnSend(messageType, context, layerData);
+                    error = layers[layerIndex].OnSend(logger, messageType, context, layerData);
                 }
                 catch (Exception ex)
                 {
@@ -93,7 +91,7 @@ namespace Bond.Comm.Layers
             return error;
         }
 
-        private Error OnReceiveImpl(MessageType messageType, ReceiveContext context, TLayerData layerData)
+        private Error OnReceiveImpl(MessageType messageType, ReceiveContext context, TLayerData layerData, Logger logger)
         {
             Error error = null;
 
@@ -102,7 +100,7 @@ namespace Bond.Comm.Layers
             {
                 try
                 {
-                    error = layers[layerIndex].OnReceive(messageType, context, layerData);
+                    error = layers[layerIndex].OnReceive(logger, messageType, context, layerData);
                 }
                 catch (Exception ex)
                 {
@@ -114,7 +112,7 @@ namespace Bond.Comm.Layers
             return error;
         }
 
-        private Error DeserializeLayerData(IBonded layerData, string uniqueId, out TLayerData realLayerData)
+        private Error DeserializeLayerData(IBonded layerData, string uniqueId, out TLayerData realLayerData, Logger logger)
         {
             Error error = null;
             if (layerData == null)
@@ -149,15 +147,13 @@ namespace Bond.Comm.Layers
     public class LayerStackProvider<TLayerData> : ILayerStackProvider where TLayerData : class, new()
     {
         readonly ILayerProvider<TLayerData>[] layerProviders;
-        readonly LayerStack<TLayerData> cachedLayerStack;
-        readonly Logger logger;
+        readonly Lazy<LayerStack<TLayerData>> cachedLayerStack;
 
         /// <summary>
         /// Construct a layer stack provider from a set of layer providers.
         /// </summary>
-        /// <param name="logger"></param>
         /// <param name="layerProviders">Layer providers for this stack provider. Must be at least one and all must not be null.</param>
-        public LayerStackProvider(Logger logger, params ILayerProvider<TLayerData>[] layerProviders)
+        public LayerStackProvider(params ILayerProvider<TLayerData>[] layerProviders)
         {
             if ((layerProviders == null) || (layerProviders.Length == 0))
             {
@@ -179,24 +175,27 @@ namespace Bond.Comm.Layers
                 layers[i] = layerProviders[i].GetLayer();
             }
 
-            bool stateless = layers.All(layer => layer is IStatelessLayer<TLayerData>);
-            if (stateless)
+            cachedLayerStack = new Lazy<LayerStack<TLayerData>>(() =>
             {
-                cachedLayerStack = new LayerStack<TLayerData>(logger, layers);
-            }
-
-            this.logger = logger;
+                bool stateless = layers.All(layer => layer is IStatelessLayer<TLayerData>);
+                if (stateless)
+                {
+                    return new LayerStack<TLayerData>(layers);
+                }
+                else
+                {
+                    return null;
+                }
+            }, LazyThreadSafetyMode.ExecutionAndPublication);
         }
 
-        public Error GetLayerStack(string uniqueId, out ILayerStack stack)
+        public Error GetLayerStack(string uniqueId, out ILayerStack stack, Logger logger)
         {
             Error error = null;
 
-            if (cachedLayerStack != null)
-            {
-                stack = cachedLayerStack;
-            }
-            else
+            stack = cachedLayerStack.Value;
+
+            if (stack == null)
             {
                 var layers = new ILayer<TLayerData>[layerProviders.Length];
                 for (int i = 0; i < layerProviders.Length; i++)
@@ -221,7 +220,7 @@ namespace Bond.Comm.Layers
                     }
                 }
 
-                stack = error == null ? new LayerStack<TLayerData>(logger, layers) : null;
+                stack = error == null ? new LayerStack<TLayerData>(layers) : null;
             }
 
             return error;

--- a/cs/src/comm/layers/LayerStackUtils.cs
+++ b/cs/src/comm/layers/LayerStackUtils.cs
@@ -17,7 +17,7 @@ namespace Bond.Comm.Layers
 
             if (layerStack != null)
             {
-                error = layerStack.OnSend(messageType, sendContext, out layerData);
+                error = layerStack.OnSend(messageType, sendContext, out layerData, logger);
                 if (error != null)
                 {
                     logger.Site().Warning("Layer error occurred sending message of type {0} (Code: {1} Message: {2}).",
@@ -40,7 +40,7 @@ namespace Bond.Comm.Layers
                     logger.Site().Warning("Layer stack present but no layer data received.");
                 }
 
-                error = layerStack.OnReceive(messageType, receiveContext, layerData);
+                error = layerStack.OnReceive(messageType, receiveContext, layerData, logger);
 
                 if (error != null)
                 {

--- a/cs/src/comm/simpleinmem-transport/SimpleInMemTransport.cs
+++ b/cs/src/comm/simpleinmem-transport/SimpleInMemTransport.cs
@@ -36,7 +36,7 @@ namespace Bond.Comm.SimpleInMem
         {
             if (layerStackProvider != null)
             {
-                return layerStackProvider.GetLayerStack(uniqueId, out stack);
+                return layerStackProvider.GetLayerStack(uniqueId, out stack, logger);
             }
             else
             {

--- a/cs/test/comm/Epoxy/EpoxyTransportTests.cs
+++ b/cs/test/comm/Epoxy/EpoxyTransportTests.cs
@@ -309,7 +309,7 @@ namespace UnitTest.Epoxy
         [Test]
         public async Task GeneratedService_GeneratedProxy_PayloadResponse_LayerData()
         {
-            var layerStackProvider = new LayerStackProvider<Dummy>(LoggerTests.BlackHole, new TestLayer_CheckPassedValue(1234));
+            var layerStackProvider = new LayerStackProvider<Dummy>(new TestLayer_CheckPassedValue(1234));
             TestClientServer<DummyTestService> testClientServer = await SetupTestClientServer<DummyTestService>(layerStackProvider, layerStackProvider);
             var proxy = new DummyTestProxy<EpoxyConnection>(testClientServer.ClientConnection);
 
@@ -324,7 +324,7 @@ namespace UnitTest.Epoxy
         public async Task GeneratedService_GeneratedProxy_PayloadResponse_ClientLayerErrors()
         {
             var errorLayer = new TestLayer_ReturnErrors();
-            var clientLayerStack = new LayerStackProvider<Dummy>(LoggerTests.BlackHole, errorLayer);
+            var clientLayerStack = new LayerStackProvider<Dummy>(errorLayer);
             TestClientServer<DummyTestService> testClientServer = await SetupTestClientServer<DummyTestService>(null, clientLayerStack);
             var proxy = new DummyTestProxy<EpoxyConnection>(testClientServer.ClientConnection);
             var request = new Dummy { int_value = 100 };
@@ -353,9 +353,9 @@ namespace UnitTest.Epoxy
         public async Task GeneratedService_GeneratedProxy_PayloadResponse_StatefulLayers()
         {
             var clientLayerProvider = new TestLayerProvider_StatefulAppend("Client");
-            var clientLayerStackProvider = new LayerStackProvider<Dummy>(LoggerTests.BlackHole, clientLayerProvider);
+            var clientLayerStackProvider = new LayerStackProvider<Dummy>(clientLayerProvider);
             var serverLayerProvider = new TestLayerProvider_StatefulAppend("Server");
-            var serverLayerStackProvider = new LayerStackProvider<Dummy>(LoggerTests.BlackHole, serverLayerProvider);
+            var serverLayerStackProvider = new LayerStackProvider<Dummy>(serverLayerProvider);
             TestClientServer<DummyTestService> testClientServer =
                 await SetupTestClientServer<DummyTestService>(serverLayerStackProvider, clientLayerStackProvider);
             var proxy = new DummyTestProxy<EpoxyConnection>(testClientServer.ClientConnection);
@@ -383,7 +383,7 @@ namespace UnitTest.Epoxy
         public async Task GeneratedService_GeneratedProxy_PayloadResponse_ServerLayerErrors()
         {
             var errorLayer = new TestLayer_ReturnErrors();
-            var serverLayerStackProvider = new LayerStackProvider<Dummy>(LoggerTests.BlackHole, errorLayer);
+            var serverLayerStackProvider = new LayerStackProvider<Dummy>(errorLayer);
             TestClientServer<DummyTestService> testClientServer = await SetupTestClientServer<DummyTestService>(serverLayerStackProvider, null);
             var proxy = new DummyTestProxy<EpoxyConnection>(testClientServer.ClientConnection);
             var request = new Dummy { int_value = 100 };
@@ -415,7 +415,7 @@ namespace UnitTest.Epoxy
         public async Task GeneratedService_GeneratedProxy_Event_ClientLayerErrors()
         {
             var errorLayer = new TestLayer_ReturnErrors();
-            var clientLayerStackProvider = new LayerStackProvider<Dummy>(LoggerTests.BlackHole, errorLayer);
+            var clientLayerStackProvider = new LayerStackProvider<Dummy>(errorLayer);
             TestClientServer<DummyTestService> testClientServer = await SetupTestClientServer<DummyTestService>(null, clientLayerStackProvider);
             var proxy = new DummyTestProxy<EpoxyConnection>(testClientServer.ClientConnection);
             var theEvent = new Dummy { int_value = 100 };
@@ -451,7 +451,7 @@ namespace UnitTest.Epoxy
         public async Task GeneratedService_GeneratedProxy_Event_ServerLayerErrors()
         {
             var errorLayer = new TestLayer_ReturnErrors();
-            var serverLayerStackProvider = new LayerStackProvider<Dummy>(LoggerTests.BlackHole, errorLayer);
+            var serverLayerStackProvider = new LayerStackProvider<Dummy>(errorLayer);
             TestClientServer<DummyTestService> testClientServer = await SetupTestClientServer<DummyTestService>(serverLayerStackProvider, null);
             var proxy = new DummyTestProxy<EpoxyConnection>(testClientServer.ClientConnection);
             var theEvent = new Dummy { int_value = 100 };
@@ -486,9 +486,9 @@ namespace UnitTest.Epoxy
         public async Task GeneratedService_GeneratedProxy_Event_StatefulLayers()
         {
             var clientLayerProvider = new TestLayerProvider_StatefulAppend("Client");
-            var clientLayerStackProvider = new LayerStackProvider<Dummy>(LoggerTests.BlackHole, clientLayerProvider);
+            var clientLayerStackProvider = new LayerStackProvider<Dummy>(clientLayerProvider);
             var serverLayerProvider = new TestLayerProvider_StatefulAppend("Server");
-            var serverLayerStackProvider = new LayerStackProvider<Dummy>(LoggerTests.BlackHole, serverLayerProvider);
+            var serverLayerStackProvider = new LayerStackProvider<Dummy>(serverLayerProvider);
             TestClientServer<DummyTestService> testClientServer =
                 await SetupTestClientServer<DummyTestService>(serverLayerStackProvider, clientLayerStackProvider);
             var proxy = new DummyTestProxy<EpoxyConnection>(testClientServer.ClientConnection);

--- a/cs/test/comm/Layers/LayerStackTests.cs
+++ b/cs/test/comm/Layers/LayerStackTests.cs
@@ -199,14 +199,14 @@ namespace UnitTest.Layers
             return this;
         }
 
-        public Error OnSend(Logger logger, MessageType messageType, SendContext context, Dummy layerData)
+        public Error OnSend(MessageType messageType, SendContext context, Dummy layerData, Logger logger)
         {
             layerData.string_value += value;
             list.Add(layerData.string_value);
             return null;
         }
 
-        public Error OnReceive(Logger logger, MessageType messageType, ReceiveContext context, Dummy layerData)
+        public Error OnReceive(MessageType messageType, ReceiveContext context, Dummy layerData, Logger logger)
         {
             layerData.string_value += value;
             list.Add(layerData.string_value);
@@ -221,12 +221,12 @@ namespace UnitTest.Layers
             return this;
         }
 
-        public Error OnSend(Logger logger, MessageType messageType, SendContext context, Dummy layerData)
+        public Error OnSend(MessageType messageType, SendContext context, Dummy layerData, Logger logger)
         {
             throw new LayerStackException();
         }
 
-        public Error OnReceive(Logger logger, MessageType messageType, ReceiveContext context, Dummy layerData)
+        public Error OnReceive(MessageType messageType, ReceiveContext context, Dummy layerData, Logger logger)
         {
             throw new LayerStackException();
         }
@@ -252,13 +252,13 @@ namespace UnitTest.Layers
             return this;
         }
 
-        public Error OnSend(Logger logger, MessageType messageType, SendContext context, Dummy layerData)
+        public Error OnSend(MessageType messageType, SendContext context, Dummy layerData, Logger logger)
         {
             layerData.int_value = expectedValue;
             return null;
         }
 
-        public Error OnReceive(Logger logger, MessageType messageType, ReceiveContext context, Dummy layerData)
+        public Error OnReceive(MessageType messageType, ReceiveContext context, Dummy layerData, Logger logger)
         {
             if (layerData.int_value != expectedValue)
             {
@@ -291,7 +291,7 @@ namespace UnitTest.Layers
             this.errorOnReceive = errorOnReceive;
         }
 
-        public Error OnSend(Logger logger, MessageType messageType, SendContext context, Dummy layerData)
+        public Error OnSend(MessageType messageType, SendContext context, Dummy layerData, Logger logger)
         {
             if (errorOnSend && messageType == badMessageType)
             {
@@ -303,7 +303,7 @@ namespace UnitTest.Layers
             }
         }
 
-        public Error OnReceive(Logger logger, MessageType messageType, ReceiveContext context, Dummy layerData)
+        public Error OnReceive(MessageType messageType, ReceiveContext context, Dummy layerData, Logger logger)
         {
             if (errorOnReceive && messageType == badMessageType)
             {
@@ -348,13 +348,13 @@ namespace UnitTest.Layers
             this.prefix = prefix;
         }
 
-        public Error OnSend(Logger logger, MessageType messageType, SendContext context, Dummy layerData)
+        public Error OnSend(MessageType messageType, SendContext context, Dummy layerData, Logger logger)
         {
             State += prefix + SendMessage;
             return null;
         }
 
-        public Error OnReceive(Logger logger, MessageType messageType, ReceiveContext context, Dummy layerData)
+        public Error OnReceive(MessageType messageType, ReceiveContext context, Dummy layerData, Logger logger)
         {
             State += prefix + ReceiveMessage;
             return null;

--- a/cs/test/comm/SimpleInMem/SimpleInMemConnectionTest.cs
+++ b/cs/test/comm/SimpleInMem/SimpleInMemConnectionTest.cs
@@ -348,7 +348,7 @@ namespace UnitTest.SimpleInMem
             var layer1 = new TestLayer_Append("foo", testList);
             var layer2 = new TestLayer_Append("bar", testList);
 
-            transportBuilder.SetLayerStackProvider(new LayerStackProvider<Dummy>(LoggerTests.BlackHole, layer1, layer2));
+            transportBuilder.SetLayerStackProvider(new LayerStackProvider<Dummy>(layer1, layer2));
             await DefaultSetup(new CalculatorService(), 1);
 
             const int first = 91;
@@ -382,7 +382,7 @@ namespace UnitTest.SimpleInMem
         public async Task MethodCall_ReqRsp_WithStatefulLayers()
         {
             var layerProvider = new TestLayerProvider_StatefulAppend("Layer");
-            var layerStackProvider = new LayerStackProvider<Dummy>(LoggerTests.BlackHole, layerProvider);
+            var layerStackProvider = new LayerStackProvider<Dummy>(layerProvider);
             transportBuilder.SetLayerStackProvider(layerStackProvider);
             await DefaultSetup(new CalculatorService(), 1);
 
@@ -411,7 +411,7 @@ namespace UnitTest.SimpleInMem
         public async Task MethodCall_ReqRsp_WithLayerStackErrors()
         {
             var errorLayer = new TestLayer_ReturnErrors();
-            transportBuilder.SetLayerStackProvider(new LayerStackProvider<Dummy>(LoggerTests.BlackHole, errorLayer));
+            transportBuilder.SetLayerStackProvider(new LayerStackProvider<Dummy>(errorLayer));
             var testService = new DummyTestService();
             await DefaultSetup(testService, 1);
 
@@ -520,7 +520,7 @@ namespace UnitTest.SimpleInMem
         public async Task MethodCall_Event_With_StatefulLayers()
         {
             var layerProvider = new TestLayerProvider_StatefulAppend("Layer");
-            var layerStackProvider = new LayerStackProvider<Dummy>(LoggerTests.BlackHole, layerProvider);
+            var layerStackProvider = new LayerStackProvider<Dummy>(layerProvider);
             transportBuilder.SetLayerStackProvider(layerStackProvider);
             var testService = new DummyTestService();
             await DefaultSetup(testService, 1);
@@ -548,7 +548,7 @@ namespace UnitTest.SimpleInMem
         public async Task MethodCall_Event_WithLayerStackErrors()
         {
             var errorLayer = new TestLayer_ReturnErrors();
-            transportBuilder.SetLayerStackProvider(new LayerStackProvider<Dummy>(LoggerTests.BlackHole, errorLayer));
+            transportBuilder.SetLayerStackProvider(new LayerStackProvider<Dummy>(errorLayer));
             var testService = new DummyTestService();
             await DefaultSetup(testService, 1);
 


### PR DESCRIPTION
LayerStackProvider's constructor no longer requires a logger.
Defer initialization of the cached layer stack in the stateless case.
Pass in logger during send/receive operations instead.