### PR TITLE
[gbc] Rename Types_Comm_cpp to Comm_cpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,17 @@ different versioning scheme, following the Haskell community's
 
 ## Unreleased ##
 
-* `gbc` & compiler library: TBD (bug fix bump needed)
+* `gbc` & compiler library: TBD (B version bump needed)
 * IDL core version: TBD
 * IDL comm version: TBD
 * C++ version: TBD (minor bump needed [Boost dependencies changed])
 * C# NuGet version: TBD (minor bump needed)
 * C# Comm NuGet version: TBD (minor bump needed [dependencies changed])
+
+### bond compiler library ###
+
+* The C++ Comm .cpp template has been renamed to `comm_cpp` from
+  `types_comm_cpp` to match the file it generates.
 
 ### C++ ###
 

--- a/compiler/Main.hs
+++ b/compiler/Main.hs
@@ -72,10 +72,10 @@ cppCodegen options@Cpp {..} = do
     concurrentlyFor_ files $ codeGen options typeMapping $
         [ reflection_h
         , types_cpp
-        , types_comm_cpp
         , types_h header enum_header allocator
         , apply_h applyProto apply_attribute
         , apply_cpp applyProto
+        , comm_cpp
         , comm_h
         ] <>
         [ enum_h | enum_header]

--- a/compiler/bond.cabal
+++ b/compiler/bond.cabal
@@ -62,8 +62,8 @@ library
                     Language.Bond.Codegen.Cpp.Enum_h
                     Language.Bond.Codegen.Cpp.Reflection_h
                     Language.Bond.Codegen.Cpp.Types_cpp
-                    Language.Bond.Codegen.Cpp.Types_Comm_cpp
                     Language.Bond.Codegen.Cpp.Types_h
+                    Language.Bond.Codegen.Cpp.Comm_cpp
                     Language.Bond.Codegen.Cpp.Comm_h
                     Language.Bond.Codegen.Cs.Types_cs
                     Language.Bond.Codegen.Cs.Comm_cs

--- a/compiler/src/Language/Bond/Codegen/Cpp/Comm_cpp.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Comm_cpp.hs
@@ -3,7 +3,7 @@
 
 {-# LANGUAGE QuasiQuotes, OverloadedStrings, RecordWildCards #-}
 
-module Language.Bond.Codegen.Cpp.Types_Comm_cpp (types_comm_cpp) where
+module Language.Bond.Codegen.Cpp.Comm_cpp (comm_cpp) where
 
 import Data.Monoid
 import Prelude
@@ -14,10 +14,10 @@ import Language.Bond.Codegen.TypeMapping
 import Language.Bond.Codegen.Util
 import qualified Language.Bond.Codegen.Cpp.Util as CPP
 
--- | Codegen template for generating /base_name/_comm_types.cpp containing
+-- | Codegen template for generating /base_name/_comm.cpp containing
 -- definitions of helper functions and schema metadata static variables.
-types_comm_cpp :: MappingContext -> String -> [Import] -> [Declaration] -> (String, Text)
-types_comm_cpp cpp file _imports declarations = ("_comm.cpp", [lt|
+comm_cpp :: MappingContext -> String -> [Import] -> [Declaration] -> (String, Text)
+comm_cpp cpp file _imports declarations = ("_comm.cpp", [lt|
 #include "#{file}_reflection.h"
 #include "#{file}_comm.h"
 #include <bond/core/exception.h>

--- a/compiler/src/Language/Bond/Codegen/Templates.hs
+++ b/compiler/src/Language/Bond/Codegen/Templates.hs
@@ -36,7 +36,6 @@ module Language.Bond.Codegen.Templates
       -- ** C++
       types_h
     , types_cpp
-    , types_comm_cpp
     , reflection_h
     , enum_h
     , apply_h
@@ -44,6 +43,7 @@ module Language.Bond.Codegen.Templates
     ,  Protocol(..)
       -- ** C++ Comm
     , comm_h
+    , comm_cpp
       -- ** C#
     , FieldMapping(..)
     , StructMapping(..)
@@ -60,8 +60,8 @@ import Language.Bond.Codegen.Cpp.ApplyOverloads
 import Language.Bond.Codegen.Cpp.Enum_h
 import Language.Bond.Codegen.Cpp.Reflection_h
 import Language.Bond.Codegen.Cpp.Types_cpp
-import Language.Bond.Codegen.Cpp.Types_Comm_cpp
 import Language.Bond.Codegen.Cpp.Types_h
+import Language.Bond.Codegen.Cpp.Comm_cpp
 import Language.Bond.Codegen.Cpp.Comm_h
 import Language.Bond.Codegen.Cs.Types_cs
 import Language.Bond.Codegen.Cs.Comm_cs

--- a/compiler/tests/Tests/Codegen.hs
+++ b/compiler/tests/Tests/Codegen.hs
@@ -67,8 +67,8 @@ verifyCppCommCodegen args baseName =
     testGroup baseName $
         map (verifyFile (processOptions args) baseName cppTypeMapping "")
             [ comm_h
+            , comm_cpp
             , types_cpp
-            , types_comm_cpp
             ]
 
 verifyCsCommCodegen :: [String] -> FilePath -> TestTree
@@ -104,7 +104,7 @@ verifyFiles options baseName =
     templates Cpp {..} =
         [ reflection_h
         , types_cpp
-        , types_comm_cpp
+        , comm_cpp
         , types_h header enum_header allocator
         ]
     templates Cs {..} =


### PR DESCRIPTION
Renamed the file, the module, and the functions.