### PR TITLE
[c#] Rearrange nuspec files by target

### DIFF
--- a/cs/nuget/.dir-locals.el
+++ b/cs/nuget/.dir-locals.el
@@ -1,0 +1,8 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+; In the .nuspec files we want line sorting for things like <files ...> to
+; be CASE SENSITIVE, otherwise Bond.dll and Bond.xml get sorted really far
+; away from each other.
+((nil
+  (sort-fold-case)))

--- a/cs/nuget/bond.comm.csharp.nuspec
+++ b/cs/nuget/bond.comm.csharp.nuspec
@@ -21,9 +21,9 @@
         <copyright>Copyright (c) Microsoft</copyright>
         <tags>Bond .NET C# RPC messaging network communication</tags>
         <dependencies>
-            <dependency id="Bond.CSharp" version ="[$coreversion$]"/>
-            <dependency id="Bond.Comm.Runtime.CSharp" version ="[$version$]"/>
-            <dependency id="Bond.Comm.Epoxy.CSharp" version ="[$version$]"/>
+            <dependency id="Bond.CSharp" version ="[$coreversion$]" />
+            <dependency id="Bond.Comm.Runtime.CSharp" version ="[$version$]" />
+            <dependency id="Bond.Comm.Epoxy.CSharp" version ="[$version$]" />
         </dependencies>
     </metadata>
     <files>

--- a/cs/nuget/bond.comm.epoxy.csharp.nuspec
+++ b/cs/nuget/bond.comm.epoxy.csharp.nuspec
@@ -21,12 +21,12 @@
         <copyright>Copyright (c) Microsoft</copyright>
         <tags>Bond .NET C# RPC messaging network communication</tags>
         <dependencies>
-            <dependency id="Bond.Comm.Runtime.CSharp" version ="[$version$]"/>
+            <dependency id="Bond.Comm.Runtime.CSharp" version ="[$version$]" />
         </dependencies>
     </metadata>
     <files>
-      <file src="net45\Bond.Comm.Epoxy.dll" target="lib\net45" />
-      <file src="net45\Bond.Comm.Epoxy.pdb" target="lib\net45" />
-      <file src="net45\Bond.Comm.Epoxy.xml" target="lib\net45" />
+      <file target="lib\net45" src="net45\Bond.Comm.Epoxy.dll" />
+      <file target="lib\net45" src="net45\Bond.Comm.Epoxy.pdb" />
+      <file target="lib\net45" src="net45\Bond.Comm.Epoxy.xml" />
     </files>
 </package>

--- a/cs/nuget/bond.comm.runtime.csharp.nuspec
+++ b/cs/nuget/bond.comm.runtime.csharp.nuspec
@@ -21,27 +21,28 @@
         <copyright>Copyright (c) Microsoft</copyright>
         <tags>Bond .NET C# RPC messaging network communication</tags>
         <dependencies>
-            <dependency id="Bond.Core.CSharp" version ="[$coreversion$]"/>
+            <dependency id="Bond.Core.CSharp" version ="[$coreversion$]" />
         </dependencies>
     </metadata>
     <files>
-      <file src="net45\Bond.Comm.Interfaces.dll" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-      <file src="net45\Bond.Comm.Interfaces.xml" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-      <file src="net45\Bond.Comm.Interfaces.pdb" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-      <file src="net45\Bond.Comm.Service.dll" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-      <file src="net45\Bond.Comm.Service.xml" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-      <file src="net45\Bond.Comm.Service.pdb" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-      <file src="net45\Bond.Comm.Layers.dll" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-      <file src="net45\Bond.Comm.Layers.xml" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-      <file src="net45\Bond.Comm.Layers.pdb" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-      <file src="net45\Bond.Comm.Interfaces.dll" target="lib\netstandard1.0" />
-      <file src="net45\Bond.Comm.Interfaces.xml" target="lib\netstandard1.0" />
-      <file src="net45\Bond.Comm.Interfaces.pdb" target="lib\netstandard1.0" />
-      <file src="net45\Bond.Comm.Service.dll" target="lib\netstandard1.0" />
-      <file src="net45\Bond.Comm.Service.xml" target="lib\netstandard1.0" />
-      <file src="net45\Bond.Comm.Service.pdb" target="lib\netstandard1.0" />
-      <file src="net45\Bond.Comm.Layers.dll" target="lib\netstandard1.0" />
-      <file src="net45\Bond.Comm.Layers.xml" target="lib\netstandard1.0" />
-      <file src="net45\Bond.Comm.Layers.pdb" target="lib\netstandard1.0" />
+      <file target="lib\netstandard1.0" src="net45\Bond.Comm.Interfaces.dll" />
+      <file target="lib\netstandard1.0" src="net45\Bond.Comm.Interfaces.pdb" />
+      <file target="lib\netstandard1.0" src="net45\Bond.Comm.Interfaces.xml" />
+      <file target="lib\netstandard1.0" src="net45\Bond.Comm.Layers.dll" />
+      <file target="lib\netstandard1.0" src="net45\Bond.Comm.Layers.pdb" />
+      <file target="lib\netstandard1.0" src="net45\Bond.Comm.Layers.xml" />
+      <file target="lib\netstandard1.0" src="net45\Bond.Comm.Service.dll" />
+      <file target="lib\netstandard1.0" src="net45\Bond.Comm.Service.pdb" />
+      <file target="lib\netstandard1.0" src="net45\Bond.Comm.Service.xml" />
+
+      <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.Comm.Interfaces.dll" />
+      <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.Comm.Interfaces.pdb" />
+      <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.Comm.Interfaces.xml" />
+      <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.Comm.Layers.dll" />
+      <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.Comm.Layers.pdb" />
+      <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.Comm.Layers.xml" />
+      <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.Comm.Service.dll" />
+      <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.Comm.Service.pdb" />
+      <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.Comm.Service.xml" />
     </files>
 </package>

--- a/cs/nuget/bond.compiler.csharp.nuspec
+++ b/cs/nuget/bond.compiler.csharp.nuspec
@@ -20,37 +20,36 @@
     </description>
     <copyright>Copyright (c) Microsoft</copyright>
     <tags>Bond .NET C# serialization</tags>
-    <dependencies />
   </metadata>
   <files>
     <!-- Ideally we'd reference the Bond.Compiler package to get the gbc
          files, but there doesn't seem to be a good way to reference
          dependent packages from MSBuild targets. Instead, we duplicate the
          files in this package. They're pretty small. -->
+    <file target="build\net40" src="cs\build\nuget\Bond.Compiler.CSharp.props" />
+    <file target="build\net40" src="cs\build\nuget\Bond.Compiler.CSharp.targets" />
+    <file target="build\net40" src="cs\build\nuget\Common.props" />
+    <file target="build\net40" src="cs\build\nuget\Common.targets" />
 
-    <file src="cs\tools\gbc.exe" target="tools" />
-    <file src="idl\bond\core\bond.bond" target="tools\inc\bond\core" />
-    <file src="idl\bond\core\bond_const.bond" target="tools\inc\bond\core" />
+    <file target="build\net45" src="cs\build\nuget\Bond.Compiler.CSharp.props" />
+    <file target="build\net45" src="cs\build\nuget\Bond.Compiler.CSharp.targets" />
+    <file target="build\net45" src="cs\build\nuget\Common.props" />
+    <file target="build\net45" src="cs\build\nuget\Common.targets" />
 
-    <file src="cs\build\nuget\Bond.Compiler.CSharp.targets" target="build\net45" />
-    <file src="cs\build\nuget\Bond.Compiler.CSharp.props" target="build\net45" />
-    <file src="cs\build\nuget\Common.props" target="build\net45" />
-    <file src="cs\build\nuget\Common.targets" target="build\net45" />
+    <file target="build\netstandard1.0" src="cs\build\nuget\Bond.Compiler.CSharp.props" />
+    <file target="build\netstandard1.0" src="cs\build\nuget\Bond.Compiler.CSharp.targets" />
+    <file target="build\netstandard1.0" src="cs\build\nuget\Common.props" />
+    <file target="build\netstandard1.0" src="cs\build\nuget\Common.targets" />
 
-    <file src="cs\build\nuget\Bond.Compiler.CSharp.targets" target="build\portable-net45+wp80+win8+wpa81+dnxcore50" />
-    <file src="cs\build\nuget\Bond.Compiler.CSharp.props" target="build\portable-net45+wp80+win8+wpa81+dnxcore50" />
-    <file src="cs\build\nuget\Common.props" target="build\portable-net45+wp80+win8+wpa81+dnxcore50" />
-    <file src="cs\build\nuget\Common.targets" target="build\portable-net45+wp80+win8+wpa81+dnxcore50" />
-    <file src="cs\build\nuget\Bond.Compiler.CSharp.targets" target="build\netstandard1.0" />
-    <file src="cs\build\nuget\Bond.Compiler.CSharp.props" target="build\netstandard1.0" />
-    <file src="cs\build\nuget\Common.props" target="build\netstandard1.0" />
-    <file src="cs\build\nuget\Common.targets" target="build\netstandard1.0" />
+    <file target="build\portable-net45+wp80+win8+wpa81+dnxcore50" src="cs\build\nuget\Bond.Compiler.CSharp.props" />
+    <file target="build\portable-net45+wp80+win8+wpa81+dnxcore50" src="cs\build\nuget\Bond.Compiler.CSharp.targets" />
+    <file target="build\portable-net45+wp80+win8+wpa81+dnxcore50" src="cs\build\nuget\Common.props" />
+    <file target="build\portable-net45+wp80+win8+wpa81+dnxcore50" src="cs\build\nuget\Common.targets" />
 
-    <file src="cs\build\nuget\Bond.Compiler.CSharp.targets" target="build\net40" />
-    <file src="cs\build\nuget\Bond.Compiler.CSharp.props" target="build\net40" />
-    <file src="cs\build\nuget\Common.props" target="build\net40" />
-    <file src="cs\build\nuget\Common.targets" target="build\net40" />
+    <file target="readme.txt" src="cs\nuget\readme.txt" />
 
-    <file src="cs\nuget\readme.txt" target="readme.txt" />
+    <file target="tools" src="cs\tools\gbc.exe" />
+    <file target="tools\inc\bond\core" src="idl\bond\core\bond.bond" />
+    <file target="tools\inc\bond\core" src="idl\bond\core\bond_const.bond" />
   </files>
 </package>

--- a/cs/nuget/bond.compiler.nuspec
+++ b/cs/nuget/bond.compiler.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Bond.Compiler</id>
@@ -22,11 +22,10 @@
         </description>
         <copyright>Copyright (c) Microsoft</copyright>
         <tags>Bond .NET C# serialization</tags>
-        <dependencies />
     </metadata>
     <files>
-        <file src="cs\tools\gbc.exe" target="tools" />
-        <file src="idl\bond\core\bond.bond" target="tools\inc\bond\core" />
-        <file src="idl\bond\core\bond_const.bond" target="tools\inc\bond\core" />
+        <file target="tools" src="cs\tools\gbc.exe" />
+        <file target="tools\inc\bond\core" src="idl\bond\core\bond.bond" />
+        <file target="tools\inc\bond\core" src="idl\bond\core\bond_const.bond" />
     </files>
 </package>

--- a/cs/nuget/bond.core.csharp.nuspec
+++ b/cs/nuget/bond.core.csharp.nuspec
@@ -24,47 +24,50 @@
         <tags>Bond .NET C# serialization</tags>
     </metadata>
     <files>
-        <file src="net45\Bond.dll" target="lib\net45" />
-        <file src="net45\Bond.xml" target="lib\net45" />
-        <file src="net45\Bond.pdb" target="lib\net45" />
-        <file src="net45\Bond.Attributes.dll" target="lib\net45" />
-        <file src="net45\Bond.Attributes.xml" target="lib\net45" />
-        <file src="net45\Bond.Attributes.pdb" target="lib\net45" />
-        <file src="net45\Bond.Reflection.dll" target="lib\net45" />
-        <file src="net45\Bond.Reflection.xml" target="lib\net45" />
-        <file src="net45\Bond.Reflection.pdb" target="lib\net45" />
-        <file src="net45\Bond.dll" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-        <file src="net45\Bond.xml" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-        <file src="net45\Bond.pdb" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-        <file src="net45\Bond.Attributes.dll" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-        <file src="net45\Bond.Attributes.pdb" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-        <file src="net45\Bond.Attributes.xml" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-        <file src="net45\Bond.Reflection.dll" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-        <file src="net45\Bond.Reflection.pdb" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-        <file src="net45\Bond.Reflection.xml" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-        <file src="net45\Bond.IO.dll" target="lib\net45" />
-        <file src="net45\Bond.IO.xml" target="lib\net45" />
-        <file src="net45\Bond.IO.pdb" target="lib\net45" />
-        <file src="net45\Bond.dll" target="lib\netstandard1.0" />
-        <file src="net45\Bond.xml" target="lib\netstandard1.0" />
-        <file src="net45\Bond.pdb" target="lib\netstandard1.0" />
-        <file src="net45\Bond.Attributes.dll" target="lib\netstandard1.0" />
-        <file src="net45\Bond.Attributes.xml" target="lib\netstandard1.0" />
-        <file src="net45\Bond.Attributes.pdb" target="lib\netstandard1.0" />
-        <file src="net45\Bond.Reflection.dll" target="lib\netstandard1.0" />
-        <file src="net45\Bond.Reflection.xml" target="lib\netstandard1.0" />
-        <file src="net45\Bond.Reflection.pdb" target="lib\netstandard1.0" />
-        <file src="net40\Bond.dll" target="lib\net40" />
-        <file src="net40\Bond.xml" target="lib\net40" />
-        <file src="net40\Bond.pdb" target="lib\net40" />
-        <file src="net40\Bond.Attributes.dll" target="lib\net40" />
-        <file src="net40\Bond.Attributes.xml" target="lib\net40" />
-        <file src="net40\Bond.Attributes.pdb" target="lib\net40" />
-        <file src="net40\Bond.Reflection.dll" target="lib\net40" />
-        <file src="net40\Bond.Reflection.xml" target="lib\net40" />
-        <file src="net40\Bond.Reflection.pdb" target="lib\net40" />
-        <file src="net40\Bond.IO.dll" target="lib\net40" />
-        <file src="net40\Bond.IO.xml" target="lib\net40" />
-        <file src="net40\Bond.IO.pdb" target="lib\net40" />
+        <file target="lib\net40" src="net40\Bond.Attributes.dll" />
+        <file target="lib\net40" src="net40\Bond.Attributes.pdb" />
+        <file target="lib\net40" src="net40\Bond.Attributes.xml" />
+        <file target="lib\net40" src="net40\Bond.IO.dll" />
+        <file target="lib\net40" src="net40\Bond.IO.pdb" />
+        <file target="lib\net40" src="net40\Bond.IO.xml" />
+        <file target="lib\net40" src="net40\Bond.Reflection.dll" />
+        <file target="lib\net40" src="net40\Bond.Reflection.pdb" />
+        <file target="lib\net40" src="net40\Bond.Reflection.xml" />
+        <file target="lib\net40" src="net40\Bond.dll" />
+        <file target="lib\net40" src="net40\Bond.pdb" />
+        <file target="lib\net40" src="net40\Bond.xml" />
+
+        <file target="lib\net45" src="net45\Bond.Attributes.dll" />
+        <file target="lib\net45" src="net45\Bond.Attributes.pdb" />
+        <file target="lib\net45" src="net45\Bond.Attributes.xml" />
+        <file target="lib\net45" src="net45\Bond.IO.dll" />
+        <file target="lib\net45" src="net45\Bond.IO.pdb" />
+        <file target="lib\net45" src="net45\Bond.IO.xml" />
+        <file target="lib\net45" src="net45\Bond.Reflection.dll" />
+        <file target="lib\net45" src="net45\Bond.Reflection.pdb" />
+        <file target="lib\net45" src="net45\Bond.Reflection.xml" />
+        <file target="lib\net45" src="net45\Bond.dll" />
+        <file target="lib\net45" src="net45\Bond.pdb" />
+        <file target="lib\net45" src="net45\Bond.xml" />
+
+        <file target="lib\netstandard1.0" src="net45\Bond.Attributes.dll" />
+        <file target="lib\netstandard1.0" src="net45\Bond.Attributes.pdb" />
+        <file target="lib\netstandard1.0" src="net45\Bond.Attributes.xml" />
+        <file target="lib\netstandard1.0" src="net45\Bond.Reflection.dll" />
+        <file target="lib\netstandard1.0" src="net45\Bond.Reflection.pdb" />
+        <file target="lib\netstandard1.0" src="net45\Bond.Reflection.xml" />
+        <file target="lib\netstandard1.0" src="net45\Bond.dll" />
+        <file target="lib\netstandard1.0" src="net45\Bond.pdb" />
+        <file target="lib\netstandard1.0" src="net45\Bond.xml" />
+
+        <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.Attributes.dll" />
+        <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.Attributes.pdb" />
+        <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.Attributes.xml" />
+        <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.Reflection.dll" />
+        <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.Reflection.pdb" />
+        <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.Reflection.xml" />
+        <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.dll" />
+        <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.pdb" />
+        <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.xml" />
     </files>
 </package>

--- a/cs/nuget/bond.csharp.nuspec
+++ b/cs/nuget/bond.csharp.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Bond.CSharp</id>
@@ -23,18 +23,20 @@
         <copyright>Copyright (c) Microsoft</copyright>
         <tags>Bond .NET C# serialization</tags>
         <dependencies>
-            <dependency id="Bond.Core.CSharp" version ="[$version$]"/>
-            <dependency id="Bond.Runtime.CSharp" version ="[$version$]"/>
+            <dependency id="Bond.Core.CSharp" version ="[$version$]" />
+            <dependency id="Bond.Runtime.CSharp" version ="[$version$]" />
         </dependencies>
     </metadata>
     <files>
-        <file src="cs\tools\gbc.exe" target="tools\" />
-        <file src="idl\bond\core\bond.bond" target="tools\inc\bond\core" />
-        <file src="idl\bond\core\bond_const.bond" target="tools\inc\bond\core" />
-        <file src="cs\build\nuget\Bond.CSharp.targets" target="build" />
-        <file src="cs\build\nuget\Bond.CSharp.props" target="build" />
-        <file src="cs\build\nuget\Common.props" target="build" />
-        <file src="cs\build\nuget\Common.targets" target="build" />
-        <file src="cs\nuget\readme.txt" target="readme.txt" />
+        <file target="build" src="cs\build\nuget\Bond.CSharp.props" />
+        <file target="build" src="cs\build\nuget\Bond.CSharp.targets" />
+        <file target="build" src="cs\build\nuget\Common.props" />
+        <file target="build" src="cs\build\nuget\Common.targets" />
+
+        <file target="readme.txt" src="cs\nuget\readme.txt" />
+
+        <file target="tools\" src="cs\tools\gbc.exe" />
+        <file target="tools\inc\bond\core" src="idl\bond\core\bond.bond" />
+        <file target="tools\inc\bond\core" src="idl\bond\core\bond_const.bond" />
     </files>
 </package>

--- a/cs/nuget/bond.runtime.csharp.nuspec
+++ b/cs/nuget/bond.runtime.csharp.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Bond.Runtime.CSharp</id>
@@ -24,21 +24,24 @@
         <tags>Bond .NET C# serialization</tags>
         <dependencies>
             <dependency id="Newtonsoft.Json" version="9.0.1" />
-            <dependency id="Bond.Core.CSharp" version ="[$version$]"/>
+            <dependency id="Bond.Core.CSharp" version ="[$version$] "/>
         </dependencies>
     </metadata>
     <files>
-        <file src="net45\Bond.JSON.dll" target="lib\net45" />
-        <file src="net45\Bond.JSON.xml" target="lib\net45" />
-        <file src="net45\Bond.JSON.pdb" target="lib\net45" />
-        <file src="net45\Bond.JSON.dll" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-        <file src="net45\Bond.JSON.xml" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-        <file src="net45\Bond.JSON.pdb" target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" />
-        <file src="net45\Bond.JSON.dll" target="lib\netstandard1.0" />
-        <file src="net45\Bond.JSON.xml" target="lib\netstandard1.0" />
-        <file src="net45\Bond.JSON.pdb" target="lib\netstandard1.0" />
-        <file src="net40\Bond.JSON.dll" target="lib\net40" />
-        <file src="net40\Bond.JSON.xml" target="lib\net40" />
-        <file src="net40\Bond.JSON.pdb" target="lib\net40" />
+        <file target="lib\net40" src="net40\Bond.JSON.dll" />
+        <file target="lib\net40" src="net40\Bond.JSON.pdb" />
+        <file target="lib\net40" src="net40\Bond.JSON.xml" />
+
+        <file target="lib\net45" src="net45\Bond.JSON.dll" />
+        <file target="lib\net45" src="net45\Bond.JSON.pdb" />
+        <file target="lib\net45" src="net45\Bond.JSON.xml" />
+
+        <file target="lib\netstandard1.0" src="net45\Bond.JSON.dll" />
+        <file target="lib\netstandard1.0" src="net45\Bond.JSON.pdb" />
+        <file target="lib\netstandard1.0" src="net45\Bond.JSON.xml" />
+
+        <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.JSON.dll" />
+        <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.JSON.pdb" />
+        <file target="lib\portable-net45+wp80+win8+wpa81+dnxcore50" src="net45\Bond.JSON.xml" />
     </files>
 </package>


### PR DESCRIPTION
The intent is to make merging easier when we add/remote target
frameworks in the future.

* List target first so everything going to the same target can easily be
  sorted together.
* Sort lines and split into logical sections.