### PR TITLE
Fix Python break due to Boost 1.63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,13 @@ different versioning scheme, following the Haskell community's
 * `gbc` & compiler library: TBD
 * IDL core version: TBD
 * IDL comm version: TBD
-* C++ version: TBD
+* C++ version: TBD (bugfix bump needed)
 * C# NuGet version: TBD (minor bump needed)
 * C# Comm NuGet version: TBD (minor bump needed)
+
+### C++ ###
+
+* Fix Python shared_ptr converter build break with Boost 1.63.
 
 ## C# ###
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -122,6 +122,15 @@
 
             }
 
+            if ($env:BOND_BUILD -eq "Python" -Or $env:BOND_BUILD -eq "C++") {
+
+                # Make sure we have Python27-64 before any other version
+                if ($env:BOND_ARCH -eq 64) {
+                    $env:Path = "C:\Python27-x64\scripts;C:\Python27-x64\;${env:Path}"
+                }
+
+            }
+
             if ($env:BOND_BUILD -eq "Python") {
 
                 mkdir build
@@ -139,11 +148,6 @@
                 mkdir build
 
                 cd build
-
-                # Make sure we have Python27-64 before any other version; Python path per https://www.appveyor.com/docs/installed-software#python
-                if ($env:BOND_ARCH -eq 64) {
-                    $env:Path = "C:\Python27-x64\scripts;C:\Python27-x64\;${env:Path}"
-                }
 
                 cmake $cmakeFlags -G $cmakeGenerator ..
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,11 @@
               BOND_VS_NUM: 14
               BOND_ARCH: 32
               BOND_BOOST: 60
+            - BOND_BUILD: Python
+              BOND_VS: "Visual Studio 14 2015"
+              BOND_VS_NUM: 14
+              BOND_ARCH: 64
+              BOND_BOOST: 63
             - BOND_BUILD: C++
               BOND_VS: "Visual Studio 14 2015"
               BOND_VS_NUM: 14

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -128,8 +128,6 @@
 
                 cd build
 
-                Wait-Process -name boost
-
                 cmake "-DBoost_ADDITIONAL_VERSIONS=1.${env:BOND_BOOST}.0" $cmakeFlags -G $cmakeGenerator ..
 
             }

--- a/python/inc/bond/python/converters.h
+++ b/python/inc/bond/python/converters.h
@@ -458,8 +458,12 @@ inline void register_builtin_converters()
             true
             >();
 
-        // Allows extraction of share_ptr<char> from python string object
+        // Allows extraction of shared_ptr<char> from python string object
+#if BOOST_VERSION >= 106300
+        converter::shared_ptr_from_python<char, boost::shared_ptr>();
+#else
         converter::shared_ptr_from_python<char>();
+#endif
 
         registered = true;
     }


### PR DESCRIPTION
Boost.Python 1.63 changed the interface to boost::python::converter::shared_ptr_from_python<>.