### PR TITLE
Reference variable, which would otherwise only be referenced in an assert()

### DIFF
--- a/examples/cpp/comm/error/error.cpp
+++ b/examples/cpp/comm/error/error.cpp
@@ -61,6 +61,7 @@ int BOND_CALL main()
     }
     catch (const bond::comm::CommException& ex)
     {
+        boost::ignore_unused_variable_warning(ex);
         // Expect InvalidInvocation when trying to access error payload.
         assert(bond::comm::ErrorCode::INVALID_INVOCATION == ex.error_code);
     }

--- a/examples/cpp/comm/uncaught_exception/uncaught_exception.cpp
+++ b/examples/cpp/comm/uncaught_exception/uncaught_exception.cpp
@@ -50,6 +50,7 @@ int BOND_CALL main()
     }
     catch (const bond::comm::CommException& ex)
     {
+        boost::ignore_unused_variable_warning(ex);
         // Expect InvalidInvocation when trying to access error payload.
         assert(bond::comm::ErrorCode::INVALID_INVOCATION == ex.error_code);
     }


### PR DESCRIPTION
Fix small compile error triggered in VS2015, update 3, in non-debug flavors.