### PR TITLE
Rename pre-compiled gbc when installing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,14 @@ install (EXPORT bond
 
 # if BOND_GBC_PATH is set we must copy over that gbc to the install location
 if (BOND_GBC_PATH)
-    install (FILES
-        ${BOND_GBC_PATH}
-        DESTINATION bin)
+  if (WIN32)
+    set(INSTALLED_GBC_NAME gbc.exe)
+  else()
+    set(INSTALLED_GBC_NAME gbc)
+  endif()
+
+  install (
+    FILES ${BOND_GBC_PATH}
+    DESTINATION bin
+    RENAME ${INSTALLED_GBC_NAME})
 endif()


### PR DESCRIPTION
The pre-compiled gbc may not be called "gbc" if the user specified the
CMake variable BOND_GBC_PATH, so we need to rename it to gbc when
installing.