### PR TITLE
Use precompiled pandoc for building documentation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,19 +69,29 @@
 
             choco install haskellplatform -version 2014.2.0.0 -y
 
-            $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine")
+            # choco install updated the path, so re-read them from the registry and reset $env:path
+
+            $userPath = [System.Environment]::GetEnvironmentVariable("Path","User")
+
+            $machinePath = [System.Environment]::GetEnvironmentVariable("Path","Machine")
+
+            $env:Path = "$userPath;$machinePath"
 
             cabal update
 
             if ($env:BOND_BUILD -eq "Doc") {
 
-                cabal install -j pandoc --constraint='mtl<=2.1.3.1'
+                choco install pandoc --version 1.19.2  -y
 
                 choco install doxygen.install -y
 
-            }
+                $userPath = [System.Environment]::GetEnvironmentVariable("Path","User")
 
-            $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine")
+                $machinePath = [System.Environment]::GetEnvironmentVariable("Path","Machine")
+
+                $env:Path = "$userPath;$machinePath"
+
+            }
 
     cache:
         - cs\packages -> cs\test\core\packages.config

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,11 +71,11 @@
 
             # choco install updated the path, so re-read them from the registry and reset $env:path
 
-            $userPath = [System.Environment]::GetEnvironmentVariable("Path","User")
-
             $machinePath = [System.Environment]::GetEnvironmentVariable("Path","Machine")
 
-            $env:Path = "$userPath;$machinePath"
+            $userPath = [System.Environment]::GetEnvironmentVariable("Path","User")
+
+            $env:Path = "$machinePath;$userPath"
 
             cabal update
 
@@ -85,11 +85,11 @@
 
                 choco install doxygen.install -y
 
-                $userPath = [System.Environment]::GetEnvironmentVariable("Path","User")
-
                 $machinePath = [System.Environment]::GetEnvironmentVariable("Path","Machine")
 
-                $env:Path = "$userPath;$machinePath"
+                $userPath = [System.Environment]::GetEnvironmentVariable("Path","User")
+
+                $env:Path = "$machinePath;$userPath"
 
             }
 


### PR DESCRIPTION
Instead of building pandoc from source, we now just use Chocolately to
install a precompiled version of pandoc. This speeds up documentation
builds and prevents random breakage due to Hackage package changes.

NB: The Chocolately Pandoc 1.19.2.1 package is currently broken. It
appears to have a pre-release Pandoc 2.0 executable that doesn't
understand all the command line flags that 1.x does (e.g., --smart).

Fixes https://github.com/Microsoft/bond/issues/341