### PR TITLE
[c++] Ensure that generated .cpp files always have an external symbol, Comm_types.hs rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,17 @@ different versioning scheme, following the Haskell community's
 
 ## Unreleased ##
 
-* `gbc` & compiler library: TBD (bug fix bump needed)
+* `gbc` & compiler library: TBD (B version bump needed)
 * IDL core version: TBD
 * IDL comm version: TBD
 * C++ version: TBD (minor bump needed [Boost dependencies changed])
 * C# NuGet version: TBD (minor bump needed)
 * C# Comm NuGet version: TBD (minor bump needed [dependencies changed])
+
+### bond compiler library ###
+
+* The C++ Comm .cpp template has been renamed to `comm_cpp` from
+  `types_comm_cpp`.
 
 ### C++ ###
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ different versioning scheme, following the Haskell community's
   [Pull request #288](https://github.com/Microsoft/bond/pull/288)
 * Fixed an issue with aliased enums.
   [Pull request #288](https://github.com/Microsoft/bond/pull/298)
+* Generated .cpp files now always include at least one definition with
+  external linkage to help avoid linker warnings about empty object files.
 
 ### C# ###
 

--- a/compiler/Main.hs
+++ b/compiler/Main.hs
@@ -72,10 +72,10 @@ cppCodegen options@Cpp {..} = do
     concurrentlyFor_ files $ codeGen options typeMapping $
         [ reflection_h
         , types_cpp
-        , types_comm_cpp
         , types_h header enum_header allocator
         , apply_h applyProto apply_attribute
         , apply_cpp applyProto
+        , comm_cpp
         , comm_h
         ] <>
         [ enum_h | enum_header]

--- a/compiler/bond.cabal
+++ b/compiler/bond.cabal
@@ -62,8 +62,8 @@ library
                     Language.Bond.Codegen.Cpp.Enum_h
                     Language.Bond.Codegen.Cpp.Reflection_h
                     Language.Bond.Codegen.Cpp.Types_cpp
-                    Language.Bond.Codegen.Cpp.Types_Comm_cpp
                     Language.Bond.Codegen.Cpp.Types_h
+                    Language.Bond.Codegen.Cpp.Comm_cpp
                     Language.Bond.Codegen.Cpp.Comm_h
                     Language.Bond.Codegen.Cs.Types_cs
                     Language.Bond.Codegen.Cs.Comm_cs

--- a/compiler/src/Language/Bond/Codegen/Cpp/Apply_cpp.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Apply_cpp.hs
@@ -24,6 +24,8 @@ apply_cpp protocols cpp file _imports declarations = ("_apply.cpp", [lt|
 #{CPP.openNamespace cpp}
     #{newlineSepEnd 1 (applyOverloads protocols cpp attr body) declarations}
 #{CPP.closeNamespace cpp}
+
+#{CPP.dummyDefinition}
 |])
   where
     body = [lt|

--- a/compiler/src/Language/Bond/Codegen/Cpp/Comm_cpp.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Comm_cpp.hs
@@ -3,7 +3,7 @@
 
 {-# LANGUAGE QuasiQuotes, OverloadedStrings, RecordWildCards #-}
 
-module Language.Bond.Codegen.Cpp.Types_Comm_cpp (types_comm_cpp) where
+module Language.Bond.Codegen.Cpp.Comm_cpp (comm_cpp) where
 
 import Data.Monoid
 import Prelude
@@ -14,10 +14,10 @@ import Language.Bond.Codegen.TypeMapping
 import Language.Bond.Codegen.Util
 import qualified Language.Bond.Codegen.Cpp.Util as CPP
 
--- | Codegen template for generating /base_name/_comm_types.cpp containing
+-- | Codegen template for generating /base_name/_comm.cpp containing
 -- definitions of helper functions and schema metadata static variables.
-types_comm_cpp :: MappingContext -> String -> [Import] -> [Declaration] -> (String, Text)
-types_comm_cpp cpp file _imports declarations = ("_comm.cpp", [lt|
+comm_cpp :: MappingContext -> String -> [Import] -> [Declaration] -> (String, Text)
+comm_cpp cpp file _imports declarations = ("_comm.cpp", [lt|
 #include "#{file}_reflection.h"
 #include "#{file}_comm.h"
 #include <bond/core/exception.h>

--- a/compiler/src/Language/Bond/Codegen/Cpp/Types_Comm_cpp.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Types_Comm_cpp.hs
@@ -25,6 +25,8 @@ types_comm_cpp cpp file _imports declarations = ("_comm.cpp", [lt|
 #{CPP.openNamespace cpp}
     #{doubleLineSepEnd 1 statics declarations}
 #{CPP.closeNamespace cpp}
+
+#{CPP.dummyDefinition}
 |])
   where
     -- definitions of Schema statics for non-generic services

--- a/compiler/src/Language/Bond/Codegen/Cpp/Types_cpp.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Types_cpp.hs
@@ -24,6 +24,8 @@ types_cpp cpp file _imports declarations = ("_types.cpp", [lt|
 #{CPP.openNamespace cpp}
     #{doubleLineSepEnd 1 statics declarations}
 #{CPP.closeNamespace cpp}
+
+#{CPP.dummyDefinition}
 |])
   where
     -- definitions of Schema statics for non-generic structs

--- a/compiler/src/Language/Bond/Codegen/Cpp/Util.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Util.hs
@@ -20,6 +20,7 @@ module Language.Bond.Codegen.Cpp.Util
     , defaultedMoveCtors
     , rvalueReferences
     , enumDefinition
+    , dummyDefinition
     ) where
 
 import Data.Monoid
@@ -167,3 +168,9 @@ enumDefinition Enum {..} = [lt|enum #{declName}
     value (-2147483648) = [lt| = static_cast<int32_t>(-2147483647-1)|]
     value x = [lt| = static_cast<int32_t>(#{x})|]
 enumDefinition _ = error "enumDefinition: impossible happened."
+
+dummyDefinition :: Text
+dummyDefinition = [lt|namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}|]

--- a/compiler/src/Language/Bond/Codegen/Templates.hs
+++ b/compiler/src/Language/Bond/Codegen/Templates.hs
@@ -36,7 +36,6 @@ module Language.Bond.Codegen.Templates
       -- ** C++
       types_h
     , types_cpp
-    , types_comm_cpp
     , reflection_h
     , enum_h
     , apply_h
@@ -44,6 +43,7 @@ module Language.Bond.Codegen.Templates
     ,  Protocol(..)
       -- ** C++ Comm
     , comm_h
+    , comm_cpp
       -- ** C#
     , FieldMapping(..)
     , StructMapping(..)
@@ -60,8 +60,8 @@ import Language.Bond.Codegen.Cpp.ApplyOverloads
 import Language.Bond.Codegen.Cpp.Enum_h
 import Language.Bond.Codegen.Cpp.Reflection_h
 import Language.Bond.Codegen.Cpp.Types_cpp
-import Language.Bond.Codegen.Cpp.Types_Comm_cpp
 import Language.Bond.Codegen.Cpp.Types_h
+import Language.Bond.Codegen.Cpp.Comm_cpp
 import Language.Bond.Codegen.Cpp.Comm_h
 import Language.Bond.Codegen.Cs.Types_cs
 import Language.Bond.Codegen.Cs.Comm_cs

--- a/compiler/tests/Tests/Codegen.hs
+++ b/compiler/tests/Tests/Codegen.hs
@@ -67,8 +67,8 @@ verifyCppCommCodegen args baseName =
     testGroup baseName $
         map (verifyFile (processOptions args) baseName cppTypeMapping "")
             [ comm_h
+            , comm_cpp
             , types_cpp
-            , types_comm_cpp
             ]
 
 verifyCsCommCodegen :: [String] -> FilePath -> TestTree
@@ -104,7 +104,7 @@ verifyFiles options baseName =
     templates Cpp {..} =
         [ reflection_h
         , types_cpp
-        , types_comm_cpp
+        , comm_cpp
         , types_h header enum_header allocator
         ]
     templates Cs {..} =

--- a/compiler/tests/generated/alias_key_comm.cpp
+++ b/compiler/tests/generated/alias_key_comm.cpp
@@ -7,3 +7,8 @@ namespace test
 {
     
 } // namespace test
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/alias_key_types.cpp
+++ b/compiler/tests/generated/alias_key_types.cpp
@@ -16,3 +16,8 @@ namespace test
 
     
 } // namespace test
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/alias_with_allocator_comm.cpp
+++ b/compiler/tests/generated/alias_with_allocator_comm.cpp
@@ -7,3 +7,8 @@ namespace test
 {
     
 } // namespace test
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/alias_with_allocator_types.cpp
+++ b/compiler/tests/generated/alias_with_allocator_types.cpp
@@ -53,3 +53,8 @@ namespace test
 
     
 } // namespace test
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/aliases_comm.cpp
+++ b/compiler/tests/generated/aliases_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/aliases_types.cpp
+++ b/compiler/tests/generated/aliases_types.cpp
@@ -46,3 +46,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/alias_key_comm.cpp
+++ b/compiler/tests/generated/allocator/alias_key_comm.cpp
@@ -7,3 +7,8 @@ namespace test
 {
     
 } // namespace test
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/alias_key_types.cpp
+++ b/compiler/tests/generated/allocator/alias_key_types.cpp
@@ -16,3 +16,8 @@ namespace test
 
     
 } // namespace test
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/aliases_comm.cpp
+++ b/compiler/tests/generated/allocator/aliases_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/aliases_types.cpp
+++ b/compiler/tests/generated/allocator/aliases_types.cpp
@@ -46,3 +46,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/attributes_comm.cpp
+++ b/compiler/tests/generated/allocator/attributes_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/attributes_types.cpp
+++ b/compiler/tests/generated/allocator/attributes_types.cpp
@@ -49,3 +49,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/basic_types_comm.cpp
+++ b/compiler/tests/generated/allocator/basic_types_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/basic_types_types.cpp
+++ b/compiler/tests/generated/allocator/basic_types_types.cpp
@@ -52,3 +52,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/bond_meta_comm.cpp
+++ b/compiler/tests/generated/allocator/bond_meta_comm.cpp
@@ -10,3 +10,8 @@ namespace bondmeta
     
 } // namespace bondmeta
 } // namespace deprecated
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/bond_meta_types.cpp
+++ b/compiler/tests/generated/allocator/bond_meta_types.cpp
@@ -19,3 +19,8 @@ namespace bondmeta
     
 } // namespace bondmeta
 } // namespace deprecated
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/complex_types_comm.cpp
+++ b/compiler/tests/generated/allocator/complex_types_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/complex_types_types.cpp
+++ b/compiler/tests/generated/allocator/complex_types_types.cpp
@@ -35,3 +35,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/defaults_comm.cpp
+++ b/compiler/tests/generated/allocator/defaults_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/defaults_types.cpp
+++ b/compiler/tests/generated/allocator/defaults_types.cpp
@@ -161,3 +161,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/empty_comm.cpp
+++ b/compiler/tests/generated/allocator/empty_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/empty_types.cpp
+++ b/compiler/tests/generated/allocator/empty_types.cpp
@@ -6,3 +6,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/field_modifiers_comm.cpp
+++ b/compiler/tests/generated/allocator/field_modifiers_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/field_modifiers_types.cpp
+++ b/compiler/tests/generated/allocator/field_modifiers_types.cpp
@@ -21,3 +21,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/generics_comm.cpp
+++ b/compiler/tests/generated/allocator/generics_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/generics_types.cpp
+++ b/compiler/tests/generated/allocator/generics_types.cpp
@@ -6,3 +6,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/inheritance_comm.cpp
+++ b/compiler/tests/generated/allocator/inheritance_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/inheritance_types.cpp
+++ b/compiler/tests/generated/allocator/inheritance_types.cpp
@@ -20,3 +20,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/maybe_blob_comm.cpp
+++ b/compiler/tests/generated/allocator/maybe_blob_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/allocator/maybe_blob_types.cpp
+++ b/compiler/tests/generated/allocator/maybe_blob_types.cpp
@@ -13,3 +13,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/apply/basic_types_apply.cpp
+++ b/compiler/tests/generated/apply/basic_types_apply.cpp
@@ -239,3 +239,8 @@ namespace tests
     }
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/attributes_comm.cpp
+++ b/compiler/tests/generated/attributes_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/attributes_types.cpp
+++ b/compiler/tests/generated/attributes_types.cpp
@@ -49,3 +49,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/basic_types_comm.cpp
+++ b/compiler/tests/generated/basic_types_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/basic_types_types.cpp
+++ b/compiler/tests/generated/basic_types_types.cpp
@@ -52,3 +52,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/bond_meta_comm.cpp
+++ b/compiler/tests/generated/bond_meta_comm.cpp
@@ -10,3 +10,8 @@ namespace bondmeta
     
 } // namespace bondmeta
 } // namespace deprecated
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/bond_meta_types.cpp
+++ b/compiler/tests/generated/bond_meta_types.cpp
@@ -19,3 +19,8 @@ namespace bondmeta
     
 } // namespace bondmeta
 } // namespace deprecated
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/complex_types_comm.cpp
+++ b/compiler/tests/generated/complex_types_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/complex_types_types.cpp
+++ b/compiler/tests/generated/complex_types_types.cpp
@@ -35,3 +35,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/custom_alias_with_allocator_comm.cpp
+++ b/compiler/tests/generated/custom_alias_with_allocator_comm.cpp
@@ -7,3 +7,8 @@ namespace test
 {
     
 } // namespace test
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/custom_alias_with_allocator_types.cpp
+++ b/compiler/tests/generated/custom_alias_with_allocator_types.cpp
@@ -43,3 +43,8 @@ namespace test
 
     
 } // namespace test
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/custom_alias_without_allocator_comm.cpp
+++ b/compiler/tests/generated/custom_alias_without_allocator_comm.cpp
@@ -7,3 +7,8 @@ namespace test
 {
     
 } // namespace test
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/custom_alias_without_allocator_types.cpp
+++ b/compiler/tests/generated/custom_alias_without_allocator_types.cpp
@@ -43,3 +43,8 @@ namespace test
 
     
 } // namespace test
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/defaults_comm.cpp
+++ b/compiler/tests/generated/defaults_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/defaults_types.cpp
+++ b/compiler/tests/generated/defaults_types.cpp
@@ -161,3 +161,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/empty_comm.cpp
+++ b/compiler/tests/generated/empty_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/empty_types.cpp
+++ b/compiler/tests/generated/empty_types.cpp
@@ -6,3 +6,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/field_modifiers_comm.cpp
+++ b/compiler/tests/generated/field_modifiers_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/field_modifiers_types.cpp
+++ b/compiler/tests/generated/field_modifiers_types.cpp
@@ -21,3 +21,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/generic_service_comm.cpp
+++ b/compiler/tests/generated/generic_service_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/generic_service_types.cpp
+++ b/compiler/tests/generated/generic_service_types.cpp
@@ -6,3 +6,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/generics_comm.cpp
+++ b/compiler/tests/generated/generics_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/generics_types.cpp
+++ b/compiler/tests/generated/generics_types.cpp
@@ -6,3 +6,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/inheritance_comm.cpp
+++ b/compiler/tests/generated/inheritance_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/inheritance_types.cpp
+++ b/compiler/tests/generated/inheritance_types.cpp
@@ -20,3 +20,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/maybe_blob_comm.cpp
+++ b/compiler/tests/generated/maybe_blob_comm.cpp
@@ -7,3 +7,8 @@ namespace tests
 {
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/maybe_blob_types.cpp
+++ b/compiler/tests/generated/maybe_blob_types.cpp
@@ -13,3 +13,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/service_attributes_comm.cpp
+++ b/compiler/tests/generated/service_attributes_comm.cpp
@@ -19,3 +19,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/service_attributes_types.cpp
+++ b/compiler/tests/generated/service_attributes_types.cpp
@@ -14,3 +14,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/service_comm.cpp
+++ b/compiler/tests/generated/service_comm.cpp
@@ -60,3 +60,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}

