### PR TITLE
[c# epoxy] Safely shutdown possibly null sockets

### DIFF
--- a/cs/src/comm/epoxy-transport/EpoxyNetworkStream.cs
+++ b/cs/src/comm/epoxy-transport/EpoxyNetworkStream.cs
@@ -369,8 +369,8 @@ namespace Bond.Comm.Epoxy
         {
             try
             {
-                socket.Shutdown(SocketShutdown.Both);
-                socket.Close();
+                socket?.Shutdown(SocketShutdown.Both);
+                socket?.Close();
             }
             catch (SocketException ex)
             {


### PR DESCRIPTION
If the function that produces the socket itself throws, we may not have a
socket to call Shutdown and Close on. This fixes a regression introducted by
2f9aeae.