### PR TITLE
Epoxy Transport shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ tag versions. The Bond compiler (`gbc`) and
 different versioning scheme, following the Haskell community's
 [package versioning policy](https://wiki.haskell.org/Package_versioning_policy).
 
+## Unreleased ##
+* `gbc` & compiler library: TBD
+* IDL core version: TBD
+* IDL comm version: TBD
+* C++ version: TBD
+* C# NuGet version: TBD
+* C# Comm NuGet version: TBD (minor bump needed)
+
+### C# Comm ###
+
+* EpoxyListener's StopAsync() now stops all the outstanding connections that
+  is accepted.
+
 ## 5.2.0: 2017-02-07 ##
 
 * `gbc` & compiler library: 0.8.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ different versioning scheme, following the Haskell community's
 
 * EpoxyListener's StopAsync() now stops all the outstanding connections that
   is accepted.
+* EpoxyTransport's StopAsync() now stops all the connections and listeners
+  that it created.
 
 ## 5.2.0: 2017-02-07 ##
 

--- a/cs/src/comm/epoxy-transport/CleanupCollection.cs
+++ b/cs/src/comm/epoxy-transport/CleanupCollection.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Bond.Comm.Epoxy
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Maintains a collection of things that will need to be cleaned up at
+    /// sometime in the future.
+    /// </summary>
+    /// <typeparam name="T">The type of the items needing to be cleaned up.</typeparam>
+    /// <remarks>
+    /// The items of type <typeparamref name="T"/> need to be comparable by
+    /// <see cref="EqualityComparer{T}.Default">EqualityComparer&lt;T&gt;.Default</see>.
+    /// </remarks>
+    internal class CleanupCollection<T>
+    {
+        readonly object lockObj = new object();
+        bool isShutdown = false;
+        HashSet<T> items = new HashSet<T>();
+
+        /// <summary>
+        /// Adds an item to the collection.
+        /// </summary>
+        /// <param name="item">The item to be added.</param>
+        /// <remarks>
+        /// It's safe to add the same item more than once. It will only be
+        /// cleaned up once.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the collection has already been cleaned up.
+        /// </exception>
+        public void Add(T item)
+        {
+            lock (lockObj)
+            {
+                if (isShutdown)
+                {
+                    throw new InvalidOperationException("The cleanup collection has been cleaned up.");
+                }
+
+                items.Add(item);
+            }
+        }
+
+        /// <summary>
+        /// Removes an item from the collection.
+        /// </summary>
+        /// <param name="item">The item to remove.</param>
+        /// <remarks>
+        /// This may be called after the collection has been cleaned up;
+        /// however, doing so is a no-op.
+        /// </remarks>
+        public void Remove(T item)
+        {
+            lock (lockObj)
+            {
+                if (isShutdown)
+                {
+                    return;
+                }
+
+                items.Remove(item);
+            }
+        }
+
+        /// <summary>
+        /// Starts cleaning up this collection. Once clean up has been started,
+        /// no new items are accepted. The optional
+        /// <paramref name="cleanupFunc"/> function will be run on all
+        /// accumulated items.
+        /// </summary>
+        /// <param name="cleanupFunc">
+        /// An optional function to run to clean up each item.
+        /// </param>
+        /// <returns>
+        /// A Task indicating that all of the invocations of
+        /// <paramref name="cleanupFunc"/> have completed.
+        /// </returns>
+        /// <remarks>The order of item clean up is unspecified.</remarks>
+        public Task CleanupAsync(Func<T, Task> cleanupFunc = null)
+        {
+            HashSet<T> localItems;
+
+            lock (lockObj)
+            {
+                if (isShutdown)
+                {
+                    return CodegenHelpers.CompletedTask;
+                }
+
+                isShutdown = true;
+                localItems = items;
+                items = null;
+            }
+
+            Debug.Assert(localItems != null);
+
+            if (localItems.Count == 0 || cleanupFunc == null)
+            {
+                return CodegenHelpers.CompletedTask;
+            }
+
+            var shutdownTasks = new Task[localItems.Count];
+            int idx = 0;
+            foreach (var item in localItems)
+            {
+                shutdownTasks[idx] = cleanupFunc(item);
+                ++idx;
+            }
+
+            return Task.WhenAll(shutdownTasks);
+        }
+    }
+}