--- a/compiler/tests/generated/service_types.cpp
+++ b/compiler/tests/generated/service_types.cpp
@@ -13,3 +13,8 @@ namespace tests
 
     
 } // namespace tests
+
+namespace {
+    // this is a dummy definition to make sure that this compilation unit is never empty
+    extern bool empty = false;
+}


### PR DESCRIPTION
Two commits to review. They should be rebased when merging in to master. I'm not doing this as different PRs, as they would conflict with each other.

commit dfbdfbc7e5f58ea052faf59b75ae0cab34091e2d
Author: Christopher Warrington <chwarr@microsoft.com>
Date:   Wed Jan 18 19:38:33 2017 -0800

    [gbc] Rename Types_Comm_cpp to Comm_cpp
    
    Renamed the file, the module, and the functions.

commit 7d2ab6f2687b30b50fe49bd115ea809e737658d2
Author: Christopher Warrington <chwarr@microsoft.com>
Date:   Wed Jan 18 18:38:59 2017 -0800

    [c++] Ensure .cpp files always have a symbol
    
    Depending on the contents of the .bond file, the generated .cpp file can
    have no (new) external definitions/symbols. When mechanically creating
    static libraries, this can cause linker warnings to be emitted. (e.g.,
    LNK4221 from the Microsoft linker)
    
    To avoid this problem, all generated .cpp files now have a dummy
    definition with external linkage in an anonymous namespace.
    
    This symbol should end up in .bss and should be omitted entirely when
    finally linked into an application/shared library.
