### PR TITLE
Remove FieldTemplate<> from field reflection type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,9 @@ get a compiler error. To fix, remove the `<Writer>` part:
 
 ### `gbc` and Bond compiler library ###
 
-* Remove FieldTemplate details from field reflection type.
+* C++ codegen generates field reflection, that uses an explicit type 
+  derrived from reflection::FieldTemplate. This hides FieldTemplate 
+  details and, as result, shortens symbol names.
 * C++ codegen ensures that parameter names do not shadow field names.
 * When generating C++ apply files, there are now explicit `bond::Apply<>`
   instantiations for `CompactBinaryWriter<OutputCounter>` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,7 @@ get a compiler error. To fix, remove the `<Writer>` part:
 
 ### `gbc` and Bond compiler library ###
 
-* C++ codegen generates field reflection, that uses an explicit type 
-  derrived from reflection::FieldTemplate. This hides FieldTemplate 
-  details and, as result, shortens symbol names.
+* C++ codegen hides FieldTemplate details, shortening symbol names.
 * C++ codegen ensures that parameter names do not shadow field names.
 * When generating C++ apply files, there are now explicit `bond::Apply<>`
   instantiations for `CompactBinaryWriter<OutputCounter>` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ get a compiler error. To fix, remove the `<Writer>` part:
 
 ### `gbc` and Bond compiler library ###
 
+* Remove FieldTemplate details from field reflection type.
 * C++ codegen ensures that parameter names do not shadow field names.
 * When generating C++ apply files, there are now explicit `bond::Apply<>`
   instantiations for `CompactBinaryWriter<OutputCounter>` and

