### PR TITLE
Update Bond Comm docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ different versioning scheme, following the Haskell community's
 
 * Fixed compatibility with RapidJSON v1.1.0.
   [Issue #271](https://github.com/Microsoft/bond/issues/271)
+* The minimum supported version of Boost is now 1.58
 
 ## 5.1.0: 2016-11-14 ##
 

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Microsoft in high scale services.
 
 We are also introducing the
 [Bond Communications framework](https://Microsoft.github.io/bond/manual/bond_comm.html)--known
-as Bond Comm--which allows for remote process communication. Currently, we
-are making the C# version of this framework available; the C++ version will
-be released in the coming weeks. This framework is based on is the successor
+as Bond Comm--which allows for remote process communication. This framework is the successor
 to an internal framework that is used by several large services inside
-Microsoft. Bond Comm is undergoing active evolution at this time and so we
-are marking the initial release as version 0.5. Consult the
-[C# manual](https://Microsoft.github.io/bond/manual/bond_cs.html#bond-comm)
-for more details on Bond Comm's usage and capabilities.
+Microsoft. We have now released versions of Bond Comm for C# and C++. Consult
+the [C# manual](https://Microsoft.github.io/bond/manual/bond_cs.html#bond-comm)
+and the [C++ manual](https://Microsoft.github.io/bond/manual/bond_cpp.html#bond-comm)
+for more details on Bond Comm's usage and capabilities. Note that the wire format should be
+considered firm at this point but the APIs and implementation are still evolving so Bond Comm is
+still considered "pre-1.0".
 
 Bond is published on GitHub at [https://github.com/Microsoft/bond/](https://github.com/Microsoft/bond/).
 
@@ -44,9 +44,10 @@ git clone --recursive https://github.com/Microsoft/bond.git
 ```
 
 In order to build Bond you will need CMake (3.1+), Haskell (ghc 7.4+ and
-cabal-install 1.18+) and Boost (1.54+). The core Bond C++ library can be used
-with C++03 compilers, although Python support, unit tests and various examples
-require some C++11 features.
+cabal-install 1.18+) and Boost (1.58+). The core Bond C++ library can be used
+with C++03 compilers, although Bond Comm, Python support, unit tests and various
+examples require some C++11 features. (Note: Boost 1.59 may not work with
+Bond Comm due to some bugs in that version of the Boost ASIO library).
 
 Following are specific instructions for building on various platforms.
 
@@ -209,7 +210,7 @@ switch is used to run the unit tests as well.
 
 The C++ and Python versions of Bond additionally require:
 
-- Boost 1.54+ ([http://www.boost.org/users/download/](http://www.boost.org/users/download/))
+- Boost 1.58+ ([http://www.boost.org/users/download/](http://www.boost.org/users/download/))
 - Python 2.7 ([https://www.python.org/downloads/](https://www.python.org/downloads/))
 
 You may need to set the environment variables `BOOST_ROOT` and `BOOST_LIBRARYDIR`
@@ -217,8 +218,8 @@ to specify where Boost and its pre-built libraries for your environment (MSVC 12
 found, e.g.:
 
 ```bash
-set BOOST_ROOT=D:\boost_1_57_0
-set BOOST_LIBRARYDIR=D:\boost_1_57_0\lib64-msvc-14.0
+set BOOST_ROOT=D:\boost_1_58_0
+set BOOST_LIBRARYDIR=D:\boost_1_58_0\lib64-msvc-14.0
 ```
 
 The core Bond library and most examples only require Boost headers. The

--- a/doc/src/bond_comm.md
+++ b/doc/src/bond_comm.md
@@ -34,8 +34,6 @@ Bond includes the following transports:
 Not all transports support all messaging patterns. Check the documentation
 for the respective transports.
 
-See the [roadmap](bond_comm_roadmap.html) for plans about future transports.
-
 ## Messaging Patterns ##
 
 There are a number of conceptual messaging patterns that are supported:
@@ -60,7 +58,32 @@ that are intriguing include--but are not limited to:
 * aggregations: send requests to multiple receivers and combine their
   responses in various ways
 
+## Layers ##
+
+Bond Comm includes extensibility points called "layers" that provides hooks
+for capabilites that are not service- or method-specific. An example of this
+would be tracing hooks like those mentioned in the [Dapper
+paper](http://research.google.com/pubs/pub36356.html).
+
+A set of layers are encapsulated together in a "layer stack", which can be
+provided to the Transport. When the Transport sends out a message, the layer
+stack invokes the layers in forward order. On the receive side, the layer
+stack invokes the layers in reverse order.
+
+The layers in a layer stack are expected to share a single Bond structure
+for passing state from the send side to the receive side. This structure is
+serialized by the transport and sent alongside the actual message payload.
+
+If any layer returns an error, the layer stack is halted and the error
+replaces the current message; therefore, layers should only return errors
+for conditions that are truly fatal for the current message.
+
+Layers may be stateful or stateless. In the case of request/response messages,
+a stateful layer instance is shared across the two halves of the conversation
+-- i.e. on the client side, a stateful layer instance can pass its state from the
+outbound request to the inbound response, and on the server side, from the
+inbound request to the outbound response.
+
 # Implementations #
 
-Bond Communications is available for [C#](bond_cs.html#bond-comm) today. C++
-support is [forthcoming](bond_comm_roadmap.html).
+Bond Communications is available for [C#](bond_cs.html#bond-comm) and [C++](bond_cpp.html#bond-comm).

--- a/doc/src/bond_comm_roadmap.md
+++ b/doc/src/bond_comm_roadmap.md
@@ -10,20 +10,19 @@ If there's a feature you think is useful and should be on the roadmap or
 would like to help implement a feature, please see the
 [guidelines for contributing](https://github.com/Microsoft/bond/blob/master/CONTRIBUTING.md).
 
-## Short term (next few weeks)
+## Short term (next couple of months)
 
 * C# Epoxy performance improvements
-* C++ support
+* C++ TLS Support
 
-## Medium term (next few months)
+## Medium Term (next six months)
 
-* additional languages, based on interest
-* HTTP(S)-based transports (HTTP 1.1 or HTTP 2 TBD)
+* Bi-directional communication support
 
-## Long term (next few years)
+## Longer Term (next two years)
 
-* additional messaging patterns
-* additional transports
+* Additional messaging patterns
+* Other language implementations
 
 ## Never
 

--- a/doc/src/bond_cpp.md
+++ b/doc/src/bond_cpp.md
@@ -16,6 +16,11 @@ serialization protocols, data streams, user defined type aliases and more.
 By design Bond is language and platform independent and is currently supported 
 for C++, C#, and Python on Linux, OS X and Windows.
 
+We are also introducing the
+[Bond Communications framework](https://Microsoft.github.io/bond/manual/bond_comm.html)--known
+as Bond Comm. More information about Bond Comm for C# can be found
+[below](#bond-comm).
+
 Bond is published on GitHub at [https://github.com/Microsoft/bond/](https://github.com/Microsoft/bond/).
 
 Basic example
@@ -1705,6 +1710,62 @@ See example: `examples/cpp/core/static_library`.
 unpredictable runtime behaviour, the Bond implementation has a built-in 
 assertion mechanism to detect it.
 
+Bond Comm
+=========
+
+The [Bond Communications framework](bond_comm.html) in C++ makes it easy and
+efficent to construct services and hook clients up to those services. Built
+on top of the Bond serialization framework, Bond Comm aims for the same
+principles of high-performance and extensibility.
+
+Today the framework supports two messaging patterns:
+
+- request-response: roundtrip messages supporting either payload or error responses
+- event: one-way, fire-and-forget messages with no responses
+
+Bond Comm is naturally asynchronous and sits on top of the Boost ASIO library, making it
+cross-platform. Only Windows 10 and Windows Server 2012 R2 have been tested to date.
+
+See the following examples:
+
+- `examples/cpp/comm/pingpong`
+- `examples/cs/comm/event`
+
+### Defining services ###
+
+Cross-language services are defined in the [Bond IDL](bond_comm.html#defining-services).
+
+The generated C++ service stub contains a service base class that the developer should subclass to
+provide the business logic of their service.
+
+The generated proxy stub provides a class with methods that the developer can call to
+exhange messages with the service.
+
+### Epoxy Transport ###
+
+Bond Comm provides a binary transport called
+[Epoxy](bond_comm_epoxy.html). This is the recommended default transport.
+
+TLS support for the Epoxy transport in C++ is forthcoming.
+
+### SimpleInMem Transport ###
+
+Bond Comm C++ does not provide an implementation of the SimpleInMem transport.
+
+### Logging Facade ###
+
+Bond Comm includes a facade for logging. By writing a simple handler for logging,
+developers can supply their own logging facility to gather log data from Bond
+Comm-based services.
+
+See the following example:
+
+- `examples/cpp/comm/logging`
+
+### Roadmap ###
+
+We have a [brief roadmap](bond_comm_roadmap.html) for Bond Comm.
+
 References
 ==========
 
@@ -1720,6 +1781,9 @@ References
 [Python User's Manual][bond_py]
 ----------------------------
 
+[Bond Comm overview][bond_comm]
+----------------------------
+
 [API_reference]: ../reference/cpp/index.html
 
 [compiler]: compiler.html
@@ -1727,6 +1791,8 @@ References
 [bond_py]: bond_py.html
 
 [bond_cs]: bond_cs.html
+
+[bond_comm]: bond_comm.html
 
 [serializing_transform_ref]: 
 ../reference/cpp/structbond_1_1_serializing_transform.html

--- a/doc/src/bond_cs.md
+++ b/doc/src/bond_cs.md
@@ -1,4 +1,4 @@
-% A Young Person's Guide to C# Bond
+﻿% A Young Person's Guide to C# Bond
 
 About
 =====
@@ -1227,12 +1227,9 @@ Today the framework supports two messaging patterns:
 Bond Comm is naturally asynchronous, and the C# implementation takes advantage of the
 idiomatic Task and async/await facilities of .NET.
 
-The initial release of Bond Comm is designed to run on Windows running
-.NET&nbsp;4.5 or .NET&nbsp;Core. Since .NET&nbsp;Core is still under development, we
-will update as needed. Mono support is forthcoming, as are Linux and
-Mac&nbsp;OS&nbsp;X.
-
-Only Windows 10 and Windows Server 2012 R2 have been tested to date.
+Bond Comm is designed to run on NET&nbsp;4.5 or .NET&nbsp;Core. Mono
+support is forthcoming, as are Linux and Mac&nbsp;OS&nbsp;X -- only Windows 10 and Windows
+Server 2012 R2 have been tested to date.
 
 See the following examples:
 
@@ -1252,7 +1249,7 @@ exhange messages with the service.
 
 ### Epoxy Transport ###
 
-The initial release of Bond Comm provides a binary transport called
+Bond Comm provides a binary transport called
 [Epoxy](bond_comm_epoxy.html). This is the recommended default Transport.
 The Epoxy transport is designed to be .NET&nbsp;Core compliant, which will
 allow for cross-platform support.
@@ -1277,31 +1274,9 @@ See the following examples:
 - `examples/cs/comm/logging`
 - `examples/cs/comm/metrics`
 
-### Layers ###
-
-Bond Comm includes extensibility points called "layers" that provides hooks
-for capabilites that are not service- or method-specific. An example of this
-would be tracing hooks like those mentioned in the [Dapper
-paper](http://research.google.com/pubs/pub36356.html).
-
-A set of layers are encapsulated together in a "layer stack", which can be
-provided to the Transport. When the Transport sends out a message, the layer
-stack invokes the layers in forward order. On the receive side, the layer
-stack invokes the layers in reverse order.
-
-The layers in a layer stack are expected to share a single Bond structure
-for passing state from the send side to the receive side. This structure is
-serialized by the transport and sent alongside the actual message payload.
-
-If any layer returns an error, the layer stack is halted and the error
-replaces the current message; therefore, layers should only return errors
-for conditions that are truly fatal for the current message.
-
-Support for layers that contain per-instance state is forthcoming.
-
 ### Roadmap ###
 
-We have a [roadmap](bond_comm_roadmap.html) for Bond Comm.
+We have a [brief roadmap](bond_comm_roadmap.html) for Bond Comm.
 
 ### Comm NuGet Packages ###
 


### PR DESCRIPTION
Include initial C++ release and updates to C# implementation. Also,
update minimum version of Boost to 1.58.