### PR TITLE
[c# epoxy] Accept multiple connections in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ different versioning scheme, following the Haskell community's
   instead, the transport's logger is passed to `OnSend`/`OnReceive`. Before,
   using the same logger with a transport and `LayerStackProvider` required a
   duplicate implementation.
+* Fixed a bug that prevented `EpoxyListener` from accepting multiple
+  connections in parallel.
 
 ## C# Comm 0.8.0: 2016-10-12 ##
 

--- a/cs/src/comm/epoxy-transport/EpoxyListener.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyListener.cs
@@ -112,11 +112,17 @@ namespace Bond.Comm.Epoxy
                     EndPoint remoteEndpoint = socket.RemoteEndPoint;
                     logger.Site().Debug("Accepted connection from {0}.", remoteEndpoint);
 
+                    // Disabling CS4014 "Because this call is not awaited,
+                    // execution of the current method continues before the
+                    // call is completed.Consider applying the 'await' operator
+                    // to the result of the call.", as we've attached a logger
+                    // task that doesn't need to be observed.
+                    #pragma warning disable 4014
                     // Don't need to wait for the connection to get fully established before
                     // accepting the next one, so fire and forget (with logging) StartAsync.
                     StartClientConnectionAsync(socket)
-                        .ContinueWith(startTask => LogClientStartResult(remoteEndpoint, startTask))
-                        .Forget();
+                        .ContinueWith(startTask => LogClientStartResult(remoteEndpoint, startTask));
+                    #pragma warning restore 4014
                 }
                 catch (SocketException ex)
                 {

--- a/cs/src/comm/service/TaskExt.cs
+++ b/cs/src/comm/service/TaskExt.cs
@@ -15,14 +15,15 @@ namespace Bond.Comm.Service
             return tcs.Task;
         }
 
-        private static Task completedTask = Task.FromResult(default(object));
+        public static Task CompletedTask { get; } = Task.FromResult(default(object));
 
-        public static Task CompletedTask
+        /// <summary>
+        /// Consumes a task and doesn't do anything with it. Useful for fire-and-forget calls to
+        /// async methods within async methods.
+        /// </summary>
+        /// <param name="task">The task whose result is to be ignored.</param>
+        public static void Forget(this Task task)
         {
-            get
-            {
-                return completedTask;
-            }
         }
     }
 }

--- a/cs/src/comm/service/TaskExt.cs
+++ b/cs/src/comm/service/TaskExt.cs
@@ -16,14 +16,5 @@ namespace Bond.Comm.Service
         }
 
         public static Task CompletedTask { get; } = Task.FromResult(default(object));
-
-        /// <summary>
-        /// Consumes a task and doesn't do anything with it. Useful for fire-and-forget calls to
-        /// async methods within async methods.
-        /// </summary>
-        /// <param name="task">The task whose result is to be ignored.</param>
-        public static void Forget(this Task task)
-        {
-        }
     }
 }

--- a/cs/test/comm/Epoxy/EpoxyListenerTests.cs
+++ b/cs/test/comm/Epoxy/EpoxyListenerTests.cs
@@ -48,7 +48,7 @@ namespace UnitTest.Epoxy
 
             await listener.StartAsync();
             var connection = await transport.ConnectToAsync(localhostAddress);
-            bool wasSignaled = connectedEventDone.Wait(TimeSpan.FromSeconds(30));
+            bool wasSignaled = connectedEventDone.Wait(TimeSpan.FromSeconds(10));
             Assert.IsTrue(wasSignaled, "Timed out waiting for Connected event to complete");
 
             Assert.AreEqual(connection.LocalEndPoint, remoteConnection.RemoteEndPoint);
@@ -116,7 +116,7 @@ namespace UnitTest.Epoxy
             var connection = await transport.ConnectToAsync(localhostAddress);
             await connection.StopAsync();
 
-            bool wasSignaled = disconnectedEventDone.Wait(TimeSpan.FromSeconds(30));
+            bool wasSignaled = disconnectedEventDone.Wait(TimeSpan.FromSeconds(10));
             Assert.IsTrue(wasSignaled, "Timed out waiting for Disconnected event to complete");
 
             Assert.IsNotNull(disconnectedConnection);
@@ -136,7 +136,7 @@ namespace UnitTest.Epoxy
             await noHandshakeConnection.ConnectAsync(localhostEndpoint.Address, localhostEndpoint.Port);
 
             var connectTask = transport.ConnectToAsync(localhostAddress);
-            bool didConnect = connectTask.Wait(TimeSpan.FromSeconds(30));
+            bool didConnect = connectTask.Wait(TimeSpan.FromSeconds(10));
             Assert.IsTrue(didConnect, "Timed out waiting for connection to be established.");
 
             await transport.StopAsync();


### PR DESCRIPTION
- Don't block in the listener's accept loop waiting for one connection
  to be established before accepting the next one.