--- a/compiler/src/Language/Bond/Codegen/Cpp/Reflection_h.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Reflection_h.hs
@@ -107,14 +107,14 @@ reflection_h export_attribute cpp file imports declarations = ("_reflection.h", 
 
         fieldTemplates = F.foldMap $ \ f@Field {..} -> [lt|
             // #{fieldName}
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 #{fieldOrdinal},
                 #{CPP.modifierTag f},
                 #{className},
                 #{cppType fieldType},
                 &#{className}::#{fieldName},
                 &s_#{fieldName}_metadata
-            > #{fieldName};
+            > {}  #{fieldName};
         |]
 
 

--- a/compiler/tests/generated/alias_key_reflection.h
+++ b/compiler/tests/generated/alias_key_reflection.h
@@ -21,24 +21,24 @@ namespace test
         public: struct var
         {
             // m
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 std::map<std::string, int32_t>,
                 &foo::m,
                 &s_m_metadata
-            > m;
+            > {}  m;
         
             // s
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 std::set<int32_t>,
                 &foo::s,
                 &s_s_metadata
-            > s;
+            > {}  s;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/alias_with_allocator_reflection.h
+++ b/compiler/tests/generated/alias_with_allocator_reflection.h
@@ -30,114 +30,114 @@ namespace test
         public: struct var
         {
             // l
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 std::list<bool, typename arena::rebind<bool>::other>,
                 &foo::l,
                 &s_l_metadata
-            > l;
+            > {}  l;
         
             // v
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 std::vector<bool, typename arena::rebind<bool>::other>,
                 &foo::v,
                 &s_v_metadata
-            > v;
+            > {}  v;
         
             // s
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 2,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 std::set<bool, std::less<bool>, typename arena::rebind<bool>::other>,
                 &foo::s,
                 &s_s_metadata
-            > s;
+            > {}  s;
         
             // m
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 3,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 std::map<std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other>, bool, std::less<std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other> >, typename arena::rebind<std::pair<const std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other>, bool> >::other>,
                 &foo::m,
                 &s_m_metadata
-            > m;
+            > {}  m;
         
             // st
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 4,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other>,
                 &foo::st,
                 &s_st_metadata
-            > st;
+            > {}  st;
         
             // d
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 5,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other>,
                 &foo::d,
                 &s_d_metadata
-            > d;
+            > {}  d;
         
             // l1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 10,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 ::bond::maybe<std::list<bool, typename arena::rebind<bool>::other> >,
                 &foo::l1,
                 &s_l1_metadata
-            > l1;
+            > {}  l1;
         
             // v1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 11,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 ::bond::maybe<std::vector<bool, typename arena::rebind<bool>::other> >,
                 &foo::v1,
                 &s_v1_metadata
-            > v1;
+            > {}  v1;
         
             // s1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 12,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 ::bond::maybe<std::set<bool, std::less<bool>, typename arena::rebind<bool>::other> >,
                 &foo::s1,
                 &s_s1_metadata
-            > s1;
+            > {}  s1;
         
             // m1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 13,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 ::bond::maybe<std::map<std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other>, bool, std::less<std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other> >, typename arena::rebind<std::pair<const std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other>, bool> >::other> >,
                 &foo::m1,
                 &s_m1_metadata
-            > m1;
+            > {}  m1;
         
             // st1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 14,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 ::bond::maybe<std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other> >,
                 &foo::st1,
                 &s_st1_metadata
-            > st1;
+            > {}  st1;
         };
 
         private: typedef boost::mpl::list<> fields0;
@@ -180,24 +180,24 @@ namespace test
         public: struct var
         {
             // f
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 withFoo,
                 ::test::foo,
                 &withFoo::f,
                 &s_f_metadata
-            > f;
+            > {}  f;
         
             // f1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::optional_field_modifier,
                 withFoo,
                 ::test::foo,
                 &withFoo::f1,
                 &s_f1_metadata
-            > f1;
+            > {}  f1;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/aliases_reflection.h
+++ b/compiler/tests/generated/aliases_reflection.h
@@ -21,14 +21,14 @@ namespace tests
         public: struct var
         {
             // aa
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Foo<T>,
                 std::vector<std::vector<T> >,
                 &Foo<T>::aa,
                 &s_aa_metadata
-            > aa;
+            > {}  aa;
         };
 
         private: typedef boost::mpl::list<> fields0;
@@ -73,14 +73,14 @@ namespace tests
         public: struct var
         {
             // aWrappedEnum
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 WrappingAnEnum,
                 ::tests::EnumToWrap,
                 &WrappingAnEnum::aWrappedEnum,
                 &s_aWrappedEnum_metadata
-            > aWrappedEnum;
+            > {}  aWrappedEnum;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/allocator/alias_key_reflection.h
+++ b/compiler/tests/generated/allocator/alias_key_reflection.h
@@ -21,24 +21,24 @@ namespace test
         public: struct var
         {
             // m
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 std::map<std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other>, int32_t, std::less<std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other> >, typename arena::rebind<std::pair<const std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other>, int32_t> >::other>,
                 &foo::m,
                 &s_m_metadata
-            > m;
+            > {}  m;
         
             // s
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 std::set<int32_t, std::less<int32_t>, typename arena::rebind<int32_t>::other>,
                 &foo::s,
                 &s_s_metadata
-            > s;
+            > {}  s;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/allocator/aliases_reflection.h
+++ b/compiler/tests/generated/allocator/aliases_reflection.h
@@ -21,14 +21,14 @@ namespace tests
         public: struct var
         {
             // aa
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Foo<T>,
                 std::vector<std::vector<T, typename arena::rebind<T>::other>, typename arena::rebind<std::vector<T, typename arena::rebind<T>::other> >::other>,
                 &Foo<T>::aa,
                 &s_aa_metadata
-            > aa;
+            > {}  aa;
         };
 
         private: typedef boost::mpl::list<> fields0;
@@ -73,14 +73,14 @@ namespace tests
         public: struct var
         {
             // aWrappedEnum
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 WrappingAnEnum,
                 ::tests::EnumToWrap,
                 &WrappingAnEnum::aWrappedEnum,
                 &s_aWrappedEnum_metadata
-            > aWrappedEnum;
+            > {}  aWrappedEnum;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/allocator/attributes_reflection.h
+++ b/compiler/tests/generated/allocator/attributes_reflection.h
@@ -20,14 +20,14 @@ namespace tests
         public: struct var
         {
             // f
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other>,
                 &Foo::f,
                 &s_f_metadata
-            > f;
+            > {}  f;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/allocator/basic_types_reflection.h
+++ b/compiler/tests/generated/allocator/basic_types_reflection.h
@@ -33,144 +33,144 @@ namespace tests
         public: struct var
         {
             // _bool
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 bool,
                 &BasicTypes::_bool,
                 &s__bool_metadata
-            > _bool;
+            > {}  _bool;
         
             // _str
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 2,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other>,
                 &BasicTypes::_str,
                 &s__str_metadata
-            > _str;
+            > {}  _str;
         
             // _wstr
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 3,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 std::basic_string<wchar_t, std::char_traits<wchar_t>, typename arena::rebind<wchar_t>::other>,
                 &BasicTypes::_wstr,
                 &s__wstr_metadata
-            > _wstr;
+            > {}  _wstr;
         
             // _uint64
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 10,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 uint64_t,
                 &BasicTypes::_uint64,
                 &s__uint64_metadata
-            > _uint64;
+            > {}  _uint64;
         
             // _uint16
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 11,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 uint16_t,
                 &BasicTypes::_uint16,
                 &s__uint16_metadata
-            > _uint16;
+            > {}  _uint16;
         
             // _uint32
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 12,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 uint32_t,
                 &BasicTypes::_uint32,
                 &s__uint32_metadata
-            > _uint32;
+            > {}  _uint32;
         
             // _uint8
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 13,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 uint8_t,
                 &BasicTypes::_uint8,
                 &s__uint8_metadata
-            > _uint8;
+            > {}  _uint8;
         
             // _int8
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 14,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 int8_t,
                 &BasicTypes::_int8,
                 &s__int8_metadata
-            > _int8;
+            > {}  _int8;
         
             // _int16
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 15,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 int16_t,
                 &BasicTypes::_int16,
                 &s__int16_metadata
-            > _int16;
+            > {}  _int16;
         
             // _int32
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 16,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 int32_t,
                 &BasicTypes::_int32,
                 &s__int32_metadata
-            > _int32;
+            > {}  _int32;
         
             // _int64
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 17,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 int64_t,
                 &BasicTypes::_int64,
                 &s__int64_metadata
-            > _int64;
+            > {}  _int64;
         
             // _double
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 18,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 double,
                 &BasicTypes::_double,
                 &s__double_metadata
-            > _double;
+            > {}  _double;
         
             // _float
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 20,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 float,
                 &BasicTypes::_float,
                 &s__float_metadata
-            > _float;
+            > {}  _float;
         
             // _blob
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 21,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 ::bond::blob,
                 &BasicTypes::_blob,
                 &s__blob_metadata
-            > _blob;
+            > {}  _blob;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/allocator/bond_meta_reflection.h
+++ b/compiler/tests/generated/allocator/bond_meta_reflection.h
@@ -23,24 +23,24 @@ namespace bondmeta
         public: struct var
         {
             // full_name
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::required_optional_field_modifier,
                 HasMetaFields,
                 std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other>,
                 &HasMetaFields::full_name,
                 &s_full_name_metadata
-            > full_name;
+            > {}  full_name;
         
             // name
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::required_optional_field_modifier,
                 HasMetaFields,
                 std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other>,
                 &HasMetaFields::name,
                 &s_name_metadata
-            > name;
+            > {}  name;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/allocator/complex_types_reflection.h
+++ b/compiler/tests/generated/allocator/complex_types_reflection.h
@@ -54,74 +54,74 @@ namespace tests
         public: struct var
         {
             // li8
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 ComplexTypes,
                 std::list<int8_t, typename arena::rebind<int8_t>::other>,
                 &ComplexTypes::li8,
                 &s_li8_metadata
-            > li8;
+            > {}  li8;
         
             // sb
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::optional_field_modifier,
                 ComplexTypes,
                 std::set<bool, std::less<bool>, typename arena::rebind<bool>::other>,
                 &ComplexTypes::sb,
                 &s_sb_metadata
-            > sb;
+            > {}  sb;
         
             // vb
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 2,
                 ::bond::reflection::optional_field_modifier,
                 ComplexTypes,
                 std::vector< ::bond::blob, typename arena::rebind< ::bond::blob>::other>,
                 &ComplexTypes::vb,
                 &s_vb_metadata
-            > vb;
+            > {}  vb;
         
             // nf
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 3,
                 ::bond::reflection::optional_field_modifier,
                 ComplexTypes,
                 ::bond::nullable<float>,
                 &ComplexTypes::nf,
                 &s_nf_metadata
-            > nf;
+            > {}  nf;
         
             // msws
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 4,
                 ::bond::reflection::optional_field_modifier,
                 ComplexTypes,
                 std::map<std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other>, std::basic_string<wchar_t, std::char_traits<wchar_t>, typename arena::rebind<wchar_t>::other>, std::less<std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other> >, typename arena::rebind<std::pair<const std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other>, std::basic_string<wchar_t, std::char_traits<wchar_t>, typename arena::rebind<wchar_t>::other> > >::other>,
                 &ComplexTypes::msws,
                 &s_msws_metadata
-            > msws;
+            > {}  msws;
         
             // bfoo
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 5,
                 ::bond::reflection::optional_field_modifier,
                 ComplexTypes,
                 ::bond::bonded< ::tests::Foo>,
                 &ComplexTypes::bfoo,
                 &s_bfoo_metadata
-            > bfoo;
+            > {}  bfoo;
         
             // m
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 6,
                 ::bond::reflection::optional_field_modifier,
                 ComplexTypes,
                 std::map<double, std::list<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, typename arena::rebind< ::bond::nullable< ::bond::bonded< ::tests::Bar> > >::other>, typename arena::rebind<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, typename arena::rebind< ::bond::nullable< ::bond::bonded< ::tests::Bar> > >::other> >::other>, std::less<double>, typename arena::rebind<std::pair<const double, std::list<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, typename arena::rebind< ::bond::nullable< ::bond::bonded< ::tests::Bar> > >::other>, typename arena::rebind<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, typename arena::rebind< ::bond::nullable< ::bond::bonded< ::tests::Bar> > >::other> >::other> > >::other>,
                 &ComplexTypes::m,
                 &s_m_metadata
-            > m;
+            > {}  m;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/allocator/defaults_reflection.h
+++ b/compiler/tests/generated/allocator/defaults_reflection.h
@@ -55,364 +55,364 @@ namespace tests
         public: struct var
         {
             // m_bool_1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 bool,
                 &Foo::m_bool_1,
                 &s_m_bool_1_metadata
-            > m_bool_1;
+            > {}  m_bool_1;
         
             // m_bool_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 bool,
                 &Foo::m_bool_2,
                 &s_m_bool_2_metadata
-            > m_bool_2;
+            > {}  m_bool_2;
         
             // m_bool_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 2,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<bool>,
                 &Foo::m_bool_3,
                 &s_m_bool_3_metadata
-            > m_bool_3;
+            > {}  m_bool_3;
         
             // m_str_1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 3,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other>,
                 &Foo::m_str_1,
                 &s_m_str_1_metadata
-            > m_str_1;
+            > {}  m_str_1;
         
             // m_str_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 4,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other> >,
                 &Foo::m_str_2,
                 &s_m_str_2_metadata
-            > m_str_2;
+            > {}  m_str_2;
         
             // m_int8_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 5,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int8_t,
                 &Foo::m_int8_4,
                 &s_m_int8_4_metadata
-            > m_int8_4;
+            > {}  m_int8_4;
         
             // m_int8_5
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 6,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<int8_t>,
                 &Foo::m_int8_5,
                 &s_m_int8_5_metadata
-            > m_int8_5;
+            > {}  m_int8_5;
         
             // m_int16_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 7,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int16_t,
                 &Foo::m_int16_4,
                 &s_m_int16_4_metadata
-            > m_int16_4;
+            > {}  m_int16_4;
         
             // m_int16_5
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 8,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<int16_t>,
                 &Foo::m_int16_5,
                 &s_m_int16_5_metadata
-            > m_int16_5;
+            > {}  m_int16_5;
         
             // m_int32_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 9,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<int32_t>,
                 &Foo::m_int32_4,
                 &s_m_int32_4_metadata
-            > m_int32_4;
+            > {}  m_int32_4;
         
             // m_int32_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 10,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int32_t,
                 &Foo::m_int32_max,
                 &s_m_int32_max_metadata
-            > m_int32_max;
+            > {}  m_int32_max;
         
             // m_int64_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 11,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<int64_t>,
                 &Foo::m_int64_4,
                 &s_m_int64_4_metadata
-            > m_int64_4;
+            > {}  m_int64_4;
         
             // m_int64_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 12,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int64_t,
                 &Foo::m_int64_max,
                 &s_m_int64_max_metadata
-            > m_int64_max;
+            > {}  m_int64_max;
         
             // m_uint8_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 13,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 uint8_t,
                 &Foo::m_uint8_2,
                 &s_m_uint8_2_metadata
-            > m_uint8_2;
+            > {}  m_uint8_2;
         
             // m_uint8_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 14,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<uint8_t>,
                 &Foo::m_uint8_3,
                 &s_m_uint8_3_metadata
-            > m_uint8_3;
+            > {}  m_uint8_3;
         
             // m_uint16_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 15,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 uint16_t,
                 &Foo::m_uint16_2,
                 &s_m_uint16_2_metadata
-            > m_uint16_2;
+            > {}  m_uint16_2;
         
             // m_uint16_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 16,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<uint16_t>,
                 &Foo::m_uint16_3,
                 &s_m_uint16_3_metadata
-            > m_uint16_3;
+            > {}  m_uint16_3;
         
             // m_uint32_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 17,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<uint32_t>,
                 &Foo::m_uint32_3,
                 &s_m_uint32_3_metadata
-            > m_uint32_3;
+            > {}  m_uint32_3;
         
             // m_uint32_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 18,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 uint32_t,
                 &Foo::m_uint32_max,
                 &s_m_uint32_max_metadata
-            > m_uint32_max;
+            > {}  m_uint32_max;
         
             // m_uint64_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 19,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<uint64_t>,
                 &Foo::m_uint64_3,
                 &s_m_uint64_3_metadata
-            > m_uint64_3;
+            > {}  m_uint64_3;
         
             // m_uint64_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 20,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 uint64_t,
                 &Foo::m_uint64_max,
                 &s_m_uint64_max_metadata
-            > m_uint64_max;
+            > {}  m_uint64_max;
         
             // m_double_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 21,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<double>,
                 &Foo::m_double_3,
                 &s_m_double_3_metadata
-            > m_double_3;
+            > {}  m_double_3;
         
             // m_double_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 22,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 double,
                 &Foo::m_double_4,
                 &s_m_double_4_metadata
-            > m_double_4;
+            > {}  m_double_4;
         
             // m_double_5
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 23,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 double,
                 &Foo::m_double_5,
                 &s_m_double_5_metadata
-            > m_double_5;
+            > {}  m_double_5;
         
             // m_float_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 24,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<float>,
                 &Foo::m_float_3,
                 &s_m_float_3_metadata
-            > m_float_3;
+            > {}  m_float_3;
         
             // m_float_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 25,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 float,
                 &Foo::m_float_4,
                 &s_m_float_4_metadata
-            > m_float_4;
+            > {}  m_float_4;
         
             // m_float_7
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 26,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 float,
                 &Foo::m_float_7,
                 &s_m_float_7_metadata
-            > m_float_7;
+            > {}  m_float_7;
         
             // m_enum1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 27,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum1,
                 &s_m_enum1_metadata
-            > m_enum1;
+            > {}  m_enum1;
         
             // m_enum2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 28,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum2,
                 &s_m_enum2_metadata
-            > m_enum2;
+            > {}  m_enum2;
         
             // m_enum3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 29,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe< ::tests::EnumType1>,
                 &Foo::m_enum3,
                 &s_m_enum3_metadata
-            > m_enum3;
+            > {}  m_enum3;
         
             // m_enum_int32min
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 30,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum_int32min,
                 &s_m_enum_int32min_metadata
-            > m_enum_int32min;
+            > {}  m_enum_int32min;
         
             // m_enum_int32max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 31,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum_int32max,
                 &s_m_enum_int32max_metadata
-            > m_enum_int32max;
+            > {}  m_enum_int32max;
         
             // m_enum_uint32_min
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 32,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum_uint32_min,
                 &s_m_enum_uint32_min_metadata
-            > m_enum_uint32_min;
+            > {}  m_enum_uint32_min;
         
             // m_enum_uint32_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 33,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum_uint32_max,
                 &s_m_enum_uint32_max_metadata
-            > m_enum_uint32_max;
+            > {}  m_enum_uint32_max;
         
             // m_wstr_1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 34,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 std::basic_string<wchar_t, std::char_traits<wchar_t>, typename arena::rebind<wchar_t>::other>,
                 &Foo::m_wstr_1,
                 &s_m_wstr_1_metadata
-            > m_wstr_1;
+            > {}  m_wstr_1;
         
             // m_wstr_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 35,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<std::basic_string<wchar_t, std::char_traits<wchar_t>, typename arena::rebind<wchar_t>::other> >,
                 &Foo::m_wstr_2,
                 &s_m_wstr_2_metadata
-            > m_wstr_2;
+            > {}  m_wstr_2;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/allocator/field_modifiers_reflection.h
+++ b/compiler/tests/generated/allocator/field_modifiers_reflection.h
@@ -22,34 +22,34 @@ namespace tests
         public: struct var
         {
             // o
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 bool,
                 &Foo::o,
                 &s_o_metadata
-            > o;
+            > {}  o;
         
             // r
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::required_field_modifier,
                 Foo,
                 int16_t,
                 &Foo::r,
                 &s_r_metadata
-            > r;
+            > {}  r;
         
             // ro
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 2,
                 ::bond::reflection::required_optional_field_modifier,
                 Foo,
                 double,
                 &Foo::ro,
                 &s_ro_metadata
-            > ro;
+            > {}  ro;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/allocator/generics_reflection.h
+++ b/compiler/tests/generated/allocator/generics_reflection.h
@@ -22,24 +22,24 @@ namespace tests
         public: struct var
         {
             // t2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Foo<T1, T2>,
                 T2,
                 &Foo<T1, T2>::t2,
                 &s_t2_metadata
-            > t2;
+            > {}  t2;
         
             // n
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::optional_field_modifier,
                 Foo<T1, T2>,
                 ::bond::nullable< ::tests::Foo<T1, bool>, arena>,
                 &Foo<T1, T2>::n,
                 &s_n_metadata
-            > n;
+            > {}  n;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/allocator/inheritance_reflection.h
+++ b/compiler/tests/generated/allocator/inheritance_reflection.h
@@ -20,14 +20,14 @@ namespace tests
         public: struct var
         {
             // x
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Base,
                 int32_t,
                 &Base::x,
                 &s_x_metadata
-            > x;
+            > {}  x;
         };
 
         private: typedef boost::mpl::list<> fields0;
@@ -59,14 +59,14 @@ namespace tests
         public: struct var
         {
             // x
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int32_t,
                 &Foo::x,
                 &s_x_metadata
-            > x;
+            > {}  x;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/allocator/maybe_blob_reflection.h
+++ b/compiler/tests/generated/allocator/maybe_blob_reflection.h
@@ -20,14 +20,14 @@ namespace tests
         public: struct var
         {
             // b
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe< ::bond::blob>,
                 &Foo::b,
                 &s_b_metadata
-            > b;
+            > {}  b;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/allocator/with_enum_header_reflection.h
+++ b/compiler/tests/generated/allocator/with_enum_header_reflection.h
@@ -55,364 +55,364 @@ namespace tests
         public: struct var
         {
             // m_bool_1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 bool,
                 &Foo::m_bool_1,
                 &s_m_bool_1_metadata
-            > m_bool_1;
+            > {}  m_bool_1;
         
             // m_bool_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 bool,
                 &Foo::m_bool_2,
                 &s_m_bool_2_metadata
-            > m_bool_2;
+            > {}  m_bool_2;
         
             // m_bool_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 2,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<bool>,
                 &Foo::m_bool_3,
                 &s_m_bool_3_metadata
-            > m_bool_3;
+            > {}  m_bool_3;
         
             // m_str_1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 3,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other>,
                 &Foo::m_str_1,
                 &s_m_str_1_metadata
-            > m_str_1;
+            > {}  m_str_1;
         
             // m_str_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 4,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<std::basic_string<char, std::char_traits<char>, typename arena::rebind<char>::other> >,
                 &Foo::m_str_2,
                 &s_m_str_2_metadata
-            > m_str_2;
+            > {}  m_str_2;
         
             // m_int8_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 5,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int8_t,
                 &Foo::m_int8_4,
                 &s_m_int8_4_metadata
-            > m_int8_4;
+            > {}  m_int8_4;
         
             // m_int8_5
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 6,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<int8_t>,
                 &Foo::m_int8_5,
                 &s_m_int8_5_metadata
-            > m_int8_5;
+            > {}  m_int8_5;
         
             // m_int16_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 7,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int16_t,
                 &Foo::m_int16_4,
                 &s_m_int16_4_metadata
-            > m_int16_4;
+            > {}  m_int16_4;
         
             // m_int16_5
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 8,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<int16_t>,
                 &Foo::m_int16_5,
                 &s_m_int16_5_metadata
-            > m_int16_5;
+            > {}  m_int16_5;
         
             // m_int32_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 9,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<int32_t>,
                 &Foo::m_int32_4,
                 &s_m_int32_4_metadata
-            > m_int32_4;
+            > {}  m_int32_4;
         
             // m_int32_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 10,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int32_t,
                 &Foo::m_int32_max,
                 &s_m_int32_max_metadata
-            > m_int32_max;
+            > {}  m_int32_max;
         
             // m_int64_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 11,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<int64_t>,
                 &Foo::m_int64_4,
                 &s_m_int64_4_metadata
-            > m_int64_4;
+            > {}  m_int64_4;
         
             // m_int64_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 12,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int64_t,
                 &Foo::m_int64_max,
                 &s_m_int64_max_metadata
-            > m_int64_max;
+            > {}  m_int64_max;
         
             // m_uint8_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 13,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 uint8_t,
                 &Foo::m_uint8_2,
                 &s_m_uint8_2_metadata
-            > m_uint8_2;
+            > {}  m_uint8_2;
         
             // m_uint8_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 14,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<uint8_t>,
                 &Foo::m_uint8_3,
                 &s_m_uint8_3_metadata
-            > m_uint8_3;
+            > {}  m_uint8_3;
         
             // m_uint16_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 15,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 uint16_t,
                 &Foo::m_uint16_2,
                 &s_m_uint16_2_metadata
-            > m_uint16_2;
+            > {}  m_uint16_2;
         
             // m_uint16_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 16,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<uint16_t>,
                 &Foo::m_uint16_3,
                 &s_m_uint16_3_metadata
-            > m_uint16_3;
+            > {}  m_uint16_3;
         
             // m_uint32_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 17,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<uint32_t>,
                 &Foo::m_uint32_3,
                 &s_m_uint32_3_metadata
-            > m_uint32_3;
+            > {}  m_uint32_3;
         
             // m_uint32_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 18,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 uint32_t,
                 &Foo::m_uint32_max,
                 &s_m_uint32_max_metadata
-            > m_uint32_max;
+            > {}  m_uint32_max;
         
             // m_uint64_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 19,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<uint64_t>,
                 &Foo::m_uint64_3,
                 &s_m_uint64_3_metadata
-            > m_uint64_3;
+            > {}  m_uint64_3;
         
             // m_uint64_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 20,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 uint64_t,
                 &Foo::m_uint64_max,
                 &s_m_uint64_max_metadata
-            > m_uint64_max;
+            > {}  m_uint64_max;
         
             // m_double_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 21,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<double>,
                 &Foo::m_double_3,
                 &s_m_double_3_metadata
-            > m_double_3;
+            > {}  m_double_3;
         
             // m_double_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 22,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 double,
                 &Foo::m_double_4,
                 &s_m_double_4_metadata
-            > m_double_4;
+            > {}  m_double_4;
         
             // m_double_5
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 23,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 double,
                 &Foo::m_double_5,
                 &s_m_double_5_metadata
-            > m_double_5;
+            > {}  m_double_5;
         
             // m_float_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 24,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<float>,
                 &Foo::m_float_3,
                 &s_m_float_3_metadata
-            > m_float_3;
+            > {}  m_float_3;
         
             // m_float_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 25,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 float,
                 &Foo::m_float_4,
                 &s_m_float_4_metadata
-            > m_float_4;
+            > {}  m_float_4;
         
             // m_float_7
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 26,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 float,
                 &Foo::m_float_7,
                 &s_m_float_7_metadata
-            > m_float_7;
+            > {}  m_float_7;
         
             // m_enum1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 27,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum1,
                 &s_m_enum1_metadata
-            > m_enum1;
+            > {}  m_enum1;
         
             // m_enum2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 28,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum2,
                 &s_m_enum2_metadata
-            > m_enum2;
+            > {}  m_enum2;
         
             // m_enum3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 29,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe< ::tests::EnumType1>,
                 &Foo::m_enum3,
                 &s_m_enum3_metadata
-            > m_enum3;
+            > {}  m_enum3;
         
             // m_enum_int32min
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 30,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum_int32min,
                 &s_m_enum_int32min_metadata
-            > m_enum_int32min;
+            > {}  m_enum_int32min;
         
             // m_enum_int32max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 31,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum_int32max,
                 &s_m_enum_int32max_metadata
-            > m_enum_int32max;
+            > {}  m_enum_int32max;
         
             // m_enum_uint32_min
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 32,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum_uint32_min,
                 &s_m_enum_uint32_min_metadata
-            > m_enum_uint32_min;
+            > {}  m_enum_uint32_min;
         
             // m_enum_uint32_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 33,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum_uint32_max,
                 &s_m_enum_uint32_max_metadata
-            > m_enum_uint32_max;
+            > {}  m_enum_uint32_max;
         
             // m_wstr_1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 34,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 std::basic_string<wchar_t, std::char_traits<wchar_t>, typename arena::rebind<wchar_t>::other>,
                 &Foo::m_wstr_1,
                 &s_m_wstr_1_metadata
-            > m_wstr_1;
+            > {}  m_wstr_1;
         
             // m_wstr_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 35,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<std::basic_string<wchar_t, std::char_traits<wchar_t>, typename arena::rebind<wchar_t>::other> >,
                 &Foo::m_wstr_2,
                 &s_m_wstr_2_metadata
-            > m_wstr_2;
+            > {}  m_wstr_2;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/attributes_reflection.h
+++ b/compiler/tests/generated/attributes_reflection.h
@@ -20,14 +20,14 @@ namespace tests
         public: struct var
         {
             // f
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 std::string,
                 &Foo::f,
                 &s_f_metadata
-            > f;
+            > {}  f;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/basic_types_reflection.h
+++ b/compiler/tests/generated/basic_types_reflection.h
@@ -33,144 +33,144 @@ namespace tests
         public: struct var
         {
             // _bool
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 bool,
                 &BasicTypes::_bool,
                 &s__bool_metadata
-            > _bool;
+            > {}  _bool;
         
             // _str
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 2,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 std::string,
                 &BasicTypes::_str,
                 &s__str_metadata
-            > _str;
+            > {}  _str;
         
             // _wstr
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 3,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 std::wstring,
                 &BasicTypes::_wstr,
                 &s__wstr_metadata
-            > _wstr;
+            > {}  _wstr;
         
             // _uint64
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 10,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 uint64_t,
                 &BasicTypes::_uint64,
                 &s__uint64_metadata
-            > _uint64;
+            > {}  _uint64;
         
             // _uint16
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 11,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 uint16_t,
                 &BasicTypes::_uint16,
                 &s__uint16_metadata
-            > _uint16;
+            > {}  _uint16;
         
             // _uint32
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 12,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 uint32_t,
                 &BasicTypes::_uint32,
                 &s__uint32_metadata
-            > _uint32;
+            > {}  _uint32;
         
             // _uint8
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 13,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 uint8_t,
                 &BasicTypes::_uint8,
                 &s__uint8_metadata
-            > _uint8;
+            > {}  _uint8;
         
             // _int8
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 14,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 int8_t,
                 &BasicTypes::_int8,
                 &s__int8_metadata
-            > _int8;
+            > {}  _int8;
         
             // _int16
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 15,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 int16_t,
                 &BasicTypes::_int16,
                 &s__int16_metadata
-            > _int16;
+            > {}  _int16;
         
             // _int32
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 16,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 int32_t,
                 &BasicTypes::_int32,
                 &s__int32_metadata
-            > _int32;
+            > {}  _int32;
         
             // _int64
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 17,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 int64_t,
                 &BasicTypes::_int64,
                 &s__int64_metadata
-            > _int64;
+            > {}  _int64;
         
             // _double
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 18,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 double,
                 &BasicTypes::_double,
                 &s__double_metadata
-            > _double;
+            > {}  _double;
         
             // _float
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 20,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 float,
                 &BasicTypes::_float,
                 &s__float_metadata
-            > _float;
+            > {}  _float;
         
             // _blob
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 21,
                 ::bond::reflection::optional_field_modifier,
                 BasicTypes,
                 ::bond::blob,
                 &BasicTypes::_blob,
                 &s__blob_metadata
-            > _blob;
+            > {}  _blob;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/bond_meta_reflection.h
+++ b/compiler/tests/generated/bond_meta_reflection.h
@@ -23,24 +23,24 @@ namespace bondmeta
         public: struct var
         {
             // full_name
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::required_optional_field_modifier,
                 HasMetaFields,
                 std::string,
                 &HasMetaFields::full_name,
                 &s_full_name_metadata
-            > full_name;
+            > {}  full_name;
         
             // name
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::required_optional_field_modifier,
                 HasMetaFields,
                 std::string,
                 &HasMetaFields::name,
                 &s_name_metadata
-            > name;
+            > {}  name;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/complex_types_reflection.h
+++ b/compiler/tests/generated/complex_types_reflection.h
@@ -54,74 +54,74 @@ namespace tests
         public: struct var
         {
             // li8
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 ComplexTypes,
                 std::list<int8_t>,
                 &ComplexTypes::li8,
                 &s_li8_metadata
-            > li8;
+            > {}  li8;
         
             // sb
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::optional_field_modifier,
                 ComplexTypes,
                 std::set<bool>,
                 &ComplexTypes::sb,
                 &s_sb_metadata
-            > sb;
+            > {}  sb;
         
             // vb
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 2,
                 ::bond::reflection::optional_field_modifier,
                 ComplexTypes,
                 std::vector< ::bond::blob>,
                 &ComplexTypes::vb,
                 &s_vb_metadata
-            > vb;
+            > {}  vb;
         
             // nf
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 3,
                 ::bond::reflection::optional_field_modifier,
                 ComplexTypes,
                 ::bond::nullable<float>,
                 &ComplexTypes::nf,
                 &s_nf_metadata
-            > nf;
+            > {}  nf;
         
             // msws
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 4,
                 ::bond::reflection::optional_field_modifier,
                 ComplexTypes,
                 std::map<std::string, std::wstring>,
                 &ComplexTypes::msws,
                 &s_msws_metadata
-            > msws;
+            > {}  msws;
         
             // bfoo
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 5,
                 ::bond::reflection::optional_field_modifier,
                 ComplexTypes,
                 ::bond::bonded< ::tests::Foo>,
                 &ComplexTypes::bfoo,
                 &s_bfoo_metadata
-            > bfoo;
+            > {}  bfoo;
         
             // m
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 6,
                 ::bond::reflection::optional_field_modifier,
                 ComplexTypes,
                 std::map<double, std::list<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> > > > >,
                 &ComplexTypes::m,
                 &s_m_metadata
-            > m;
+            > {}  m;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/custom_alias_with_allocator_reflection.h
+++ b/compiler/tests/generated/custom_alias_with_allocator_reflection.h
@@ -30,114 +30,114 @@ namespace test
         public: struct var
         {
             // l
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 my::list<bool, arena>,
                 &foo::l,
                 &s_l_metadata
-            > l;
+            > {}  l;
         
             // v
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 my::vector<bool, arena>,
                 &foo::v,
                 &s_v_metadata
-            > v;
+            > {}  v;
         
             // s
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 2,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 my::set<bool, arena>,
                 &foo::s,
                 &s_s_metadata
-            > s;
+            > {}  s;
         
             // m
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 3,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 my::map<my::string<arena>, bool, arena>,
                 &foo::m,
                 &s_m_metadata
-            > m;
+            > {}  m;
         
             // st
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 4,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 my::string<arena>,
                 &foo::st,
                 &s_st_metadata
-            > st;
+            > {}  st;
         
             // d
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 5,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 my::string<arena>,
                 &foo::d,
                 &s_d_metadata
-            > d;
+            > {}  d;
         
             // l1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 10,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 ::bond::maybe<my::list<bool, arena> >,
                 &foo::l1,
                 &s_l1_metadata
-            > l1;
+            > {}  l1;
         
             // v1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 11,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 ::bond::maybe<my::vector<bool, arena> >,
                 &foo::v1,
                 &s_v1_metadata
-            > v1;
+            > {}  v1;
         
             // s1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 12,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 ::bond::maybe<my::set<bool, arena> >,
                 &foo::s1,
                 &s_s1_metadata
-            > s1;
+            > {}  s1;
         
             // m1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 13,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 ::bond::maybe<my::map<my::string<arena>, bool, arena> >,
                 &foo::m1,
                 &s_m1_metadata
-            > m1;
+            > {}  m1;
         
             // st1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 14,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 ::bond::maybe<my::string<arena> >,
                 &foo::st1,
                 &s_st1_metadata
-            > st1;
+            > {}  st1;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/custom_alias_without_allocator_reflection.h
+++ b/compiler/tests/generated/custom_alias_without_allocator_reflection.h
@@ -30,114 +30,114 @@ namespace test
         public: struct var
         {
             // l
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 my::list<bool>,
                 &foo::l,
                 &s_l_metadata
-            > l;
+            > {}  l;
         
             // v
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 my::vector<bool>,
                 &foo::v,
                 &s_v_metadata
-            > v;
+            > {}  v;
         
             // s
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 2,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 my::set<bool>,
                 &foo::s,
                 &s_s_metadata
-            > s;
+            > {}  s;
         
             // m
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 3,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 my::map<my::string, bool>,
                 &foo::m,
                 &s_m_metadata
-            > m;
+            > {}  m;
         
             // st
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 4,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 my::string,
                 &foo::st,
                 &s_st_metadata
-            > st;
+            > {}  st;
         
             // d
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 5,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 my::string,
                 &foo::d,
                 &s_d_metadata
-            > d;
+            > {}  d;
         
             // l1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 10,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 ::bond::maybe<my::list<bool> >,
                 &foo::l1,
                 &s_l1_metadata
-            > l1;
+            > {}  l1;
         
             // v1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 11,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 ::bond::maybe<my::vector<bool> >,
                 &foo::v1,
                 &s_v1_metadata
-            > v1;
+            > {}  v1;
         
             // s1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 12,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 ::bond::maybe<my::set<bool> >,
                 &foo::s1,
                 &s_s1_metadata
-            > s1;
+            > {}  s1;
         
             // m1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 13,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 ::bond::maybe<my::map<my::string, bool> >,
                 &foo::m1,
                 &s_m1_metadata
-            > m1;
+            > {}  m1;
         
             // st1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 14,
                 ::bond::reflection::optional_field_modifier,
                 foo,
                 ::bond::maybe<my::string>,
                 &foo::st1,
                 &s_st1_metadata
-            > st1;
+            > {}  st1;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/defaults_reflection.h
+++ b/compiler/tests/generated/defaults_reflection.h
@@ -55,364 +55,364 @@ namespace tests
         public: struct var
         {
             // m_bool_1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 bool,
                 &Foo::m_bool_1,
                 &s_m_bool_1_metadata
-            > m_bool_1;
+            > {}  m_bool_1;
         
             // m_bool_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 bool,
                 &Foo::m_bool_2,
                 &s_m_bool_2_metadata
-            > m_bool_2;
+            > {}  m_bool_2;
         
             // m_bool_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 2,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<bool>,
                 &Foo::m_bool_3,
                 &s_m_bool_3_metadata
-            > m_bool_3;
+            > {}  m_bool_3;
         
             // m_str_1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 3,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 std::string,
                 &Foo::m_str_1,
                 &s_m_str_1_metadata
-            > m_str_1;
+            > {}  m_str_1;
         
             // m_str_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 4,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<std::string>,
                 &Foo::m_str_2,
                 &s_m_str_2_metadata
-            > m_str_2;
+            > {}  m_str_2;
         
             // m_int8_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 5,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int8_t,
                 &Foo::m_int8_4,
                 &s_m_int8_4_metadata
-            > m_int8_4;
+            > {}  m_int8_4;
         
             // m_int8_5
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 6,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<int8_t>,
                 &Foo::m_int8_5,
                 &s_m_int8_5_metadata
-            > m_int8_5;
+            > {}  m_int8_5;
         
             // m_int16_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 7,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int16_t,
                 &Foo::m_int16_4,
                 &s_m_int16_4_metadata
-            > m_int16_4;
+            > {}  m_int16_4;
         
             // m_int16_5
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 8,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<int16_t>,
                 &Foo::m_int16_5,
                 &s_m_int16_5_metadata
-            > m_int16_5;
+            > {}  m_int16_5;
         
             // m_int32_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 9,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<int32_t>,
                 &Foo::m_int32_4,
                 &s_m_int32_4_metadata
-            > m_int32_4;
+            > {}  m_int32_4;
         
             // m_int32_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 10,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int32_t,
                 &Foo::m_int32_max,
                 &s_m_int32_max_metadata
-            > m_int32_max;
+            > {}  m_int32_max;
         
             // m_int64_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 11,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<int64_t>,
                 &Foo::m_int64_4,
                 &s_m_int64_4_metadata
-            > m_int64_4;
+            > {}  m_int64_4;
         
             // m_int64_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 12,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int64_t,
                 &Foo::m_int64_max,
                 &s_m_int64_max_metadata
-            > m_int64_max;
+            > {}  m_int64_max;
         
             // m_uint8_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 13,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 uint8_t,
                 &Foo::m_uint8_2,
                 &s_m_uint8_2_metadata
-            > m_uint8_2;
+            > {}  m_uint8_2;
         
             // m_uint8_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 14,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<uint8_t>,
                 &Foo::m_uint8_3,
                 &s_m_uint8_3_metadata
-            > m_uint8_3;
+            > {}  m_uint8_3;
         
             // m_uint16_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 15,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 uint16_t,
                 &Foo::m_uint16_2,
                 &s_m_uint16_2_metadata
-            > m_uint16_2;
+            > {}  m_uint16_2;
         
             // m_uint16_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 16,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<uint16_t>,
                 &Foo::m_uint16_3,
                 &s_m_uint16_3_metadata
-            > m_uint16_3;
+            > {}  m_uint16_3;
         
             // m_uint32_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 17,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<uint32_t>,
                 &Foo::m_uint32_3,
                 &s_m_uint32_3_metadata
-            > m_uint32_3;
+            > {}  m_uint32_3;
         
             // m_uint32_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 18,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 uint32_t,
                 &Foo::m_uint32_max,
                 &s_m_uint32_max_metadata
-            > m_uint32_max;
+            > {}  m_uint32_max;
         
             // m_uint64_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 19,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<uint64_t>,
                 &Foo::m_uint64_3,
                 &s_m_uint64_3_metadata
-            > m_uint64_3;
+            > {}  m_uint64_3;
         
             // m_uint64_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 20,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 uint64_t,
                 &Foo::m_uint64_max,
                 &s_m_uint64_max_metadata
-            > m_uint64_max;
+            > {}  m_uint64_max;
         
             // m_double_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 21,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<double>,
                 &Foo::m_double_3,
                 &s_m_double_3_metadata
-            > m_double_3;
+            > {}  m_double_3;
         
             // m_double_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 22,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 double,
                 &Foo::m_double_4,
                 &s_m_double_4_metadata
-            > m_double_4;
+            > {}  m_double_4;
         
             // m_double_5
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 23,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 double,
                 &Foo::m_double_5,
                 &s_m_double_5_metadata
-            > m_double_5;
+            > {}  m_double_5;
         
             // m_float_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 24,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<float>,
                 &Foo::m_float_3,
                 &s_m_float_3_metadata
-            > m_float_3;
+            > {}  m_float_3;
         
             // m_float_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 25,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 float,
                 &Foo::m_float_4,
                 &s_m_float_4_metadata
-            > m_float_4;
+            > {}  m_float_4;
         
             // m_float_7
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 26,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 float,
                 &Foo::m_float_7,
                 &s_m_float_7_metadata
-            > m_float_7;
+            > {}  m_float_7;
         
             // m_enum1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 27,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum1,
                 &s_m_enum1_metadata
-            > m_enum1;
+            > {}  m_enum1;
         
             // m_enum2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 28,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum2,
                 &s_m_enum2_metadata
-            > m_enum2;
+            > {}  m_enum2;
         
             // m_enum3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 29,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe< ::tests::EnumType1>,
                 &Foo::m_enum3,
                 &s_m_enum3_metadata
-            > m_enum3;
+            > {}  m_enum3;
         
             // m_enum_int32min
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 30,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum_int32min,
                 &s_m_enum_int32min_metadata
-            > m_enum_int32min;
+            > {}  m_enum_int32min;
         
             // m_enum_int32max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 31,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum_int32max,
                 &s_m_enum_int32max_metadata
-            > m_enum_int32max;
+            > {}  m_enum_int32max;
         
             // m_enum_uint32_min
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 32,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum_uint32_min,
                 &s_m_enum_uint32_min_metadata
-            > m_enum_uint32_min;
+            > {}  m_enum_uint32_min;
         
             // m_enum_uint32_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 33,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum_uint32_max,
                 &s_m_enum_uint32_max_metadata
-            > m_enum_uint32_max;
+            > {}  m_enum_uint32_max;
         
             // m_wstr_1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 34,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 std::wstring,
                 &Foo::m_wstr_1,
                 &s_m_wstr_1_metadata
-            > m_wstr_1;
+            > {}  m_wstr_1;
         
             // m_wstr_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 35,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<std::wstring>,
                 &Foo::m_wstr_2,
                 &s_m_wstr_2_metadata
-            > m_wstr_2;
+            > {}  m_wstr_2;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/exports/service_reflection.h
+++ b/compiler/tests/generated/exports/service_reflection.h
@@ -24,14 +24,14 @@ namespace tests
         public: struct var
         {
             // count
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 dummy,
                 int32_t,
                 &dummy::count,
                 &s_count_metadata
-            > count;
+            > {}  count;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/field_modifiers_reflection.h
+++ b/compiler/tests/generated/field_modifiers_reflection.h
@@ -22,34 +22,34 @@ namespace tests
         public: struct var
         {
             // o
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 bool,
                 &Foo::o,
                 &s_o_metadata
-            > o;
+            > {}  o;
         
             // r
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::required_field_modifier,
                 Foo,
                 int16_t,
                 &Foo::r,
                 &s_r_metadata
-            > r;
+            > {}  r;
         
             // ro
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 2,
                 ::bond::reflection::required_optional_field_modifier,
                 Foo,
                 double,
                 &Foo::ro,
                 &s_ro_metadata
-            > ro;
+            > {}  ro;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/generics_reflection.h
+++ b/compiler/tests/generated/generics_reflection.h
@@ -22,24 +22,24 @@ namespace tests
         public: struct var
         {
             // t2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Foo<T1, T2>,
                 T2,
                 &Foo<T1, T2>::t2,
                 &s_t2_metadata
-            > t2;
+            > {}  t2;
         
             // n
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::optional_field_modifier,
                 Foo<T1, T2>,
                 ::bond::nullable< ::tests::Foo<T1, bool> >,
                 &Foo<T1, T2>::n,
                 &s_n_metadata
-            > n;
+            > {}  n;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/inheritance_reflection.h
+++ b/compiler/tests/generated/inheritance_reflection.h
@@ -20,14 +20,14 @@ namespace tests
         public: struct var
         {
             // x
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Base,
                 int32_t,
                 &Base::x,
                 &s_x_metadata
-            > x;
+            > {}  x;
         };
 
         private: typedef boost::mpl::list<> fields0;
@@ -59,14 +59,14 @@ namespace tests
         public: struct var
         {
             // x
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int32_t,
                 &Foo::x,
                 &s_x_metadata
-            > x;
+            > {}  x;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/maybe_blob_reflection.h
+++ b/compiler/tests/generated/maybe_blob_reflection.h
@@ -20,14 +20,14 @@ namespace tests
         public: struct var
         {
             // b
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe< ::bond::blob>,
                 &Foo::b,
                 &s_b_metadata
-            > b;
+            > {}  b;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/compiler/tests/generated/with_enum_header_reflection.h
+++ b/compiler/tests/generated/with_enum_header_reflection.h
@@ -55,364 +55,364 @@ namespace tests
         public: struct var
         {
             // m_bool_1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 0,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 bool,
                 &Foo::m_bool_1,
                 &s_m_bool_1_metadata
-            > m_bool_1;
+            > {}  m_bool_1;
         
             // m_bool_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 1,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 bool,
                 &Foo::m_bool_2,
                 &s_m_bool_2_metadata
-            > m_bool_2;
+            > {}  m_bool_2;
         
             // m_bool_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 2,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<bool>,
                 &Foo::m_bool_3,
                 &s_m_bool_3_metadata
-            > m_bool_3;
+            > {}  m_bool_3;
         
             // m_str_1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 3,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 std::string,
                 &Foo::m_str_1,
                 &s_m_str_1_metadata
-            > m_str_1;
+            > {}  m_str_1;
         
             // m_str_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 4,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<std::string>,
                 &Foo::m_str_2,
                 &s_m_str_2_metadata
-            > m_str_2;
+            > {}  m_str_2;
         
             // m_int8_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 5,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int8_t,
                 &Foo::m_int8_4,
                 &s_m_int8_4_metadata
-            > m_int8_4;
+            > {}  m_int8_4;
         
             // m_int8_5
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 6,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<int8_t>,
                 &Foo::m_int8_5,
                 &s_m_int8_5_metadata
-            > m_int8_5;
+            > {}  m_int8_5;
         
             // m_int16_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 7,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int16_t,
                 &Foo::m_int16_4,
                 &s_m_int16_4_metadata
-            > m_int16_4;
+            > {}  m_int16_4;
         
             // m_int16_5
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 8,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<int16_t>,
                 &Foo::m_int16_5,
                 &s_m_int16_5_metadata
-            > m_int16_5;
+            > {}  m_int16_5;
         
             // m_int32_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 9,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<int32_t>,
                 &Foo::m_int32_4,
                 &s_m_int32_4_metadata
-            > m_int32_4;
+            > {}  m_int32_4;
         
             // m_int32_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 10,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int32_t,
                 &Foo::m_int32_max,
                 &s_m_int32_max_metadata
-            > m_int32_max;
+            > {}  m_int32_max;
         
             // m_int64_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 11,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<int64_t>,
                 &Foo::m_int64_4,
                 &s_m_int64_4_metadata
-            > m_int64_4;
+            > {}  m_int64_4;
         
             // m_int64_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 12,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 int64_t,
                 &Foo::m_int64_max,
                 &s_m_int64_max_metadata
-            > m_int64_max;
+            > {}  m_int64_max;
         
             // m_uint8_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 13,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 uint8_t,
                 &Foo::m_uint8_2,
                 &s_m_uint8_2_metadata
-            > m_uint8_2;
+            > {}  m_uint8_2;
         
             // m_uint8_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 14,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<uint8_t>,
                 &Foo::m_uint8_3,
                 &s_m_uint8_3_metadata
-            > m_uint8_3;
+            > {}  m_uint8_3;
         
             // m_uint16_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 15,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 uint16_t,
                 &Foo::m_uint16_2,
                 &s_m_uint16_2_metadata
-            > m_uint16_2;
+            > {}  m_uint16_2;
         
             // m_uint16_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 16,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<uint16_t>,
                 &Foo::m_uint16_3,
                 &s_m_uint16_3_metadata
-            > m_uint16_3;
+            > {}  m_uint16_3;
         
             // m_uint32_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 17,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<uint32_t>,
                 &Foo::m_uint32_3,
                 &s_m_uint32_3_metadata
-            > m_uint32_3;
+            > {}  m_uint32_3;
         
             // m_uint32_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 18,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 uint32_t,
                 &Foo::m_uint32_max,
                 &s_m_uint32_max_metadata
-            > m_uint32_max;
+            > {}  m_uint32_max;
         
             // m_uint64_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 19,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<uint64_t>,
                 &Foo::m_uint64_3,
                 &s_m_uint64_3_metadata
-            > m_uint64_3;
+            > {}  m_uint64_3;
         
             // m_uint64_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 20,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 uint64_t,
                 &Foo::m_uint64_max,
                 &s_m_uint64_max_metadata
-            > m_uint64_max;
+            > {}  m_uint64_max;
         
             // m_double_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 21,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<double>,
                 &Foo::m_double_3,
                 &s_m_double_3_metadata
-            > m_double_3;
+            > {}  m_double_3;
         
             // m_double_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 22,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 double,
                 &Foo::m_double_4,
                 &s_m_double_4_metadata
-            > m_double_4;
+            > {}  m_double_4;
         
             // m_double_5
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 23,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 double,
                 &Foo::m_double_5,
                 &s_m_double_5_metadata
-            > m_double_5;
+            > {}  m_double_5;
         
             // m_float_3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 24,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<float>,
                 &Foo::m_float_3,
                 &s_m_float_3_metadata
-            > m_float_3;
+            > {}  m_float_3;
         
             // m_float_4
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 25,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 float,
                 &Foo::m_float_4,
                 &s_m_float_4_metadata
-            > m_float_4;
+            > {}  m_float_4;
         
             // m_float_7
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 26,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 float,
                 &Foo::m_float_7,
                 &s_m_float_7_metadata
-            > m_float_7;
+            > {}  m_float_7;
         
             // m_enum1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 27,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum1,
                 &s_m_enum1_metadata
-            > m_enum1;
+            > {}  m_enum1;
         
             // m_enum2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 28,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum2,
                 &s_m_enum2_metadata
-            > m_enum2;
+            > {}  m_enum2;
         
             // m_enum3
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 29,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe< ::tests::EnumType1>,
                 &Foo::m_enum3,
                 &s_m_enum3_metadata
-            > m_enum3;
+            > {}  m_enum3;
         
             // m_enum_int32min
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 30,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum_int32min,
                 &s_m_enum_int32min_metadata
-            > m_enum_int32min;
+            > {}  m_enum_int32min;
         
             // m_enum_int32max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 31,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum_int32max,
                 &s_m_enum_int32max_metadata
-            > m_enum_int32max;
+            > {}  m_enum_int32max;
         
             // m_enum_uint32_min
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 32,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum_uint32_min,
                 &s_m_enum_uint32_min_metadata
-            > m_enum_uint32_min;
+            > {}  m_enum_uint32_min;
         
             // m_enum_uint32_max
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 33,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::tests::EnumType1,
                 &Foo::m_enum_uint32_max,
                 &s_m_enum_uint32_max_metadata
-            > m_enum_uint32_max;
+            > {}  m_enum_uint32_max;
         
             // m_wstr_1
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 34,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 std::wstring,
                 &Foo::m_wstr_1,
                 &s_m_wstr_1_metadata
-            > m_wstr_1;
+            > {}  m_wstr_1;
         
             // m_wstr_2
-            typedef ::bond::reflection::FieldTemplate<
+            typedef struct : ::bond::reflection::FieldTemplate<
                 35,
                 ::bond::reflection::optional_field_modifier,
                 Foo,
                 ::bond::maybe<std::wstring>,
                 &Foo::m_wstr_2,
                 &s_m_wstr_2_metadata
-            > m_wstr_2;
+            > {}  m_wstr_2;
         };
 
         private: typedef boost::mpl::list<> fields0;

--- a/cpp/inc/bond/core/reflection.h
+++ b/cpp/inc/bond/core/reflection.h
@@ -93,7 +93,7 @@ struct FieldTemplate
     static const Metadata& metadata;
 
     /// @brief Static data member representing the field pointer
-    static const field_pointer field;
+    static constexpr field_pointer field = field_ptr;
 
     /// @brief Static data member equal to the field ordinal
     BOND_STATIC_CONSTEXPR uint16_t id = field_id;
@@ -125,18 +125,6 @@ template <
     const Metadata* metadata_ptr>
 const bond::Metadata&
     FieldTemplate<field_id, ModifierTag, Struct, FieldType, field_ptr, metadata_ptr>::metadata = *metadata_ptr;
-
-template
-<
-    uint16_t field_id,
-    typename ModifierTag,
-    typename Struct,
-    typename FieldType,
-    FieldType Struct::*field_ptr,
-    const Metadata* metadata_ptr
->
-const typename FieldTemplate<field_id, ModifierTag, Struct, FieldType, field_ptr, metadata_ptr>::field_pointer
-    FieldTemplate<field_id, ModifierTag, Struct, FieldType, field_ptr, metadata_ptr>::field = field_ptr;
 
 
 template <typename Service, typename Input, typename Result> struct

--- a/cpp/inc/bond/core/reflection.h
+++ b/cpp/inc/bond/core/reflection.h
@@ -92,6 +92,9 @@ struct FieldTemplate
     /// @brief Static data member describing field metadata
     static const Metadata& metadata;
 
+    /// @brief Static data member representing the field pointer
+    static const field_pointer field;
+
     /// @brief Static data member equal to the field ordinal
     BOND_STATIC_CONSTEXPR uint16_t id = field_id;
 
@@ -122,6 +125,18 @@ template <
     const Metadata* metadata_ptr>
 const bond::Metadata&
     FieldTemplate<field_id, ModifierTag, Struct, FieldType, field_ptr, metadata_ptr>::metadata = *metadata_ptr;
+
+template
+<
+    uint16_t field_id,
+    typename ModifierTag,
+    typename Struct,
+    typename FieldType,
+    FieldType Struct::*field_ptr,
+    const Metadata* metadata_ptr
+>
+const typename FieldTemplate<field_id, ModifierTag, Struct, FieldType, field_ptr, metadata_ptr>::field_pointer
+    FieldTemplate<field_id, ModifierTag, Struct, FieldType, field_ptr, metadata_ptr>::field = field_ptr;
 
 
 template <typename Service, typename Input, typename Result> struct

--- a/cpp/inc/bond/core/reflection.h
+++ b/cpp/inc/bond/core/reflection.h
@@ -92,9 +92,6 @@ struct FieldTemplate
     /// @brief Static data member describing field metadata
     static const Metadata& metadata;
 
-    /// @brief Static data member representing the field pointer
-    static constexpr field_pointer field = field_ptr;
-
     /// @brief Static data member equal to the field ordinal
     BOND_STATIC_CONSTEXPR uint16_t id = field_id;
 
@@ -102,14 +99,14 @@ struct FieldTemplate
     static
     const value_type& GetVariable(const struct_type& object)
     {
-        return object.*field;
+        return object.*field_ptr;
     }
 
     /// @brief Static method returning reference to the field value for a particular object
     static
     value_type& GetVariable(struct_type& object)
     {
-        return object.*field;
+        return object.*field_ptr;
     }
 
     BOOST_STATIC_ASSERT(field_id != invalid_field_id);

--- a/cpp/test/core/container_extensibility.cpp
+++ b/cpp/test/core/container_extensibility.cpp
@@ -123,8 +123,8 @@ TEST_CASE_BEGIN(MultiIndexTest)
                 SimpleStructView, 
                 boost::multi_index::indexed_by<
                     boost::multi_index::sequenced<>,
-                    ordered_non_unique_field<SimpleStructView::Schema::var::m_str>,
-                    ordered_non_unique_field<SimpleStructView::Schema::var::m_uint64>
+                    ordered_non_unique_field<SimpleStructView::Schema::var::m_str, get_field_template<SimpleStructView::Schema::var::m_str>::type>,
+                    ordered_non_unique_field<SimpleStructView::Schema::var::m_uint64, get_field_template<SimpleStructView::Schema::var::m_uint64>::type>
                 >
             >
         > Custom;

--- a/cpp/test/core/container_extensibility.cpp
+++ b/cpp/test/core/container_extensibility.cpp
@@ -123,8 +123,8 @@ TEST_CASE_BEGIN(MultiIndexTest)
                 SimpleStructView, 
                 boost::multi_index::indexed_by<
                     boost::multi_index::sequenced<>,
-                    ordered_non_unique_field<SimpleStructView::Schema::var::m_str, get_field_template<SimpleStructView::Schema::var::m_str>::type>,
-                    ordered_non_unique_field<SimpleStructView::Schema::var::m_uint64, get_field_template<SimpleStructView::Schema::var::m_uint64>::type>
+                    ordered_non_unique_field<SimpleStructView::Schema::var::m_str>,
+                    ordered_non_unique_field<SimpleStructView::Schema::var::m_uint64>
                 >
             >
         > Custom;

--- a/cpp/test/core/multi_index.h
+++ b/cpp/test/core/multi_index.h
@@ -58,32 +58,13 @@ namespace bond
     };
 }
 
-    
 // Help to define multi_index::ordered_non_unique index for field in Bond structure
 template <typename T>
-struct ordered_non_unique_field;
-    
-template <
-    uint16_t id,
-    typename modifierTag,
-    typename structType,
-    typename fieldType,
-    fieldType structType::*fieldAddr,
-    const bond::Metadata* metadata
->
-struct ordered_non_unique_field<
-    bond::reflection::FieldTemplate<
-        id, 
-        modifierTag, 
-        structType, 
-        fieldType, 
-        fieldAddr, 
-        metadata
-    >
->   : boost::multi_index::ordered_non_unique<
+struct ordered_non_unique_field 
+    : boost::multi_index::ordered_non_unique<
         boost::multi_index::tag<
-            bond::reflection::FieldTemplate<id, modifierTag, structType, fieldType, fieldAddr, metadata> 
+            T 
         >,
-        boost::multi_index::member<structType, fieldType, fieldAddr>
+        boost::multi_index::member<typename T::struct_type, typename T::value_type, T::field>
         >
 {};

--- a/cpp/test/core/multi_index.h
+++ b/cpp/test/core/multi_index.h
@@ -58,13 +58,28 @@ namespace bond
     };
 }
 
-// Help to define multi_index::ordered_non_unique index for field in Bond structure
-template <typename T>
-struct ordered_non_unique_field 
+
+template <typename T> struct
+get_field_template
+{
+    template <uint16_t field_id, typename ModifierTag, typename Struct, typename FieldType, FieldType Struct::*field_ptr, const bond::Metadata* metadata_ptr>
+    static bond::reflection::FieldTemplate<field_id, ModifierTag, Struct, FieldType, field_ptr, metadata_ptr> helper(
+        const bond::reflection::FieldTemplate<field_id, ModifierTag, Struct, FieldType, field_ptr, metadata_ptr>&);
+    
+    typedef decltype(helper(T())) type;
+};
+
+
+template <typename T, typename U>
+struct ordered_non_unique_field;
+
+
+template <typename T, uint16_t field_id, typename ModifierTag, typename Struct, typename FieldType, FieldType Struct::*field_ptr, const bond::Metadata* metadata_ptr>
+struct ordered_non_unique_field<T, bond::reflection::FieldTemplate<field_id, ModifierTag, Struct, FieldType, field_ptr, metadata_ptr> >
     : boost::multi_index::ordered_non_unique<
         boost::multi_index::tag<
             T 
         >,
-        boost::multi_index::member<typename T::struct_type, typename T::value_type, T::field>
+        boost::multi_index::member<Struct, FieldType, field_ptr>
         >
 {};

--- a/cpp/test/core/multi_index.h
+++ b/cpp/test/core/multi_index.h
@@ -70,7 +70,7 @@ get_field_template
 };
 
 
-template <typename T, typename U>
+template <typename T, typename U = typename get_field_template<T>::type>
 struct ordered_non_unique_field;
 
 

--- a/python/inc/bond/python/struct.h
+++ b/python/inc/bond/python/struct.h
@@ -26,14 +26,14 @@ public:
         : c(c)
     {}
 
-    template <typename Field>
-    void operator()(const Field&) const
+    template <uint16_t field_id, typename ModifierTag, typename Struct, typename FieldType, FieldType Struct::*field_ptr, const bond::Metadata* metadata_ptr>
+    void operator()(const bond::reflection::FieldTemplate<field_id, ModifierTag, Struct, FieldType, field_ptr, metadata_ptr>&) const
     {
         // Define read-write property
-        add_property(Field::metadata.name, Field::field);
+        add_property(metadata_ptr->name, field_ptr);
 
         // Define field type
-        def_type<typename Field::value_type>();
+        def_type<FieldType>();
     }
 
 private:

--- a/python/inc/bond/python/struct.h
+++ b/python/inc/bond/python/struct.h
@@ -26,14 +26,14 @@ public:
         : c(c)
     {}
 
-    template <uint16_t field_id, typename ModifierTag, typename Struct, typename FieldType, FieldType Struct::*field_ptr, const bond::Metadata* metadata_ptr>
-    void operator()(const bond::reflection::FieldTemplate<field_id, ModifierTag, Struct, FieldType, field_ptr, metadata_ptr>&) const
+    template <typename Field>
+    void operator()(const Field&) const
     {
         // Define read-write property
-        add_property(metadata_ptr->name, field_ptr);
+        add_property(Field::metadata.name, Field::field);
 
         // Define field type
-        def_type<FieldType>();
+        def_type<typename Field::value_type>();
     }
 
 private:


### PR DESCRIPTION
- FieldTemplate<> params are part of field relfection type, this unnecessary increases  generated symbol names.