### PR TITLE
[c++] Use memcpy to type pun; fix alias violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ different versioning scheme, following the Haskell community's
 * Eliminate need for warning suppression on MSVC14 via warning.h in Bond
   itself. warning.h is still in place on MSVC12; furthermore, we don't alter
   warning.h for now as it may be depended upon by application code.
+* Avoid unaligned memory access on non-x86/x64 platforms.
+  [Issue #305](https://github.com/Microsoft/bond/issues/305)
+* Improve compliance with strict-aliasing rules.
+    * Bond now builds on Clang/GCC with `-fstrict-aliasing`.
 
 ## C# ###
 

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -114,6 +114,7 @@ add_definitions (-D_ENABLE_ATOMIC_ALIGNMENT_FIX)
 
 cxx_add_compile_options(Clang
     -fPIC
+    -fstrict-aliasing
     --std=c++11
     -Wall
     -Werror
@@ -122,6 +123,7 @@ cxx_add_compile_options(Clang
 
 cxx_add_compile_options(AppleClang
     -fPIC
+    -fstrict-aliasing
     --std=c++11
     -Wall
     -Werror
@@ -130,6 +132,7 @@ cxx_add_compile_options(AppleClang
 
 cxx_add_compile_options(GNU
     -fPIC
+    -fstrict-aliasing
     --std=c++11
     -Wall
     -Werror

--- a/cpp/inc/bond/protocol/random_protocol.h
+++ b/cpp/inc/bond/protocol/random_protocol.h
@@ -6,9 +6,8 @@
 #include <bond/core/containers.h>
 #include <bond/core/blob.h>
 #include <bond/core/traits.h>
-
-#include <cstring>
 #include <boost/static_assert.hpp>
+#include <cstring>
 
 namespace bond
 {
@@ -116,6 +115,8 @@ public:
 
     void Read(double& value)
     {
+        BOOST_STATIC_ASSERT(sizeof(double) == sizeof(uint64_t));
+
         uint8_t sign;
         uint8_t exponent;
         uint32_t mantissa;
@@ -129,12 +130,13 @@ public:
             exponent = 0x80;
 
         uint64_t bits = ((uint64_t)(sign) << 63) | ((uint64_t)(exponent) << (52 + 3)) | (uint64_t)mantissa;
-
-        *reinterpret_cast<uint64_t*>(&value) = bits;
+        std::memcpy(&value, &bits, sizeof(bits));
     }
 
     void Read(float& value)
     {
+        BOOST_STATIC_ASSERT(sizeof(float) == sizeof(uint32_t));
+
         uint8_t sign;
         uint8_t exponent;
         uint16_t mantissa;
@@ -148,8 +150,7 @@ public:
             exponent = 0x80;
 
         uint32_t bits = ((uint32_t)(sign) << 31) | ((uint32_t)(exponent) << 23) | (uint32_t)mantissa;
-
-        *reinterpret_cast<uint32_t*>(&value) = bits;
+        std::memcpy(&value, &bits, sizeof(bits));
     }
 
     template <typename T>

--- a/cpp/inc/bond/stream/output_buffer.h
+++ b/cpp/inc/bond/stream/output_buffer.h
@@ -6,7 +6,9 @@
 
 #include <bond/core/blob.h>
 #include <bond/core/containers.h>
+#include <bond/core/traits.h>
 #include <boost/static_assert.hpp>
+#include <cstring>
 
 namespace bond
 {
@@ -19,18 +21,19 @@ struct VariableUnsignedUnchecked
 {
     BOOST_STATIC_ASSERT(N < 10);
 
-    static uint32_t Write(uint8_t* p, T value)
+    static uint32_t Write(char* p, T value)
     {
         uint8_t byte = static_cast<uint8_t>(value);
 
         if (value >>= 7)
         {
-            p[N-1] = byte | 0x80;
+            byte |= 0x80;
+            std::memcpy(p + N - 1, &byte, 1);
             return VariableUnsignedUnchecked<T, N+1>::Write(p, value);
         }
         else
         {
-            p[N-1] = byte;
+            std::memcpy(p + N - 1, &byte, 1);
             return N;
         }
     }
@@ -40,10 +43,11 @@ struct VariableUnsignedUnchecked
 template <>
 struct VariableUnsignedUnchecked<uint64_t, 10>
 {
-    static uint32_t Write(uint8_t* p, uint64_t value)
+    static uint32_t Write(char* p, uint64_t value)
     {
         BOOST_VERIFY(value == 1);
-        p[9] = 1;
+        const uint8_t byte = 1;
+        std::memcpy(p + 9, &byte, 1);
         return 10;
     }
 };
@@ -52,9 +56,10 @@ struct VariableUnsignedUnchecked<uint64_t, 10>
 template <>
 struct VariableUnsignedUnchecked<uint32_t, 5>
 {
-    static uint32_t Write(uint8_t* p, uint32_t value)
+    static uint32_t Write(char* p, uint32_t value)
     {
-        p[4] = static_cast<uint8_t>(value);
+        const uint8_t byte = static_cast<uint8_t>(value);
+        std::memcpy(p + 4, &byte, 1);
         return 5;
     }
 };
@@ -63,9 +68,10 @@ struct VariableUnsignedUnchecked<uint32_t, 5>
 template <>
 struct VariableUnsignedUnchecked<uint16_t, 3>
 {
-    static uint32_t Write(uint8_t* p, uint16_t value)
+    static uint32_t Write(char* p, uint16_t value)
     {
-        p[2] = static_cast<uint8_t>(value);
+        const uint8_t byte = static_cast<uint8_t>(value);
+        std::memcpy(p + 2, &byte, 1);
         return 3;
     }
 };
@@ -109,8 +115,8 @@ public:
     {
         _blobs.reserve(reserveBlobs);
     }
-    
-    
+
+
     /// @brief Construct OutputMemoryStream with the first buffer of the specified
     /// size and a preallocated vector to store additional buffers.
     explicit OutputMemoryStream(uint32_t reserveSize,
@@ -130,23 +136,23 @@ public:
     {
         _blobs.reserve(reserveBlobs);
     }
-    
-    
+
+
     /// @brief Get content of the stream as a vector of memory blobs
     template <typename T>
     void GetBuffers(std::vector<blob, T>& buffers) const
     {
         buffers.reserve(_blobs.size() + 1);
-        
+
         //
         // insert all "ready" blobs
         //
         buffers.assign(_blobs.begin(), _blobs.end());
-        
+
         if (_rangeSize > 0)
         {
             //
-            // attach current array, if not empty, 
+            // attach current array, if not empty,
             // as a last blob
             //
             buffers.push_back(blob(_buffer, _rangeOffset, _rangeSize));
@@ -165,15 +171,16 @@ public:
         return merge(_allocator, merge(_allocator, _blobs.begin(), _blobs.end()), current);
     }
 
-    
+
     template<typename T>
     void Write(const T& value)
     {
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386) || defined(_M_IX86)
         //
-        // Performance tweak: for small types don't go into generic Write(),
-        // which results in call to memcpy() and additional memory access.
-        // The direct copy of the value (which is likely on register already)
-        // is faster.
+        // x86/x64 performance tweak: for small types don't go into generic
+        // Write(), which results in call to memcpy() and additional memory
+        // access. The direct copy of the value (which is likely on register
+        // already) is faster.
         //
         if (sizeof(T) + _rangeSize + _rangeOffset <= _bufferSize)
         {
@@ -184,30 +191,39 @@ public:
         {
             Write(&value, sizeof(value));
         }
+#else
+        //
+        // We can't use the trick above on platforms that don't support
+        // unaligned memory access, so fall back to the version of Write
+        // that is implemented with memcpy. memcpy handles the alignment for
+        // us.
+        //
+        Write(&value, sizeof(value));
+#endif
     }
-    
+
 
     void Write(const void* value, uint32_t size)
-    {    
+    {
         uint32_t    sizePart = _bufferSize - _rangeSize - _rangeOffset;
         const char* buffer = static_cast<const char*>(value);
-        
+
         if (sizePart > size)
         {
             sizePart = size;
         }
-        
+
         //
         // copy to the tail of current range
-        ::memcpy(_rangePtr + _rangeSize,
-                 buffer,
-                 sizePart);
+        std::memcpy(_rangePtr + _rangeSize,
+                    buffer,
+                    sizePart);
 
         //
         // increase current range size
         //
         _rangeSize += sizePart;
-        
+
         //
         // if there is more bytes to copy, allocate a new buffer
         //
@@ -220,39 +236,39 @@ public:
             //
             size -= sizePart;
             buffer += sizePart;
-            
+
             //
             // snap current range to internal list of blobs, if not empty
             //
             if (_rangeSize > 0)
             {
                 _blobs.push_back(blob(_buffer, _rangeOffset, _rangeSize));
-            }                
+            }
 
             //
-            // grow buffer by 50% (at least 4096 bytes for initial buffer) 
+            // grow buffer by 50% (at least 4096 bytes for initial buffer)
             // and enough to store left overs of specified buffer
             //
             _bufferSize += _bufferSize ? _bufferSize / 2 : 4096;
             _bufferSize = (std::max)(_bufferSize, size);
-            
+
             _buffer = boost::allocate_shared_noinit<char[]>(_allocator, _bufferSize);
-        
+
             //
             // init range
             //
             _rangeOffset = 0;
             _rangePtr = _buffer.get();
             _rangeSize = size;
-            
+
             //
             // copy to the tail of current range
-            ::memcpy(_rangePtr,
-                     buffer,
-                     size);
+            std::memcpy(_rangePtr,
+                        buffer,
+                        size);
         }
     }
-    
+
     void Write(const blob& buffer)
     {
         if (buffer.size() < _minChainningSize || _blobs.size() >= _maxChainLength)
@@ -263,30 +279,30 @@ public:
 
         //
         // Internal list of blobs must represent valid sequence of bytes
-        
-        // 
+
+        //
         // First snap current buffer range, if it is not empty
         //
         if (_rangeSize > 0)
         {
             _blobs.push_back(blob(_buffer, _rangeOffset, _rangeSize));
-            
+
             _rangeOffset += _rangeSize;
-            _rangePtr += _rangeSize; 
-            
+            _rangePtr += _rangeSize;
+
             //
             // reset range size
             //
             _rangeSize = 0;
         }
-        
+
         //
         // attach specified blob to the end of the list
         //
         _blobs.push_back(buffer);
     }
-    
-    void Flush() 
+
+    void Flush()
     {
         //
         // nop
@@ -298,7 +314,7 @@ public:
     {
         if (sizeof(T) * 8 / 7 + _rangeSize + _rangeOffset < _bufferSize)
         {
-            uint8_t* ptr = reinterpret_cast<uint8_t*>(_rangePtr + _rangeSize);
+            char* ptr = _rangePtr + _rangeSize;
             _rangeSize += output_buffer::VariableUnsignedUnchecked<T, 1>::Write(ptr, value);
         }
         else
@@ -310,16 +326,16 @@ public:
 protected:
     // allocator instance
     A _allocator;
-    
+
     // current buffer
     boost::shared_ptr<char[]> _buffer;
-    
+
     // size of current buffer
     uint32_t _bufferSize;
-    
+
     // size of current buffer range
     uint32_t _rangeSize;
-    
+
     // offset of current buffer range
     uint32_t _rangeOffset;
 
@@ -331,10 +347,10 @@ protected:
 
     // pointer of current buffer range
     char* _rangePtr;
-    
+
     // list of blobs
     std::vector<blob, typename A::template rebind<blob>::other> _blobs;
-    
+
 }; // class OutputMemoryStream
 
 


### PR DESCRIPTION
We now use `memcpy` to pun from one type to another, avoiding aliasing
violations as well as alignment errors. x86-like chips never failed due
to the alignment errors, but others, like some ARM chips, did. This
should also fix emscripten cross-compilation.

Fixes https://github.com/Microsoft/bond/issues/305