### PR TITLE
[C#] Cap incremental memory usage in InputStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ different versioning scheme, following the Haskell community's
 ## C# ###
 
 * Added controls to cap incremental allocation between reads in
-  IO.UnsafeInputStream.
+  Bond.IO.Unsafe.InputStream.
 
 ### C# Comm ###
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ different versioning scheme, following the Haskell community's
 ## C# ###
 
 * Added controls to cap incremental allocation between reads in
-  Bond.IO.Unsafe.InputStream.
+  `Bond.IO.Unsafe.InputStream`.
 
 ### C# Comm ###
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,13 @@ different versioning scheme, following the Haskell community's
 * IDL core version: TBD
 * IDL comm version: TBD
 * C++ version: TBD
-* C# NuGet version: TBD
+* C# NuGet version: TBD (minor bump needed)
 * C# Comm NuGet version: TBD (minor bump needed)
+
+## C# ###
+
+* Added controls to cap incremental allocation between reads in
+  IO.UnsafeInputStream.
 
 ### C# Comm ###
 

--- a/cs/src/io/unsafe/InputStream.cs
+++ b/cs/src/io/unsafe/InputStream.cs
@@ -11,9 +11,6 @@ namespace Bond.IO.Unsafe
     /// </summary>
     public class InputStream : InputBuffer, ICloneable<InputStream>
     {
-        readonly Stream stream;
-        readonly int bufferLength;
-
         // Default setting for maximum incremental allocation chunk size before reading from stream
         public const int DefaultAllocationChunk = 128 * 1024 * 1024;
 
@@ -31,12 +28,15 @@ namespace Bond.IO.Unsafe
             }
         }
 
+        static int activeAllocationChunk;
+
+        readonly Stream stream;
+        readonly int bufferLength;
+
         static InputStream()
         {
             ActiveAllocationChunk = DefaultAllocationChunk;
         }
-
-        static int activeAllocationChunk;
 
         // When we read more data from the stream we can override existing buffer
         // only if it hasn't been exposed via ReadBytes or Clone. Otherwise a new

--- a/cs/src/io/unsafe/InputStream.cs
+++ b/cs/src/io/unsafe/InputStream.cs
@@ -13,6 +13,31 @@ namespace Bond.IO.Unsafe
     {
         readonly Stream stream;
         readonly int bufferLength;
+
+        // Default setting for maximum incremental allocation chunk size before reading from stream
+        public const int DefaultAllocationChunk = 128 * 1024 * 1024;
+
+        // Active setting for maximum incremental allocation chunk size before reading from stream
+        public static int ActiveAllocationChunk
+        {
+            get { return activeAllocationChunk; }
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException("value", "Value cannot be negative");
+                }
+                activeAllocationChunk = value;
+            }
+        }
+
+        static InputStream()
+        {
+            ActiveAllocationChunk = DefaultAllocationChunk;
+        }
+
+        static int activeAllocationChunk;
+
         // When we read more data from the stream we can override existing buffer
         // only if it hasn't been exposed via ReadBytes or Clone. Otherwise a new
         // buffer has to be allocated.
@@ -65,31 +90,68 @@ namespace Bond.IO.Unsafe
             canReuseBuffer = false;
             return result;
         }
