### PR TITLE
[c++] Remove unused UNIT_TEST_SUBSET

### DIFF
--- a/cpp/test/core/blob_tests.cpp
+++ b/cpp/test/core/blob_tests.cpp
@@ -87,7 +87,6 @@ void BlobTests(const char* name)
     AddTestCase<TEST_ID(N),
         AllBindingAndMapping1, Reader, Writer, BondStruct<bond::blob> >(suite, "blob deserialization");
 
-#ifndef UNIT_TEST_SUBSET
     AddTestCase<TEST_ID(N),
         AllBindingAndMapping2, Reader, Writer, BondStruct<bond::blob>, BondStruct<std::vector<int8_t> > >(suite, "blob-vector interop");
 
@@ -99,7 +98,6 @@ void BlobTests(const char* name)
 
     AddTestCase<TEST_ID(N),
         OutputBufferBlobs, Reader, Writer>(suite, "OutputBuffer blobs");
-#endif
 }
 
 
@@ -139,4 +137,3 @@ bool init_unit_test()
     BlobTestsInit();
     return true;
 }
-

--- a/cpp/test/core/inheritance_test.cpp
+++ b/cpp/test/core/inheritance_test.cpp
@@ -18,42 +18,40 @@ void InheritanceTests(const char* name)
 {
     UnitTestSuite suite(name);
 
-#ifndef UNIT_TEST_SUBSET
     // Deserialize the same type as was serialized
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping1, Reader, Writer, StructWithBase>(suite, "Simple struct");
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping1, Reader, Writer, NestedWithBase>(suite, "Nested struct");
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping1, Reader, Writer, ListWithBase>(suite, "Containers");
 
     // Deserialize a different version of the type that was serialized
     AddTestCase<TEST_ID(N),
         AllBindingAndMapping2, Reader, Writer, StructWithBase, StructWithBaseView>(suite, "Simple struct, partial view");
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping2, Reader, Writer, NestedWithBase, NestedWithBaseView>(suite, "Nested struct, partial view");
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping2, Reader, Writer, ListWithBase, ListWithBaseView>(suite, "Containers, partial view");
 
     // Deserialize base class only
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping2, Reader, Writer, StructWithBase, SimpleStruct>(suite, "Simple struct, base view");
-#endif
 
     // Deserialize partial hierarchy
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping2, Reader, Writer, StructWithBase, SimpleBase>(suite, "Simple struct, partial view");
 
     // Deserialize base class only via partial schema
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping3, Reader, Writer, StructWithBase, SimpleStruct, SimpleBase>(suite, "Base via partial hierarchy");
 
     // Deserialize as containers of base/partial hierarchy
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping2, Reader, Writer, ListWithBase, ListOfBase>(suite, "Containers, partial hierarchy");
 }
 
@@ -94,4 +92,3 @@ bool init_unit_test()
     InheritanceTestsInit();
     return true;
 }
-

--- a/cpp/test/core/list_tests.cpp
+++ b/cpp/test/core/list_tests.cpp
@@ -36,19 +36,17 @@ void SimpleListTests(const char* name)
 {
     UnitTestSuite suite(name);
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping1, Reader, Writer, SimpleListsStruct>(suite, "Simple lists");
 
-#ifndef UNIT_TEST_SUBSET
-    AddTestCase<TEST_ID(N),  
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping2, Reader, Writer, SimpleListsStruct, SimpleListsStructView>(suite, "Simple lists partial view");
-    
-    AddTestCase<TEST_ID(N), 
+
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping1, Reader, Writer, NestedListsStruct>(suite, "Nested lists");
-    
-    AddTestCase<TEST_ID(N), 
+
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping2, Reader, Writer, NestedListsStruct, NestedListsStructView>(suite, "Nested lists partial view");
-#endif
 }
 
 void ListTestsInit()
@@ -87,4 +85,3 @@ bool init_unit_test()
     ListTestsInit();
     return true;
 }
-

