### PR TITLE
[C#] Add preallocation controls in deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ different versioning scheme, following the Haskell community's
 * The `bf` utility now supports multiple payloads.
   [Pull request #288](https://github.com/Microsoft/bond/pull/288)
 
+### C# ###
+
+* Added controls to cap pre-allocation during deserialization of containers
+  and blobs.
+
 ## 5.1.0: 2016-11-14 ##
 
 * `gbc` & compiler library: 0.7.0.0

--- a/cs/test/core/Core.csproj
+++ b/cs/test/core/Core.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildFramework Condition="'$(Configuration)' == 'Net40'">net40</BuildFramework>
@@ -36,6 +36,7 @@
     <Compile Include="BondedTests.cs" />
     <Compile Include="CloningTests.cs" />
     <Compile Include="CustomBondedTests.cs" />
+    <Compile Include="DeserializerControlsTests.cs" />
     <Compile Include="EnumString.cs" />
     <Compile Include="Equal.cs" />
     <Compile Include="GuidConversionTests.cs" />

--- a/cs/test/core/DeserializerControlsTests.cs
+++ b/cs/test/core/DeserializerControlsTests.cs
@@ -1,0 +1,153 @@
+﻿namespace UnitTest
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using System.Xml;
+    using Bond;
+    using Bond.IO.Unsafe;
+    using Bond.Protocols;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class DeserializerControlsTests
+    {
+        // Data that is designed to preallocate an extremely large container/blob
+        // (0x7F7F7F7F elements/bytes) when used with SimpleBinary and a struct that
+        // starts with a container/blob
+        static readonly byte[] badData = new byte[] { 0x7F, 0x7F, 0x7F, 0x7F, 0x7f };
+
+        // Data for a simple valid blob
+        static readonly byte[] blobData = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30 };
+
+        static T DeserializeBadData<T>()
+        {
+            // Untagged protocol used to trigger errors more easily
+            var reader = new SimpleBinaryReader<InputBuffer>(new InputBuffer(badData));
+            return new Deserializer<SimpleBinaryReader<InputBuffer>>(typeof(T)).Deserialize<T>(reader);
+        }
+
+        // Restore the default settings at the start and end of each test
+        [SetUp]
+        [TearDown]
+        public void RestoreDefaults()
+        {
+            DeserializerControls.Active = DeserializerControls.Default;
+        }
+
+        void RoundtripObject<T>(T obj)
+        {
+            // SimpleBinary
+            {
+                var output = new OutputBuffer();
+                var writer = new SimpleBinaryWriter<OutputBuffer>(output);
+                Serialize.To(writer, obj);
+
+                var input = new InputBuffer(output.Data);
+                var reader = new SimpleBinaryReader<InputBuffer>(input);
+                T obj2 = Deserialize<T>.From(reader);
+
+                Assert.True(Comparer.Equal<T>(obj, obj2));
+            }
+
+            // CompactBinary
+            {
+                var output = new OutputBuffer();
+                var writer = new CompactBinaryWriter<OutputBuffer>(output);
+                Serialize.To(writer, obj);
+
+                var input = new InputBuffer(output.Data);
+                var reader = new CompactBinaryReader<InputBuffer>(input);
+                T obj2 = new Deserializer<CompactBinaryReader<InputBuffer>>(typeof(T)).Deserialize<T>(reader);
+
+                Assert.True(Comparer.Equal<T>(obj, obj2));
+            }
+
+            // SimpleXML
+            {
+                var xmlString = new StringBuilder();
+                var xmlWriter = new SimpleXmlWriter(XmlWriter.Create(xmlString));
+
+                Serialize.To(xmlWriter, obj);
+                xmlWriter.Flush();
+
+                var reader = new SimpleXmlReader(XmlReader.Create(new StringReader(xmlString.ToString())));
+                T obj2 = new Deserializer<SimpleXmlReader>(typeof(T)).Deserialize<T>(reader);
+
+                Assert.True(Comparer.Equal<T>(obj, obj2));
+            }
+        }
+
+        void RoundtripTests()
+        {
+            var containers = new SimpleContainers();
+            for (int i = 0; i < 30; i++)
+            {
+                containers.strings.Add(i.ToString());
+                containers.numbers.Add(i, i.ToString());
+            }
+
+            RoundtripObject<SimpleContainers>(containers);
+
+            var blobs = new StructWithBlobs();
+            blobs.b = new ArraySegment<byte>(blobData, 0, 30);
+            blobs.lb.Add(new ArraySegment<byte>(blobData, 0, 30));
+            blobs.lb.Add(new ArraySegment<byte>(blobData, 1, 30));
+
+            RoundtripObject<StructWithBlobs>(blobs);
+        }
+
+        [Test]
+        public void DeserializerControls_InvalidArguments()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => DeserializerControls.Active.MaxPreallocatedContainerElements = -1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => DeserializerControls.Active.MaxPreallocatedBlobBytes = -1);
+        }
+
+        [Test]
+        public void DeserializerControls_InvalidData()
+        {
+            DeserializerControls.Active.MaxPreallocatedContainerElements = 20;
+            DeserializerControls.Active.MaxPreallocatedBlobBytes = 20;
+
+            // These tests MUST return EndOfStreamException
+            Assert.Throws<EndOfStreamException>(() => DeserializeBadData<SimpleContainers>());
+            Assert.Throws<EndOfStreamException>(() => DeserializeBadData<Lists>());
+            Assert.Throws<EndOfStreamException>(() => DeserializeBadData<Vectors>());
+            Assert.Throws<EndOfStreamException>(() => DeserializeBadData<Sets>());
+            Assert.Throws<EndOfStreamException>(() => DeserializeBadData<Maps>());
+            Assert.Throws<EndOfStreamException>(() => DeserializeBadData<StructWithBlobs>());
+            Assert.Throws<EndOfStreamException>(() => DeserializeBadData<StructWithBonded>());
+            Assert.Throws<EndOfStreamException>(() => DeserializeBadData<StructWithByteLists>());
+
+            DeserializerControls.Active.MaxPreallocatedContainerElements = Int32.MaxValue;
+            DeserializerControls.Active.MaxPreallocatedBlobBytes = Int32.MaxValue;
+
+            // These tests may return EndOfStreamException or OutOfMemoryException depending
+            // environment -- either is acceptable
+            Assert.Throws(Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(), () => DeserializeBadData<SimpleContainers>());
+            Assert.Throws(Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(), () => DeserializeBadData<Lists>());
+            Assert.Throws(Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(), () => DeserializeBadData<Vectors>());
+            Assert.Throws(Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(), () => DeserializeBadData<Sets>());
+            Assert.Throws(Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(), () => DeserializeBadData<Maps>());
+            Assert.Throws(Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(), () => DeserializeBadData<StructWithBlobs>());
+            Assert.Throws(Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(), () => DeserializeBadData<StructWithBonded>());
+            Assert.Throws(Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(), () => DeserializeBadData<StructWithByteLists>());
+        }
+
+        [Test]
+        public void DeserializerControls_ValidData()
+        {
+            DeserializerControls.Active.MaxPreallocatedContainerElements = 80;
+            DeserializerControls.Active.MaxPreallocatedBlobBytes = 80;
+            RoundtripTests();
+            DeserializerControls.Active.MaxPreallocatedContainerElements = 20;
+            DeserializerControls.Active.MaxPreallocatedBlobBytes = 20;
+            RoundtripTests();
+            DeserializerControls.Active.MaxPreallocatedContainerElements = 0;
+            DeserializerControls.Active.MaxPreallocatedBlobBytes = 0;
+            RoundtripTests();
+        }
+
+    }
+}

