### PR TITLE
[c++] Fully implement RapidJSON output stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ tag versions. The Bond compiler (`gbc`) and
 different versioning scheme, following the Haskell community's
 [package versioning policy](https://wiki.haskell.org/Package_versioning_policy).
 
+## Unreleased ##
+
+### C++ ###
+
+* Fixed compatibility with RapidJSON v1.1.0.
+  [Issue #271](https://github.com/Microsoft/bond/issues/271)
+
 ## 5.1.0: 2016-11-14 ##
 
 * `gbc` & compiler library: 0.7.0.0

--- a/cpp/inc/bond/protocol/detail/rapidjson_helper.h
+++ b/cpp/inc/bond/protocol/detail/rapidjson_helper.h
@@ -101,6 +101,8 @@ public:
     {
     }
 
+    typedef char Ch;
+
     // not implemented for write-only stream
     char Peek() { BOOST_ASSERT(false); return 0; }
     size_t Tell() const { BOOST_ASSERT(false); return 0; }
@@ -111,6 +113,10 @@ public:
     void Put(char c)
     {
         output.Write(c);
+    }
+
+    void Flush()
+    {
     }
 
 private:


### PR DESCRIPTION
The [RapidJSON (output) stream concept][1] needs a `Ch` typedef and a
`Flush` method.

Fixes https://github.com/Microsoft/bond/issues/271

I've tested with fix with the current version of RapidJSON we use, as
well as v1.0.0 and v1.1.0.

[1]: http://rapidjson.org/md_doc_stream.html#CustomStream