--- a/cpp/test/core/nullable.cpp
+++ b/cpp/test/core/nullable.cpp
@@ -143,7 +143,7 @@ void NullableTests(T& x, T& y, const S& s1, const L& l1)
 
     UT_AssertIsFalse(nl.empty());
     UT_AssertIsTrue(nl.value() == l);
-    
+
     float f = 3.14f;
     bond::nullable<float> nf(f);
     bond::nullable<bond::nullable<float> > nnf(nf);
@@ -213,13 +213,13 @@ void NullableTests(T& x, T& y, const S& s1, const L& l1)
 TEST_CASE_BEGIN(NullableInterface)
 {
     StructWithNullables x, y;
-    
+
     list<float> l;
     SimpleStruct s;
-    
+
     bond::nullable<list<float> > l1(l);
     bond::nullable<SimpleStruct> s1(s);
-    
+
     NullableTests(x, y, s1, l1);
 }
 TEST_CASE_END
@@ -231,13 +231,13 @@ TEST_CASE_BEGIN(NullableAllocators)
 
     allocator_test::NullableFields x(a1);
     allocator_test::NullableFields y(a1);
-    
+
     list<float, detail::TestAllocator<float> > l(a2);
     allocator_test::SimpleType s(a2);
-    
+
     bond::nullable<list<float, detail::TestAllocator<float> > > l1(l);
     bond::nullable<allocator_test::SimpleType, TestAllocator> s1(s, a2);
-    
+
     NullableTests(x, y, s1, l1);
 
     bond::nullable<std::set<bool, std::less<bool>, detail::TestAllocator<bool> > > n1(std::less<bool>(), a1);
@@ -275,19 +275,17 @@ TEST_CASE_BEGIN(NullableAllocators)
     UT_AssertIsTrue(ns1.nullable_struct.empty());
 }
 TEST_CASE_END
-    
+
 
 template <uint16_t N, typename Reader, typename Writer>
 void BasicTypesNullableTests(const char* name)
 {
     UnitTestSuite suite(name);
 
-#ifndef UNIT_TEST_SUBSET
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         AllBasicTypesNullables, Reader, Writer>(suite, "Nullable types and containers");
-#endif
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         StructNullables, Reader, Writer>(suite, "Nullable of structs");
 }
 
@@ -336,4 +334,3 @@ bool init_unit_test()
     NullableTestsInit();
     return true;
 }
-