--- a/cs/src/comm/epoxy-transport/EpoxyConnection.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyConnection.cs
@@ -494,8 +494,7 @@ namespace Bond.Comm.Epoxy
 
             if (connectionType == ConnectionType.Server)
             {
-                var args = new ConnectedEventArgs(this);
-                Error disconnectError = parentListener.InvokeOnConnected(args);
+                Error disconnectError = parentListener.InformConnected(this);
 
                 if (disconnectError == null)
                 {
@@ -656,8 +655,7 @@ namespace Bond.Comm.Epoxy
 
             if (connectionType == ConnectionType.Server)
             {
-                var args = new DisconnectedEventArgs(this, errorDetails);
-                parentListener.InvokeOnDisconnected(args);
+                parentListener.InformDisconnected(this, errorDetails);
             }
 
             responseMap.Shutdown();

--- a/cs/src/comm/epoxy-transport/EpoxyListener.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyListener.cs
@@ -8,7 +8,6 @@ namespace Bond.Comm.Epoxy
     using System.Diagnostics;
     using System.Net;
     using System.Net.Sockets;
-    using System.Security.Authentication;
     using System.Threading;
     using System.Threading.Tasks;
     using Bond.Comm.Service;
@@ -87,12 +86,13 @@ namespace Bond.Comm.Epoxy
         {
             // Request that the accept loop stop
             shutdownTokenSource.Cancel();
+
             // Stop listening. This causes the accept loop's wait for an
-            // incomming socket to fail, which then causes the accept loop to
+            // incoming socket to fail, which then causes the accept loop to
             // look at the value of shutdownTokenSource.Token.
             listener.Stop();
 
-            // Wait for the accept loop to exit. Once it has exited, no new
+             // Wait for the accept loop to exit. Once it has exited, no new
             // connections will be accepted, so we can close the outstanding
             // ones.
             await acceptTask;
@@ -112,10 +112,12 @@ namespace Bond.Comm.Epoxy
             int idx = 0;
             foreach (var connection in connectionsToClose)
             {
+                logger.Site().Debug("{0} stopping connection {1}", this, connection);
                 connectionShutdownTasks[idx] = connection.StopAsync();
                 ++idx;
             }
 
+            logger.Site().Debug("Waiting for all connections to stop.");
             await Task.WhenAll(connectionShutdownTasks);
         }
 

--- a/cs/src/comm/epoxy-transport/EpoxyTransport.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyTransport.cs
@@ -305,14 +305,7 @@ namespace Bond.Comm.Epoxy
                 }
                 catch (InvalidOperationException)
                 {
-                    // TODO
-                    // Handle a race condition: if the transport is shutdown
-                    // after we've created this connection, but before we've
-                    // added it to this collection, we need to clean up this
-                    // connection on its own. However, we haven't started the
-                    // connection yet, so EpoxyConnection.StopAsync() will
-                    // never complete. For now, we're just going to leak this
-                    // connection.
+                    await connection.StopAsync();
                     throw new InvalidOperationException("This EpoxyTransport has been stopped already.");
                 }
 

--- a/cs/src/comm/epoxy-transport/epoxy-transport.csproj
+++ b/cs/src/comm/epoxy-transport/epoxy-transport.csproj
@@ -15,6 +15,7 @@
     <BondImportDirectory Include="..\interfaces" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CleanupCollection.cs" />
     <Compile Include="Frame.cs" />
     <Compile Include="properties\AssemblyInfo.cs" />
     <Compile Include="EpoxyConnection.cs" />

--- a/cs/test/comm/Epoxy/CleanupCollectionTests.cs
+++ b/cs/test/comm/Epoxy/CleanupCollectionTests.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace UnitTest.Epoxy
+{
+    using System;
+    using System.Threading.Tasks;
+    using Bond.Comm;
+    using Bond.Comm.Epoxy;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class CleanupCollectionTests
+    {
+        [Test]
+        public async Task EmptyCollection_CanBeShutdown()
+        {
+            var c = new CleanupCollection<object>();
+            await c.CleanupAsync();
+        }
+
+        [Test]
+        public async Task EmptyCollection_CanBeShutdownTwice()
+        {
+            var c = new CleanupCollection<object>();
+            await c.CleanupAsync();
+            await c.CleanupAsync();
+        }
+
+        [Test]
+        public async Task NonEmptyCollection_NullCleanupFunc_CanBeShutdown()
+        {
+            var c = new CleanupCollection<object>();
+            c.Add(new object());
+            await c.CleanupAsync();
+        }
+
+        [Test]
+        public async Task AfterShutdown_CanStillRemove()
+        {
+            var c = new CleanupCollection<object>();
+            var obj1 = new object();
+
+            c.Add(obj1);
+            await c.CleanupAsync();
+
+            c.Remove(obj1);
+        }
+
+        [Test]
+        public async Task Shutdown_InvokesPassedCleanupFunc()
+        {
+            var c = new CleanupCollection<ShutdownRecorder>();
+            Func<ShutdownRecorder, Task> cleanupFunc = sr =>
+            {
+                sr.Shutdown();
+                return CodegenHelpers.CompletedTask;
+            };
+
+            var obj1 = new ShutdownRecorder();
+            var obj2 = new ShutdownRecorder();
+            var obj3 = new ShutdownRecorder();
+
+            Assert.AreEqual(0, obj1.NumTimesShutdown);
+            Assert.AreEqual(0, obj2.NumTimesShutdown);
+            Assert.AreEqual(0, obj3.NumTimesShutdown);
+
+            c.Add(obj1);
+            c.Add(obj2);
+
+            c.Add(obj3);
+            c.Remove(obj3);
+
+            await c.CleanupAsync(cleanupFunc);
+
+            Assert.AreEqual(1, obj1.NumTimesShutdown);
+            Assert.AreEqual(1, obj2.NumTimesShutdown);
+            Assert.AreEqual(0, obj3.NumTimesShutdown);
+
+            await c.CleanupAsync(cleanupFunc);
+
+            Assert.AreEqual(1, obj1.NumTimesShutdown);
+            Assert.AreEqual(1, obj2.NumTimesShutdown);
+            Assert.AreEqual(0, obj3.NumTimesShutdown);
+        }
+
+        class ShutdownRecorder
+        {
+            public int NumTimesShutdown;
+
+            public void Shutdown()
+            {
+                NumTimesShutdown += 1;
+            }
+        }
+    }
+}

--- a/cs/test/comm/Epoxy/EpoxyConnectionTests.cs
+++ b/cs/test/comm/Epoxy/EpoxyConnectionTests.cs
@@ -5,7 +5,6 @@ namespace UnitTest.Epoxy
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Bond;

--- a/cs/test/comm/Epoxy/EpoxyListenerTests.cs
+++ b/cs/test/comm/Epoxy/EpoxyListenerTests.cs
@@ -4,7 +4,6 @@
 namespace UnitTest.Epoxy
 {
     using System;
-    using System.Diagnostics;
     using System.Net;
     using System.Net.Sockets;
     using System.Threading;
@@ -28,7 +27,7 @@ namespace UnitTest.Epoxy
         public async Task ListenOnPortZero_ActuallyListensOnSomeOtherPort()
         {
             EpoxyTransport transport = MakeTransport();
-            listener = transport.MakeListener(localhostEndpoint);
+            var listener = transport.MakeListener(localhostEndpoint);
 
             await listener.StartAsync();
 
@@ -39,7 +38,7 @@ namespace UnitTest.Epoxy
         public async Task ConnectedEvent_HasRightRemoteEndpointDetails()
         {
             EpoxyTransport transport = MakeTransport();
-            listener = transport.MakeListener(localhostEndpoint);
+            var listener = transport.MakeListener(localhostEndpoint);
 
             EpoxyConnection remoteConnection = null;
             var connectedEventDone = new ManualResetEventSlim(initialState: false);
@@ -58,8 +57,6 @@ namespace UnitTest.Epoxy
 
             Assert.AreEqual(connection.LocalEndPoint, remoteConnection.RemoteEndPoint);
             Assert.AreEqual(connection.RemoteEndPoint, remoteConnection.LocalEndPoint);
-
-            await transport.StopAsync();
         }
 
         [Test]
@@ -70,7 +67,7 @@ namespace UnitTest.Epoxy
             const string DisconnectMessage = "Go away!";
 
             EpoxyTransport transport = MakeTransport();
-            listener = transport.MakeListener(localhostEndpoint);
+            var listener = transport.MakeListener(localhostEndpoint);
 
             var connectedEventDone = new ManualResetEventSlim(initialState: false);
             listener.Connected += (sender, args) =>
@@ -107,7 +104,7 @@ namespace UnitTest.Epoxy
         public async Task DisconnectedEvent_ClientDisconnects_GetsFired()
         {
             EpoxyTransport transport = MakeTransport();
-            listener = transport.MakeListener(localhostEndpoint);
+            var listener = transport.MakeListener(localhostEndpoint);
 
             var disconnectedEventDone = new ManualResetEventSlim(initialState: false);
             EpoxyConnection disconnectedConnection = null;
@@ -132,7 +129,7 @@ namespace UnitTest.Epoxy
         public async Task OneConnectionStalledDuringHandshake_CanAcceptAnother()
         {
             EpoxyTransport transport = MakeTransport();
-            listener = transport.MakeListener(localhostEndpoint);
+            var listener = transport.MakeListener(localhostEndpoint);
             await listener.StartAsync();
 
             var noHandshakeConnection = new TcpClient();
@@ -143,15 +140,13 @@ namespace UnitTest.Epoxy
             var connectTask = transport.ConnectToAsync(localhostAddress);
             bool didConnect = connectTask.Wait(TimeSpan.FromSeconds(10));
             Assert.IsTrue(didConnect, "Timed out waiting for connection to be established.");
-
-            await transport.StopAsync();
         }
 
         [Test]
         public async Task StopAsync_ClosesAllOutstandingConnections()
         {
             EpoxyTransport transport = MakeTransport();
-            listener = transport.MakeListener(localhostEndpoint);
+            var listener = transport.MakeListener(localhostEndpoint);
 
             await listener.StartAsync();
             var clientConnection = await transport.ConnectToAsync(localhostAddress);
@@ -163,9 +158,10 @@ namespace UnitTest.Epoxy
                     AnyServiceName, AnyMethodName, AnyMessage, CancellationToken.None));
         }
 
-        private static EpoxyTransport MakeTransport()
+        private EpoxyTransport MakeTransport()
         {
             var transport = new EpoxyTransportBuilder().Construct();
+            transports.Add(transport);
             return transport;
         }
     }

--- a/cs/test/comm/Epoxy/EpoxyTransportTests.cs
+++ b/cs/test/comm/Epoxy/EpoxyTransportTests.cs
@@ -4,6 +4,7 @@
 namespace UnitTest.Epoxy
 {
     using System;
+    using System.Diagnostics;
     using System.Net;
     using System.Net.Security;
     using System.Security.Authentication;
@@ -198,7 +199,9 @@ namespace UnitTest.Epoxy
         public void Builder_Construct_NoArgs_Succeeds()
         {
             var builder = new EpoxyTransportBuilder();
-            Assert.NotNull(builder.Construct());
+            EpoxyTransport result = builder.Construct();
+            Assert.NotNull(result);
+            transports.Add(result);
         }
 
         [Test]
@@ -213,9 +216,6 @@ namespace UnitTest.Epoxy
             Assert.IsNull(response.Error);
 
             Assert.AreEqual(1, testClientServer.Service.RespondWithEmpty_CallCount);
-
-            await testClientServer.ServiceTransport.StopAsync();
-            await testClientServer.ClientTransport.StopAsync();
         }
 
         [Test]
@@ -230,9 +230,6 @@ namespace UnitTest.Epoxy
 
             var error = response.Error.Deserialize<Error>();
             Assert.AreEqual((int)ErrorCode.INTERNAL_SERVER_ERROR, error.error_code);
-
-            await testClientServer.ServiceTransport.StopAsync();
-            await testClientServer.ClientTransport.StopAsync();
         }
 
         [Test]