--- a/cs/test/core/DeserializerControlsTests.cs
+++ b/cs/test/core/DeserializerControlsTests.cs
@@ -125,14 +125,30 @@
 
             // These tests may return EndOfStreamException or OutOfMemoryException depending
             // environment -- either is acceptable
-            Assert.Throws(Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(), () => DeserializeBadData<SimpleContainers>());
-            Assert.Throws(Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(), () => DeserializeBadData<Lists>());
-            Assert.Throws(Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(), () => DeserializeBadData<Vectors>());
-            Assert.Throws(Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(), () => DeserializeBadData<Sets>());
-            Assert.Throws(Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(), () => DeserializeBadData<Maps>());
-            Assert.Throws(Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(), () => DeserializeBadData<StructWithBlobs>());
-            Assert.Throws(Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(), () => DeserializeBadData<StructWithBonded>());
-            Assert.Throws(Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(), () => DeserializeBadData<StructWithByteLists>());
+            Assert.Throws(
+                Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(),
+                () => DeserializeBadData<SimpleContainers>());
+            Assert.Throws(
+                Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(),
+                () => DeserializeBadData<Lists>());
+            Assert.Throws(
+                Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(),
+                () => DeserializeBadData<Vectors>());
+            Assert.Throws(
+                Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(),
+                () => DeserializeBadData<Sets>());
+            Assert.Throws(
+                Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(),
+                () => DeserializeBadData<Maps>());
+            Assert.Throws(
+                Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(),
+                () => DeserializeBadData<StructWithBlobs>());
+            Assert.Throws(
+                Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(),
+                () => DeserializeBadData<StructWithBonded>());
+            Assert.Throws(
+                Is.InstanceOf<EndOfStreamException>().Or.InstanceOf<OutOfMemoryException>(),
+                () => DeserializeBadData<StructWithByteLists>());
         }
 
         [Test]

