### PR TITLE
[c#] Swap in a custom list for SynchronizedCollection

### DIFF
--- a/cs/test/core/Aliases.bond
+++ b/cs/test/core/Aliases.bond
@@ -1,6 +1,6 @@
 ﻿namespace UnitTest.Aliases
 
-using SynchronizedList<T> = list<T>;
+using CustomList<T> = list<T>;
 using OrderedSet<T> = set<T>;
 using Decimal = blob;
 using EnumString<T> = string;
@@ -24,9 +24,9 @@ struct Foo
 
 struct ContainerAlias
 {
-    0: SynchronizedList<string> syncListString;
-    1: nullable<SynchronizedList<Foo>> syncListFoo;
-    2: SynchronizedList<OrderedSet<string>> syncListOrderedSetString;
+    0: CustomList<string> customListString;
+    1: nullable<CustomList<Foo>> customListFoo;
+    2: CustomList<OrderedSet<string>> customListOrderedSetString;
     // Don't get rid of the `nothing` here. Bond will attempt to use "normal"
     // C# init syntax here. Arrays have irregular syntax though, so
     // `new bool[]()` won't work. To compensate, we just leave it null.

--- a/cs/test/core/Core.csproj
+++ b/cs/test/core/Core.csproj
@@ -55,8 +55,8 @@
     <Compile Include="Util.cs" />
     <Compile Include="XmlTests.cs" />
     <BondCodegen Include="Aliases.bond">
-      <Options Condition="'$(TargetFrameworkVersion)' == 'v4.5'">$(BondOptions) --using="Lazy=Lazy&lt;{0}&gt;" --using="OrderedSet=SortedSet&lt;{0}&gt;" --using="Decimal=decimal" --using="EnumString=Alias.EnumString&lt;{0}&gt;" --using="Array={0}[]" --using=ArrayBlob=byte[] --using="SynchronizedList=SynchronizedCollection&lt;{0}&gt;"</Options>
-      <Options Condition="'$(TargetFrameworkVersion)' == 'v4.0'">$(BondOptions) --using="Lazy=Lazy&lt;{0}&gt;" --using="OrderedSet=SortedSet&lt;{0}&gt;" --using="Decimal=decimal" --using="EnumString=Alias.EnumString&lt;{0}&gt;" --using="Array={0}[]" --using=ArrayBlob=byte[]</Options>
+      <Options Condition="'$(TargetFrameworkVersion)' == 'v4.5'">$(BondOptions) --using="Lazy=Lazy&lt;{0}&gt;" --using="OrderedSet=SortedSet&lt;{0}&gt;" --using="Decimal=decimal" --using="EnumString=Alias.EnumString&lt;{0}&gt;" --using="Array={0}[]" --using=ArrayBlob=byte[] --using="CustomList=UnitTest.Aliases.SomeCustomList&lt;{0}&gt;"</Options>
+      <Options Condition="'$(TargetFrameworkVersion)' == 'v4.0'">$(BondOptions) --using="Lazy=Lazy&lt;{0}&gt;" --using="OrderedSet=SortedSet&lt;{0}&gt;" --using="Decimal=decimal" --using="EnumString=Alias.EnumString&lt;{0}&gt;" --using="Array={0}[]" --using=ArrayBlob=byte[] --using="CustomList=UnitTest.Aliases.SomeCustomList&lt;{0}&gt;"</Options>
     </BondCodegen>
     <BondCodegen Include="NamespaceConflict.bond" />
     <BondCodegen Include="NamespaceConflictBond.bond" />
@@ -95,7 +95,6 @@
     <Reference Include="Newtonsoft.Json" Condition="'$(TargetFrameworkVersion)' == 'v4.0'">
       <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Bond.Attributes">

--- a/cs/test/core/TypeAliasTests.cs
+++ b/cs/test/core/TypeAliasTests.cs
@@ -1,10 +1,11 @@
 ﻿namespace UnitTest.Aliases
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
+    using System.Linq;
     using Bond;
     using NUnit.Framework;
-    using System.Linq;
 
     public class Lazy<T> : IBonded<T>
     {
@@ -69,7 +70,7 @@
 
         public override bool Equals(object obj)
         {
-            return Comparer.Equal(Value, (obj as Lazy<T>).Value);
+            return Bond.Comparer.Equal(Value, (obj as Lazy<T>).Value);
         }
 
         public override int GetHashCode()
@@ -244,7 +245,7 @@
 
                 switch (field.Name)
                 {
-                    case "syncListFoo":
+                    case "customListFoo":
                         Assert.AreEqual(ListSubType.NULLABLE_SUBTYPE, fieldListSubType);
                         break;
 
@@ -280,6 +281,78 @@
 
             var to = Clone<T>.From(Clone<U>.From(from));
             Assert.IsTrue(from.IsEqual<T>(to));
+        }
+    }
+
+    // An extremely simple example of a custom container implementation.
+    public class SomeCustomList<T> : ICollection<T>, ICollection
+    {
+        readonly List<T> backingList = new List<T>();
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return backingList.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable)backingList).GetEnumerator();
+        }
+
+        public void Add(T item)
+        {
+            backingList.Add(item);
+        }
+
+        public void Clear()
+        {
+            backingList.Clear();
+        }
+
+        public bool Contains(T item)
+        {
+            return backingList.Contains(item);
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            backingList.CopyTo(array, arrayIndex);
+        }
+
+        public bool Remove(T item)
+        {
+            return backingList.Remove(item);
+        }
+
+        public void CopyTo(Array array, int index)
+        {
+            ((ICollection)backingList).CopyTo(array, index);
+        }
+
+        public int Count
+        {
+            get { return backingList.Count; }
+        }
+
+        bool ICollection<T>.IsReadOnly
+        {
+            get { return ((ICollection<T>)backingList).IsReadOnly; }
+        }
+
+        public object SyncRoot
+        {
+            get
+            {
+                return ((ICollection)backingList).SyncRoot;
+            }
+        }
+
+        public bool IsSynchronized
+        {
+            get
+            {
+                return ((ICollection)backingList).IsSynchronized;
+            }
         }
     }
 }

