### PR TITLE
Reduce AppVeyor CI time for VC2013

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,9 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -C ${CMAKE_CFG_INTDIR} --
 
 if (NOT BOND_GBC_PATH)
     add_subfolder (compiler "compiler")
-    add_dependencies (check gbc-tests)
+    if (NOT BOND_SKIP_GBC_TESTS)
+        add_dependencies (check gbc-tests)
+    endif()
 endif()
 
 add_subdirectory (cpp)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@
               BOND_ARCH: 32
               BOND_BOOST: 60
             - BOND_BUILD: C++
-              BOND_VS: "Visual Studio 14 2015 Win64"
+              BOND_VS: "Visual Studio 14 2015"
               BOND_VS_NUM: 14
               BOND_ARCH: 64
               BOND_BOOST: 60
@@ -40,6 +40,13 @@
               BOND_VS_NUM: 12
               BOND_ARCH: 32
               BOND_BOOST: 58
+              BOND_CMAKE_FLAGS: "-DBOND_CORE_ONLY=TRUE"
+            - BOND_BUILD: C++
+              BOND_VS: "Visual Studio 12 2013"
+              BOND_VS_NUM: 12
+              BOND_ARCH: 64
+              BOND_BOOST: 58
+              BOND_CMAKE_FLAGS: "-DBOND_SKIP_CORE_TESTS=TRUE"
             - BOND_BUILD: C#
               BOND_OUTPUT: Fields
               BOND_CONFIG: Fields
@@ -82,6 +89,18 @@
 
     before_build:
         - ps: >-
+            $env:PreferredToolArchitecture = "x64"
+
+            $env:_IsNativeEnvironment = "true"
+
+            $cmakeGenerator = $env:BOND_VS
+
+            if ($env:BOND_ARCH -eq 64) {
+                $cmakeGenerator += " Win64"
+            }
+
+            $cmakeFlags = $env:BOND_CMAKE_FLAGS -split ';'
+
             if ($env:BOND_BUILD -eq "C#" -Or $env:BOND_BUILD -eq "C++") {
 
                 nuget restore cs\cs.sln
@@ -96,7 +115,7 @@
 
                 Wait-Process -name boost
 
-                cmake "-DBoost_ADDITIONAL_VERSIONS=1.${env:BOND_BOOST}.0" -G $env:BOND_VS ..
+                cmake "-DBoost_ADDITIONAL_VERSIONS=1.${env:BOND_BOOST}.0" $cmakeFlags -G $cmakeGenerator ..
 
             }
 
@@ -113,7 +132,7 @@
                     $env:Path = "C:\Python27-x64\scripts;C:\Python27-x64\;${env:Path}"
                 }
 
-                cmake -G $env:BOND_VS ..
+                cmake $cmakeFlags -G $cmakeGenerator ..
 
             }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,13 +40,13 @@
               BOND_VS_NUM: 12
               BOND_ARCH: 32
               BOND_BOOST: 58
-              BOND_CMAKE_FLAGS: "-DBOND_CORE_ONLY=TRUE"
+              BOND_CMAKE_FLAGS: "-DBOND_CORE_ONLY=TRUE;-DBOND_SKIP_GBC_TESTS=TRUE"
             - BOND_BUILD: C++
               BOND_VS: "Visual Studio 12 2013"
               BOND_VS_NUM: 12
               BOND_ARCH: 64
               BOND_BOOST: 58
-              BOND_CMAKE_FLAGS: "-DBOND_SKIP_CORE_TESTS=TRUE"
+              BOND_CMAKE_FLAGS: "-DBOND_SKIP_CORE_TESTS=TRUE;-DBOND_SKIP_GBC_TESTS=TRUE"
             - BOND_BUILD: C#
               BOND_OUTPUT: Fields
               BOND_CONFIG: Fields

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -134,6 +134,10 @@ set (BOND_CORE_ONLY
     "FALSE"
     CACHE BOOL "If TRUE, then only build the Bond Core")
 
+set (BOND_SKIP_CORE_TESTS
+    "FALSE"
+    CACHE BOOL "If TRUE, then skip Bond Core tests and examples")
+
 if ((NOT BOND_CORE_ONLY) AND ((CXX_STANDARD LESS 11) OR (MSVC_VERSION LESS 1800)))
     message(FATAL_ERROR "BOND_CORE_ONLY is FALSE but compiler specified does not support C++11 standard")
 endif()

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -134,6 +134,10 @@ set (BOND_CORE_ONLY
     "FALSE"
     CACHE BOOL "If TRUE, then only build the Bond Core")
 
+set (BOND_SKIP_GBC_TESTS
+    "FALSE"
+    CACHE BOOL "If TRUE, then skip gbc tests")
+
 set (BOND_SKIP_CORE_TESTS
     "FALSE"
     CACHE BOOL "If TRUE, then skip Bond Core tests and examples")

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -104,9 +104,11 @@ add_cabal_build (gbc
     DEPENDS sandbox ${completion}
     SOURCES ${sources})
 
-add_cabal_test (gbc-tests
-    DEPENDS gbc
-    SOURCES ${test_sources})
+if(NOT BOND_SKIP_GBC_TESTS)
+    add_cabal_test (gbc-tests
+        DEPENDS gbc
+        SOURCES ${test_sources})
+endif()
 
 install (FILES ${output}
     PERMISSIONS OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -4,10 +4,14 @@ cxx_add_compile_options(MSVC /wd4310)
 # Core unit tests don't build under VS2013 without this.
 cxx_add_compile_options(MSVC /EHa)
 
-add_subfolder (compat/core "tests/compat/core")
+if (NOT BOND_SKIP_CORE_TESTS)
+    add_subfolder (compat/core "tests/compat/core")
+endif()
 
 if (Boost_UNIT_TEST_FRAMEWORK_FOUND)
-    add_subfolder (core "tests/unit_test/core")
+    if (NOT BOND_SKIP_CORE_TESTS)
+        add_subfolder (core "tests/unit_test/core")
+    endif()
     if (NOT BOND_CORE_ONLY)
         add_subfolder (comm "tests/unit_test/comm")
         add_subfolder (comm/epoxy "tests/unit_test/comm/epoxy")

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_subfolder (core "examples/core")
+if (NOT BOND_SKIP_CORE_TESTS)
+    add_subfolder (core "examples/core")
+endif()
 
 if (NOT BOND_CORE_ONLY)
     #add_subfolder (comm "examples/comm")

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -3,5 +3,7 @@ if (NOT BOND_SKIP_CORE_TESTS)
 endif()
 
 if (NOT BOND_CORE_ONLY)
-    #add_subfolder (comm "examples/comm")
+    if (MSVC)
+        add_subfolder (comm "examples/comm")
+    endif()
 endif()

--- a/python/test/CMakeLists.txt
+++ b/python/test/CMakeLists.txt
@@ -1,2 +1,4 @@
-add_subfolder (core "tests/python/unit_test/core")
-add_subfolder (compat "tests/python/compat")
+if (NOT BOND_SKIP_CORE_TESTS)
+    add_subfolder (core "tests/python/unit_test/core")
+    add_subfolder (compat "tests/python/compat")
+endif()


### PR DESCRIPTION
Adds some knobs to reduce individual build times by skipping portions of test/example build/run time.

Split the VC2013 run on AppVeyor CI into Core and Comm portions and stop running the gbc tests on VC2013 configurations.

VC2013 Comm portion now runs quickly. VC2013 Core portion still exceeds the 1 hour limit so will require further work but I think this PR represents a chunk of progress.