### PR TITLE
Extend bf utility to support multiple payloads

### DIFF
--- a/cpp/inc/bond/protocol/detail/rapidjson_helper.h
+++ b/cpp/inc/bond/protocol/detail/rapidjson_helper.h
@@ -85,7 +85,7 @@ public:
     }
 
 private:
-    Buffer* input;
+    typename std::remove_reference<Buffer>::type* input;
     uint8_t current;
     size_t count;
 };

--- a/examples/cpp/core/bf/cmd_arg.bond
+++ b/examples/cpp/core/bf/cmd_arg.bond
@@ -24,17 +24,17 @@ struct Options
     [help("output file")]
     1: string output = "stdout";
 
-    [help("guess | marshal | compact | compact2 | fast | simple | simple2")]
-    2: Protocol from = guess;
+    [help("guess | marshal | compact | compact2 | fast | simple | simple2, default guess")]
+    2: list<Protocol> from;
 
     [help("json | compact | compact2 | fast | simple | simple2")]
     3: Protocol to = json;
 
-    [help("include values for omitted optional fields when transcoding to json format with input schema)")]
+    [help("include values for omitted optional fields when transcoding to json format with input schema")]
     4: bool all_fields;
     
     [help("file with marshaled schema of the input; required when input format is simple*")]
-    5: string schema;
+    5: list<string> schema;
 
     [help("input file")]
     [naked("")]


### PR DESCRIPTION
The `bf` C++ example is a handy utility to work with files containing
arbitrary Bond payloads. This change extends it to support files with
more than one Bond payload.

The most obvious use case is files with a sequence of records (e.g.
logs). The less obvious but very powerful scenario is extracting some
kind of header that precedes the actual Bond payload of interest. This
is possible because a Bond schema in Simple Binary protocol can be used
to model many kinds of arbitrary headers (e.g. any fixed size header
aligned to octet boundary).

The change is backward compatible and existing command line arguments
retain their old semantics. In order to process multiple payloads user
can specified multiple `--schema` and/or multiple `--from` arguments,
e.g.:

    bf --from=simple --schema=header.json,payload.json file

In the above example `bf` will first use Simple Binary to decode header
in schema specified in `header.json` and then will try to guess the
protocol of the next payload (since only one `--from` argument was
specified) and decode it using schema specified by the `payload.json`
file.

Multiple values for the `--schema` and `--from` arguments can be
specified either as comma delimited values (like in the example above)
or by passing the argument multiple times, e.g.:

    bf --from=fast --from=fast file