### PR TITLE
Fix is_nullable for msvc 2015u3

### DIFF
--- a/cpp/inc/bond/core/nullable.h
+++ b/cpp/inc/bond/core/nullable.h
@@ -726,8 +726,8 @@ is_list_container<nullable<T, Allocator, useValue> >
     : true_type {};
 
 
-template <typename T, typename Allocator> struct
-is_nullable<nullable<T, Allocator> >
+template <typename T, typename Allocator, bool useValue> struct
+is_nullable<nullable<T, Allocator, useValue> >
     : true_type {};
 
 } // namespace bond


### PR DESCRIPTION
This fixes #306 by helping msvc 2015u3 handle template parameters.