### PR TITLE
[C++] Remove MSVC warning suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,17 @@ different versioning scheme, following the Haskell community's
 [package versioning policy](https://wiki.haskell.org/Package_versioning_policy).
 
 ## Unreleased ##
-* `gbc` & compiler library: TBD
+* `gbc` & compiler library: TBD (minor bump needed)
 * IDL core version: TBD
 * IDL comm version: TBD
-* C++ version: TBD (minor bump needed)
+* C++ version: TBD (major bump needed)
+>>>>>>> [c++] Avoid name shadowing warnings
 * C# NuGet version: TBD (minor bump needed)
 * C# Comm NuGet version: TBD (minor bump needed)
+
+### `gbc` & compiler library ###
+
+* C++ codegen ensures that parameter names do not shadow field names.
 
 ### C++ ###
 
@@ -28,6 +33,10 @@ different versioning scheme, following the Haskell community's
       [`_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES`](https://msdn.microsoft.com/en-us/library/ms175759.aspx)
       instead of `_CTR_SECURE_NO_WARNINGS`.
     * Bond builds on MSVC with SDL recommended warnings enabled.
+* **Breaking change:** Suppression of MSVC name shadowing warnings is no
+  longed needed, and Bond's warning.h header no longer supresses C4456,
+  C4458, or C4459. This may cause these warnings to now be triggered on
+  other code.
 
 ## C# ###
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@ different versioning scheme, following the Haskell community's
 * `gbc` & compiler library: TBD (minor bump needed)
 * IDL core version: TBD
 * IDL comm version: TBD
-* C++ version: TBD (major bump needed)
->>>>>>> [c++] Avoid name shadowing warnings
+* C++ version: TBD (minor bump needed)
 * C# NuGet version: TBD (minor bump needed)
 * C# Comm NuGet version: TBD (minor bump needed)
 
@@ -33,10 +32,9 @@ different versioning scheme, following the Haskell community's
       [`_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES`](https://msdn.microsoft.com/en-us/library/ms175759.aspx)
       instead of `_CTR_SECURE_NO_WARNINGS`.
     * Bond builds on MSVC with SDL recommended warnings enabled.
-* **Breaking change:** Suppression of MSVC name shadowing warnings is no
-  longed needed, and Bond's warning.h header no longer supresses C4456,
-  C4458, or C4459. This may cause these warnings to now be triggered on
-  other code.
+* Eliminate need for warning suppression on MSVC14 via warning.h in Bond
+  itself. warning.h is still in place on MSVC12; furthermore, we don't alter
+  warning.h for now as it may be depended upon by application code.
 
 ## C# ###
 

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -21,8 +21,10 @@ endif()
 if (MSVC)
     # MSVC needs this because of how template-heavy our code is.
     add_compile_options (/bigobj)
-    # inject disabling of some MSVC warnings
-    add_compile_options (/FIbond/core/warning.h)
+    # inject disabling of some MSVC warnings for versions prior to MSVC14
+    if (MSVC_VERSION LESS 1900)
+        add_compile_options (/FIbond/core/warning.h)
+    endif()
     # turn up warning level
     add_compile_options (/W4 /WX /sdl)
     # Enable SDL recommended warnings that aren't enabled by /W4

--- a/compiler/bond.cabal
+++ b/compiler/bond.cabal
@@ -79,6 +79,7 @@ test-suite gbc-tests
   hs-source-dirs:   tests, .
   main-is:          Main.hs
   other-modules:    Tests.Codegen
+                    Tests.Codegen.Util
                     Tests.Syntax
   ghc-options:      -threaded -Wall
   build-depends:    bond,

--- a/compiler/src/Language/Bond/Codegen/Util.hs
+++ b/compiler/src/Language/Bond/Codegen/Util.hs
@@ -11,8 +11,8 @@ Maintainer  : adamsap@microsoft.com
 Stability   : provisional
 Portability : portable
 
-Helper functions for creating common text structures useful in code generation.
-These functions operate on 'Text' objects.
+Helper functions for creating common structures useful in code generation.
+These functions often operate on 'Text' objects.
 -}
 
 module Language.Bond.Codegen.Util
@@ -23,6 +23,7 @@ module Language.Bond.Codegen.Util
     , newlineBeginSep
     , doubleLineSep
     , doubleLineSepEnd
+    , uniqueName
     ) where
 
 import Data.Int (Int64)
@@ -31,7 +32,7 @@ import Prelude
 import Data.Text.Lazy (Text, justifyRight)
 import Text.Shakespeare.Text
 import Paths_bond (version)
-import Data.Version (showVersion) 
+import Data.Version (showVersion)
 import Language.Bond.Util
 
 instance ToText Word16 where
@@ -59,7 +60,7 @@ doubleLine n = [lt|
 
 #{indent n}|]
 
-newlineSep, commaLineSep, newlineSepEnd, newlineBeginSep, doubleLineSep, doubleLineSepEnd 
+newlineSep, commaLineSep, newlineSepEnd, newlineBeginSep, doubleLineSep, doubleLineSepEnd
     :: Int64 -> (a -> Text) -> [a] -> Text
 
 -- | Separates elements of a list with new lines. Starts new lines at the
@@ -102,3 +103,12 @@ commonHeader c file = [lt|
 #{c}------------------------------------------------------------------------------
 |]
 
+-- | Given an intended name and a list of already taken names, returns a
+-- unique name. Assumes that it's legal to appen digits to the end of the
+-- intended name.
+uniqueName :: String -> [String] -> String
+uniqueName baseName taken = go baseName (0::Integer)
+  where go name counter
+          | not (name `elem` taken) = name
+          | otherwise = go newName (counter + 1)
+                        where newName = baseName ++ (show counter)

--- a/compiler/tests/Main.hs
+++ b/compiler/tests/Main.hs
@@ -6,6 +6,7 @@ import Test.Tasty.QuickCheck
 import Test.Tasty.HUnit (testCase)
 import Tests.Syntax
 import Tests.Codegen
+import Tests.Codegen.Util(utilTestGroup)
 
 tests :: TestTree
 tests = testGroup "Compiler tests"
@@ -54,7 +55,8 @@ tests = testGroup "Compiler tests"
         , testCase "Out of range" $ failBadSyntax "Should fail, out of range for int16" "int_out_of_range"
         ]
     , testGroup "Codegen"
-        [ testGroup "C++"
+        [ utilTestGroup,
+          testGroup "C++"
             [ verifyCppCodegen "attributes"
             , verifyCppCodegen "basic_types"
             , verifyCppCodegen "bond_meta"

--- a/compiler/tests/Tests/Codegen/Util.hs
+++ b/compiler/tests/Tests/Codegen/Util.hs
@@ -1,0 +1,20 @@
+-- Copyright (c) Microsoft. All rights reserved.
+-- Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+
+module Tests.Codegen.Util
+    (
+      utilTestGroup
+    ) where
+
+import Language.Bond.Codegen.Util(uniqueName)
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+utilTestGroup = testGroup "Codegen Utils"
+  [ testGroup "uniqueName" [ testProperty "unique when taken" prop_collisionReturnsNotSame,
+                             testProperty "given when not taken" prop_noCollisionReturnsSame]]
+
+prop_collisionReturnsNotSame xs = not (null xs) ==> uniqueName (head xs) xs /= head xs
+prop_noCollisionReturnsSame xs = not ("some" `elem` xs) ==> uniqueName "some" xs == "some"

--- a/compiler/tests/generated/alias_key_types.h
+++ b/compiler/tests/generated/alias_key_types.h
@@ -31,11 +31,11 @@ namespace test
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        foo(const foo& other) = default;
+        foo(const foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        foo(foo&& other) = default;
+        foo(foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         foo(foo&& other)
           : m(std::move(other.m)),
@@ -47,7 +47,7 @@ namespace test
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        foo& operator=(const foo& other) = default;
+        foo& operator=(const foo&) = default;
 #endif
 
         bool operator==(const foo& other) const

--- a/compiler/tests/generated/alias_with_allocator_types.h
+++ b/compiler/tests/generated/alias_with_allocator_types.h
@@ -41,11 +41,11 @@ namespace test
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        foo(const foo& other) = default;
+        foo(const foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        foo(foo&& other) = default;
+        foo(foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         foo(foo&& other)
           : l(std::move(other.l)),
@@ -82,7 +82,7 @@ namespace test
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        foo& operator=(const foo& other) = default;
+        foo& operator=(const foo&) = default;
 #endif
 
         bool operator==(const foo& other) const
@@ -148,11 +148,11 @@ namespace test
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        withFoo(const withFoo& other) = default;
+        withFoo(const withFoo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        withFoo(withFoo&& other) = default;
+        withFoo(withFoo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         withFoo(withFoo&& other)
           : f(std::move(other.f)),
@@ -171,7 +171,7 @@ namespace test
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        withFoo& operator=(const withFoo& other) = default;
+        withFoo& operator=(const withFoo&) = default;
 #endif
 
         bool operator==(const withFoo& other) const

--- a/compiler/tests/generated/aliases_types.h
+++ b/compiler/tests/generated/aliases_types.h
@@ -31,11 +31,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Foo(const Foo& other) = default;
+        Foo(const Foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Foo(Foo&& other) = default;
+        Foo(Foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Foo(Foo&& other)
           : aa(std::move(other.aa))
@@ -46,7 +46,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Foo& operator=(const Foo& other) = default;
+        Foo& operator=(const Foo&) = default;
 #endif
 
         bool operator==(const Foo& other) const
@@ -167,11 +167,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        WrappingAnEnum(const WrappingAnEnum& other) = default;
+        WrappingAnEnum(const WrappingAnEnum&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        WrappingAnEnum(WrappingAnEnum&& other) = default;
+        WrappingAnEnum(WrappingAnEnum&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         WrappingAnEnum(WrappingAnEnum&& other)
           : aWrappedEnum(std::move(other.aWrappedEnum))
@@ -182,7 +182,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        WrappingAnEnum& operator=(const WrappingAnEnum& other) = default;
+        WrappingAnEnum& operator=(const WrappingAnEnum&) = default;
 #endif
 
         bool operator==(const WrappingAnEnum& other) const

--- a/compiler/tests/generated/allocator/alias_key_types.h
+++ b/compiler/tests/generated/allocator/alias_key_types.h
@@ -31,11 +31,11 @@ namespace test
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        foo(const foo& other) = default;
+        foo(const foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        foo(foo&& other) = default;
+        foo(foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         foo(foo&& other)
           : m(std::move(other.m)),
@@ -54,7 +54,7 @@ namespace test
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        foo& operator=(const foo& other) = default;
+        foo& operator=(const foo&) = default;
 #endif
 
         bool operator==(const foo& other) const

--- a/compiler/tests/generated/allocator/aliases_types.h
+++ b/compiler/tests/generated/allocator/aliases_types.h
@@ -31,11 +31,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Foo(const Foo& other) = default;
+        Foo(const Foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Foo(Foo&& other) = default;
+        Foo(Foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Foo(Foo&& other)
           : aa(std::move(other.aa))
@@ -52,7 +52,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Foo& operator=(const Foo& other) = default;
+        Foo& operator=(const Foo&) = default;
 #endif
 
         bool operator==(const Foo& other) const
@@ -173,11 +173,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        WrappingAnEnum(const WrappingAnEnum& other) = default;
+        WrappingAnEnum(const WrappingAnEnum&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        WrappingAnEnum(WrappingAnEnum&& other) = default;
+        WrappingAnEnum(WrappingAnEnum&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         WrappingAnEnum(WrappingAnEnum&& other)
           : aWrappedEnum(std::move(other.aWrappedEnum))
@@ -194,7 +194,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        WrappingAnEnum& operator=(const WrappingAnEnum& other) = default;
+        WrappingAnEnum& operator=(const WrappingAnEnum&) = default;
 #endif
 
         bool operator==(const WrappingAnEnum& other) const

--- a/compiler/tests/generated/allocator/attributes_types.h
+++ b/compiler/tests/generated/allocator/attributes_types.h
@@ -104,11 +104,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Foo(const Foo& other) = default;
+        Foo(const Foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Foo(Foo&& other) = default;
+        Foo(Foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Foo(Foo&& other)
           : f(std::move(other.f))
@@ -125,7 +125,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Foo& operator=(const Foo& other) = default;
+        Foo& operator=(const Foo&) = default;
 #endif
 
         bool operator==(const Foo& other) const

--- a/compiler/tests/generated/allocator/basic_types_types.h
+++ b/compiler/tests/generated/allocator/basic_types_types.h
@@ -54,11 +54,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        BasicTypes(const BasicTypes& other) = default;
+        BasicTypes(const BasicTypes&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        BasicTypes(BasicTypes&& other) = default;
+        BasicTypes(BasicTypes&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         BasicTypes(BasicTypes&& other)
           : _bool(std::move(other._bool)),
@@ -100,7 +100,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        BasicTypes& operator=(const BasicTypes& other) = default;
+        BasicTypes& operator=(const BasicTypes&) = default;
 #endif
 
         bool operator==(const BasicTypes& other) const

--- a/compiler/tests/generated/allocator/bond_meta_types.h
+++ b/compiler/tests/generated/allocator/bond_meta_types.h
@@ -83,10 +83,10 @@ namespace bondmeta
         struct Schema;
 
     protected:
-        void InitMetadata(const char* name, const char* qualified_name)
+        void InitMetadata(const char*name0, const char*qual_name)
         {
-            this->name = name;
-            this->full_name = qualified_name;
+            this->name = name0;
+            this->full_name = qual_name;
         }
     };
 

--- a/compiler/tests/generated/allocator/complex_types_types.h
+++ b/compiler/tests/generated/allocator/complex_types_types.h
@@ -31,11 +31,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Foo(const Foo& other) = default;
+        Foo(const Foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Foo(Foo&& other) = default;
+        Foo(Foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Foo(Foo&&)
         {
@@ -50,7 +50,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Foo& operator=(const Foo& other) = default;
+        Foo& operator=(const Foo&) = default;
 #endif
 
         bool operator==(const Foo&) const
@@ -101,11 +101,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        ComplexTypes(const ComplexTypes& other) = default;
+        ComplexTypes(const ComplexTypes&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        ComplexTypes(ComplexTypes&& other) = default;
+        ComplexTypes(ComplexTypes&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         ComplexTypes(ComplexTypes&& other)
           : li8(std::move(other.li8)),
@@ -133,7 +133,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        ComplexTypes& operator=(const ComplexTypes& other) = default;
+        ComplexTypes& operator=(const ComplexTypes&) = default;
 #endif
 
         bool operator==(const ComplexTypes& other) const

--- a/compiler/tests/generated/allocator/defaults_types.h
+++ b/compiler/tests/generated/allocator/defaults_types.h
@@ -171,11 +171,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Foo(const Foo& other) = default;
+        Foo(const Foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Foo(Foo&& other) = default;
+        Foo(Foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Foo(Foo&& other)
           : m_bool_1(std::move(other.m_bool_1)),
@@ -262,7 +262,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Foo& operator=(const Foo& other) = default;
+        Foo& operator=(const Foo&) = default;
 #endif
 
         bool operator==(const Foo& other) const

--- a/compiler/tests/generated/allocator/field_modifiers_types.h
+++ b/compiler/tests/generated/allocator/field_modifiers_types.h
@@ -35,11 +35,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Foo(const Foo& other) = default;
+        Foo(const Foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Foo(Foo&& other) = default;
+        Foo(Foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Foo(Foo&& other)
           : o(std::move(other.o)),
@@ -60,7 +60,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Foo& operator=(const Foo& other) = default;
+        Foo& operator=(const Foo&) = default;
 #endif
 
         bool operator==(const Foo& other) const

--- a/compiler/tests/generated/allocator/generics_types.h
+++ b/compiler/tests/generated/allocator/generics_types.h
@@ -33,11 +33,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Foo(const Foo& other) = default;
+        Foo(const Foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Foo(Foo&& other) = default;
+        Foo(Foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Foo(Foo&& other)
           : t2(std::move(other.t2)),
@@ -56,7 +56,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Foo& operator=(const Foo& other) = default;
+        Foo& operator=(const Foo&) = default;
 #endif
 
         bool operator==(const Foo& other) const

--- a/compiler/tests/generated/allocator/inheritance_types.h
+++ b/compiler/tests/generated/allocator/inheritance_types.h
@@ -31,11 +31,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Base(const Base& other) = default;
+        Base(const Base&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Base(Base&& other) = default;
+        Base(Base&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Base(Base&& other)
           : x(std::move(other.x))
@@ -52,7 +52,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Base& operator=(const Base& other) = default;
+        Base& operator=(const Base&) = default;
 #endif
 
         bool operator==(const Base& other) const
@@ -99,11 +99,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Foo(const Foo& other) = default;
+        Foo(const Foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Foo(Foo&& other) = default;
+        Foo(Foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Foo(Foo&& other)
           : ::tests::Base(std::move(other)),
@@ -122,7 +122,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Foo& operator=(const Foo& other) = default;
+        Foo& operator=(const Foo&) = default;
 #endif
 
         bool operator==(const Foo& other) const
@@ -147,9 +147,9 @@ namespace tests
         struct Schema;
 
     protected:
-        void InitMetadata(const char* name, const char* qualified_name)
+        void InitMetadata(const char*name, const char*qual_name)
         {
-            ::tests::Base::InitMetadata(name, qualified_name);
+            ::tests::Base::InitMetadata(name, qual_name);
         }
     };
 

--- a/compiler/tests/generated/allocator/maybe_blob_types.h
+++ b/compiler/tests/generated/allocator/maybe_blob_types.h
@@ -30,11 +30,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Foo(const Foo& other) = default;
+        Foo(const Foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Foo(Foo&& other) = default;
+        Foo(Foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Foo(Foo&& other)
           : b(std::move(other.b))
@@ -50,7 +50,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Foo& operator=(const Foo& other) = default;
+        Foo& operator=(const Foo&) = default;
 #endif
 
         bool operator==(const Foo& other) const

--- a/compiler/tests/generated/attributes_types.h
+++ b/compiler/tests/generated/attributes_types.h
@@ -104,11 +104,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Foo(const Foo& other) = default;
+        Foo(const Foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Foo(Foo&& other) = default;
+        Foo(Foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Foo(Foo&& other)
           : f(std::move(other.f))
@@ -119,7 +119,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Foo& operator=(const Foo& other) = default;
+        Foo& operator=(const Foo&) = default;
 #endif
 
         bool operator==(const Foo& other) const

--- a/compiler/tests/generated/basic_types_types.h
+++ b/compiler/tests/generated/basic_types_types.h
@@ -54,11 +54,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        BasicTypes(const BasicTypes& other) = default;
+        BasicTypes(const BasicTypes&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        BasicTypes(BasicTypes&& other) = default;
+        BasicTypes(BasicTypes&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         BasicTypes(BasicTypes&& other)
           : _bool(std::move(other._bool)),
@@ -82,7 +82,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        BasicTypes& operator=(const BasicTypes& other) = default;
+        BasicTypes& operator=(const BasicTypes&) = default;
 #endif
 
         bool operator==(const BasicTypes& other) const

--- a/compiler/tests/generated/bond_meta_types.h
+++ b/compiler/tests/generated/bond_meta_types.h
@@ -75,10 +75,10 @@ namespace bondmeta
         struct Schema;
 
     protected:
-        void InitMetadata(const char* name, const char* qualified_name)
+        void InitMetadata(const char*name0, const char*qual_name)
         {
-            this->name = name;
-            this->full_name = qualified_name;
+            this->name = name0;
+            this->full_name = qual_name;
         }
     };
 

--- a/compiler/tests/generated/complex_types_types.h
+++ b/compiler/tests/generated/complex_types_types.h
@@ -31,11 +31,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Foo(const Foo& other) = default;
+        Foo(const Foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Foo(Foo&& other) = default;
+        Foo(Foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Foo(Foo&&)
         {
@@ -45,7 +45,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Foo& operator=(const Foo& other) = default;
+        Foo& operator=(const Foo&) = default;
 #endif
 
         bool operator==(const Foo&) const
@@ -96,11 +96,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        ComplexTypes(const ComplexTypes& other) = default;
+        ComplexTypes(const ComplexTypes&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        ComplexTypes(ComplexTypes&& other) = default;
+        ComplexTypes(ComplexTypes&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         ComplexTypes(ComplexTypes&& other)
           : li8(std::move(other.li8)),
@@ -117,7 +117,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        ComplexTypes& operator=(const ComplexTypes& other) = default;
+        ComplexTypes& operator=(const ComplexTypes&) = default;
 #endif
 
         bool operator==(const ComplexTypes& other) const

--- a/compiler/tests/generated/custom_alias_with_allocator_types.h
+++ b/compiler/tests/generated/custom_alias_with_allocator_types.h
@@ -46,11 +46,11 @@ namespace test
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        foo(const foo& other) = default;
+        foo(const foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        foo(foo&& other) = default;
+        foo(foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         foo(foo&& other)
           : l(std::move(other.l)),
@@ -87,7 +87,7 @@ namespace test
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        foo& operator=(const foo& other) = default;
+        foo& operator=(const foo&) = default;
 #endif
 
         bool operator==(const foo& other) const

--- a/compiler/tests/generated/custom_alias_without_allocator_types.h
+++ b/compiler/tests/generated/custom_alias_without_allocator_types.h
@@ -46,11 +46,11 @@ namespace test
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        foo(const foo& other) = default;
+        foo(const foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        foo(foo&& other) = default;
+        foo(foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         foo(foo&& other)
           : l(std::move(other.l)),
@@ -87,7 +87,7 @@ namespace test
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        foo& operator=(const foo& other) = default;
+        foo& operator=(const foo&) = default;
 #endif
 
         bool operator==(const foo& other) const

--- a/compiler/tests/generated/defaults_types.h
+++ b/compiler/tests/generated/defaults_types.h
@@ -171,11 +171,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Foo(const Foo& other) = default;
+        Foo(const Foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Foo(Foo&& other) = default;
+        Foo(Foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Foo(Foo&& other)
           : m_bool_1(std::move(other.m_bool_1)),
@@ -221,7 +221,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Foo& operator=(const Foo& other) = default;
+        Foo& operator=(const Foo&) = default;
 #endif
 
         bool operator==(const Foo& other) const

--- a/compiler/tests/generated/field_modifiers_types.h
+++ b/compiler/tests/generated/field_modifiers_types.h
@@ -35,11 +35,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Foo(const Foo& other) = default;
+        Foo(const Foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Foo(Foo&& other) = default;
+        Foo(Foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Foo(Foo&& other)
           : o(std::move(other.o)),
@@ -52,7 +52,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Foo& operator=(const Foo& other) = default;
+        Foo& operator=(const Foo&) = default;
 #endif
 
         bool operator==(const Foo& other) const

--- a/compiler/tests/generated/generics_types.h
+++ b/compiler/tests/generated/generics_types.h
@@ -33,11 +33,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Foo(const Foo& other) = default;
+        Foo(const Foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Foo(Foo&& other) = default;
+        Foo(Foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Foo(Foo&& other)
           : t2(std::move(other.t2)),
@@ -49,7 +49,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Foo& operator=(const Foo& other) = default;
+        Foo& operator=(const Foo&) = default;
 #endif
 
         bool operator==(const Foo& other) const

--- a/compiler/tests/generated/inheritance_types.h
+++ b/compiler/tests/generated/inheritance_types.h
@@ -31,11 +31,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Base(const Base& other) = default;
+        Base(const Base&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Base(Base&& other) = default;
+        Base(Base&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Base(Base&& other)
           : x(std::move(other.x))
@@ -46,7 +46,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Base& operator=(const Base& other) = default;
+        Base& operator=(const Base&) = default;
 #endif
 
         bool operator==(const Base& other) const
@@ -93,11 +93,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Foo(const Foo& other) = default;
+        Foo(const Foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Foo(Foo&& other) = default;
+        Foo(Foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Foo(Foo&& other)
           : ::tests::Base(std::move(other)),
@@ -109,7 +109,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Foo& operator=(const Foo& other) = default;
+        Foo& operator=(const Foo&) = default;
 #endif
 
         bool operator==(const Foo& other) const
@@ -134,9 +134,9 @@ namespace tests
         struct Schema;
 
     protected:
-        void InitMetadata(const char* name, const char* qualified_name)
+        void InitMetadata(const char*name, const char*qual_name)
         {
-            ::tests::Base::InitMetadata(name, qualified_name);
+            ::tests::Base::InitMetadata(name, qual_name);
         }
     };
 

--- a/compiler/tests/generated/maybe_blob_types.h
+++ b/compiler/tests/generated/maybe_blob_types.h
@@ -30,11 +30,11 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated copy ctor OK
-        Foo(const Foo& other) = default;
+        Foo(const Foo&) = default;
 #endif
         
 #if !defined(BOND_NO_CXX11_DEFAULTED_MOVE_CTOR)
-        Foo(Foo&& other) = default;
+        Foo(Foo&&) = default;
 #elif !defined(BOND_NO_CXX11_RVALUE_REFERENCES)
         Foo(Foo&& other)
           : b(std::move(other.b))
@@ -45,7 +45,7 @@ namespace tests
         
 #ifndef BOND_NO_CXX11_DEFAULTED_FUNCTIONS
         // Compiler generated operator= OK
-        Foo& operator=(const Foo& other) = default;
+        Foo& operator=(const Foo&) = default;
 #endif
 
         bool operator==(const Foo& other) const

--- a/cpp/inc/bond/core/bonded_void.h
+++ b/cpp/inc/bond/core/bonded_void.h
@@ -111,7 +111,14 @@ public:
     template <typename T>
     void Deserialize(bonded<T>& var) const
     {
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4127) // C4127: conditional expression is constant
+#endif
         if (uses_marshaled_bonded<Reader>::value && _schema.GetType().bonded_type)
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
         {
             bonded<T> tmp;
             _SelectProtocolAndApply(boost::ref(tmp));
@@ -148,7 +155,14 @@ private:
     template <typename Transform>
     bool _Apply(const Transform& transform) const
     {
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4127) // C4127: conditional expression is constant
+#endif
         if (uses_marshaled_bonded<Reader>::value && _schema.GetType().bonded_type)
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
         {
             return _SelectProtocolAndApply(transform);
         }

--- a/cpp/inc/bond/core/detail/tuple_fields.h
+++ b/cpp/inc/bond/core/detail/tuple_fields.h
@@ -31,9 +31,9 @@ struct tuple_field
 
     static Metadata GetMetadata()
     {
-        Metadata metadata;
-        metadata.name = "item" + std::to_string(id);
-        return metadata;
+        Metadata m;
+        m.name = "item" + std::to_string(id);
+        return m;
     }
 };
 

--- a/cpp/inc/bond/core/reflection.h
+++ b/cpp/inc/bond/core/reflection.h
@@ -288,12 +288,12 @@ bond::Metadata MetadataInit(const nothing&, const char* name, bond::Modifier mod
 
 // Metadata initializer for structs
 inline
-bond::Metadata MetadataInit(const char* name, const char* qualified_name, const Attributes& attributes)
+bond::Metadata MetadataInit(const char* name, const char* qual_name, const Attributes& attributes)
 {
     bond::Metadata metadata;
 
     metadata.name = name;
-    metadata.qualified_name = qualified_name;
+    metadata.qualified_name = qual_name;
     metadata.attributes = attributes;
 
     return metadata;
@@ -302,9 +302,9 @@ bond::Metadata MetadataInit(const char* name, const char* qualified_name, const 
 
 // Metadata initializer for generic structs
 template <typename Params>
-bond::Metadata MetadataInit(const char* name, const char* qualified_name, const Attributes& attributes)
+bond::Metadata MetadataInit(const char* name, const char* qual_name, const Attributes& attributes)
 {
-    bond::Metadata metadata = MetadataInit(name, qualified_name, attributes);
+    bond::Metadata metadata = MetadataInit(name, qual_name, attributes);
 
     std::string params;
 

--- a/cpp/inc/bond/core/schema.h
+++ b/cpp/inc/bond/core/schema.h
@@ -133,10 +133,10 @@ namespace detail
         static SchemaDef NewSchemaDef()
         {
             // SchemaDef for unknown types: struct with no fields
-            SchemaDef schema;
-            schema.root.id = BT_STRUCT;
-            schema.structs.resize(1);
-            return schema;
+            SchemaDef s;
+            s.root.id = BT_STRUCT;
+            s.structs.resize(1);
+            return s;
         }
 
     private:

--- a/cpp/inc/bond/core/tuple.h
+++ b/cpp/inc/bond/core/tuple.h
@@ -30,7 +30,7 @@ struct schema<std::tuple<T...>>
 
         static Metadata GetMetadata()
         {
-            Metadata metadata = reflection::MetadataInit(
+            Metadata m = reflection::MetadataInit(
                 "tuple", "bond.tuple", reflection::Attributes());
 
             std::string params;
@@ -38,10 +38,10 @@ struct schema<std::tuple<T...>>
             boost::mpl::for_each<typename detail::param_list<T...>::type>(
                 detail::TypeListBuilder(params));
 
-            metadata.name += "<" + params + ">";
-            metadata.qualified_name += "<" + params + ">";
+            m.name += "<" + params + ">";
+            m.qualified_name += "<" + params + ">";
 
-            return metadata;
+            return m;
         }
     };
 };

--- a/cpp/inc/bond/core/warning.h
+++ b/cpp/inc/bond/core/warning.h
@@ -23,14 +23,5 @@
 // C4482: nonstandard extension used: enum 'enum' used in qualified name
 #pragma warning(disable: 4482)
 
-// C4456: declaration of 'symbol' hides previous local declaration
-#pragma warning(disable: 4456)
-
-// C4458: declaration of 'symbol' hides class member
-#pragma warning(disable: 4458)
-
-// C4458: declaration of 'symbol' hides global declaration
-#pragma warning(disable: 4459)
-
 // C4512: assignment operator could not be generated
 #pragma warning(disable: 4512)

--- a/cpp/inc/bond/core/warning.h
+++ b/cpp/inc/bond/core/warning.h
@@ -23,5 +23,14 @@
 // C4482: nonstandard extension used: enum 'enum' used in qualified name
 #pragma warning(disable: 4482)
 
+// C4456: declaration of 'symbol' hides previous local declaration
+#pragma warning(disable: 4456)
+
+// C4458: declaration of 'symbol' hides class member
+#pragma warning(disable: 4458)
+
+// C4458: declaration of 'symbol' hides global declaration
+#pragma warning(disable: 4459)
+
 // C4512: assignment operator could not be generated
 #pragma warning(disable: 4512)

--- a/cpp/inc/bond/protocol/compact_binary.h
+++ b/cpp/inc/bond/protocol/compact_binary.h
@@ -149,9 +149,9 @@ public:
 
     /// @brief Construct from input buffer/stream containing serialized data.
     CompactBinaryReader(typename boost::call_traits<Buffer>::param_type input,
-                        uint16_t version = default_version<CompactBinaryReader>::value)
+                        uint16_t version_value = default_version<CompactBinaryReader>::value)
         : _input(input),
-          _version(version)
+          _version(version_value)
     {
         BOOST_ASSERT(protocol_has_multiple_versions<CompactBinaryReader>::value
             ? _version <= CompactBinaryReader::version
@@ -186,12 +186,12 @@ public:
 
     bool ReadVersion()
     {
-        uint16_t magic;
+        uint16_t magic_value;
 
-        _input.Read(magic);
+        _input.Read(magic_value);
         _input.Read(_version);
 
-        return magic == CompactBinaryReader::magic
+        return magic_value == CompactBinaryReader::magic
             && (protocol_has_multiple_versions<CompactBinaryReader>::value
                 ? _version <= CompactBinaryReader::version
                 : _version == default_version<CompactBinaryReader>::value);

--- a/cpp/inc/bond/protocol/fast_binary.h
+++ b/cpp/inc/bond/protocol/fast_binary.h
@@ -136,13 +136,13 @@ public:
 
     bool ReadVersion()
     {
-        uint16_t magic, version;
+        uint16_t magic_value, version_value;
 
-        _input.Read(magic);
-        _input.Read(version);
+        _input.Read(magic_value);
+        _input.Read(version_value);
 
-        return magic == FastBinaryReader::magic
-            && version <= FastBinaryReader::version;
+        return magic_value == FastBinaryReader::magic
+            && version_value <= FastBinaryReader::version;
     }
 
 

--- a/cpp/inc/bond/protocol/simple_binary.h
+++ b/cpp/inc/bond/protocol/simple_binary.h
@@ -32,9 +32,9 @@ public:
 
     /// @brief Construct from input buffer/stream containing serialized data.
     SimpleBinaryReader(typename boost::call_traits<Buffer>::param_type input,
-                       uint16_t version = default_version<SimpleBinaryReader>::value)
+                       uint16_t version_value = default_version<SimpleBinaryReader>::value)
         : _input(input),
-          _version(version)
+          _version(version_value)
     {
         BOOST_ASSERT(_version <= SimpleBinaryReader::version);
     }
@@ -67,12 +67,12 @@ public:
 
     bool ReadVersion()
     {
-        uint16_t magic;
+        uint16_t magic_value;
 
-        _input.Read(magic);
+        _input.Read(magic_value);
         _input.Read(_version);
 
-        return magic == SimpleBinaryReader::magic
+        return magic_value == SimpleBinaryReader::magic
             && _version <= SimpleBinaryReader::version;
     }
 

--- a/cpp/test/comm/main.cpp
+++ b/cpp/test/comm/main.cpp
@@ -8,10 +8,21 @@
  * Using boost/test/included/unit_test.hpp on *nix causes segfaults during
  * teardown in some suites.
  */
+
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4702) // C4702: unreachable code
+#endif
+
 #if defined(_WIN32)
     #include <boost/test/included/unit_test.hpp>
 #else
     #include <boost/test/unit_test.hpp>
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(pop)
 #endif
 
 #include "../core/unit_test_framework.h"

--- a/cpp/test/core/bonded_tests.cpp
+++ b/cpp/test/core/bonded_tests.cpp
@@ -6,7 +6,7 @@ template <typename T>
 void BondedVoid(const bond::bonded<void>& bonded, const T& expected)
 {
     T value;
-    
+
     bonded.Deserialize(value);
 
     UT_AssertIsTrue(Equal(expected, value));
@@ -38,7 +38,7 @@ template <typename T1, typename T2>
 void BondedCast(const bond::bonded<T1>& bonded, const T2& expected)
 {
     T2 value;
-    
+
     bonded.Deserialize(value);
 
     UT_AssertIsTrue(Equal(expected, value));
@@ -52,34 +52,34 @@ template <typename Reader, typename Writer, typename T>
 TEST_CASE_BEGIN(BondedCasts)
 {
     T value = InitRandom<T>();
-    
+
     {
         bond::bonded<T> bonded(Serialize<Reader, Writer>(value, Reader::version));
-        
+
         // Deserialize T from bonded<T>
         BondedTyped(bonded, value);
 
         // Cast from bonded<T>
         BondedCast(bonded, value);
-        
+
         // Cast bonded<T> to bonded<void>
         BondedVoid(bonded, value);
     }
 
     {
         bond::bonded<bond::SchemaDef> bondedSchema(Serialize<Reader, Writer>(bond::GetRuntimeSchema<T>().GetSchema()));
-        
+
         boost::shared_ptr<bond::SchemaDef> schema(new bond::SchemaDef);
 
         bondedSchema.Deserialize(*schema);
-        
+
         bond::bonded<void> bondedVoid(Serialize<Reader, Writer>(value, Reader::version), schema);
-        
+
         // Deserialize from bonded<void>
         BondedVoid(bondedVoid, value);
 
-        bond::bonded<T> bonded(bondedVoid); 
-        
+        bond::bonded<T> bonded(bondedVoid);
+
         // cast bonded<void> to bonded<T>
         BondedTyped(bonded, value);
     }
@@ -90,73 +90,75 @@ TEST_CASE_END
 template <typename Reader, typename Writer>
 TEST_CASE_BEGIN(BondedConstructors)
 {
-    SimpleStruct simple = InitRandom<SimpleStruct>();
-    SimpleStruct original(simple); 
-
     {
-        NestedStruct1BondedView from, from2;
+        SimpleStruct simple = InitRandom<SimpleStruct>();
+        SimpleStruct original(simple);
 
-        from.s = bond::bonded<SimpleStruct>(simple);
+        {
+            NestedStruct1BondedView from, from2;
 
-        from2 = from;
+            from.s = bond::bonded<SimpleStruct>(simple);
 
-        simple.m_int8++;           
+            from2 = from;
 
-        UT_AssertIsTrue(from == from2);
+            simple.m_int8++;
 
-        NestedStruct1 to, to2;
-        
-        SerializeDeserialize<Reader, Writer>(from, to);
-        SerializeDeserialize<Reader, Writer>(from2, to2, Reader::version);
+            UT_AssertIsTrue(from == from2);
 
-        UT_AssertIsTrue(simple != original);
-        UT_Equal(to.s, original);
-        UT_Equal(to, to2);
-    }
+            NestedStruct1 to, to2;
 
-    {
-        NestedStruct1BondedView from, from2;
+            SerializeDeserialize<Reader, Writer>(from, to);
+            SerializeDeserialize<Reader, Writer>(from2, to2, Reader::version);
 
-        from.s = bond::bonded<SimpleStruct>(boost::cref(simple));  
+            UT_AssertIsTrue(simple != original);
+            UT_Equal(to.s, original);
+            UT_Equal(to, to2);
+        }
 
-        from2 = from; 
+        {
+            NestedStruct1BondedView from, from2;
 
-        simple.m_int8++;
+            from.s = bond::bonded<SimpleStruct>(boost::cref(simple));
 
-        UT_AssertIsTrue(from == from2);
+            from2 = from;
 
-        NestedStruct1 to, to2;
-        
-        SerializeDeserialize<Reader, Writer>(from, to);
-        SerializeDeserialize<Reader, Writer>(from2, to2, Reader::version);
+            simple.m_int8++;
 
-        UT_AssertIsTrue(simple != original);
-        UT_Equal(to.s, simple);
-        UT_Equal(to, to2);
-    }
+            UT_AssertIsTrue(from == from2);
 
-    {
-        NestedStruct1BondedView         from, from2;
-        boost::shared_ptr<SimpleStruct> simple_ptr(new SimpleStruct(simple));
+            NestedStruct1 to, to2;
 
-        from.s = bond::bonded<SimpleStruct>(simple_ptr);
+            SerializeDeserialize<Reader, Writer>(from, to);
+            SerializeDeserialize<Reader, Writer>(from2, to2, Reader::version);
 
-        from2 = from;
+            UT_AssertIsTrue(simple != original);
+            UT_Equal(to.s, simple);
+            UT_Equal(to, to2);
+        }
 
-        simple.m_int8++;
-        simple_ptr->m_int16++;
+        {
+            NestedStruct1BondedView         from, from2;
+            boost::shared_ptr<SimpleStruct> simple_ptr(new SimpleStruct(simple));
 
-        UT_AssertIsTrue(from == from2);
+            from.s = bond::bonded<SimpleStruct>(simple_ptr);
 
-        NestedStruct1 to, to2;
-        
-        SerializeDeserialize<Reader, Writer>(from, to);
-        SerializeDeserialize<Reader, Writer>(from2, to2, Reader::version);
+            from2 = from;
 
-        UT_AssertIsTrue(*simple_ptr != original);
-        UT_AssertIsTrue(*simple_ptr != simple);
-        UT_Equal(to.s, *simple_ptr);
-        UT_Equal(to, to2);
+            simple.m_int8++;
+            simple_ptr->m_int16++;
+
+            UT_AssertIsTrue(from == from2);
+
+            NestedStruct1 to, to2;
+
+            SerializeDeserialize<Reader, Writer>(from, to);
+            SerializeDeserialize<Reader, Writer>(from2, to2, Reader::version);
+
+            UT_AssertIsTrue(*simple_ptr != original);
+            UT_AssertIsTrue(*simple_ptr != simple);
+            UT_Equal(to.s, *simple_ptr);
+            UT_Equal(to, to2);
+        }
     }
 
     for (unsigned i = 0; i < 3; ++i)
@@ -186,12 +188,12 @@ TEST_CASE_BEGIN(BondedConstructors)
             bonded_simple_struct = bond::bonded<SimpleStruct>(
                                         boost::shared_ptr<StructWithBase>(new StructWithBase(simple)));
         }
-        
+
         // StructWithBase derives from SimpleBase which derives from SimpleStruct
 
         // explicit down-cast from bonded<SimpleStruct> to bonded<SimpleBase>
         from.s1 = bond::bonded<SimpleBase>(bonded_simple_struct);
-        
+
         // implicit up-cast from bonded<SimpleBase> to bonded<SimpleStruct>
         from.s2 = bonded_simple_base;
 
@@ -200,7 +202,7 @@ TEST_CASE_BEGIN(BondedConstructors)
         UT_AssertIsTrue(from == from2);
 
         NestedWithBase1BaseView to, to2;
-        
+
         SerializeDeserialize<Reader, Writer>(from, to);
         SerializeDeserialize<Reader, Writer>(from2, to2, Reader::version);
 
@@ -309,7 +311,7 @@ TEST_CASE_BEGIN(MarshaledBondedDerived)
     // 1.b. Deserialize T2
     {
         To2 to;
-        // Saying that payload is of type To is a bit of a hack that allows us 
+        // Saying that payload is of type To is a bit of a hack that allows us
         // to deserialize into instance of T2 directly instead of going via bonded<T2>
         UT_AssertIsFalse(bond::Validate(bond::GetRuntimeSchema<To>(), bond::GetRuntimeSchema<To2>()));
         bond::Deserialize(reader, to, bond::GetRuntimeSchema<To>());
@@ -326,7 +328,7 @@ void BondedTests(const char* name)
 
     AddTestCase<TEST_ID(N), BondedConstructors, Reader, Writer>(suite, "bonded constructors");
     AddTestCase<TEST_ID(N), BondedCasts, Reader, Writer, unittest::NestedStruct>(suite, "bonded casts");
-    
+
     TEST_SIMPLE_PROTOCOL(
         // Uses Simple protocol for random initialization of struct with bonded<T>
         AddTestCase<TEST_ID(N), BondedSerialize, Reader, Writer>(suite, "bonded serialization");
@@ -339,13 +341,13 @@ void MarshaledBondedTests(const char* name)
 {
     UnitTestSuite suite(name);
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         MarshaledBonded, Reader, Writer, SimpleStruct, bond::bonded<SimpleStruct> >(suite, "T to bonded");
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         MarshaledBonded, Reader, Writer, bond::bonded<SimpleStruct>, SimpleStruct>(suite, "bonded to T");
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         MarshaledBondedDerived, Reader, Writer, SimpleStruct, StructWithBase>(suite, "bonded base to bonded derived");
 }
 
@@ -394,4 +396,3 @@ bool init_unit_test()
     BondedTest::Initialize();
     return true;
 }
-

--- a/cpp/test/core/cmdargs.cpp
+++ b/cpp/test/core/cmdargs.cpp
@@ -21,7 +21,7 @@ typedef boost::mpl::push_front
 typedef boost::mpl::list
     <
         EnumType
-    > 
+    >
     EnumTypes;
 
 
@@ -81,25 +81,25 @@ struct CmdArg : boost::noncopyable
 
         options = bond::cmd::GetArgs<T>(argc(), argv());
     }
-    
+
     // Single param
     template <typename T>
     void Add(const std::string& param, const T& value)
     {
         Add(param + ToString(value));
     }
-    
+
     template <typename T>
     void AddRaw(const std::string& param, const T& value)
     {
         _Add(param + ToString(value));
     }
-    
+
     // Comma-separated list
     template <typename T>
     void Add(std::string param, const std::list<T>& value)
     {
-        BOOST_FOREACH(const T& item, value)
+        for (const auto& item : value)
         {
             param += ToString(item) + ",";
         }
@@ -118,15 +118,15 @@ struct CmdArg : boost::noncopyable
 
         if (space > quote)
             space = std::string::npos;
-        
+
         _Add(param.substr(0, space));
-        
+
         if (space != std::string::npos)
             _Add(param.substr(space + 1));
     }
 
 private:
-    int argc() const 
+    int argc() const
     {
         return static_cast<int>(params.size());
     }
@@ -230,7 +230,7 @@ struct SingleParam
         //  --field=1
         //  --field:Value3
         //  -f 0
-        BOOST_FOREACH(std::string param, ParameterVariants)
+        for (const auto& param : ParameterVariants)
         {
             CmdArg data(variant);
             Option<T> options;
@@ -247,7 +247,7 @@ struct SingleParam
         // Flags, e.g.:
         //  --field
         //  -f
-        BOOST_FOREACH(std::string flag, FlagVariants)
+        for (const auto& flag : FlagVariants)
         {
             CmdArg data(variant);
             Option<bool> options;
@@ -259,7 +259,7 @@ struct SingleParam
         }
     }
 
-    
+
     void TestNaked(const bool&, int)
     {
         // naked bool not supported
@@ -290,7 +290,7 @@ struct ParamList
     {
         T input = boost::lexical_cast<T>(1);
 
-        for (int i = 0; i <= 4; ++i) 
+        for (int i = 0; i <= 4; ++i)
             Test(input, i);
     }
 
@@ -303,14 +303,14 @@ struct ParamList
     void Test(const T&, int variant)
     {
         list<T> input;
-        
+
         input.push_back(boost::lexical_cast<T>(0));
         input.push_back(boost::lexical_cast<T>(1));
         input.push_back(boost::lexical_cast<T>(2));
-        
+
         // Flags - list item per param, e.g.:
         //  -f 0 -f 1 -f 2
-        BOOST_FOREACH(std::string param, ParameterVariants)
+        for (std::string param : ParameterVariants)
         {
             if (param == "-xf ")
                 continue;
@@ -318,11 +318,11 @@ struct ParamList
             CmdArg data(variant);
             Option<list<T> > options;
 
-            BOOST_FOREACH(const T& item, input)
+            for (const auto& item : input)
             {
                 data.Add(param, item);
             }
-        
+
             data.Get(options);
 
             UT_AssertIsTrue(input == options.field);
@@ -336,11 +336,11 @@ struct ParamList
             CmdArg data(variant);
             Naked<list<T> > naked;
 
-            BOOST_FOREACH(const T& item, input)
+            for (const auto& item : input)
             {
                 data.Add("", item);
             }
-        
+
             data.Get(naked);
 
             UT_AssertIsTrue(input == naked.field);
@@ -352,7 +352,7 @@ struct ParamList
         SingleParam single;
 
         single.Test(input, variant);
-        
+
         // variant 0 not supported for naked list because they are greedy
         if (variant != 0)
             single.TestNaked(input, variant);
@@ -380,7 +380,7 @@ TEST_CASE_BEGIN(ListTests)
     boost::mpl::for_each<EnumTypes>(ParamList());
 
     // list tokenizer
-    BOOST_FOREACH(std::string param, ParameterVariants)
+    for (const auto& param : ParameterVariants)
     {
         {
             Option<std::vector<std::string> > options;
@@ -423,11 +423,11 @@ TEST_CASE_END
 
 TEST_CASE_BEGIN(SpecialTests)
 {
-    BOOST_FOREACH(std::string param, ParameterVariants)
+    for (const auto& param : ParameterVariants)
     {
-        BOOST_FOREACH(std::string value, SpecialStrings)
+        for (std::string value: SpecialStrings)
         {
-            for (int variant = 0; variant <= 4; ++variant) 
+            for (int variant = 0; variant <= 4; ++variant)
             {
                 {
                     CmdArg data(variant);
@@ -470,7 +470,7 @@ TEST_CASE_END
 
 TEST_CASE_BEGIN(FailureTests)
 {
-    BOOST_FOREACH(std::string param, Failures)
+    for (const auto& param : Failures)
     {
         // invalid types, unexpected arguments, invalind enum
         CmdArg data;
@@ -479,11 +479,11 @@ TEST_CASE_BEGIN(FailureTests)
         data.Add("naked");
         data.Add("--need=required");
         data.Add(param);
-        
+
         UT_AssertThrows(data.Get(options), std::exception);
     }
 
-    BOOST_FOREACH(std::string value, SpecialStrings)
+    for (const auto& value : SpecialStrings)
     {
         // special string as unexpected command line argument
         CmdArg data;
@@ -492,7 +492,7 @@ TEST_CASE_BEGIN(FailureTests)
         data.Add("naked");
         data.Add("--need=required");
         data.Add("", value);
-               
+
         UT_AssertThrows(data.Get(options), std::exception);
     }
 
@@ -539,7 +539,7 @@ TEST_CASE_BEGIN(UsageTests)
     std::ostringstream actual;
     Usage options;
     Apply(bond::cmd::detail::Usage("example.exe", actual), options);
-    
+
     UT_AssertAreEqual(expected, actual.str());
 }
 TEST_CASE_END
@@ -563,4 +563,3 @@ bool init_unit_test()
     CmdArgs::Initialize();
     return true;
 }
-

--- a/cpp/test/core/json_tests.cpp
+++ b/cpp/test/core/json_tests.cpp
@@ -48,29 +48,33 @@ template <typename T, typename Reader, typename Writer>
 TEST_CASE_BEGIN(StreamDeserializationTest)
 {
     const int count = 10;
-
     T from[count];
-    
-    // Serialize random objects
-    typename Writer::Buffer output;
-    Writer writer(output);
 
-    for (int i = count; i--;)
+    typename Writer::Buffer output;
+
+    // Serialize random objects
     {
-        from[i] = InitRandom<T>();
-        Serialize(from[i], writer);
+        Writer writer(output);
+
+        for (int i = count; i--;)
+        {
+            from[i] = InitRandom<T>();
+            Serialize(from[i], writer);
+        }
     }
 
     // Deserialize the objects
-    Reader reader(output.GetBuffer());
-    bond::bonded<T, Reader&> stream(reader);
-    
-    for (int i = count; i--;)
     {
-        T record = InitRandom<T>();
-    
-        stream.Deserialize(record);
-        UT_AssertIsTrue(Equal(from[i], record));
+        Reader reader(output.GetBuffer());
+        bond::bonded<T, Reader&> stream(reader);
+
+        for (int i = count; i--;)
+        {
+            T record = InitRandom<T>();
+
+            stream.Deserialize(record);
+            UT_AssertIsTrue(Equal(from[i], record));
+        }
     }
 
     // Deserialize the first object twice
@@ -83,7 +87,7 @@ TEST_CASE_BEGIN(StreamDeserializationTest)
         Deserialize(reader, r1);
         Deserialize(reader, r2);
         UT_AssertIsTrue(Equal(r1, r2));
-    
+
         bond::bonded<T> bonded(reader);
         r1 = InitRandom<T>();
         r2 = InitRandom<T>();
@@ -101,7 +105,7 @@ void StreamTranscoding(uint16_t version = bond::v1)
     const int count = 10;
 
     Record records[count];
-    
+
     // Serialize random objects using protocol 1
     typename Writer1::Buffer output1;
     Writer1 writer1(output1);
@@ -125,15 +129,15 @@ void StreamTranscoding(uint16_t version = bond::v1)
         bond::bonded<Intermediate, Reader1&>(reader1).Deserialize(record);
         Serialize(record, writer2);
     }
-    
+
     // Deserialize the objects from protocol 2
     Reader2 reader2(output2.GetBuffer(), version);
     bond::bonded<Record, Reader2&> stream(reader2);
-    
+
     for (int i = count; i--;)
     {
         Record record = InitRandom<Record>();
-    
+
         stream.Deserialize(record);
         UT_AssertIsTrue(Equal(records[i], record));
     }
@@ -146,51 +150,51 @@ TEST_CASE_BEGIN(StreamTranscodingTest)
     StreamTranscoding<
         StructWithBase,
         SimpleStruct,
-        Reader, 
-        Writer, 
-        bond::CompactBinaryReader<bond::InputBuffer>, 
+        Reader,
+        Writer,
+        bond::CompactBinaryReader<bond::InputBuffer>,
         bond::CompactBinaryWriter<bond::OutputBuffer>
     >(bond::v1);
 
     StreamTranscoding<
         StructWithBase,
         SimpleStruct,
-        Reader, 
-        Writer, 
-        bond::CompactBinaryReader<bond::InputBuffer>, 
+        Reader,
+        Writer,
+        bond::CompactBinaryReader<bond::InputBuffer>,
         bond::CompactBinaryWriter<bond::OutputBuffer>
     >(bond::v2);
 
     StreamTranscoding<
         NestedStruct,
         NestedStructBondedView,
-        Reader, 
-        Writer, 
-        bond::CompactBinaryReader<bond::InputBuffer>, 
+        Reader,
+        Writer,
+        bond::CompactBinaryReader<bond::InputBuffer>,
         bond::CompactBinaryWriter<bond::OutputBuffer>
     >(bond::v1);
 
     StreamTranscoding<
         NestedStruct,
         NestedStructBondedView,
-        Reader, 
-        Writer, 
-        bond::CompactBinaryReader<bond::InputBuffer>, 
+        Reader,
+        Writer,
+        bond::CompactBinaryReader<bond::InputBuffer>,
         bond::CompactBinaryWriter<bond::OutputBuffer>
     >(bond::v2);
 }
 TEST_CASE_END
-        
+
 
 template <uint16_t N, typename Reader, typename Writer>
 void StringTests(const char* name)
 {
     UnitTestSuite suite(name);
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         StringRoundtripTest, Reader, Writer>(suite, "Roundtrip string/wstring");
 
-    AddTestCase<TEST_ID(N), 
+    AddTestCase<TEST_ID(N),
         StreamDeserializationTest, NestedStruct, Reader, Writer>(suite, "Stream deserialization test");
 }
 
@@ -210,4 +214,3 @@ bool init_unit_test()
     JSONTest::Initialize();
     return true;
 }
-

--- a/cpp/test/core/main.cpp
+++ b/cpp/test/core/main.cpp
@@ -8,10 +8,20 @@
  * Using boost/test/included/unit_test.hpp on *nix causes segfaults during
  * teardown in some suites.
  */
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4702) // C4702: unreachable code
+#endif
+
 #if defined(_WIN32)
     #include <boost/test/included/unit_test.hpp>
 #else
     #include <boost/test/unit_test.hpp>
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(pop)
 #endif
 
 #include "../logging.h"

--- a/cpp/test/core/merge_test.cpp
+++ b/cpp/test/core/merge_test.cpp
@@ -15,7 +15,15 @@ void Merging(Payload payload, const T& obj, uint16_t version = bond::v1, bool me
     {
         T to;
         
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4127) // C4127: conditional expression is constant
+#endif
         if (boost::mpl::count_if<typename T::Schema::fields, is_optional_field<_> >::value == 0)
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
         {
             to = InitRandom<T>();
             Fixup(to);
@@ -31,7 +39,14 @@ void Merging(Payload payload, const T& obj, uint16_t version = bond::v1, bool me
     {
         Payload to;
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4127) // C4127: conditional expression is constant
+#endif
         if (boost::mpl::count_if<typename Payload::Schema::fields, is_optional_field<_> >::value == 0)
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
         {
             to = InitRandom<Payload>();
             Fixup(to);

--- a/cpp/test/core/pass_through.cpp
+++ b/cpp/test/core/pass_through.cpp
@@ -373,7 +373,14 @@ TEST_CASE_BEGIN(DefaultValuesTranscoding)
 
     T init;
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4127) // C4127: conditional expression is constant
+#endif
     if (bond::uses_dynamic_parser<Reader1>::value && !bond::may_omit_fields<Writer2>::value)
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
     {
         // transcoding from tagged protocol using runtime schema fills-in default values
         // so we can use random object as initial value of 'to'.

--- a/cpp/test/core/serialization_test.cpp
+++ b/cpp/test/core/serialization_test.cpp
@@ -22,14 +22,18 @@ TEST_CASE_BEGIN(Streaming)
     InitRandom(from1);
     InitRandom(from2);
 
-    typename Writer::Buffer buffer;
-    Writer writer(buffer);
+    bond::blob data;
 
-    // Serialize 2 records
-    bond::Serialize(from1, writer);
-    bond::Serialize(from2, writer);
+    {
+        typename Writer::Buffer buffer;
+        Writer writer(buffer);
 
-    bond::blob data = buffer.GetBuffer();
+        // Serialize 2 records
+        bond::Serialize(from1, writer);
+        bond::Serialize(from2, writer);
+
+        data = buffer.GetBuffer();
+    }
 
     {
         Reader reader(data);

--- a/cpp/test/core/unit_test_util.h
+++ b/cpp/test/core/unit_test_util.h
@@ -379,8 +379,15 @@ void Binding(const From& from, uint16_t version = bond::v1)
         bond::bonded<BondedType> bonded(GetBonded<Reader, Writer, BondedType>(from, version));
 
         To to;
-        
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4127) // C4127: conditional expression is constant
+#endif
         if (boost::mpl::count_if<typename From::Schema::fields, is_optional_field<_> >::value == 0)
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
         {
             to = InitRandom<To>();
             Fixup(to);
@@ -396,8 +403,15 @@ void Binding(const From& from, uint16_t version = bond::v1)
         bond::bonded<void> bonded(GetBonded<Reader, Writer, BondedType>(from, version));
 
         To to;
-        
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4127) // C4127: conditional expression is constant
+#endif
         if (boost::mpl::count_if<typename From::Schema::fields, is_optional_field<_> >::value == 0)
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
         {
             to = InitRandom<To>();
             Fixup(to);

--- a/python/inc/bond/python/converters.h
+++ b/python/inc/bond/python/converters.h
@@ -6,7 +6,7 @@
 #if defined(_MSC_VER)
 // Disable warnings in boost::python
 #   pragma warning (push)
-#   pragma warning (disable : 4512 4127 4244 4100 4121 4267)
+#   pragma warning (disable : 4100 4121 4127 4244 4267 4456 4459 4512)
 
 #   if _MSC_VER < 1800
 #       define HAVE_ROUND
@@ -171,11 +171,11 @@ bool map_insert(Map& map, const Key& key, const boost::python::object& obj)
     using namespace boost::python;
     typedef typename Map::value_type value_type;
 
-    extract<const typename value_type::second_type&> value(obj);
+    extract<const typename value_type::second_type&> valueRef(obj);
 
-    if (value.check())
+    if (valueRef.check())
     {
-        map.insert(std::make_pair(key(), value()));
+        map.insert(std::make_pair(key(), valueRef()));
         return true;
     }
     else
@@ -217,11 +217,11 @@ extend_map(Map& map, const boost::python::object& obj)
             stl_input_iterator<object>()
             ))
     {
-        extract<const typename value_type::first_type&> key(k);
+        extract<const typename value_type::first_type&> keyRef(k);
 
-        if (key.check())
+        if (keyRef.check())
         {
-            if (map_insert(map, key, dict.get(k)))
+            if (map_insert(map, keyRef, dict.get(k)))
             {
                 continue;
             }
@@ -281,11 +281,11 @@ extend_set(T& set, const boost::python::object& obj)
             stl_input_iterator<object>()
             ))
     {
-        extract<data_type const&> x(elem);
+        extract<data_type const&> xRef(elem);
 
-        if (x.check())
+        if (xRef.check())
         {
-            set.insert(x());
+            set.insert(xRef());
         }
         else
         {
@@ -405,11 +405,11 @@ struct nullable_maybe_converter
 
     static void extract(T& dst, const boost::python::object& src)
     {
-        boost::python::extract<const typename T::value_type&> value(src);
+        boost::python::extract<const typename T::value_type&> valueRef(src);
 
-        if (value.check())
+        if (valueRef.check())
         {
-            dst = T(static_cast<const typename T::value_type&>(value));
+            dst = T(static_cast<const typename T::value_type&>(valueRef));
             return;
         }
         else

--- a/python/inc/bond/python/set_indexing_suite.h
+++ b/python/inc/bond/python/set_indexing_suite.h
@@ -9,7 +9,7 @@ namespace bond
 {
 namespace python
 {
-            
+
 // Indexing suite for std::set
 
 template <typename T, bool NoProxy, typename DerivedPolicies>
@@ -18,20 +18,20 @@ class set_indexing_suite;
 namespace detail
 {
     template <typename T, bool NoProxy>
-    class final_set_derived_policies 
+    class final_set_derived_policies
         : public bond::python::set_indexing_suite<
-            T, 
-            NoProxy, 
-            final_set_derived_policies<T, NoProxy> > 
+            T,
+            NoProxy,
+            final_set_derived_policies<T, NoProxy> >
     {};
 }
 
 template <
-    typename T, 
+    typename T,
     bool NoProxy = false,
     typename DerivedPolicies = detail::final_set_derived_policies<T, NoProxy>
 >
-class set_indexing_suite 
+class set_indexing_suite
     : public list_indexing_suite<T, NoProxy, DerivedPolicies>
 {
     typedef list_indexing_suite<T, NoProxy, DerivedPolicies> base;
@@ -41,7 +41,7 @@ public:
     typedef typename base::key_type key_type;
 
     template <class Class>
-    static void 
+    static void
     extension_def(Class& class_)
     {
         class_
@@ -58,19 +58,19 @@ public:
         return set.find(key) != set.end();
     }
 
-    static void 
+    static void
     add(T& set, data_type const& v)
     {
         set.insert(v);
     }
 
-    static void 
+    static void
     discard(T& set, data_type const& v)
     {
         set.erase(v);
     }
 
-    static void 
+    static void
     remove(T& set, data_type const& v)
     {
         if (!set.erase(v))
@@ -79,7 +79,7 @@ public:
             boost::python::throw_error_already_set();
         }
     }
-    
+
     static void
     clear(T& set)
     {
@@ -93,20 +93,20 @@ public:
         return data_type();
     }
 
-    static void 
+    static void
     set_item(T&, index_type, data_type const&)
     {
         not_supported();
     }
 
-    static void 
+    static void
     set_slice(T&, index_type, index_type, data_type const&)
     {
         not_supported();
     }
 
     template <typename Iter>
-    static void 
+    static void
     set_slice(T&, index_type, index_type, Iter, Iter)
     {
         not_supported();
@@ -119,11 +119,11 @@ private:
     {
         using namespace boost::python;
 
-        extract<data_type&> elem(v);
-        
-        if (elem.check())
+        extract<data_type&> elemRef(v);
+
+        if (elemRef.check())
         {
-            fn(set, elem());
+            fn(set, elemRef());
         }
         else
         {
@@ -140,7 +140,7 @@ private:
             }
         }
     }
-    
+
     static void
     not_supported()
     {
@@ -148,7 +148,7 @@ private:
         boost::python::throw_error_already_set();
     }
 };
-       
+
 } // namespace python
 
 } // namespace bond


### PR DESCRIPTION
Clear out all warnings generated at -W4 on MSVC. Eliminate the need for the warning suppression header inc/bond/core/warning.h. Includes changes to codegen to ensure there is no name shadowing between parameters names and field names. warning.h is left in place in case applications are dependent on it. This will be removed in a few months.