@@ -248,9 +245,6 @@ namespace UnitTest.Epoxy
             var error = response.Error.Deserialize<Error>();
             Assert.AreEqual((int)ErrorCode.INTERNAL_SERVER_ERROR, error.error_code);
             Assert.That(error.message, Is.StringContaining(Errors.InternalErrorMessage));
-
-            await testClientServer.ServiceTransport.StopAsync();
-            await testClientServer.ClientTransport.StopAsync();
         }
 
         [Test]
@@ -259,12 +253,12 @@ namespace UnitTest.Epoxy
             await SetupTestClientServer<DummyTestService>();
 
             var clientTransport = new EpoxyTransportBuilder().SetResolver(ResolveEverythingToLocalhost).Construct();
+            transports.Add(clientTransport);
             EpoxyConnection clientConnection = await clientTransport.ConnectToAsync("epoxy://resolve-this-to-localhost/");
             var proxy = new DummyTestProxy<EpoxyConnection>(clientConnection);
 
             await AssertRequestResponseWorksAsync(proxy);
 
-            await clientTransport.StopAsync();
         }
 
         [Test]
@@ -281,9 +275,6 @@ namespace UnitTest.Epoxy
             Assert.AreEqual(1, testClientServer.Service.RequestCount);
             Assert.AreEqual(0, testClientServer.Service.EventCount);
             Assert.AreEqual(request.int_value, testClientServer.Service.LastRequestReceived.int_value);