--- a/cs/test/expressions/DeserializeCB.expressions
+++ b/cs/test/expressions/DeserializeCB.expressions
@@ -32,7 +32,15 @@
                                                         $elementType);
                                                     .If ($elementType == .Constant<Bond.BondDataType>(BT_LIST)) {
                                                         .Block(System.Collections.Generic.List`1[System.UInt64] $Convert(Example).vvb_item) {
-                                                            (((ExpressionsTest.Base)$Example).vvb).Capacity = $count;
+                                                            .Block(System.Int32 $Convert(Example).vvb_count) {
+                                                                $Convert(Example).vvb_count = $count;
+                                                                .If ($Convert(Example).vvb_count > 65536) {
+                                                                    $Convert(Example).vvb_count = 65536
+                                                                } .Else {
+                                                                    .Default(System.Void)
+                                                                };
+                                                                (((ExpressionsTest.Base)$Example).vvb).Capacity = $Convert(Example).vvb_count
+                                                            };
                                                             .Loop  {
                                                                 .If ($count-- > 0) {
                                                                     .Block() {
@@ -44,7 +52,15 @@
                                                                                 $elementType);
                                                                             .If ($elementType == .Constant<Bond.BondDataType>(BT_UINT64)) {
                                                                                 .Block(System.UInt64 $Convert(Example).vvb_item_item) {
-                                                                                    $Convert(Example).vvb_item = .New System.Collections.Generic.List`1[System.UInt64]($count);
+                                                                                    .Block(System.Int32 $Convert(Example).vvb_item_count) {
+                                                                                        $Convert(Example).vvb_item_count = $count;
+                                                                                        .If ($Convert(Example).vvb_item_count > 65536) {
+                                                                                            $Convert(Example).vvb_item_count = 65536
+                                                                                        } .Else {
+                                                                                            .Default(System.Void)
+                                                                                        };
+                                                                                        $Convert(Example).vvb_item = .New System.Collections.Generic.List`1[System.UInt64]($Convert(Example).vvb_item_count)
+                                                                                    };
                                                                                     .Loop  {
                                                                                         .If ($count-- > 0) {
                                                                                             .Block() {
@@ -61,7 +77,15 @@
                                                                             } .Else {
                                                                                 .If ($elementType == .Constant<Bond.BondDataType>(BT_UINT32)) {
                                                                                     .Block(System.UInt64 $Convert(Example).vvb_item_item) {
-                                                                                        $Convert(Example).vvb_item = .New System.Collections.Generic.List`1[System.UInt64]($count);
+                                                                                        .Block(System.Int32 $Convert(Example).vvb_item_count) {
+                                                                                            $Convert(Example).vvb_item_count = $count;
+                                                                                            .If ($Convert(Example).vvb_item_count > 65536) {
+                                                                                                $Convert(Example).vvb_item_count = 65536
+                                                                                            } .Else {
+                                                                                                .Default(System.Void)
+                                                                                            };
+                                                                                            $Convert(Example).vvb_item = .New System.Collections.Generic.List`1[System.UInt64]($Convert(Example).vvb_item_count)
+                                                                                        };
                                                                                         .Loop  {
                                                                                             .If ($count-- > 0) {
                                                                                                 .Block() {
@@ -78,7 +102,15 @@
                                                                                 } .Else {
                                                                                     .If ($elementType == .Constant<Bond.BondDataType>(BT_UINT16)) {
                                                                                         .Block(System.UInt64 $Convert(Example).vvb_item_item) {
-                                                                                            $Convert(Example).vvb_item = .New System.Collections.Generic.List`1[System.UInt64]($count);
+                                                                                            .Block(System.Int32 $Convert(Example).vvb_item_count) {
+                                                                                                $Convert(Example).vvb_item_count = $count;
+                                                                                                .If ($Convert(Example).vvb_item_count > 65536) {
+                                                                                                    $Convert(Example).vvb_item_count = 65536
+                                                                                                } .Else {
+                                                                                                    .Default(System.Void)
+                                                                                                };
+                                                                                                $Convert(Example).vvb_item = .New System.Collections.Generic.List`1[System.UInt64]($Convert(Example).vvb_item_count)
+                                                                                            };
                                                                                             .Loop  {
                                                                                                 .If ($count-- > 0) {
                                                                                                     .Block() {
@@ -95,7 +127,15 @@
                                                                                     } .Else {
                                                                                         .If ($elementType == .Constant<Bond.BondDataType>(BT_UINT8)) {
                                                                                             .Block(System.UInt64 $Convert(Example).vvb_item_item) {
-                                                                                                $Convert(Example).vvb_item = .New System.Collections.Generic.List`1[System.UInt64]($count);
+                                                                                                .Block(System.Int32 $Convert(Example).vvb_item_count) {
+                                                                                                    $Convert(Example).vvb_item_count = $count;
+                                                                                                    .If ($Convert(Example).vvb_item_count > 65536) {
+                                                                                                        $Convert(Example).vvb_item_count = 65536
+                                                                                                    } .Else {
+                                                                                                        .Default(System.Void)
+                                                                                                    };
+                                                                                                    $Convert(Example).vvb_item = .New System.Collections.Generic.List`1[System.UInt64]($Convert(Example).vvb_item_count)
+                                                                                                };
                                                                                                 .Loop  {
                                                                                                     .If ($count-- > 0) {
                                                                                                         .Block() {
@@ -810,7 +850,15 @@
                                                 $elementType);
                                             .If ($elementType == .Constant<Bond.BondDataType>(BT_INT32)) {
                                                 .Block(System.Int32 $Example._int32Vector_item) {
-                                                    ($Example._int32Vector).Capacity = $count;
+                                                    .Block(System.Int32 $Example._int32Vector_count) {
+                                                        $Example._int32Vector_count = $count;
+                                                        .If ($Example._int32Vector_count > 65536) {
+                                                            $Example._int32Vector_count = 65536
+                                                        } .Else {
+                                                            .Default(System.Void)
+                                                        };
+                                                        ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                    };
                                                     .Loop  {
                                                         .If ($count-- > 0) {
                                                             .Block() {
@@ -827,7 +875,15 @@
                                             } .Else {
                                                 .If ($elementType == .Constant<Bond.BondDataType>(BT_INT16)) {
                                                     .Block(System.Int32 $Example._int32Vector_item) {
-                                                        ($Example._int32Vector).Capacity = $count;
+                                                        .Block(System.Int32 $Example._int32Vector_count) {
+                                                            $Example._int32Vector_count = $count;
+                                                            .If ($Example._int32Vector_count > 65536) {
+                                                                $Example._int32Vector_count = 65536
+                                                            } .Else {
+                                                                .Default(System.Void)
+                                                            };
+                                                            ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                        };
                                                         .Loop  {
                                                             .If ($count-- > 0) {
                                                                 .Block() {
@@ -844,7 +900,15 @@
                                                 } .Else {
                                                     .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
                                                         .Block(System.Int32 $Example._int32Vector_item) {
-                                                            ($Example._int32Vector).Capacity = $count;
+                                                            .Block(System.Int32 $Example._int32Vector_count) {
+                                                                $Example._int32Vector_count = $count;
+                                                                .If ($Example._int32Vector_count > 65536) {
+                                                                    $Example._int32Vector_count = 65536
+                                                                } .Else {
+                                                                    .Default(System.Void)
+                                                                };
+                                                                ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                            };
                                                             .Loop  {
                                                                 .If ($count-- > 0) {
                                                                     .Block() {

--- a/cs/test/expressions/DeserializeJson.expressions
+++ b/cs/test/expressions/DeserializeJson.expressions
@@ -72,7 +72,11 @@
                                                         .Block() {
                                                             .Call $reader.Read();
                                                             .Block(System.Collections.Generic.List`1[System.UInt64] $Convert(Example).vvb_item) {
-                                                                (((ExpressionsTest.Base)$Example).vvb).Capacity = 0;
+                                                                .Block(System.Int32 $Convert(Example).vvb_count) {
+                                                                    $Convert(Example).vvb_count = 0;
+                                                                    .Default(System.Void);
+                                                                    (((ExpressionsTest.Base)$Example).vvb).Capacity = $Convert(Example).vvb_count
+                                                                };
                                                                 .Loop  {
                                                                     .Break end { }
                                                                 }
@@ -85,7 +89,11 @@
                                                             .Block() {
                                                                 .Call $reader.Read();
                                                                 .Block(System.Collections.Generic.List`1[System.UInt64] $Convert(Example).vvb_item) {
-                                                                    (((ExpressionsTest.Base)$Example).vvb).Capacity = 0;
+                                                                    .Block(System.Int32 $Convert(Example).vvb_count) {
+                                                                        $Convert(Example).vvb_count = 0;
+                                                                        .Default(System.Void);
+                                                                        (((ExpressionsTest.Base)$Example).vvb).Capacity = $Convert(Example).vvb_count
+                                                                    };
                                                                     .Loop  {
                                                                         .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
                                                                             .Block() {
@@ -93,7 +101,11 @@
                                                                                     .Block() {
                                                                                         .Call $reader.Read();
                                                                                         .Block(System.UInt64 $Convert(Example).vvb_item_item) {
-                                                                                            $Convert(Example).vvb_item = .New System.Collections.Generic.List`1[System.UInt64](0);
+                                                                                            .Block(System.Int32 $Convert(Example).vvb_item_count) {
+                                                                                                $Convert(Example).vvb_item_count = 0;
+                                                                                                .Default(System.Void);
+                                                                                                $Convert(Example).vvb_item = .New System.Collections.Generic.List`1[System.UInt64]($Convert(Example).vvb_item_count)
+                                                                                            };
                                                                                             .Loop  {
                                                                                                 .Break end { }
                                                                                             }
@@ -106,7 +118,11 @@
                                                                                         .Block() {
                                                                                             .Call $reader.Read();
                                                                                             .Block(System.UInt64 $Convert(Example).vvb_item_item) {
-                                                                                                $Convert(Example).vvb_item = .New System.Collections.Generic.List`1[System.UInt64](0);
+                                                                                                .Block(System.Int32 $Convert(Example).vvb_item_count) {
+                                                                                                    $Convert(Example).vvb_item_count = 0;
+                                                                                                    .Default(System.Void);
+                                                                                                    $Convert(Example).vvb_item = .New System.Collections.Generic.List`1[System.UInt64]($Convert(Example).vvb_item_count)
+                                                                                                };
                                                                                                 .Loop  {
                                                                                                     .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
                                                                                                         .Block() {
@@ -257,9 +273,13 @@
                                                                     .Block(
                                                                         System.Int32 $index,
                                                                         System.Byte[] $array) {
-                                                                        .Block() {
-                                                                            $index = 0;
-                                                                            $array = .NewArray System.Byte[0]
+                                                                        .Block(System.Int32 $Example.b_count) {
+                                                                            $Example.b_count = 0;
+                                                                            .Default(System.Void);
+                                                                            .Block() {
+                                                                                $index = 0;
+                                                                                $array = .NewArray System.Byte[$Example.b_count]
+                                                                            }
                                                                         };
                                                                         .Loop  {
                                                                             .Break end { }
@@ -278,9 +298,13 @@
                                                                         .Block(
                                                                             System.Int32 $index,
                                                                             System.Byte[] $array) {
-                                                                            .Block() {
-                                                                                $index = 0;
-                                                                                $array = .NewArray System.Byte[0]
+                                                                            .Block(System.Int32 $Example.b_count) {
+                                                                                $Example.b_count = 0;
+                                                                                .Default(System.Void);
+                                                                                .Block() {
+                                                                                    $index = 0;
+                                                                                    $array = .NewArray System.Byte[$Example.b_count]
+                                                                                }
                                                                             };
                                                                             .Loop  {
                                                                                 .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
@@ -540,7 +564,11 @@
                                                                         .Block() {
                                                                             .Call $reader.Read();
                                                                             .Block(System.Int32 $Example._int32Vector_item) {
-                                                                                ($Example._int32Vector).Capacity = 0;
+                                                                                .Block(System.Int32 $Example._int32Vector_count) {
+                                                                                    $Example._int32Vector_count = 0;
+                                                                                    .Default(System.Void);
+                                                                                    ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                                                };
                                                                                 .Loop  {
                                                                                     .Break end { }
                                                                                 }
@@ -553,7 +581,11 @@
                                                                             .Block() {
                                                                                 .Call $reader.Read();
                                                                                 .Block(System.Int32 $Example._int32Vector_item) {
-                                                                                    ($Example._int32Vector).Capacity = 0;
+                                                                                    .Block(System.Int32 $Example._int32Vector_count) {
+                                                                                        $Example._int32Vector_count = 0;
+                                                                                        .Default(System.Void);
+                                                                                        ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                                                    };
                                                                                     .Loop  {
                                                                                         .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
                                                                                             .Block() {

--- a/cs/test/expressions/DeserializeSP.expressions
+++ b/cs/test/expressions/DeserializeSP.expressions
@@ -16,14 +16,30 @@
                             .Block(System.Int32 $count) {
                                 $count = .Call $reader.ReadContainerBegin();
                                 .Block(System.Collections.Generic.List`1[System.UInt64] $Convert(Example).vvb_item) {
-                                    (((ExpressionsTest.Base)$Example).vvb).Capacity = $count;
+                                    .Block(System.Int32 $Convert(Example).vvb_count) {
+                                        $Convert(Example).vvb_count = $count;
+                                        .If ($Convert(Example).vvb_count > 65536) {
+                                            $Convert(Example).vvb_count = 65536
+                                        } .Else {
+                                            .Default(System.Void)
+                                        };
+                                        (((ExpressionsTest.Base)$Example).vvb).Capacity = $Convert(Example).vvb_count
+                                    };
                                     .Loop  {
                                         .If ($count-- > 0) {
                                             .Block() {
                                                 .Block(System.Int32 $count) {
                                                     $count = .Call $reader.ReadContainerBegin();
                                                     .Block(System.UInt64 $Convert(Example).vvb_item_item) {
-                                                        $Convert(Example).vvb_item = .New System.Collections.Generic.List`1[System.UInt64]($count);
+                                                        .Block(System.Int32 $Convert(Example).vvb_item_count) {
+                                                            $Convert(Example).vvb_item_count = $count;
+                                                            .If ($Convert(Example).vvb_item_count > 65536) {
+                                                                $Convert(Example).vvb_item_count = 65536
+                                                            } .Else {
+                                                                .Default(System.Void)
+                                                            };
+                                                            $Convert(Example).vvb_item = .New System.Collections.Generic.List`1[System.UInt64]($Convert(Example).vvb_item_count)
+                                                        };
                                                         .Loop  {
                                                             .If ($count-- > 0) {
                                                                 .Block() {
@@ -146,7 +162,15 @@
                     .Block(System.Int32 $count) {
                         $count = .Call $reader.ReadContainerBegin();
                         .Block(System.Int32 $Example._int32Vector_item) {
-                            ($Example._int32Vector).Capacity = $count;
+                            .Block(System.Int32 $Example._int32Vector_count) {
+                                $Example._int32Vector_count = $count;
+                                .If ($Example._int32Vector_count > 65536) {
+                                    $Example._int32Vector_count = 65536
+                                } .Else {
+                                    .Default(System.Void)
+                                };
+                                ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                            };
                             .Loop  {
                                 .If ($count-- > 0) {
                                     .Block() {

--- a/cs/test/expressions/DeserializeXml.expressions
+++ b/cs/test/expressions/DeserializeXml.expressions
@@ -49,7 +49,11 @@
                                                         .Block(System.Boolean $isEmpty) {
                                                             $isEmpty = $reader.IsEmptyElement;
                                                             .Block(System.Collections.Generic.List`1[System.UInt64] $Convert(Example).vvb_item) {
-                                                                (((ExpressionsTest.Base)$Example).vvb).Capacity = 0;
+                                                                .Block(System.Int32 $Convert(Example).vvb_count) {
+                                                                    $Convert(Example).vvb_count = 0;
+                                                                    .Default(System.Void);
+                                                                    (((ExpressionsTest.Base)$Example).vvb).Capacity = $Convert(Example).vvb_count
+                                                                };
                                                                 .Loop  {
                                                                     .If (
                                                                         .If (
@@ -98,7 +102,11 @@
                                                                             .Block(System.Boolean $isEmpty) {
                                                                                 $isEmpty = $reader.IsEmptyElement;
                                                                                 .Block(System.UInt64 $Convert(Example).vvb_item_item) {
-                                                                                    $Convert(Example).vvb_item = .New System.Collections.Generic.List`1[System.UInt64](0);
+                                                                                    .Block(System.Int32 $Convert(Example).vvb_item_count) {
+                                                                                        $Convert(Example).vvb_item_count = 0;
+                                                                                        .Default(System.Void);
+                                                                                        $Convert(Example).vvb_item = .New System.Collections.Generic.List`1[System.UInt64]($Convert(Example).vvb_item_count)
+                                                                                    };
                                                                                     .Loop  {
                                                                                         .If (
                                                                                             .If (
@@ -434,9 +442,13 @@
                                                                     .Block(
                                                                         System.Int32 $index,
                                                                         System.Byte[] $array) {
-                                                                        .Block() {
-                                                                            $index = 0;
-                                                                            $array = .NewArray System.Byte[0]
+                                                                        .Block(System.Int32 $Example.b_count) {
+                                                                            $Example.b_count = 0;
+                                                                            .Default(System.Void);
+                                                                            .Block() {
+                                                                                $index = 0;
+                                                                                $array = .NewArray System.Byte[$Example.b_count]
+                                                                            }
                                                                         };
                                                                         .Loop  {
                                                                             .If (
@@ -799,7 +811,11 @@
                                                                         .Block(System.Boolean $isEmpty) {
                                                                             $isEmpty = $reader.IsEmptyElement;
                                                                             .Block(System.Int32 $Example._int32Vector_item) {
-                                                                                ($Example._int32Vector).Capacity = 0;
+                                                                                .Block(System.Int32 $Example._int32Vector_count) {
+                                                                                    $Example._int32Vector_count = 0;
+                                                                                    .Default(System.Void);
+                                                                                    ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                                                };
                                                                                 .Loop  {
                                                                                     .If (
                                                                                         .If (


### PR DESCRIPTION
Provide controls that cap the amount of pre-allocation done for
containers and blobs.

This is intended as a failsafe against out-of-memory conditions when deserializing invalid data (e.g.: corrupted payloads), not for fine-grained control over per-request allocation.