### PR TITLE
[c#] Fix container alias tests and example

### DIFF
--- a/cs/test/core/TypeAliasTests.cs
+++ b/cs/test/core/TypeAliasTests.cs
@@ -245,7 +245,7 @@
 
                 switch (field.Name)
                 {
-                    case "syncListFoo":
+                    case "customListFoo":
                         Assert.AreEqual(ListSubType.NULLABLE_SUBTYPE, fieldListSubType);
                         break;
 
@@ -285,7 +285,7 @@
     }
 
     // An extremely simple example of a custom container implementation.
-    public class SomeCustomList<T> : ICollection<T>
+    public class SomeCustomList<T> : ICollection<T>, ICollection
     {
         readonly List<T> backingList = new List<T>();
 
@@ -324,9 +324,24 @@
             return backingList.Remove(item);
         }
 
+        public void CopyTo(Array array, int index)
+        {
+            ((ICollection)backingList).CopyTo(array, index);
+        }
+
         public int Count
         {
             get { return backingList.Count; }
+        }
+
+        public object SyncRoot
+        {
+            get { return ((ICollection)backingList).SyncRoot; }
+        }
+
+        public bool IsSynchronized
+        {
+            get { return ((ICollection)backingList).IsSynchronized; }
         }
 
         bool ICollection<T>.IsReadOnly

--- a/examples/cs/core/container_alias/program.cs
+++ b/examples/cs/core/container_alias/program.cs
@@ -1,5 +1,6 @@
 ﻿namespace Examples
 {
+    using System;
     using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics;
@@ -31,7 +32,7 @@
     }
 
     // An extremely simple example of a custom container implementation.
-    public class SomeCustomList<T> : ICollection<T>
+    public class SomeCustomList<T> : ICollection<T>, ICollection
     {
         readonly List<T> backingList = new List<T>();
 
@@ -70,9 +71,24 @@
             return backingList.Remove(item);
         }
 
+        public void CopyTo(Array array, int index)
+        {
+            ((ICollection)backingList).CopyTo(array, index);
+        }
+
         public int Count
         {
             get { return backingList.Count; }
+        }
+
+        public object SyncRoot
+        {
+            get { return ((ICollection)backingList).SyncRoot; }
+        }
+
+        public bool IsSynchronized
+        {
+            get { return ((ICollection)backingList).IsSynchronized; }
         }
 
         bool ICollection<T>.IsReadOnly


### PR DESCRIPTION
During the merge of commit 30b2c660a649fd6fc9d49e5df9d4bca0b33062cb,
SomeCustomList<T> lost its implementation of ICollection, a required
interface for a custom list-like container.

See also: https://github.com/Microsoft/bond/issues/254