-
-            await testClientServer.ServiceTransport.StopAsync();
-            await testClientServer.ClientTransport.StopAsync();
         }
 
         [Test]
@@ -301,9 +292,6 @@ namespace UnitTest.Epoxy
             Assert.AreEqual(0, testClientServer.Service.RequestCount);
             Assert.AreEqual(1, testClientServer.Service.EventCount);
             Assert.AreEqual(theEvent.int_value, testClientServer.Service.LastEventReceived.int_value);
-
-            await testClientServer.ServiceTransport.StopAsync();
-            await testClientServer.ClientTransport.StopAsync();
          }
 
         [Test]
@@ -315,9 +303,6 @@ namespace UnitTest.Epoxy
 
             await AssertRequestResponseWorksAsync(proxy);
             Assert.AreEqual(1, testClientServer.Service.RequestCount);
-
-            await testClientServer.ServiceTransport.StopAsync();
-            await testClientServer.ClientTransport.StopAsync();
          }
 
         [Test]
@@ -344,9 +329,6 @@ namespace UnitTest.Epoxy
 
             Assert.AreEqual(1, testClientServer.Service.RequestCount);
             Assert.AreEqual(request.int_value, testClientServer.Service.LastRequestReceived.int_value);
-
-            await testClientServer.ServiceTransport.StopAsync();
-            await testClientServer.ClientTransport.StopAsync();
         }
 
         [Test]
