### PR TITLE
[gbc] Temporarily pin derive dependency to < 2.6

### DIFF
--- a/compiler/bond.cabal
+++ b/compiler/bond.cabal
@@ -91,7 +91,7 @@ test-suite gbc-tests
                     filepath >= 1.0,
                     monad-loops >= 0.4,
                     text >= 0.11,
-                    derive,
+                    derive < 2.6,
                     HUnit,
                     QuickCheck,
                     Diff >= 0.2 && < 0.4,


### PR DESCRIPTION
gbc-tests no longer builds with derive 2.6 or later. While we
investigate that problem, pin the dependency to < 2.6 to keep gbc-tests
building.

Mitigates https://github.com/Microsoft/bond/issues/342