### PR TITLE
[c# epoxy] Make generated interfaces public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ different versioning scheme, following the Haskell community's
 
 * Resources are now properly cleaned up if failures are encountered when
   establishing client-side Epoxy connections.
+* The generated interfaces for services are now public. There were
+  inadvertently internal before.
 
 ## 5.1.0: 2016-11-14 ##
 

--- a/compiler/src/Language/Bond/Codegen/Cs/Comm_cs.hs
+++ b/compiler/src/Language/Bond/Codegen/Cs/Comm_cs.hs
@@ -49,7 +49,7 @@ namespace #{csNamespace}
   where
     csNamespace = sepBy "." toText $ getNamespace cs
 
-    comm s@Service{..} = [lt|#{CS.typeAttributes cs s}interface I#{declName}#{generics}
+    comm s@Service{..} = [lt|#{CS.typeAttributes cs s}public interface I#{declName}#{generics}
     {
         #{doubleLineSep 2 methodDeclaration serviceMethods}
     }

--- a/compiler/tests/generated/generic_service_interfaces.cs
+++ b/compiler/tests/generated/generic_service_interfaces.cs
@@ -16,7 +16,7 @@
 namespace tests
 {
     [System.CodeDom.Compiler.GeneratedCode("gbc", "0.7.0.0")]
-    interface IFoo<Payload>
+    public interface IFoo<Payload>
     {
         global::System.Threading.Tasks.Task<global::Bond.Comm.IMessage<global::Bond.Void>> foo31Async(global::Bond.Comm.IMessage<Payload> param, global::System.Threading.CancellationToken ct);
 

--- a/compiler/tests/generated/service_interfaces.cs
+++ b/compiler/tests/generated/service_interfaces.cs
@@ -16,7 +16,7 @@
 namespace tests
 {
     [System.CodeDom.Compiler.GeneratedCode("gbc", "0.7.0.0")]
-    interface IFoo
+    public interface IFoo
     {
         void foo11Async(global::Bond.Comm.IMessage<global::Bond.Void> param);
 


### PR DESCRIPTION
The interfaces were inadvertently internal before.