### PR TITLE
[c++] pre-generate missing protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ different versioning scheme, following the Haskell community's
 * C# NuGet version: TBD (minor bump needed)
 * C# Comm NuGet version: TBD (minor bump needed)
 
+### `gbc` and Bond compiler library ###
+
+* **Breaking change:** Split Haskell Protocol data type, pair: {protocolReader, protocolWriter} into explicit
+  ProtocolReader and ProtocolWriter types (in `Language.Bond.Codegen.Cpp.ApplyOverloads` module).
+* Add explicit bond::Apply<> instantiation for CompactBinaryWriter<OutputCounter> and SimpleBinaryWriter<Null> writers.
+
 ### `gbc` & compiler library ###
 
 * C++ codegen ensures that parameter names do not shadow field names.

--- a/compiler/Main.hs
+++ b/compiler/Main.hs
@@ -83,12 +83,13 @@ cppCodegen options@Cpp {..} = do
     applyProto = map snd $ filter (enabled apply) protocols
     enabled a p = null a || fst p `elem` a
     protocols =
-        [ (Compact, Protocol " ::bond::CompactBinaryReader< ::bond::InputBuffer>"
-                             " ::bond::CompactBinaryWriter< ::bond::OutputBuffer>")
-        , (Fast,    Protocol " ::bond::FastBinaryReader< ::bond::InputBuffer>"
-                             " ::bond::FastBinaryWriter< ::bond::OutputBuffer>")
-        , (Simple,  Protocol " ::bond::SimpleBinaryReader< ::bond::InputBuffer>"
-                             " ::bond::SimpleBinaryWriter< ::bond::OutputBuffer>")
+        [ (Compact, ProtocolReader " ::bond::CompactBinaryReader< ::bond::InputBuffer>")
+        , (Compact, ProtocolWriter " ::bond::CompactBinaryWriter< ::bond::OutputBuffer>")
+        , (Compact, ProtocolWriter " ::bond::CompactBinaryWriter< ::bond::OutputCounter>")
+        , (Fast,    ProtocolReader " ::bond::FastBinaryReader< ::bond::InputBuffer>")
+        , (Fast,    ProtocolWriter " ::bond::FastBinaryWriter< ::bond::OutputBuffer>")
+        , (Simple,  ProtocolReader " ::bond::SimpleBinaryReader< ::bond::InputBuffer>")
+        , (Simple,  ProtocolWriter " ::bond::SimpleBinaryWriter< ::bond::OutputBuffer>")
         ]
 cppCodegen _ = error "cppCodegen: impossible happened."
 

--- a/compiler/tests/Tests/Codegen.hs
+++ b/compiler/tests/Tests/Codegen.hs
@@ -55,12 +55,13 @@ verifyApplyCodegen args baseName =
         , apply_cpp protocols
         ]
     protocols =
-        [ Protocol "bond::CompactBinaryReader<bond::InputBuffer>"
-                   "bond::CompactBinaryWriter<bond::OutputBuffer>"
-        , Protocol "bond::FastBinaryReader<bond::InputBuffer>"
-                   "bond::FastBinaryWriter<bond::OutputBuffer>"
-        , Protocol "bond::SimpleBinaryReader<bond::InputBuffer>"
-                   "bond::SimpleBinaryWriter<bond::OutputBuffer>"
+        [ ProtocolReader "bond::CompactBinaryReader<bond::InputBuffer>"
+        , ProtocolWriter "bond::CompactBinaryWriter<bond::OutputBuffer>"
+        , ProtocolWriter "bond::CompactBinaryWriter<bond::OutputCounter>"
+        , ProtocolReader "bond::FastBinaryReader<bond::InputBuffer>"
+        , ProtocolWriter "bond::FastBinaryWriter<bond::OutputBuffer>"
+        , ProtocolReader "bond::SimpleBinaryReader<bond::InputBuffer>"
+        , ProtocolWriter "bond::SimpleBinaryWriter<bond::OutputBuffer>"
         ]
 
 verifyExportsCodegen :: [String] -> FilePath -> TestTree

--- a/compiler/tests/generated/apply/basic_types_apply.cpp
+++ b/compiler/tests/generated/apply/basic_types_apply.cpp
@@ -21,6 +21,12 @@ namespace tests
     {
         return ::bond::Apply<>(transform, value);
     }
+
+    bool Apply(const ::bond::Null& transform,
+               const ::bond::bonded< ::tests::BasicTypes, ::bond::SimpleBinaryReader< ::bond::InputBuffer>&>& value)
+    {
+        return ::bond::Apply<>(transform, value);
+    }
     
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value)
@@ -89,6 +95,66 @@ namespace tests
     }
     
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
+               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value)
+    {
+        return ::bond::Apply<>(transform, value);
+    }
+    
+    bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::tests::BasicTypes& value)
+    {
+        return ::bond::Apply<>(transform, value);
+    }
+
+    bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::bond::bonded< ::tests::BasicTypes>& value)
+    {
+        return ::bond::Apply<>(transform, value);
+    }
+    
+    bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value)
+    {
+        return ::bond::Apply<>(transform, value);
+    }
+    
+    bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value)
+    {
+        return ::bond::Apply<>(transform, value);
+    }
+    
+    bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value)
+    {
+        return ::bond::Apply<>(transform, value);
+    }
+    
+    bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::tests::BasicTypes& value)
+    {
+        return ::bond::Apply<>(transform, value);
+    }
+
+    bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::bond::bonded< ::tests::BasicTypes>& value)
+    {
+        return ::bond::Apply<>(transform, value);
+    }
+    
+    bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value)
+    {
+        return ::bond::Apply<>(transform, value);
+    }
+    
+    bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value)
+    {
+        return ::bond::Apply<>(transform, value);
+    }
+    
+    bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value)
     {
         return ::bond::Apply<>(transform, value);

--- a/compiler/tests/generated/apply/basic_types_apply.h
+++ b/compiler/tests/generated/apply/basic_types_apply.h
@@ -21,6 +21,10 @@ namespace tests
     DllExport
     bool Apply(const ::bond::InitSchemaDef& transform,
                const ::tests::BasicTypes& value);
+
+    DllExport
+    bool Apply(const ::bond::Null& transform,
+               const ::bond::bonded< ::tests::BasicTypes, ::bond::SimpleBinaryReader< ::bond::InputBuffer>&>& value);
     
     DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
@@ -68,6 +72,46 @@ namespace tests
     
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
+               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
+    
+    DllExport
+    bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::tests::BasicTypes& value);
+
+    DllExport
+    bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::bond::bonded< ::tests::BasicTypes>& value);
+    
+    DllExport
+    bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
+    
+    DllExport
+    bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
+    
+    DllExport
+    bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
+    
+    DllExport
+    bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::tests::BasicTypes& value);
+
+    DllExport
+    bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::bond::bonded< ::tests::BasicTypes>& value);
+    
+    DllExport
+    bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
+    
+    DllExport
+    bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
+               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
+    
+    DllExport
+    bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
     DllExport


### PR DESCRIPTION
- generated files *_apply.h/cpp are missing explicit Apply<>
  instantiations for CompactBinaryWriter<OutputCounter> and
  SimpleBinaryWriter<Null> protocols.