### PR TITLE
[c# comm] Simplify redundant return await

### DIFF
--- a/cs/src/comm/epoxy-transport/EpoxyTransport.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyTransport.cs
@@ -260,7 +260,7 @@ namespace Bond.Comm.Epoxy
 
         /// <param name="address">A URI with a scheme of epoxy:// (insecure epoxy) or epoxys:// (epoxy over TLS).</param>
         /// <param name="ct">Unused.</param>
-        public override async Task<EpoxyConnection> ConnectToAsync(string address, CancellationToken ct)
+        public override Task<EpoxyConnection> ConnectToAsync(string address, CancellationToken ct)
         {
             var endpoint = Parse(address, logger);
             if (endpoint == null)
@@ -268,13 +268,13 @@ namespace Bond.Comm.Epoxy
                 throw new ArgumentException(address + " was not a valid Epoxy URI", nameof(address));
             }
 
-            return await ConnectToAsync(endpoint.Value, ct);
+            return ConnectToAsync(endpoint.Value, ct);
         }
 
         /// <param name="address">A URI with a scheme of epoxy:// (insecure epoxy) or epoxys:// (epoxy over TLS).</param>
-        public override async Task<EpoxyConnection> ConnectToAsync(string address)
+        public override Task<EpoxyConnection> ConnectToAsync(string address)
         {
-            return await ConnectToAsync(address, CancellationToken.None);
+            return ConnectToAsync(address, CancellationToken.None);
         }
 
         public async Task<EpoxyConnection> ConnectToAsync(Endpoint endpoint, CancellationToken ct)
@@ -293,9 +293,9 @@ namespace Bond.Comm.Epoxy
             return connection;
         }
 
-        public async Task<EpoxyConnection> ConnectToAsync(Endpoint endpoint)
+        public Task<EpoxyConnection> ConnectToAsync(Endpoint endpoint)
         {
-            return await ConnectToAsync(endpoint, CancellationToken.None);
+            return ConnectToAsync(endpoint, CancellationToken.None);
         }
 
         public override EpoxyListener MakeListener(string address)

--- a/cs/src/comm/simpleinmem-transport/SimpleInMemTransport.cs
+++ b/cs/src/comm/simpleinmem-transport/SimpleInMemTransport.cs
@@ -50,7 +50,7 @@ namespace Bond.Comm.SimpleInMem
         /// </summary>
         /// <returns>a <see cref="SimpleInMemConnection"/> that may be used to perform request operations.</returns>
         /// <exception cref="ArgumentException">the listener for given address does not exist.</exception>
-        public async override Task<SimpleInMemConnection> ConnectToAsync(string address, CancellationToken ct)
+        public override Task<SimpleInMemConnection> ConnectToAsync(string address, CancellationToken ct)
         {
             logger.Site().Information("Connecting to {0}.", address);
             SimpleInMemListener listener;
@@ -64,7 +64,7 @@ namespace Bond.Comm.SimpleInMem
                 }
             }
 
-            return await Task.Run(() => listener.CreateConnectionPair().Client, ct);
+            return Task.Run(() => listener.CreateConnectionPair().Client, ct);
         }
 
         /// <summary>

--- a/cs/test/comm/Interfaces/ServiceIsolationTests.cs
+++ b/cs/test/comm/Interfaces/ServiceIsolationTests.cs
@@ -35,7 +35,6 @@ namespace UnitTest.Interfaces
             public readonly List<ConnectionMetrics> ConnectionMetricses = new List<ConnectionMetrics>();
             public readonly List<RequestMetrics> RequestMetricses = new List<RequestMetrics>();
 
-
             public void Emit(ConnectionMetrics metrics)
             {
                 ConnectionMetricses.Add(metrics);
@@ -65,13 +64,10 @@ namespace UnitTest.Interfaces
             return transport;
         }
 
-        private static async Task<EpoxyConnection> ClientConn(string address)
+        private static Task<EpoxyConnection> ClientConn(string address)
         {
-            var transport = new EpoxyTransportBuilder()
-                .Construct();
-
-            return await transport.ConnectToAsync(address);
-
+            var transport = new EpoxyTransportBuilder().Construct();
+            return transport.ConnectToAsync(address);
         }
 
         [TearDown]


### PR DESCRIPTION
Methods that never await anything except what they return can simply return
the Task that they were awaiting, eliminating some compiler-generated async
machinery.