### PR TITLE
[c++ protocol] Add Read/Write/Skip type_alias methods to protocols

### DIFF
--- a/cpp/inc/bond/protocol/compact_binary.h
+++ b/cpp/inc/bond/protocol/compact_binary.h
@@ -347,6 +347,17 @@ public:
     }
 
 
+    // Read for type alias
+    template <typename T>
+    typename boost::enable_if<is_type_alias<T> >::type
+    Read(T& value)
+    {
+        typename aliased_type<T>::type x;
+        Read(x);
+        set_aliased_value(value, x);
+    }
+
+
     // Read for blob
     void Read(blob& value, uint32_t size)
     {
@@ -713,6 +724,14 @@ public:
 
         Write(length);
         detail::WriteStringData(_output, value, length);
+    }
+
+    // Write for type alias
+    template <typename T>
+    typename boost::enable_if<is_type_alias<T> >::type
+    Write(T& value)
+    {
+        Write(get_aliased_value(value));
     }
 
     // Write for blob

--- a/cpp/inc/bond/protocol/fast_binary.h
+++ b/cpp/inc/bond/protocol/fast_binary.h
@@ -148,7 +148,7 @@ public:
 
     // Read for primitive types
     template <typename T>
-    typename boost::disable_if<is_string_type<T> >::type
+    typename boost::disable_if_c<is_string_type<T>::value || is_type_alias<T>::value >::type
     Read(T& value)
     {
         _input.Read(value);
@@ -164,6 +164,17 @@ public:
 
         ReadVariableUnsigned(_input, length);
         detail::ReadStringData(_input, value, length);
+    }
+
+
+    // Read for type alias
+    template <typename T>
+    typename boost::enable_if<is_type_alias<T> >::type
+    Read(T& value)
+    {
+        typename aliased_type<T>::type x;
+        Read(x);
+        set_aliased_value(value, x);
     }
 
 
@@ -457,6 +468,14 @@ public:
 
         WriteVariableUnsigned(_output, length);
         detail::WriteStringData(_output, value, length);
+    }
+
+    // Write for type alias
+    template <typename T>
+    typename boost::enable_if<is_type_alias<T> >::type
+    Write(T& value)
+    {
+        Write(get_aliased_value(value));
     }
 
     // Write for blob

--- a/cpp/inc/bond/protocol/random_protocol.h
+++ b/cpp/inc/bond/protocol/random_protocol.h
@@ -177,6 +177,18 @@ public:
         }
     }
 
+
+    // Read for type alias
+    template <typename T>
+    typename boost::enable_if<is_type_alias<T> >::type
+    Read(T& value)
+    {
+        typename aliased_type<T>::type x;
+        Read(x);
+        set_aliased_value(value, x);
+    }
+
+
     // Read for blob
     void Read(blob& value, uint32_t size)
     {


### PR DESCRIPTION
Read/Write/Skip methods are present in JSON protocol, but are missed in all other protocols. I copy-pasted them to Compact Binary, Fast Binary, Simple Binary and Random. 