### PR TITLE
[c#] Increase unit test's UnsafeBufferSize

### DIFF
--- a/cs/test/core/Util.cs
+++ b/cs/test/core/Util.cs
@@ -17,7 +17,7 @@ namespace UnitTest
 
     public static class Util
     {
-        private const int UnsafeBufferSize = 192 * 1024;
+        private const int UnsafeBufferSize = 4 * 1024 * 1024;
 
         public static IEnumerable<MethodInfo> GetDeclaredMethods(this Type type, string name)
         {


### PR DESCRIPTION
The GenericInheritance test case generates random payloads. Sometimes
these are larger than the current UnsafeBufferSize (192 * 1024 bytes),
so the test fails when writing to an OutputPointer, which cannot
automatically grow its buffer.

To compute the new value of 4 MiB, I changed RandomReader to always
return the maximum length for strings and containers and to return the
largest numbers possible. When transcoding to the Simple Binary
protocol, the payload was ~168KiB shy of 4 MiB, so I picked 4 MiB. The
other protocols were in the 3.8 MiB range.