-        
+
         internal override void EndOfStream(int count)
         {
             var oldBuffer = buffer;
 
-            if (!canReuseBuffer || count > buffer.Length)
-            {
-                buffer = new byte[Math.Max(bufferLength, count)];
-                canReuseBuffer = true;
-            }
-
             var remaining = end - position;
 
-            if (remaining > 0)
-            {
-                Buffer.BlockCopy(oldBuffer, position, buffer, 0, remaining);
-            }
-            else if (remaining < 0)
+            if (remaining < 0)
             {
                 stream.Seek(-remaining, SeekOrigin.Current);
                 remaining = 0;
             }
 
-            end = remaining + stream.Read(buffer, remaining, buffer.Length - remaining);
-            position = 0;
+            bool failed = false;
+            byte[][] tempBuffers = null;
+            int numTempBuffers = 0;
+            if ((count > buffer.Length && (count - buffer.Length > ActiveAllocationChunk)))
+            {
+                // Calculate number of temp buffers -1 in case difference is exactly
+                // multiple of chunk size.
+                numTempBuffers = (count - buffer.Length - 1) / ActiveAllocationChunk;
+
+                tempBuffers = new byte[numTempBuffers][];
+                for (int i = 0; i < numTempBuffers; i++)
+                {
+                    tempBuffers[i] = new byte[ActiveAllocationChunk];
+
+                    var bytesRead = stream.Read(tempBuffers[i], 0, ActiveAllocationChunk);
+                    if (bytesRead != ActiveAllocationChunk)
+                    {
+                        failed = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!failed)
+            {
+                if (!canReuseBuffer || count > buffer.Length)
+                {
+                    buffer = new byte[Math.Max(bufferLength, count)];
+                    canReuseBuffer = true;
+                }
+
+                if (remaining > 0)
+                {
+                    Buffer.BlockCopy(oldBuffer, position, buffer, 0, remaining);
+                }
+
+                int offset = remaining;
+                if (numTempBuffers > 0)
+                {
+                    for (int i = 0; i < numTempBuffers; i++)
+                    {
+                        Buffer.BlockCopy(tempBuffers[i], 0, buffer, offset, ActiveAllocationChunk);
+                        offset += ActiveAllocationChunk;
+                    }
+                }
+                end = offset + stream.Read(buffer, offset, buffer.Length - offset);
+
+                position = 0;
+            }
 
             if (count > end)
             {

--- a/cs/test/core/StreamTests.cs
+++ b/cs/test/core/StreamTests.cs
@@ -113,14 +113,14 @@
         delegate void IntTest<T>(T value);
 
         [Test]
-        public void VarintTest()
+        public void VarIntTest()
         {
-            VarintTestImpl();
+            VarIntTestImpl();
             InputStream.ActiveAllocationChunk = 8;
-            VarintTestImpl();
+            VarIntTestImpl();
         }
 
-        internal void VarintTestImpl()
+        internal void VarIntTestImpl()
         {
             IntTest<ushort> test16 = (value) =>
             {

--- a/cs/test/core/StreamTests.cs
+++ b/cs/test/core/StreamTests.cs
@@ -9,8 +9,24 @@
     [TestFixture]
     public class StreamTests
     {
+
+        // Restore the default settings at the start and end of each test
+        [SetUp]
+        [TearDown]
+        public void RestoreDefaults()
+        {
+            InputStream.ActiveAllocationChunk = InputStream.DefaultAllocationChunk;
+        }
+
         [Test]
         public void StreamPositionLengthTest()
+        {
+            StreamPositionLengthTestImpl();
+            InputStream.ActiveAllocationChunk = 8;
+            StreamPositionLengthTestImpl();
+        }
+
+        internal void StreamPositionLengthTestImpl()
         {
             const int _50MB = 50*1024*1024;
 
@@ -63,6 +79,15 @@
         [Test]
         public void StreamBufferReuseTest()
         {
+            StreamBufferReuseTestImpl();
+            InputStream.ActiveAllocationChunk = 8;
+            StreamBufferReuseTestImpl();
+            InputStream.ActiveAllocationChunk = 2;
+            StreamBufferReuseTestImpl();
+        }
+
+        internal void StreamBufferReuseTestImpl()
+        {
             var buffer = new byte[5 * 1024];
             
             for (var i = 0; i < buffer.Length; ++i)
@@ -88,7 +113,14 @@
         delegate void IntTest<T>(T value);
 
         [Test]
-        public void Varint()
+        public void VarintTest()
+        {
+            VarintTestImpl();
+            InputStream.ActiveAllocationChunk = 8;
+            VarintTestImpl();
+        }
+
+        internal void VarintTestImpl()
         {
             IntTest<ushort> test16 = (value) =>
             {


### PR DESCRIPTION
Prevent InputStream from preallocating large amounts of memory without reading from underlying stream in incremental chunks. Default is set to 128MB to prevent massive preallocation by corrupted data, similar to the DeserializerControls introduced in https://github.com/Microsoft/bond/pull/297