### PR TITLE
[c# epoxy] Improve multiple shutdown test

### DIFF
--- a/cs/test/comm/Epoxy/EpoxyConnectionTests.cs
+++ b/cs/test/comm/Epoxy/EpoxyConnectionTests.cs
@@ -77,15 +77,12 @@ namespace UnitTest.Epoxy
             var testClientServer = await SetupTestClientServer<TestService>();
             EpoxyConnection connection = testClientServer.ClientConnection;
 
-            var stopTasks = new[] {connection.StopAsync(), connection.StopAsync()};
+            var stopTasks = Task.WhenAll(connection.StopAsync(), connection.StopAsync());
             var timeoutTask = Task.Delay(TimeSpan.FromSeconds(10));
-            var allTasks = new List<Task>(stopTasks) { timeoutTask };
 
-            var completedTask = await Task.WhenAny(allTasks);
+            var completedTask = await Task.WhenAny(stopTasks, timeoutTask);
 
             Assert.AreNotSame(timeoutTask, completedTask, "Timed out waiting for connection to be shutdown.");
-
-            await connection.StopAsync();
         }
 
         [Test]


### PR DESCRIPTION
Before, the `Connection_CanBeStoppedMultipleTimes` test was just asserting
that the connection had been shutdown once--not twice--before the
timeout.

Now, we assert that both shutdowns have happened.