### PR TITLE
Add netstandard support to NuGet packages

### DIFF
--- a/cs/nuget/App.config
+++ b/cs/nuget/App.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <!-- Required until the published Bond libraries have a Newtonsoft.Json dependency of v9.0.1 -->
+        <bindingRedirect oldVersion="7.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/cs/nuget/bond.comm.runtime.csharp.nuspec
+++ b/cs/nuget/bond.comm.runtime.csharp.nuspec
@@ -34,5 +34,14 @@
       <file src="net45\Bond.Comm.Layers.dll" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
       <file src="net45\Bond.Comm.Layers.xml" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
       <file src="net45\Bond.Comm.Layers.pdb" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
+      <file src="net45\Bond.Comm.Interfaces.dll" target="lib\netstandard1.0" />
+      <file src="net45\Bond.Comm.Interfaces.xml" target="lib\netstandard1.0" />
+      <file src="net45\Bond.Comm.Interfaces.pdb" target="lib\netstandard1.0" />
+      <file src="net45\Bond.Comm.Service.dll" target="lib\netstandard1.0" />
+      <file src="net45\Bond.Comm.Service.xml" target="lib\netstandard1.0" />
+      <file src="net45\Bond.Comm.Service.pdb" target="lib\netstandard1.0" />
+      <file src="net45\Bond.Comm.Layers.dll" target="lib\netstandard1.0" />
+      <file src="net45\Bond.Comm.Layers.xml" target="lib\netstandard1.0" />
+      <file src="net45\Bond.Comm.Layers.pdb" target="lib\netstandard1.0" />
     </files>
 </package>

--- a/cs/nuget/bond.compiler.csharp.nuspec
+++ b/cs/nuget/bond.compiler.csharp.nuspec
@@ -41,6 +41,10 @@
     <file src="cs\build\nuget\Bond.Compiler.CSharp.props" target="build\portable-net45+wp80+win8+wpa81+dnxcore50" />
     <file src="cs\build\nuget\Common.props" target="build\portable-net45+wp80+win8+wpa81+dnxcore50" />
     <file src="cs\build\nuget\Common.targets" target="build\portable-net45+wp80+win8+wpa81+dnxcore50" />
+    <file src="cs\build\nuget\Bond.Compiler.CSharp.targets" target="build\netstandard1.0" />
+    <file src="cs\build\nuget\Bond.Compiler.CSharp.props" target="build\netstandard1.0" />
+    <file src="cs\build\nuget\Common.props" target="build\netstandard1.0" />
+    <file src="cs\build\nuget\Common.targets" target="build\netstandard1.0" />
 
     <file src="cs\build\nuget\Bond.Compiler.CSharp.targets" target="build\net40" />
     <file src="cs\build\nuget\Bond.Compiler.CSharp.props" target="build\net40" />

--- a/cs/nuget/bond.core.csharp.nuspec
+++ b/cs/nuget/bond.core.csharp.nuspec
@@ -39,6 +39,12 @@
         <file src="net45\Bond.Attributes.dll" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
         <file src="net45\Bond.Attributes.xml" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
         <file src="net45\Bond.Attributes.pdb" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
+        <file src="net45\Bond.dll" target="lib\netstandard1.0" />
+        <file src="net45\Bond.xml" target="lib\netstandard1.0" />
+        <file src="net45\Bond.pdb" target="lib\netstandard1.0" />
+        <file src="net45\Bond.Attributes.dll" target="lib\netstandard1.0" />
+        <file src="net45\Bond.Attributes.xml" target="lib\netstandard1.0" />
+        <file src="net45\Bond.Attributes.pdb" target="lib\netstandard1.0" />
         <file src="net40\Bond.dll" target="lib\net40" />
         <file src="net40\Bond.xml" target="lib\net40" />
         <file src="net40\Bond.pdb" target="lib\net40" />

--- a/cs/nuget/bond.csharp.test.csproj
+++ b/cs/nuget/bond.csharp.test.csproj
@@ -111,7 +111,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\portable-net45+wp80+win8+wpa81+dnxcore50\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
@@ -121,6 +121,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/cs/nuget/bond.runtime.csharp.nuspec
+++ b/cs/nuget/bond.runtime.csharp.nuspec
@@ -23,7 +23,7 @@
         <copyright>Copyright (c) Microsoft</copyright>
         <tags>Bond .NET C# serialization</tags>
         <dependencies>
-            <dependency id="Newtonsoft.Json" version="7.0.1" />
+            <dependency id="Newtonsoft.Json" version="9.0.1" />
             <dependency id="Bond.Core.CSharp" version ="[$version$]"/>
         </dependencies>
     </metadata>

