### PR TITLE
Improve Bond's compliance with Microsoft's SDL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ different versioning scheme, following the Haskell community's
     * Bond now builds on MSVC with
       [`_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES`](https://msdn.microsoft.com/en-us/library/ms175759.aspx)
       instead of `_CTR_SECURE_NO_WARNINGS`.
+    * Bond builds on MSVC with SDL recommended warnings enabled.
 
 ## C# ###
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,18 @@ different versioning scheme, following the Haskell community's
 * `gbc` & compiler library: TBD
 * IDL core version: TBD
 * IDL comm version: TBD
-* C++ version: TBD (bugfix bump needed)
+* C++ version: TBD (minor bump needed)
 * C# NuGet version: TBD (minor bump needed)
 * C# Comm NuGet version: TBD (minor bump needed)
 
 ### C++ ###
 
 * Fix Python shared_ptr converter build break with Boost 1.63.
+* Improve compliance with
+  [Microsoft's SDL](https://www.microsoft.com/en-us/sdl/).
+    * Bond now builds on MSVC with
+      [`_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES`](https://msdn.microsoft.com/en-us/library/ms175759.aspx)
+      instead of `_CTR_SECURE_NO_WARNINGS`.
 
 ## C# ###
 

--- a/cmake/Compiler.cmake
+++ b/cmake/Compiler.cmake
@@ -5,6 +5,13 @@ function (cxx_target_compile_options compiler)
     endif()
 endfunction()
 
+function (cxx_target_compile_definitions compiler)
+    list (REMOVE_AT ARGV 0)
+    if (${CMAKE_CXX_COMPILER_ID} STREQUAL ${compiler})
+        target_compile_definitions (${ARGV})
+    endif()
+endfunction()
+
 function (cxx_add_compile_options compiler)
     list (REMOVE_AT ARGV 0)
     if (${CMAKE_CXX_COMPILER_ID} STREQUAL ${compiler})

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -19,9 +19,16 @@ if (BOND_GBC_PATH)
 endif()
 
 if (MSVC)
-    # disable MSVC warnings
-    add_compile_options (/bigobj /FIbond/core/warning.h /W4 /WX)
-    add_definitions (-D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS)
+    # MSVC needs this because of how template-heavy our code is.
+    add_compile_options (/bigobj)
+    # inject disabling of some MSVC warnings
+    add_compile_options (/FIbond/core/warning.h)
+    # turn up warning level
+    add_compile_options (/W4 /WX /sdl)
+    # use secure CRT functions via template overloads to avoid polluting
+    # Bond with MSVC CRT-specific code too much. More details at
+    # https://msdn.microsoft.com/en-us/library/ms175759.aspx
+    add_definitions (-D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES=1 -D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT=1)
     set (Boost_USE_STATIC_LIBS ON)
 endif (MSVC)
 

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -25,6 +25,10 @@ if (MSVC)
     add_compile_options (/FIbond/core/warning.h)
     # turn up warning level
     add_compile_options (/W4 /WX /sdl)
+    # Enable SDL recommended warnings that aren't enabled by /W4
+    # 4242: 'identifier': conversion from 'type1' to 'type2', possible loss of data
+    # 4302: 'conversion': truncation from 'type1' to 'type2'
+    add_compile_options (/we4242 /we4302)
     # use secure CRT functions via template overloads to avoid polluting
     # Bond with MSVC CRT-specific code too much. More details at
     # https://msdn.microsoft.com/en-us/library/ms175759.aspx

--- a/cpp/inc/bond/comm/address.h
+++ b/cpp/inc/bond/comm/address.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include "exception.h"
@@ -7,7 +6,16 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/asio/ip/address.hpp>
-#include <boost/asio/ip/tcp.hpp>
+
+#ifdef _MSC_VER
+    #pragma warning(push)
+    #pragma warning(disable: 4242) // C4242: 'identifier' : conversion from 'type1' to 'type2', possible loss of data
+    #include <boost/asio/ip/tcp.hpp>
+    #pragma warning(pop)
+#else
+    #include <boost/asio/ip/tcp.hpp>
+#endif
+
 #include <boost/lexical_cast.hpp>
 
 
@@ -16,7 +24,7 @@ namespace bond { namespace comm
 //
 // Wrapper of endpoint socket address information.
 //
-class SocketAddress 
+class SocketAddress
     : public boost::asio::ip::tcp::endpoint
 {
 public:

--- a/cpp/inc/bond/comm/thread_pool.h
+++ b/cpp/inc/bond/comm/thread_pool.h
@@ -1,14 +1,18 @@
-
 #pragma once
 
-#ifdef __APPLE__
+#if defined (__APPLE__)
     // Work-around: 'OSMemoryBarrier' has been explicitly marked deprecated
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#include <boost/asio.hpp>
+    #include <boost/asio.hpp>
     #pragma GCC diagnostic pop
+#elif defined (_MSC_VER)
+    #pragma warning(push)
+    #pragma warning(disable: 4242) // C4242: 'identifier' : conversion from 'type1' to 'type2', possible loss of data
+    #include <boost/asio.hpp>
+    #pragma warning(pop)
 #else
-#include <boost/asio.hpp>
+    #include <boost/asio.hpp>
 #endif
 
 #include <boost/thread/scoped_thread.hpp>
@@ -72,7 +76,7 @@ public:
     }
 
     //
-    // Provide io_service 
+    // Provide io_service
     //
     boost::asio::io_service& get_io_service()
     {

--- a/cpp/inc/bond/comm/transport/epoxy.h
+++ b/cpp/inc/bond/comm/transport/epoxy.h
@@ -1,13 +1,18 @@
 #pragma once
 
-#ifdef __APPLE__
+#if defined(__APPLE__)
     // Work-around: 'OSMemoryBarrier' has been explicitly marked deprecated
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#include <boost/asio.hpp>
+    #include <boost/asio.hpp>
     #pragma GCC diagnostic pop
+#elif defined (_MSC_VER)
+    #pragma warning(push)
+    #pragma warning(disable: 4242) // C4242: 'identifier' : conversion from 'type1' to 'type2', possible loss of data
+    #include <boost/asio.hpp>
+    #pragma warning(pop)
 #else
-#include <boost/asio.hpp>
+    #include <boost/asio.hpp>
 #endif
 
 #include <bond/comm/layers.h>

--- a/cpp/inc/bond/comm/transport/thread_service.h
+++ b/cpp/inc/bond/comm/transport/thread_service.h
@@ -2,14 +2,19 @@
 
 #include <thread>
 
-#ifdef __APPLE__
+#if defined (__APPLE__)
     // Work-around: 'OSMemoryBarrier' has been explicitly marked deprecated
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#include <boost/asio.hpp>
+    #include <boost/asio.hpp>
     #pragma GCC diagnostic pop
+#elif defined (_MSC_VER)
+    #pragma warning(push)
+    #pragma warning(disable: 4242) // C4242: 'identifier' : conversion from 'type1' to 'type2', possible loss of data
+    #include <boost/asio.hpp>
+    #pragma warning(pop)
 #else
-#include <boost/asio.hpp>
+    #include <boost/asio.hpp>
 #endif
 
 #include <boost/scoped_ptr.hpp>

--- a/cpp/inc/bond/core/detail/metadata.h
+++ b/cpp/inc/bond/core/detail/metadata.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "sdl.h"
 #include "tags.h"
 
 namespace bond
@@ -186,8 +187,14 @@ typename boost::enable_if<is_string<T> >::type
 VariantGet(const bond::Variant& variant, T& var)
 {
     BOOST_ASSERT(!variant.nothing);
-    resize_string(var, static_cast<uint32_t>(variant.string_value.size()));
-    variant.string_value.copy(string_data(var), variant.string_value.size());
+
+    const size_t size = variant.string_value.size();
+    resize_string(var, static_cast<uint32_t>(size));
+
+    std::copy(
+        variant.string_value.begin(),
+        variant.string_value.end(),
+        detail::make_checked_array_iterator(string_data(var), size));
 }
 
 
@@ -197,8 +204,14 @@ typename boost::enable_if<is_wstring<T> >::type
 VariantGet(const bond::Variant& variant, T& var)
 {
     BOOST_ASSERT(!variant.nothing);
-    resize_string(var, static_cast<uint32_t>(variant.wstring_value.size()));
-    variant.wstring_value.copy(string_data(var), variant.wstring_value.size());
+
+    const size_t size = variant.wstring_value.size();
+    resize_string(var, static_cast<uint32_t>(size));
+
+    std::copy(
+        variant.wstring_value.begin(),
+        variant.wstring_value.end(),
+        detail::make_checked_array_iterator(string_data(var), size));
 }
 
 

--- a/cpp/inc/bond/core/detail/sdl.h
+++ b/cpp/inc/bond/core/detail/sdl.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <boost/assert.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <iterator>
 
 namespace bond { namespace detail
@@ -38,10 +40,13 @@ stdext::checked_array_iterator<Iterator> make_checked_array_iterator(
 template<class Iterator> inline
 Iterator make_checked_array_iterator(
     Iterator array,
-    size_t /* size */,
-    size_t /* index */ = 0)
+    size_t size,
+    size_t index  = 0)
 {
-    return array;
+    boost::ignore_unused(size);
+    BOOST_ASSERT(index <= size);
+
+    return array + index;
 }
 
 #endif

--- a/cpp/inc/bond/core/detail/sdl.h
+++ b/cpp/inc/bond/core/detail/sdl.h
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/* Microsoft publishes the Security Development Lifecycle (SDL) which "is a
+ * software development process that helps developers build more secure
+ * software and address security compliance requirements while reducing
+ * development cost."
+ *
+ * Some more details at https://www.microsoft.com/en-us/sdl/
+ *
+ * The code in this file allows Bond to access features in MSVC that are
+ * specific to the SDL while maintaining Bond's cross-compiler and
+ * cross-platform compability.
+ */
+
+#pragma once
+
+#include <iterator>
+
+namespace bond { namespace detail
+{
+
+#ifdef _MSC_VER
+
+template<class Iterator> inline
+stdext::checked_array_iterator<Iterator> make_checked_array_iterator(
+    Iterator array,
+    size_t size,
+    size_t index = 0)
+{
+    // Allows algorithms like std::copy to work on pointers by encoding
+    // bounds information.
+    return stdext::checked_array_iterator<Iterator>(array, size, index);
+}
+
+#else
+
+template<class Iterator> inline
+Iterator make_checked_array_iterator(
+    Iterator array,
+    size_t /* size */,
+    size_t /* index */ = 0)
+{
+    return array;
+}
+
+#endif
+
+}}

--- a/cpp/inc/bond/protocol/detail/rapidjson_helper.h
+++ b/cpp/inc/bond/protocol/detail/rapidjson_helper.h
@@ -8,6 +8,7 @@
 #define RAPIDJSON_PARSE_ERROR(err, offset) bond::RapidJsonException(rapidjson::GetParseError_En(err), offset)
 
 #include <bond/core/bond_const_enum.h>
+#include <bond/core/detail/sdl.h>
 #include <bond/core/exception.h>
 #include <boost/call_traits.hpp>
 #include <boost/noncopyable.hpp>
@@ -16,6 +17,7 @@
 #include "rapidjson/error/en.h"
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
+#include <algorithm>
 
 namespace bond
 {
@@ -238,10 +240,12 @@ template <typename T>
 typename boost::enable_if<is_string<T> >::type
 Read(const rapidjson::Value& value, T& var)
 {
-    uint32_t length = value.GetStringLength();
-
+    const uint32_t length = value.GetStringLength();
     resize_string(var, length);
-    memcpy(string_data(var), value.GetString(), length);
+
+    std::copy(make_checked_array_iterator(value.GetString(), length),
+              make_checked_array_iterator(value.GetString(), length, length),
+              make_checked_array_iterator(string_data(var), length));
 }
 
 
@@ -250,13 +254,19 @@ template <typename T>
 typename boost::enable_if<is_wstring<T> >::type
 Read(const rapidjson::Value& value, T& var)
 {
-    std::basic_string<uint16_t> str =
+    const std::basic_string<uint16_t> str =
         boost::locale::conv::utf_to_utf<uint16_t>(
-            value.GetString(), value.GetString() + value.GetStringLength(), boost::locale::conv::stop);
-    const uint32_t length = static_cast<uint32_t>(str.size());
+            value.GetString(),
+            value.GetString() + value.GetStringLength(),
+            boost::locale::conv::stop);
 
-    resize_string(var, length);
-    std::copy(str.begin(), str.end(), string_data(var));
+    const size_t length = str.size();
+    resize_string(var, static_cast<uint32_t>(length));
+
+    std::copy(
+        str.begin(),
+        str.end(),
+        make_checked_array_iterator(string_data(var), length));
 }
 
 

--- a/examples/cpp/comm/layer/CMakeLists.txt
+++ b/examples/cpp/comm/layer/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_bond_test (layer layer.bond layer.cpp COMM)
 
-target_compile_definitions (layer PRIVATE -D_WIN32_WINNT=0x0600)
+cxx_target_compile_definitions (MSVC layer PRIVATE -D_WIN32_WINNT=0x0600)
+
+# Deep in the guts of Boost we get a warning about not using a "secure"
+# routine. Suppress them for this example.
+cxx_target_compile_options(MSVC layer PRIVATE -D_SCL_SECURE_NO_WARNINGS)

--- a/examples/cpp/core/bf/err.h
+++ b/examples/cpp/core/bf/err.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string.h>
+#include <string>
+
+// Convert an error number into a human-readable string.
+inline std::string ErrorString(int errnum)
+{
+    std::string result;
+
+#ifdef _MSC_VER
+    // strerrorlen_s hasn't made it into the Microsoft C runtime yet. Until
+    // it has, we're just going to reserve a buffer that's pretty big and
+    // get as much of the error message as we can.
+    result.reserve(240);
+
+    (void)strerror_s(&result[0], result.size(), errnum);
+
+    // strerror_s wrote an embedded NUL, so truncate to that size so the
+    // result doesn't have an embedded NUL.
+    result.resize(strlen(result.c_str()));
+#else
+    // strerror isn't guaranteed to be thread-safe, but bf is single
+    // threaded.
+    result = strerror(errnum);
+#endif
+
+    return result;
+}

--- a/examples/cpp/core/bf/input_file.h
+++ b/examples/cpp/core/bf/input_file.h
@@ -1,8 +1,10 @@
 #pragma once
 
-#include <fstream>
-#include <bond/core/exception.h>
+#include "err.h"
 #include <bond/core/blob.h>
+#include <bond/core/exception.h>
+#include <fstream>
+#include <string>
 
 class InputFile
 {
@@ -20,10 +22,10 @@ public:
         }
         else
         {
-            BOND_THROW(bond::StreamException, "Error " << std::strerror(errno) << " opening file " << name);
+            BOND_THROW(bond::StreamException, "Error " << ErrorString(errno) << " opening file " << name);
         }
     }
-        
+
     // Copy ctor opens a new stream in order to keep independent file pointer.
     InputFile(const InputFile& that)
         : file(that.name, std::ios::binary),
@@ -36,7 +38,7 @@ public:
         }
         else
         {
-            BOND_THROW(bond::StreamException, "Error " << std::strerror(errno) << " opening file " << that.name);
+            BOND_THROW(bond::StreamException, "Error " << ErrorString(errno) << " opening file " << that.name);
         }
     }
 
@@ -52,12 +54,12 @@ public:
     {
         Read(&value, sizeof(T));
     }
-    
+
     void Read(void *buffer, uint32_t size)
     {
         file.read(static_cast<char*>(buffer), size);
     }
-    
+
     void Read(bond::blob& blob, uint32_t size)
     {
         boost::shared_ptr<char[]> buffer = boost::make_shared_noinit<char[]>(size);
@@ -65,14 +67,13 @@ public:
         Read(buffer.get(), size);
         blob.assign(buffer, 0, size);
     }
-    
-    void Skip(uint32_t size) 
+
+    void Skip(uint32_t size)
     {
         file.seekg(size, std::ios::cur);
     }
-    
+
 private:
     mutable std::ifstream file;
     std::string name;
 };
-

--- a/examples/cpp/core/bf/main.cpp
+++ b/examples/cpp/core/bf/main.cpp
@@ -1,11 +1,40 @@
-#include <iostream>
-#include "input_file.h"
 #include "cmd_arg_reflection.h"
+#include "err.h"
+#include "input_file.h"
 #include <bond/core/cmdargs.h>
-#include <bond/stream/stdio_output_stream.h>
 #include <bond/protocol/simple_json_writer.h>
+#include <bond/stream/stdio_output_stream.h>
+#include <errno.h>
+#include <iostream>
+#include <stdio.h>
 
 using namespace bf;
+
+FILE* OpenFile(const std::string& path, const char* mode)
+{
+    FILE* file;
+
+#ifdef _MSC_VER
+    // Under the compiler settings we use with MSVC, fopen is not considered
+    // "secure", so we use the "secure" variant.
+    errno_t err = fopen_s(&file, path.c_str(), mode);
+    if (err != 0)
+    {
+        BOND_THROW(bond::StreamException, "Error " << ErrorString(err) << " opening file " << path);
+    }
+
+#else
+
+    file = fopen(path.c_str(), mode);
+    if (file == nullptr)
+    {
+        BOND_THROW(bond::StreamException, "Error " << ErrorString(errno) << " opening file " << path);
+    }
+
+#endif
+
+    return file;
+}
 
 inline bool IsValidType(bond::BondDataType type)
 {
@@ -144,9 +173,13 @@ bool TranscodeFrom(Reader reader, const Options& options)
     FILE* file;
 
     if (options.output == "stdout")
+    {
         file = stdout;
+    }
     else
-        file = fopen(options.output.c_str(), "wb");
+    {
+        file = OpenFile(options.output.c_str(), "wb");
+    }
 
     bond::StdioOutputStream out(file);
 
@@ -271,4 +304,3 @@ int main(int argc, char** argv)
 
     return 1;
 }
-

--- a/examples/cpp/core/multiprecision/CMakeLists.txt
+++ b/examples/cpp/core/multiprecision/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_bond_codegen (multiprecision.bond
-    OPTIONS 
+    OPTIONS
         --using=uint512=boost::multiprecision::uint512_t
         --using=uint1024=boost::multiprecision::uint1024_t
         --using=integer=boost::multiprecision::cpp_int
@@ -8,3 +8,7 @@ add_bond_codegen (multiprecision.bond
 add_bond_test (multiprecision
     ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/multiprecision_types.cpp
     multiprecision.cpp)
+
+# Deep in the guts of Boost we get a warning about not using a "secure"
+# routine. Suppress them for this example.
+cxx_target_compile_options(MSVC multiprecision PRIVATE -D_SCL_SECURE_NO_WARNINGS)


### PR DESCRIPTION
For projects that use Microsoft's SDL, these commits help minimize the amount of work needed to use Bond.

As a bonus, the changes are relatively contained, and don't materially affect Clang or GCC.

These commits should be rebased atop master, or a full merge should be done.