@@ -374,9 +356,6 @@ namespace UnitTest.Epoxy
             Assert.AreEqual(2, serverLayerProvider.Layers.Count);
             Assert.AreEqual("Client1SendClient1Receive", clientLayerProvider.Layers[1].State);
             Assert.AreEqual("Server1ReceiveServer1Send", serverLayerProvider.Layers[1].State);
-
-            await testClientServer.ServiceTransport.StopAsync();
-            await testClientServer.ClientTransport.StopAsync();
         }
 
         [Test]
@@ -406,9 +385,6 @@ namespace UnitTest.Epoxy
 
             Assert.AreEqual(1, testClientServer.Service.RequestCount);
             Assert.AreEqual(request.int_value, testClientServer.Service.LastRequestReceived.int_value);
-
-            await testClientServer.ServiceTransport.StopAsync();
-            await testClientServer.ClientTransport.StopAsync();
         }
 
         [Test]
@@ -442,9 +418,6 @@ namespace UnitTest.Epoxy
 
             Assert.AreEqual(1, testClientServer.Service.EventCount);
             Assert.AreEqual(theEvent.int_value, testClientServer.Service.LastEventReceived.int_value);
-
-            await testClientServer.ServiceTransport.StopAsync();
-            await testClientServer.ClientTransport.StopAsync();
         }
 
         [Test]
@@ -477,9 +450,6 @@ namespace UnitTest.Epoxy
 
             Assert.AreEqual(1, testClientServer.Service.EventCount);
             Assert.AreEqual(theEvent.int_value, testClientServer.Service.LastEventReceived.int_value);
-
-            await testClientServer.ServiceTransport.StopAsync();
-            await testClientServer.ClientTransport.StopAsync();
         }
 
         [Test]