--- a/cs/nuget/bond.runtime.csharp.nuspec
+++ b/cs/nuget/bond.runtime.csharp.nuspec
@@ -34,6 +34,9 @@
         <file src="net45\Bond.JSON.dll" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
         <file src="net45\Bond.JSON.xml" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
         <file src="net45\Bond.JSON.pdb" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
+        <file src="net45\Bond.JSON.dll" target="lib\netstandard1.0" />
+        <file src="net45\Bond.JSON.xml" target="lib\netstandard1.0" />
+        <file src="net45\Bond.JSON.pdb" target="lib\netstandard1.0" />
         <file src="net40\Bond.JSON.dll" target="lib\net40" />
         <file src="net40\Bond.JSON.xml" target="lib\net40" />
         <file src="net40\Bond.JSON.pdb" target="lib\net40" />

--- a/cs/nuget/packages.config
+++ b/cs/nuget/packages.config
@@ -3,7 +3,7 @@
   <package id="Bond.Core.CSharp" version="5.0.0" targetFramework="net45" />
   <package id="Bond.CSharp" version="5.0.0" targetFramework="net45" />
   <package id="Bond.Runtime.CSharp" version="5.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="portable-net45+wp80+win8+wpa81+dnxcore50" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="portable-net45+wp80+win8+wpa81" />
   <package id="NUnit" version="2.6.4" targetFramework="portable-net45+wp80+win" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/cs/src/json/JSON.csproj
+++ b/cs/src/json/JSON.csproj
@@ -27,10 +27,10 @@
       <HintPath>..\attributes\$(OutputPath)\Bond.Attributes.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json" Condition="'$(TargetFrameworkVersion)' == 'v4.5'">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\portable-net45+wp80+win8+wpa81+dnxcore50\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json" Condition="'$(TargetFrameworkVersion)' == 'v4.0'">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/cs/src/json/packages.config
+++ b/cs/src/json/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="portable-net45+wp80+win8+wpa81+dnxcore50" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="portable-net45+wp80+win8+wpa81" />
 </packages>

--- a/cs/test/comm/comm.csproj
+++ b/cs/test/comm/comm.csproj
@@ -86,10 +86,10 @@
       <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json" Condition="'$(TargetFrameworkVersion)' == 'v4.5'">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\portable-net45+wp80+win8+wpa81+dnxcore50\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json" Condition="'$(TargetFrameworkVersion)' == 'v4.0'">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/cs/test/comm/packages.config
+++ b/cs/test/comm/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="portable-net45+wp80+win8+wpa81+dnxcore50" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="portable-net45+wp80+win8+wpa81" />
   <package id="NUnit" version="2.6.4" targetFramework="portable-net45+wp80+win" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/cs/test/core/Core.csproj
+++ b/cs/test/core/Core.csproj
@@ -90,10 +90,10 @@
       <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json" Condition="'$(TargetFrameworkVersion)' == 'v4.5'">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\portable-net45+wp80+win8+wpa81+dnxcore50\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json" Condition="'$(TargetFrameworkVersion)' == 'v4.0'">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.ServiceModel" />
   </ItemGroup>

--- a/cs/test/core/packages.config
+++ b/cs/test/core/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="portable-net45+wp80+win8+wpa81+dnxcore50" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="portable-net45+wp80+win8+wpa81" />
   <package id="NUnit" version="2.6.4" targetFramework="portable-net45+wp80+win" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/examples/cs/core/simple_json/simple_json.csproj
+++ b/examples/cs/core/simple_json/simple_json.csproj
@@ -58,7 +58,7 @@
       <HintPath>$(BOND_BINARY_PATH)\net45\Bond.JSON.dll</HintPath>
     </Reference>    
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\cs\packages\Newtonsoft.Json.7.0.1\lib\portable-net45+wp80+win8+wpa81+dnxcore50\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\..\..\cs\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
I think this should resolve #171.

Adding support for NETStandard requires upgrading Newtonsoft.Json from 9.0.1, since that is the lowest version of that library that supports NETStandard.

Per https://docs.nuget.org/ndocs/schema/target-frameworks, the existing `Profile78` is equivalent to `netstandard1.0`, so that is what I used.

Per https://github.com/davidfowl/NetStandard/issues/5, the current way to support both PCL and NETStandard projects is to have a copy of the DLL in both lib folders in the NuGet package, so I added a `netstandard1.0` lib folder to the nuspec files that already had a `portable-net45+wp80+win8+wpa81+dnxcore50` lib folder.

All unit tests in `cs\cs.sln` and `cs\nuget\nuget.sln` passed, but I had to add an assembly binding redirect for `cs\nuget\nuget.sln` because it references the currently-published `5.0.0` NuGet packages which still reference the `7.x` version of `Newtonsoft.Json`.

I also created another test solution on my workstation with both a PCL and NETStandard project. I was able to add the modified NuGet packages to both projects, and I was able to serialize and deserialize a simple struct in CompactBinary, SimpleBinary, and Json formats.
