### PR TITLE
Address issue with multiple defines in C++ Comm

### DIFF
--- a/cpp/inc/bond/comm/transport/detail/epoxy_data_structs.h
+++ b/cpp/inc/bond/comm/transport/detail/epoxy_data_structs.h
@@ -35,7 +35,7 @@ struct FrameState
     std::vector<std::pair<FrameletType, blob>> framelets;
 };
 
-
+inline
 std::shared_ptr<std::vector<blob>> MakeConfigFrame(std::allocator<char> allocator)
 {
     OutputBuffer stream(256, static_cast<uint32_t>(256));


### PR DESCRIPTION
Addresses https://github.com/Microsoft/bond/issues/294
Includes a new example written by Christopher that reproduces the issue.