--- a/examples/cs/core/container_alias/container_alias.csproj
+++ b/examples/cs/core/container_alias/container_alias.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\..\..\cs\build\nuget\Bond.CSharp.props" />
@@ -8,7 +8,7 @@
     <RootNamespace>container_alias</RootNamespace>
     <AssemblyName>container_alias</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <BondOptions>--using="SynchronizedList=SynchronizedCollection&lt;{0}>"</BondOptions>
+    <BondOptions>--using="CustomList=Examples.SomeCustomList&lt;{0}&gt;"</BondOptions>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,9 +32,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="program.cs" />
@@ -46,8 +44,6 @@
     <!-- End Resharper Workaround -->
   </ItemGroup>
   <ItemGroup>
-    <!-- For SynchronizedCollection -->
-    <Reference Include="System.ServiceModel" />      
     <Reference Include="Attributes">
       <HintPath>$(BOND_BINARY_PATH)\net45\Bond.Attributes.dll</HintPath>
     </Reference>

--- a/examples/cs/core/container_alias/program.cs
+++ b/examples/cs/core/container_alias/program.cs
@@ -1,9 +1,12 @@
 ﻿namespace Examples
 {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using Bond;
-    using Bond.Protocols;
     using Bond.IO.Unsafe;
+    using Bond.Protocols;
 
     static class Program
     {
@@ -24,7 +27,79 @@
             var reader = new CompactBinaryReader<InputBuffer>(input);
 
             var dst = Deserialize<Example>.From(reader);
-            Debug.Assert(Comparer.Equal(src, dst));
+            Debug.Assert(Bond.Comparer.Equal(src, dst));
+        }
+    }
+
+    // An extremely simple example of a custom container implementation.
+    public class SomeCustomList<T> : ICollection<T>, ICollection
+    {
+        readonly List<T> backingList = new List<T>();
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return backingList.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable)backingList).GetEnumerator();
+        }
+
+        public void Add(T item)
+        {
+            backingList.Add(item);
+        }
+
+        public void Clear()
+        {
+            backingList.Clear();
+        }
+
+        public bool Contains(T item)
+        {
+            return backingList.Contains(item);
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            backingList.CopyTo(array, arrayIndex);
+        }
+
+        public bool Remove(T item)
+        {
+            return backingList.Remove(item);
+        }
+
+        public void CopyTo(Array array, int index)
+        {
+            ((ICollection)backingList).CopyTo(array, index);
+        }
+
+        public int Count
+        {
+            get { return backingList.Count; }
+        }
+
+        bool ICollection<T>.IsReadOnly
+        {
+            get { return ((ICollection<T>) backingList).IsReadOnly; }
+        }
+
+        public object SyncRoot
+        {
+            get
+            {
+                return ((ICollection)backingList).SyncRoot;
+            }
+        }
+
+        public bool IsSynchronized
+        {
+            get
+            {
+                return ((ICollection)backingList).IsSynchronized;
+            }
         }
     }
 }

--- a/examples/cs/core/container_alias/schema.bond
+++ b/examples/cs/core/container_alias/schema.bond
@@ -1,9 +1,9 @@
 ﻿namespace Examples
 
-using SynchronizedList<T> = list<T>;
+using CustomList<T> = list<T>;
 
 struct Example
 {
     0: string Name;
-    1: SynchronizedList<double> Constants;
+    1: CustomList<double> Constants;
 }


### PR DESCRIPTION
SynchronizedCollection is not present in .NET Standard 1.6, among others. It
was only being used to demonstrate how collection type aliasing works, so it
has been replaced with SomeCustomList<T> which just wraps List<T> to
demonstrate how this would work.