@@ -524,9 +494,6 @@ namespace UnitTest.Epoxy
             Assert.AreEqual(2, serverLayerProvider.Layers.Count);
             Assert.AreEqual("Client1Send", clientLayerProvider.Layers[1].State);
             Assert.AreEqual("Server1Receive", serverLayerProvider.Layers[1].State);
-
-            await testClientServer.ServiceTransport.StopAsync();
-            await testClientServer.ClientTransport.StopAsync();
         }
 
         [Test]
@@ -546,9 +513,6 @@ namespace UnitTest.Epoxy
             Error error = response.Error.Deserialize();
             Assert.AreEqual((int)ErrorCode.INTERNAL_SERVER_ERROR, error.error_code);
             Assert.AreEqual(TestLayerStackProvider_Fails.InternalDetails, error.message);
-
-            await testClientServer.ServiceTransport.StopAsync();
-            await testClientServer.ClientTransport.StopAsync();
         }
 
         [Test]
@@ -568,9 +532,6 @@ namespace UnitTest.Epoxy
             Error error = response.Error.Deserialize();
             Assert.AreEqual((int)ErrorCode.INTERNAL_SERVER_ERROR, error.error_code);
             Assert.AreEqual(Errors.InternalErrorMessage, error.message);
-
-            await testClientServer.ServiceTransport.StopAsync();
-            await testClientServer.ClientTransport.StopAsync();
         }
 
         [Test]
@@ -607,9 +568,6 @@ namespace UnitTest.Epoxy
             Assert.AreEqual(0, testClientServer.Service.RequestCount);
             Assert.AreEqual(1, testClientServer.Service.EventCount);
             Assert.AreEqual(theEvent.int_value, testClientServer.Service.LastEventReceived.int_value);
-
-            await testClientServer.ServiceTransport.StopAsync();
-            await testClientServer.ClientTransport.StopAsync();
         }
 
         [Test]
@@ -627,7 +585,8 @@ namespace UnitTest.Epoxy
         public async Task IPv6Listener_RequestReply_PayloadResponse()
         {
             var transport = new EpoxyTransportBuilder().Construct();
-            listener = transport.MakeListener(new IPEndPoint(IPAddress.IPv6Loopback, EpoxyTransport.DefaultInsecurePort));
+            transports.Add(transport);
+            var listener = transport.MakeListener(new IPEndPoint(IPAddress.IPv6Loopback, EpoxyTransport.DefaultInsecurePort));
             listener.AddService(new DummyTestService());
             await listener.StartAsync();
 
@@ -638,8 +597,6 @@ namespace UnitTest.Epoxy
             IMessage<Dummy> response = await proxy.ReqRspMethodAsync(request);
             Assert.IsFalse(response.IsError);
             Assert.AreEqual(101, response.Payload.Deserialize().int_value);
-
-            await transport.StopAsync();
         }
 
         [Test]
@@ -648,7 +605,8 @@ namespace UnitTest.Epoxy
             var serverTlsConfig = new EpoxyServerTlsConfig(testServerCert, checkCertificateRevocation: false);
 
             var serverTransport = new EpoxyTransportBuilder().SetServerTlsConfig(serverTlsConfig).Construct();
-            listener = serverTransport.MakeListener(new IPEndPoint(IPAddress.Loopback, EpoxyTransport.DefaultSecurePort));
+            transports.Add(serverTransport);
+            var listener = serverTransport.MakeListener(new IPEndPoint(IPAddress.Loopback, EpoxyTransport.DefaultSecurePort));
             listener.AddService(new DummyTestService());
             await listener.StartAsync();
 
@@ -660,14 +618,12 @@ namespace UnitTest.Epoxy
                 .SetResolver(ResolveEverythingToLocalhost)
                 .SetClientTlsConfig(clientTlsConfig)
                 .Construct();
+            transports.Add(clientTransport);
             EpoxyConnection clientConnection = await clientTransport.ConnectToAsync("epoxys://bond-test-server1");
 
             var proxy = new DummyTestProxy<EpoxyConnection>(clientConnection);
 
             await AssertRequestResponseWorksAsync(proxy);
-
-            await clientTransport.StopAsync();
-            await serverTransport.StopAsync();
         }
 
         [Test]