--- a/cpp/test/core/pass_through.cpp
+++ b/cpp/test/core/pass_through.cpp
@@ -92,11 +92,11 @@ void Transcoding(uint16_t version1 = bond::v1, uint16_t version2 = bond::v1)
 
     // Run-time schema
     {
-        bond::bonded<void> bonded_from(GetBonded<Reader1, Writer1, 
-                                       typename boost::mpl::if_<bond::has_schema<BondedType>, 
-                                                                BondedType, 
+        bond::bonded<void> bonded_from(GetBonded<Reader1, Writer1,
+                                       typename boost::mpl::if_<bond::has_schema<BondedType>,
+                                                                BondedType,
                                                                 From>::type>(from, version1));
-        
+
         bond::bonded<To> bonded_to(GetBonded<Reader2, Writer2, To>(bonded_from, version2));
 
         To to = InitRandom<To>();
@@ -187,7 +187,7 @@ AllTypesTranscoding()
 }
 
 
-// Simple JSON flattens inheritance hierarchy and thus doesn't always supprot transcoding with w/o schema becase 
+// Simple JSON flattens inheritance hierarchy and thus doesn't always supprot transcoding with w/o schema becase
 // ordinal used for fields in JSON when names are not available can collide.
 template <typename Reader1, typename Writer1, typename Reader2, typename Writer2, typename From, typename To>
 typename boost::enable_if_c<bond::uses_static_parser<Reader1>::value || bond::uses_static_parser<Reader2>::value || std::is_same<Reader2, bond::SimpleJsonReader<typename Reader2::Buffer> >::value>::type
@@ -311,7 +311,7 @@ namespace bond
     namespace detail
     {
         // Supress assert on optional fields being set to default values
-        // for OptionalContainers and StructWithDefaults used in 
+        // for OptionalContainers and StructWithDefaults used in
         // DefaultValuesTranscoding test case.
         template <>
         class OptionalDefault<OptionalContainers>
@@ -353,13 +353,13 @@ void DefaultValuesTranscodingTest(T to, uint16_t version1 = bond::v1, uint16_t v
     // which is required for our test untagged protocol. However it works if
     // memory for OutputBuffer is preallocated.
     typename Writer2::Buffer output_buffer(4096);
-    
+
     Factory<Writer2>::Call(output_buffer, version2, boost::bind(
         &bond::bonded<Bonded>::template Serialize<Writer2>, bonded1, _1));
 
     typename Reader2::Buffer input_buffer(output_buffer.GetBuffer());
     Reader2 input = Factory<Reader2>::Create(input_buffer, version2);
-        
+
     bond::Deserialize(input, to);
 
     UT_AssertIsTrue(from == to);
@@ -370,9 +370,9 @@ template <typename Reader1, typename Writer1, typename Reader2, typename Writer2
 TEST_CASE_BEGIN(DefaultValuesTranscoding)
 {
     typedef OptionalContainers T;
-    
-    T init; 
-    
+
+    T init;
+
     if (bond::uses_dynamic_parser<Reader1>::value && !bond::may_omit_fields<Writer2>::value)
     {
         // transcoding from tagged protocol using runtime schema fills-in default values
@@ -391,7 +391,7 @@ template <typename Reader1, typename Writer1, typename Reader2, typename Writer2
 TEST_CASE_BEGIN(OmittedDefaultValuesTranscoding)
 {
     typedef OptionalNothing T;
-    
+
     T init;
 
     DefaultValuesTranscodingTest<Reader1, Writer1, Reader2, Writer2, T>(init);
@@ -406,31 +406,28 @@ void PassThroughTests(const char* name)
 {
     UnitTestSuite suite(name);
 
-#ifndef UNIT_TEST_SUBSET
     AddTestCase<TEST_ID(N),
-        AllBondedSerialize, Reader1, Writer1, Reader2, Writer2, 
+        AllBondedSerialize, Reader1, Writer1, Reader2, Writer2,
         unittest::NestedStruct, unittest::NestedStructBondedView>(suite, "Serialize bonded T");
 
     AddTestCase<TEST_ID(N),
-        AllPassThrough, Reader1, Writer1, Reader2, Writer2, 
+        AllPassThrough, Reader1, Writer1, Reader2, Writer2,
         unittest::NestedWithBase1, unittest::NestedWithBase1BondedBaseView>(suite, "Pass-through base");
 
     AddTestCase<TEST_ID(N),
-        AllPassThrough, Reader1, Writer1, Reader2, Writer2, 
+        AllPassThrough, Reader1, Writer1, Reader2, Writer2,
         unittest::NestedListsStruct, unittest::NestedListsStructPassThrough>(suite, "Pass-through containers");
-    
+
     AddTestCase<TEST_ID(N),
-        AllBondedSerialize, Reader1, Writer1, Reader2, Writer2, 
+        AllBondedSerialize, Reader1, Writer1, Reader2, Writer2,
         unittest::NestedListsStruct, unittest::NestedListsStructBondedView>(suite, "Serialize list of bonded");
-    
+
     AddTestCase<TEST_ID(N),
-        AllTranscoding, Reader1, Writer1, Reader2, Writer2, 
+        AllTranscoding, Reader1, Writer1, Reader2, Writer2,
         unittest::NestedListsStruct, unittest::NestedListsStruct>(suite, "Transcoding containers");
 
-#endif
-
     AddTestCase<TEST_ID(N),
-        AllTranscoding, Reader1, Writer1, Reader2, Writer2, 
+        AllTranscoding, Reader1, Writer1, Reader2, Writer2,
         unittest::NestedWithBase, unittest::NestedWithBase>(suite, "Transcoding with inheritance");
 
     AddTestCase<TEST_ID(N),
@@ -454,7 +451,7 @@ void TranscodingTests(const char* name)
     UnitTestSuite suite(name);
 
     AddTestCase<TEST_ID(N),
-        TranscodingTest, Reader1, Writer1, Reader2, Writer2, 
+        TranscodingTest, Reader1, Writer1, Reader2, Writer2,
         unittest::NestedWithBase, unittest::NestedWithBase>(suite, "Transcoding with inheritance");
 
     AddTestCase<TEST_ID(N),
@@ -544,4 +541,3 @@ bool init_unit_test()
     PassThroughTestsInit();
     return true;
 }
-

--- a/cpp/test/core/serialization_test.cpp
+++ b/cpp/test/core/serialization_test.cpp
@@ -21,10 +21,10 @@ TEST_CASE_BEGIN(Streaming)
 
     InitRandom(from1);
     InitRandom(from2);
-    
+
     typename Writer::Buffer buffer;
     Writer writer(buffer);
-    
+
     // Serialize 2 records
     bond::Serialize(from1, writer);
     bond::Serialize(from2, writer);
@@ -54,7 +54,7 @@ TEST_CASE_BEGIN(Streaming)
         typename rebind_buffer_by_reference<Reader>::type reader(buffer);
 
         T to1, to2;
-        
+
         Deserialize(reader, to1);
 
         UT_AssertIsFalse(buffer.IsEof());
@@ -71,7 +71,7 @@ TEST_CASE_END
 
 
 // 1 bit per every 8 fields
-// This simplified count obviously doesn't work for nested structures but 
+// This simplified count obviously doesn't work for nested structures but
 // the tests that check payload length don't use nested structs.
 template <typename T> struct
 untagged_payload_size
@@ -217,35 +217,34 @@ void SimpleStructTests(const char* name)
 {
     UnitTestSuite suite(name);
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         SerializeAPIs, Reader, Writer, NestedStruct>(suite, "De/serialization APIs");
 
-    AddTestCase<COND_TEST_ID(N, (!bond::uses_dom_parser<Reader>::value)), 
+    AddTestCase<COND_TEST_ID(N, (!bond::uses_dom_parser<Reader>::value)),
         MarshalAPIs, Reader, Writer, NestedStruct>(suite, "Un/marshal APIs");
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping1, Reader, Writer, SimpleStruct>(suite, "Simple struct");
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping1, Reader, Writer, UsingImport>(suite, "Imported struct");
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         DefaultValues, Reader, Writer, StructWithDefaults>(suite, "Omitting default values");
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         DefaultValues, Reader, Writer, OptionalContainers>(suite, "Omitting empty containers");
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping2, Reader, Writer, NestedStruct1, NestedStruct1OptionalBondedView>(suite, "Optional bonded field");
 
-#ifndef UNIT_TEST_SUBSET
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping2, Reader, Writer, SimpleStruct, SimpleStructView>(suite, "Simple struct partial view");
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping1, Reader, Writer, NestedStruct>(suite, "Nested struct");
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         AllBindingAndMapping2, Reader, Writer, NestedStruct, NestedStructView>(suite, "Nested struct partial view");
 
     AddTestCase<COND_TEST_ID(N, (!bond::uses_dom_parser<Reader>::value)),
@@ -253,7 +252,6 @@ void SimpleStructTests(const char* name)
 
     AddTestCase<TEST_ID(N),
         SerializeAPIs, Reader, Writer, EnumValueWrapper>(suite, "Struct with alias-wrapped enum");
-#endif
 }
 
 
@@ -262,13 +260,13 @@ void OmittingDefaultsTests(const char* name)
 {
     UnitTestSuite suite(name);
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         DefaultValues, Reader, Writer, StructWithDefaults>(suite, "Omitting default values");
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         DefaultValues, Reader, Writer, OptionalContainers>(suite, "Omitting empty containers");
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         DefaultValues, Reader, Writer, OptionalNothing>(suite, "Omitting nothing");
 }
 
@@ -315,4 +313,3 @@ bool init_unit_test()
     SerializationTest::Initialize();
     return true;
 }
-


### PR DESCRIPTION
This macro is less useful now that the tests have been exploded into
smaller executables.