### PR TITLE
Add CMake option to install generated .cpp files

### DIFF
--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -133,6 +133,10 @@ set (BOND_LIBRARIES_ONLY
     "FALSE"
     CACHE BOOL "If TRUE, then only build the Bond library files, skipping any tools. gbc will still be built if it cannot be found, however, as gbc is needed to build the libraries.")
 
+set (BOND_LIBRARIES_INSTALL_CPP
+    "FALSE"
+    CACHE BOOL "If TRUE, the generated .cpp files for the Bond libraries will be installed under src/ as part of the INSTALL target.")
+
 set (BOND_CORE_ONLY
     "FALSE"
     CACHE BOOL "If TRUE, then only build the Bond Core")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -141,4 +141,11 @@ if (NOT BOND_CORE_ONLY)
     install (DIRECTORY ${BOND_IDL}/bond/comm DESTINATION include/bond)
 endif()
 
+if (BOND_LIBRARIES_INSTALL_CPP)
+  install (
+    DIRECTORY ${BOND_GENERATED}/bond/
+    DESTINATION src/bond/generated
+    FILES_MATCHING PATTERN "*.cpp")
+endif()
+
 add_subdirectory (test)


### PR DESCRIPTION
The CMake cache variable `BOND_LIBRARIES_INSTALL_CPP` controls whether the
generated .cpp files are installed under src/. This can be used to keep the
code around for debugging purposes or to create a self-contained copy of
Bond that can be built with something other than CMake.