@@ -675,8 +631,11 @@ namespace UnitTest.Epoxy
         {
             var serverTlsConfig = new EpoxyServerTlsConfig(testServerCert, checkCertificateRevocation: false);
 
-            var serverTransport = new EpoxyTransportBuilder().SetServerTlsConfig(serverTlsConfig).Construct();
-            listener = serverTransport.MakeListener(new IPEndPoint(IPAddress.Loopback, EpoxyTransport.DefaultSecurePort));
+            var serverTransport =
+                new EpoxyTransportBuilder().SetServerTlsConfig(serverTlsConfig)
+                    .Construct();
+            transports.Add(serverTransport);
+            var listener = serverTransport.MakeListener(new IPEndPoint(IPAddress.Loopback, EpoxyTransport.DefaultSecurePort));
             listener.AddService(new DummyTestService());
             await listener.StartAsync();
 
@@ -693,11 +652,9 @@ namespace UnitTest.Epoxy
                 .SetResolver(ResolveEverythingToLocalhost)
                 .SetClientTlsConfig(clientTlsConfig)
                 .Construct();
+            transports.Add(clientTransport);
 
             Assert.Throws<AuthenticationException>(async () => await clientTransport.ConnectToAsync("epoxys://bond-test-server1"));
-
-            await clientTransport.StopAsync();
-            await serverTransport.StopAsync();
         }
 
         [Test]
@@ -720,8 +677,9 @@ namespace UnitTest.Epoxy
                 .SetServerTlsConfig(serverTlsConfig)
                 .SetClientTlsConfig(clientTlsConfig)
                 .Construct();
+            transports.Add(transport);
 
-            listener = transport.MakeListener(new IPEndPoint(IPAddress.Loopback, EpoxyTransport.DefaultSecurePort));
+            var listener = transport.MakeListener(new IPEndPoint(IPAddress.Loopback, EpoxyTransport.DefaultSecurePort));
             listener.AddService(new DummyTestService());
             await listener.StartAsync();
 
@@ -730,8 +688,6 @@ namespace UnitTest.Epoxy
             var proxy = new DummyTestProxy<EpoxyConnection>(clientConnection);
 
             await AssertRequestResponseWorksAsync(proxy);
-
-            await transport.StopAsync();
         }
 
         [Test]
@@ -753,8 +709,9 @@ namespace UnitTest.Epoxy
                 .SetServerTlsConfig(serverTlsConfig)
                 .SetClientTlsConfig(clientTlsConfig)
                 .Construct();
+            transports.Add(transport);
 
-            listener = transport.MakeListener(new IPEndPoint(IPAddress.Loopback, EpoxyTransport.DefaultSecurePort));
+            var listener = transport.MakeListener(new IPEndPoint(IPAddress.Loopback, EpoxyTransport.DefaultSecurePort));
             listener.AddService(new DummyTestService());
             await listener.StartAsync();
 
@@ -778,10 +735,6 @@ namespace UnitTest.Epoxy
             catch (Exception ex)
             {
                 Assert.Fail("Unexpected exception of type {0}: {1}", ex.GetType(), ex);
-            }
-            finally
-            {
-                await transport.StopAsync();
             }
         }
 

--- a/cs/test/comm/comm.csproj
+++ b/cs/test/comm/comm.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildFramework Condition="'$(Configuration)' == 'Net40'">net40</BuildFramework>
@@ -50,6 +50,7 @@
     <BondCodegen Include="SimpleInMem\Calculator.bond">
       <Options>--namespace=unittest.simpleinmem=UnitTest.SimpleInMem</Options>
     </BondCodegen>
+    <Compile Include="Epoxy\CleanupCollectionTests.cs" />
     <Compile Include="Epoxy\EpoxyConnectionTests.cs" />
     <Compile Include="Epoxy\EpoxyListenerTests.cs" />
     <Compile Include="Epoxy\EpoxyProtocolTests.cs" />


### PR DESCRIPTION
Make EpoxyTransport and EpoxyListener's StopAsync shutdown everything that they created.

TODO:

* [x] EpoxyConnection and EpoxyListener collection management is currently duplicated in both transport and listener. The code in the two is very similar. There's an opportunity to distill out this collection management. Fixed in a later commit in this PR.
* [x] Address TODO comment about bug in another test. Fixed in PR #321.