### PR TITLE
[c#] Rename Bond.BondReflection back to Reflection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,20 @@ different versioning scheme, following the Haskell community's
 
 * Added controls to cap incremental allocation between reads in
   `Bond.IO.Unsafe.InputStream`.
-* Extended bug parsing JSON when a string value is a date.
+* Extended fix for bug parsing JSON when a string value is a date.
   [Pull request #358](https://github.com/Microsoft/bond/pull/358)
+* Bond C# 5.1.0 accidentally broke backward compability by renaming
+  `Bond.Reflection` to `Bond.BondReflection`. This has been fixed:
+  `Bond.BondReflection` was unrenamed back to `Bond.Reflection`, and a shim
+  `Bond.BondReflection` type now redirects all calls to their original names
+  to minimize further breakage.
+  [Issue #369](https://github.com/Microsoft/bond/issues/369)
+    * Code that started using `Bond.BondReflection` by name will encounter
+      warning CS0618 indicating use of an obselete method/type. To fix this,
+      use the original name `Bond.Reflection`. This warning can be
+      suppressed if needed. However...
+    * ...the shim type `Bond.BondReflection` will be removed during or after
+      the next major release of C# Bond.
 
 ### C# Comm ###
 

--- a/cs/src/core/Bond.csproj
+++ b/cs/src/core/Bond.csproj
@@ -17,6 +17,7 @@
     <Compile Include="Blob.cs" />
     <Compile Include="Bond.cs" />
     <Compile Include="Bonded.cs" />
+    <Compile Include="BondReflection.cs" />
     <Compile Include="Clone.cs" />
     <Compile Include="Comparer.cs" />
     <Compile Include="Deserializer.cs" />
@@ -72,7 +73,7 @@
     <Compile Include="protocols\SimpleXmlReader.cs" />
     <Compile Include="protocols\SimpleXmlWriter.cs" />
     <Compile Include="protocols\XmlMetadata.cs" />
-    <Compile Include="BondReflection.cs" />
+    <Compile Include="Reflection.cs" />
     <Compile Include="RuntimeSchema.cs" />
     <Compile Include="Schema.cs" />
     <Compile Include="Serializer.cs" />

--- a/cs/src/core/BondReflection.cs
+++ b/cs/src/core/BondReflection.cs
@@ -4,329 +4,162 @@
 namespace Bond
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
-    using System.Globalization;
-    using System.Linq;
-    using System.Linq.Expressions;
-    using System.Reflection;
-    using System.Text;
-    using Bond.Reflection;
 
+    /// <summary>
+    /// A helper type that redirects methods from Bond.BondReflection to
+    /// their original name in Bond.Reflection.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The type Bond.Reflection was accidentally renamed to
+    /// Bond.BondReflection in C# Bond 5.1.0, breaking backward
+    /// compatibility. This has been fixed. Until the next major release of
+    /// C# Bond, this type exists to redirect anyone who started using
+    /// Bond.BondReflection in the interim.
+    /// </para>
+    /// <para>
+    /// This type will be removed during or after the next major release of
+    /// C# Bond.
+    /// </para>
+    /// </remarks>
+    [Obsolete("Use Bond.Reflection instead. Bond.BondReflection will be removed in a subsequent version.")]
     public static class BondReflection
     {
-        static readonly object Empty = new object();
-        static readonly Dictionary<BondDataType, string> bondTypeName = new Dictionary<BondDataType, string>
-        {
-            {BondDataType.BT_BOOL, "bool"},
-            {BondDataType.BT_UINT8, "uint8"},
-            {BondDataType.BT_UINT16, "uint16"},
-            {BondDataType.BT_UINT32, "uint32"},
-            {BondDataType.BT_UINT64, "uint64"},
-            {BondDataType.BT_FLOAT, "float"},
-            {BondDataType.BT_DOUBLE, "double"},
-            {BondDataType.BT_STRING, "string"},
-            {BondDataType.BT_LIST, "list"},
-            {BondDataType.BT_SET, "set"},
-            {BondDataType.BT_MAP, "map"},
-            {BondDataType.BT_INT8, "int8"},
-            {BondDataType.BT_INT16, "int16"},
-            {BondDataType.BT_INT32, "int32"},
-            {BondDataType.BT_INT64, "int64"},
-            {BondDataType.BT_WSTRING, "wstring"}
-        };
-
-        #region Public APIs
-
         /// <summary>
         /// Get list of fields for a Bond schema
         /// </summary>
-        public static IEnumerable<ISchemaField> GetSchemaFields(this Type type)
+        [Obsolete("Use Bond.Reflection.GetGetSchemaFields instead. Bond.BondReflection will be removed in a subsequent version.")]
+        public static IEnumerable<ISchemaField> GetSchemaFields(Type type)
         {
-            var fields = from fieldInfo in type.GetDeclaredFields().Where(f => f.IsPublic)
-                         let idAttr = fieldInfo.GetAttribute<IdAttribute>()
-                         where idAttr != null
-                         select new Field(fieldInfo, idAttr.Value) as ISchemaField;
-
-            var properties =
-                from propertyInfo in type.GetDeclaredProperties()
-                let idAttr = propertyInfo.GetAttribute<IdAttribute>()
-                where idAttr != null
-                select new Property(propertyInfo, idAttr.Value) as ISchemaField;
-
-            var concatenated = fields.Concat(properties);
-            return concatenated.OrderBy(m => m.Id);
+            return Reflection.GetSchemaFields(type);
         }
 
         /// <summary>
         /// Get the inner Type of composite/container types
         /// </summary>
-        public static Type GetValueType(this Type type)
+        [Obsolete("Use Bond.Reflection.GetValueType instead. Bond.BondReflection will be removed in a subsequent version.")]
+        public static Type GetValueType(Type type)
         {
-            if (type.IsBondNullable() || type.IsBonded())
-                return type.GetGenericArguments()[0];
-
-            if (type.IsArray)
-                return type.GetElementType();
-
-            if (type.IsBondBlob())
-                return typeof(sbyte);
-
-            return type.GetMethod(typeof(IEnumerable<>), "GetEnumerator")
-                .ReturnType
-                .GetDeclaredProperty("Current")
-                .PropertyType;
+            return Reflection.GetValueType(type);
         }
 
         /// <summary>
         /// Get the key and value Type for a map
         /// </summary>
-        public static KeyValuePair<Type, Type> GetKeyValueType(this Type type)
+        [Obsolete("Use Bond.Reflection.GetKeyValueType instead. Bond.BondReflection will be removed in a subsequent version.")]
+        public static KeyValuePair<Type, Type> GetKeyValueType(Type type)
         {
-            var types = GetValueType(type).GetGenericArguments();
-
-            if (types.Length != 2)
-            {
-                throw new InvalidOperationException("Expected generic type with 2 type arguments.");
-            }
-
-            return new KeyValuePair<Type, Type>(types[0], types[1]);
+            return Reflection.GetKeyValueType(type);
         }
 
         /// <summary>
         /// Get a value indicating whether the Type is a Bond schema
         /// </summary>
-        public static bool IsBondStruct(this Type type)
+        [Obsolete("Use Bond.Reflection.IsBondStruct instead. Bond.BondReflection will be removed in a subsequent version.")]
+        public static bool IsBondStruct(Type type)
         {
-            return null != type.GetAttribute<SchemaAttribute>();
+            return Reflection.IsBondStruct(type);
         }
 
         /// <summary>
         /// Get a value indicating whether the Type is a bonded&lt;T>
         /// </summary>
-        public static bool IsBonded(this Type type)
+        [Obsolete("Use Bond.Reflection.IsBonded instead. Bond.BondReflection will be removed in a subsequent version.")]
+        public static bool IsBonded(Type type)
         {
-            if (type.IsGenericType())
-            {
-                var definition = type.GetGenericTypeDefinition();
-                return definition == typeof(IBonded<>) || definition == typeof(Tag.bonded<>);
-            }
-
-            return false;
+            return Reflection.IsBonded(type);
         }
 
         /// <summary>
         /// Get a value indicating whether the Type is a Bond nullable type
         /// </summary>
-        public static bool IsBondNullable(this Type type)
+        [Obsolete("Use Bond.Reflection.IsBondNullable instead. Bond.BondReflection will be removed in a subsequent version.")]
+        public static bool IsBondNullable(Type type)
         {
-            return type.IsGenericType() &&
-                   (type.GetGenericTypeDefinition() == typeof(Tag.nullable<>));
+            return Reflection.IsBondNullable(type);
         }
 
         /// <summary>
         /// Get a value indicating whether the Type is a Bond string
         /// </summary>
-        public static bool IsBondString(this Type type)
+        [Obsolete("Use Bond.Reflection.IsBondString instead. Bond.BondReflection will be removed in a subsequent version.")]
+        public static bool IsBondString(Type type)
         {
-            return type == typeof(Tag.wstring) || type == typeof(string);
+            return Reflection.IsBondString(type);
         }
 
         /// <summary>
         /// Get a value indicating whether the Type is a Bond blob
         /// </summary>
-        public static bool IsBondBlob(this Type type)
+        [Obsolete("Use Bond.Reflection.IsBondBlob instead. Bond.BondReflection will be removed in a subsequent version.")]
+        public static bool IsBondBlob(Type type)
         {
-            return type == typeof(Tag.blob) || type == typeof(ArraySegment<byte>);
+            return Reflection.IsBondBlob(type);
         }
 
         /// <summary>
         /// Get a value indicating whether the Type is a Bond list
         /// or a Bond vector
         /// </summary>
-        public static bool IsBondList(this Type type)
+        [Obsolete("Use Bond.Reflection.IsBondList instead. Bond.BondReflection will be removed in a subsequent version.")]
+        public static bool IsBondList(Type type)
         {
-            if (type.IsGenericType())
-            {
-                var genericType = type.GetGenericTypeDefinition();
-                if (genericType == typeof(IList<>) || genericType == typeof(ICollection<>))
-                    return true;
-            }
-
-            return typeof(IList).IsAssignableFrom(type) ||
-                   typeof(ICollection).IsAssignableFrom(type);
+            return Reflection.IsBondList(type);
         }
 
         /// <summary>
         /// Get a value indicating whether the Type is a Bond map
         /// </summary>
-        public static bool IsBondMap(this Type type)
+        [Obsolete("Use Bond.Reflection.IsBondMap instead. Bond.BondReflection will be removed in a subsequent version.")]
+        public static bool IsBondMap(Type type)
         {
-            if (type.IsGenericType())
-            {
-                var genericType = type.GetGenericTypeDefinition();
-                if (genericType == typeof(IDictionary<,>))
-                    return true;
-            }
-
-            return typeof(IDictionary).IsAssignableFrom(type);
+            return Reflection.IsBondMap(type);
         }
 
         /// <summary>
         /// Get a value indicating whether the Type is a Bond set
         /// </summary>
-        public static bool IsBondSet(this Type type)
+        [Obsolete("Use Bond.Reflection.IsBondSet instead. Bond.BondReflection will be removed in a subsequent version.")]
+        public static bool IsBondSet(Type type)
         {
-            if (!type.IsGenericType())
-                return false;
-
-            return typeof(ISet<>).MakeGenericType(type.GetGenericArguments()[0]).IsAssignableFrom(type);
+            return Reflection.IsBondSet(type);
         }
 
         /// <summary>
         /// Get a value indicating whether the Type is a Bond container
         /// </summary>
-        public static bool IsBondContainer(this Type type)
+        [Obsolete("Use Bond.Reflection.IsBondContainer instead. Bond.BondReflection will be removed in a subsequent version.")]
+        public static bool IsBondContainer(Type type)
         {
-            return type.IsBondList() ||
-                   type.IsBondSet() ||
-                   type.IsBondMap() ||
-                   type.IsBondBlob();
+            return Reflection.IsBondContainer(type);
         }
 
         /// <summary>
         /// Get the BondDataType value for the Type
         /// </summary>
-        public static BondDataType GetBondDataType(this Type type)
+        [Obsolete("Use Bond.Reflection.GetBondDataType instead. Bond.BondReflection will be removed in a subsequent version.")]
+        public static BondDataType GetBondDataType(Type type)
         {
-            while (true)
-            {
-                if (type.IsBondStruct() || type.IsBonded())
-                    return BondDataType.BT_STRUCT;
-
-                if (type.IsBondNullable())
-                    return BondDataType.BT_LIST;
-
-                if (type.IsBondMap())
-                    return BondDataType.BT_MAP;
-
-                if (type.IsBondSet())
-                    return BondDataType.BT_SET;
-
-                if (type.IsBondList() || type.IsBondBlob())
-                    return BondDataType.BT_LIST;
-
-                if (type.IsEnum())
-                    return BondDataType.BT_INT32;
-
-                if (type == typeof(string))
-                    return BondDataType.BT_STRING;
-
-                if (type == typeof(Tag.wstring))
-                    return BondDataType.BT_WSTRING;
-
-                if (type == typeof(bool))
-                    return BondDataType.BT_BOOL;
-
-                if (type == typeof(byte))
-                    return BondDataType.BT_UINT8;
-
-                if (type == typeof(UInt16))
-                    return BondDataType.BT_UINT16;
-
-                if (type == typeof(UInt32))
-                    return BondDataType.BT_UINT32;
-
-                if (type == typeof(UInt64))
-                    return BondDataType.BT_UINT64;
-
-                if (type == typeof(float))
-                    return BondDataType.BT_FLOAT;
-
-                if (type == typeof(double))
-                    return BondDataType.BT_DOUBLE;
-
-                if (type == typeof(sbyte))
-                    return BondDataType.BT_INT8;
-
-                if (type == typeof(Int16))
-                    return BondDataType.BT_INT16;
-
-                if (type == typeof(Int32))
-                    return BondDataType.BT_INT32;
-
-                if (type == typeof(Int64))
-                    return BondDataType.BT_INT64;
-
-                if (type.IsGenericType() && type.GetGenericTypeDefinition() == typeof(Nullable<>))
-                {
-                    type = type.GetValueType();
-                    continue;
-                }
-
-                return BondDataType.BT_UNAVAILABLE;
-            }
+            return Reflection.GetBondDataType(type);
         }
 
         /// <summary>
         /// Get the ListSubType value for the Type
         /// </summary>
-        public static ListSubType GetBondListDataType(this Type type)
+        [Obsolete("Use Bond.Reflection.GetBondListDataType instead. Bond.BondReflection will be removed in a subsequent version.")]
+        public static ListSubType GetBondListDataType(Type type)
         {
-            while (true)
-            {
-                if (type.IsBondNullable())
-                    return ListSubType.NULLABLE_SUBTYPE;
-
-                if (type.IsBondBlob())
-                    return ListSubType.BLOB_SUBTYPE;
-
-                if (type.IsBondList())
-                    return ListSubType.NO_SUBTYPE;
-
-                if (type.IsGenericType() && type.GetGenericTypeDefinition() == typeof(Nullable<>))
-                {
-                    type = type.GetValueType();
-                    continue;
-                }
-
-                return ListSubType.NO_SUBTYPE;
-            }
+            return Reflection.GetBondListDataType(type);
         }
 
         /// <summary>
         /// Get the Type representing the base schema or null if the schema has no base
         /// </summary>
-        public static Type GetBaseSchemaType(this Type type)
+        [Obsolete("Use Bond.Reflection.GetBaseSchemaType instead. Bond.BondReflection will be removed in a subsequent version.")]
+        public static Type GetBaseSchemaType(Type type)
         {
-            if (type.IsClass())
-            {
-                var baseType = type.GetBaseType();
-                return baseType != null && baseType.GetAttribute<SchemaAttribute>() != null ? baseType : null;
-            }
-
-            if (type.IsInterface())
-            {
-                // Get all base interfaces. In case if an inheritance chain longer than 2, this returns all 
-                // the base interfaces flattened in no particular order, so we have to find the direct parent.
-                var baseInterfaces = type.GetInterfaces()
-                    .Where(t => t.GetAttribute<SchemaAttribute>() != null).ToArray();
-
-                for (var i = 0; i < baseInterfaces.Length; i++)
-                {
-                    var baseInterface = baseInterfaces[i];
-                    var indirectBaseInterfacesCount =
-                        baseInterface.GetInterfaces()
-                        .Count(t => t.GetAttribute<SchemaAttribute>() != null);
-
-                    if (indirectBaseInterfacesCount == baseInterfaces.Length - 1)
-                    {
-                        return baseInterface;
-                    }
-                }
-            }
-
-            return null;
+            return Reflection.GetBaseSchemaType(type);
         }
 
         /// <summary>
@@ -338,499 +171,10 @@ namespace Bond
         /// and can provide schema information that is not available on the actual 
         /// property/field type.
         /// </remarks>
-        public static Type GetSchemaType(this ISchemaField schemaField)
+        [Obsolete("Use Bond.Reflection.GetSchemaType instead. Bond.BondReflection will be removed in a subsequent version.")]
+        public static Type GetSchemaType(ISchemaField schemaField)
         {
-            var type = schemaField.MemberType;
-
-            var typeAttr = schemaField.GetAttribute<TypeAttribute>();
-            if (typeAttr != null)
-            {
-                type = ResolveTypeArgumentTags(type, typeAttr.Value);
-            }
-
-            return type;
+            return Reflection.GetSchemaType(schemaField);
         }
-
-        #endregion
-
-        #region Internal
-
-        /// <summary>
-        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
-        /// </summary>
-        /// <typeparam name="T">Input type of the lambda.</typeparam>
-        /// <typeparam name="TResult">Return type of the lambda.</typeparam>
-        /// <param name="expression">Lambda expression to extract reflection information from</param>
-        /// <returns>Member information of the top-level node in the body of the lambda expression. An exception occurs if this node does not contain member information.</returns>
-        /// <example>
-        /// To obtain the MethodInfo for the "int Math::Abs(int)" overload, you can write:
-        /// <code>(MethodInfo)BondReflection.InfoOf((int x) => Math.Abs(x))</code>
-        /// </example>
-        static MemberInfo InfoOf<T, TResult>(Expression<Func<T, TResult>> expression)
-        {
-            if (expression == null)
-                throw new ArgumentNullException("expression");
-
-            return InfoOf(expression.Body);
-        }
-
-        /// <summary>
-        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
-        /// </summary>
-        /// <typeparam name="T">Input type of the lambda.</typeparam>
-        /// <typeparam name="TResult">Return type of the lambda.</typeparam>
-        /// <param name="expression">Lambda expression to extract reflection information from</param>
-        /// <returns>Member information of the top-level node in the body of the lambda expression. Return null if that member is not a method. An exception occurs if this node does not contain member information.</returns>
-        /// <example>
-        /// To obtain the MethodInfo for the "int Math::Abs(int)" overload, you can write:
-        /// <code>BondReflection.MethodInfoOf((int x) => Math.Abs(x))</code>
-        /// </example>
-        internal static MethodInfo MethodInfoOf<T, TResult>(Expression<Func<T, TResult>> expression)
-        {
-            return InfoOf(expression) as MethodInfo;
-        }
-
-        /// <summary>
-        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
-        /// </summary>
-        /// <typeparam name="T">Input type of the lambda.</typeparam>
-        /// <typeparam name="TResult">Return type of the lambda.</typeparam>
-        /// <param name="expression">Lambda expression to extract reflection information from</param>
-        /// <returns>Member information of the top-level node in the body of the lambda expression. Return null if the member is not a generic method definition. An exception occurs if this node does not contain member information.</returns>
-        /// <example>
-        /// To obtain the generic method definition for some "int Foo::Bar&lt;T>(T)" overload, you can write:
-        /// <code>BondReflection.GenericMethodInfoOf((int x) => Foo.Bar(x))</code>, which returns the definition Foo.Bar&lt;>
-        /// </example>
-        internal static MethodInfo GenericMethodInfoOf<T, TResult>(Expression<Func<T, TResult>> expression)
-        {
-            var methodInfo = MethodInfoOf(expression);
-            return methodInfo == null ? null : methodInfo.GetGenericMethodDefinition();
-        }
-
-        /// <summary>
-        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
-        /// </summary>
-        /// <typeparam name="T">Input type of the lambda.</typeparam>
-        /// <typeparam name="TResult">Return type of the lambda.</typeparam>
-        /// <param name="expression">Lambda expression to extract reflection information from</param>
-        /// <returns>Member information of the top-level node in the body of the lambda expression. Return null if the member is not a PropertyInfo. An exception occurs if this node does not contain member information.</returns>
-        /// <example>
-        /// To obtain the PropertyInfo for the "int Foo::SomeProperty", you can write:
-        /// <code>BondReflection.PropertyInfoOf((Foo f) => f.SomeProperty)</code>
-        /// </example>
-        internal static PropertyInfo PropertyInfoOf<T, TResult>(Expression<Func<T, TResult>> expression)
-        {
-            return InfoOf(expression) as PropertyInfo;
-        }
-
-        /// <summary>
-        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
-        /// </summary>
-        /// <typeparam name="T">Input type of the lambda.</typeparam>
-        /// <typeparam name="TResult">Return type of the lambda.</typeparam>
-        /// <param name="expression">Lambda expression to extract reflection information from</param>
-        /// <returns>Member information of the top-level node in the body of the lambda expression. Return null if the member is not a FieldInfo. An exception occurs if this node does not contain member information.</returns>
-        /// <example>
-        /// To obtain the FieldInfo for the "int Foo::someField" field, you can write:
-        /// <code>BondReflection.FieldInfoOf((Foo f) => f.someField)</code>
-        /// </example>
-        internal static FieldInfo FieldInfoOf<T, TResult>(Expression<Func<T, TResult>> expression)
-        {
-            return InfoOf(expression) as FieldInfo;
-        }
-
-        /// <summary>
-        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
-        /// </summary>
-        /// <typeparam name="TResult">Return type of the lambda.</typeparam>
-        /// <param name="expression">Lambda expression to extract reflection information from</param>
-        /// <returns>Member information of the top-level node in the body of the lambda expression. An exception occurs if this node does not contain member information.</returns>
-        /// <example>
-        /// To obtain the PropertyInfo of "DateTime DateTime::Now { get; }", you can write:
-        /// <code>(PropertyInfo)BondReflection.InfoOf(() => DateTime.Now)</code>
-        /// </example>
-        static MemberInfo InfoOf<TResult>(Expression<Func<TResult>> expression)
-        {
-            if (expression == null)
-                throw new ArgumentNullException("expression");
-
-            return InfoOf(expression.Body);
-        }
-
-        /// <summary>
-        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
-        /// </summary>
-        /// <typeparam name="TResult">Return type of the lambda.</typeparam>
-        /// <param name="expression">Lambda expression to extract reflection information from</param>
-        /// <returns>Member information of the top-level node in the body of the lambda expression. Return null if that member is not a method. An exception occurs if this node does not contain member information.</returns>
-        /// <example>
-        /// To obtain the MethodInfo for the "int Math::Abs(int)" overload, you can write:
-        /// <code>BondReflection.MethodInfoOf(() => Math.Abs(default(int)))</code>
-        /// </example>
-        internal static MethodInfo MethodInfoOf<TResult>(Expression<Func<TResult>> expression)
-        {
-            return InfoOf(expression) as MethodInfo;
-        }
-
-        /// <summary>
-        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
-        /// </summary>
-        /// <typeparam name="TResult">Return type of the lambda.</typeparam>
-        /// <param name="expression">Lambda expression to extract reflection information from</param>
-        /// <returns>Member information of the top-level node in the body of the lambda expression. Return null if the member is not a generic method definition. An exception occurs if this node does not contain member information.</returns>
-        /// <example>
-        /// To obtain the generic method definition for some "int Foo::Bar&lt;T>(T)" overload, you can write:
-        /// <code>BondReflection.GenericMethodInfoOf(() => Foo.Bar(default(int)))</code>, which returns the definition Foo.Bar&lt;>
-        /// </example>
-        internal static MethodInfo GenericMethodInfoOf<TResult>(Expression<Func<TResult>> expression)
-        {
-            var methodInfo = MethodInfoOf(expression);
-            return methodInfo == null ? null : methodInfo.GetGenericMethodDefinition();
-        }
-
-        /// <summary>
-        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
-        /// </summary>
-        /// <typeparam name="T">Input type of the lambda.</typeparam>
-        /// <param name="expression">Lambda expression to extract reflection information from</param>
-        /// <returns>Member information of the top-level node in the body of the lambda expression. An exception occurs if this node does not contain member information.</returns>
-        /// <example>
-        /// To obtain the MethodInfo for the "void Console::WriteLine(string)" overload, you can write:
-        /// <code>(MethodInfo)BondReflection.InfoOf((string s) => Console.WriteLine(s))</code>
-        /// </example>
-        static MemberInfo InfoOf<T>(Expression<Action<T>> expression)
-        {
-            if (expression == null)
-                throw new ArgumentNullException("expression");
-
-            return InfoOf(expression.Body);
-        }
-
-        /// <summary>
-        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
-        /// </summary>
-        /// <typeparam name="T">Input type of the lambda.</typeparam>
-        /// <param name="expression">Lambda expression to extract reflection information from</param>
-        /// <returns>Member information of the top-level node in the body of the lambda expression. Return null if that member is not a method. An exception occurs if this node does not contain member information.</returns>
-        /// <example>
-        /// To obtain the MethodInfo for the "void Foo::DoThing(int)" overload, you can write:
-        /// <code>BondReflection.MethodInfoOf(() => Foo.DoThing(default(int)))</code>
-        /// </example>
-        internal static MethodInfo MethodInfoOf<T>(Expression<Action<T>> expression)
-        {
-            return InfoOf(expression) as MethodInfo;
-        }
-
-        /// <summary>
-        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
-        /// </summary>
-        /// <typeparam name="T">Input type of the lambda.</typeparam>
-        /// <param name="expression">Lambda expression to extract reflection information from</param>
-        /// <returns>Member information of the top-level node in the body of the lambda expression. Return null if the member is not a generic method definition. An exception occurs if this node does not contain member information.</returns>
-        /// <example>
-        /// To obtain the generic method definition for some "void Foo::Bar&lt;T>(T)" overload, you can write:
-        /// <code>BondReflection.GenericMethodInfoOf(() => Foo.Bar(default(int)))</code>, which returns the definition Foo.Bar&lt;>
-        /// </example>
-        internal static MethodInfo GenericMethodInfoOf<T>(Expression<Action<T>> expression)
-        {
-            var methodInfo = MethodInfoOf(expression);
-            return methodInfo == null ? null : methodInfo.GetGenericMethodDefinition();
-        }
-
-        /// <summary>
-        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
-        /// </summary>
-        /// <param name="expression">Lambda expression to extract reflection information from</param>
-        /// <returns>Member information of the top-level node in the body of the lambda expression. An exception occurs if this node does not contain member information.</returns>
-        static MemberInfo InfoOf(Expression expression)
-        {
-            if (expression == null)
-                throw new ArgumentNullException("expression");
-
-            MethodCallExpression mce;
-            MemberExpression me;
-            NewExpression ne;
-            UnaryExpression ue;
-            BinaryExpression be;
-
-            if ((mce = expression as MethodCallExpression) != null)
-            {
-                return mce.Method;
-            }
-            else if ((me = expression as MemberExpression) != null)
-            {
-                return me.Member;
-            }
-            else if ((ne = expression as NewExpression) != null)
-            {
-                return ne.Constructor;
-            }
-            else if ((ue = expression as UnaryExpression) != null)
-            {
-                if (ue.Method != null)
-                {
-                    return ue.Method;
-                }
-            }
-            else if ((be = expression as BinaryExpression) != null)
-            {
-                if (be.Method != null)
-                {
-                    return be.Method;
-                }
-            }
-
-            throw new NotSupportedException("Expression tree type doesn't have an extractable MemberInfo object.");
-        }
-
-        internal static Modifier GetModifier(this ISchemaField schemaField)
-        {
-            return schemaField.GetAttribute<RequiredAttribute>() != null
-                ? Modifier.Required
-                : schemaField.GetAttribute<RequiredOptionalAttribute>() != null
-                ? Modifier.RequiredOptional
-                : Modifier.Optional;
-        }
-
-        internal static int GetHierarchyDepth(this RuntimeSchema schema)
-        {
-            if (!schema.IsStruct)
-                return 0;
-
-            var depth = 0;
-            for (var type = schema.TypeDef; type != null; type = schema.SchemaDef.structs[type.struct_def].base_def)
-                depth++;
-            return depth;
-        }
-
-        internal static int GetHierarchyDepth(this Type type)
-        {
-            var depth = 0;
-            for (; type != null; type = type.GetBaseSchemaType()) depth++;
-            return depth;
-        }
-
-        internal static string GetSchemaName(this Type type)
-        {
-            string name;
-
-            if (type.IsBondStruct() || type.IsEnum())
-            {
-                name = type.Name;
-                var n = name.IndexOf('`');
-                if (n >= 0)
-                    name = name.Remove(n);
-            }
-            else if (type.IsBondBlob())
-            {
-                return "blob";
-            }
-            else if (type.IsBonded())
-            {
-                name = "bonded";
-            }
-            else if (type.IsBondNullable())
-            {
-                name = "nullable";
-            }
-            else
-            {
-                name = bondTypeName[type.GetBondDataType()];
-            }
-
-            if (!type.IsGenericType())
-                return name;
-
-            var args = type.GetGenericArguments();
-            var builder = new StringBuilder(name, args.Length * 64);
-
-            builder.Append("<");
-            for (var i = 0; i < args.Length; ++i)
-            {
-                if (i != 0)
-                    builder.Append(", ");
-
-                builder.Append(args[i].GetSchemaFullName());
-            }
-            builder.Append(">");
-            return builder.ToString();
-        }
-
-        internal static string GetSchemaFullName(this Type type)
-        {
-            if (type.IsBondStruct() || type.IsEnum())
-                return type.GetSchemaNamespace() + "." + type.GetSchemaName();
-
-            return type.GetSchemaName();
-        }
-
-        static string GetSchemaNamespace(this Type type)
-        {
-            var attr = type.GetAttribute<NamespaceAttribute>();
-            if (attr != null)
-                return attr.Value;
-
-            return type.Namespace;
-        }
-
-        static T GetAttribute<T>(this MemberInfo type)
-            where T : class
-        {
-            return type.GetCustomAttributes(typeof(T), false).FirstOrDefault() as T;
-        }
-
-        internal static T GetAttribute<T>(this Type type)
-            where T : class
-        {
-            // ReSharper disable once RedundantCast
-            // This explicit cast is needed because when targeting non-portable runtime,
-            // type.GetTypeInfo returns an object which is also a Type, causing wrong call.
-            return GetAttribute<T>(type.GetTypeInfo() as MemberInfo);
-        }
-
-        static T GetAttribute<T>(this ISchemaField schemaField)
-            where T : class
-        {
-            return schemaField.MemberInfo.GetAttribute<T>();
-        }
-
-        static Type ResolveTypeArgumentTags(Type memberType, Type schemaType)
-        {
-            if (schemaType.IsGenericType())
-            {
-                Type[] memberTypeArguments;
-
-                var schemaGenericType = schemaType.GetGenericTypeDefinition();
-                var memberGenericType = memberType.IsGenericType() ? memberType.GetGenericTypeDefinition() : null;
-
-                if ((schemaGenericType == typeof(Tag.nullable<>) && memberGenericType != typeof(Nullable<>)) ||
-                    (schemaGenericType == typeof(Tag.bonded<>) && memberGenericType != typeof(IBonded<>)))
-                {
-                    memberTypeArguments = new[] { memberType };
-                }
-                else
-                {
-                    memberTypeArguments = memberType.GetGenericArguments();
-                }
-
-                return schemaGenericType.MakeGenericType(Enumerable.Zip(
-                    memberTypeArguments,
-                    schemaType.GetGenericArguments(), 
-                    ResolveTypeArgumentTags).ToArray());
-            }
-
-            return (schemaType == typeof(Tag.structT) || schemaType == typeof(Tag.classT)) ?
-                memberType : 
-                schemaType;
-        }
-
-        internal static Type GetObjectType(this Type schemaType)
-        {
-            if (schemaType == typeof(Tag.wstring))
-            {
-                return typeof(string);
-            }
-
-            if (schemaType == typeof(Tag.blob))
-            {
-                return typeof(ArraySegment<byte>);
-            }
-            
-            if (schemaType.IsGenericType())
-            {
-                return schemaType.GetGenericTypeDefinition().MakeGenericType(
-                    schemaType.GetGenericArguments().Select(type =>
-                    {
-                        if (type.IsGenericType())
-                        {
-                            var genericType = type.GetGenericTypeDefinition();
-                            if (genericType == typeof(Tag.nullable<>))
-                            {
-                                var nullableValue = type.GetGenericArguments()[0];
-                                return nullableValue.IsClass() || nullableValue.IsBondBlob()
-                                    ? nullableValue.GetObjectType()
-                                    : typeof(Nullable<>).MakeGenericType(nullableValue.GetObjectType());
-                            }
-
-                            if (genericType == typeof(Tag.bonded<>))
-                            {
-                                return typeof(IBonded<>).MakeGenericType(type.GetGenericArguments()[0].GetObjectType());
-                            }
-                        }
-
-                        return type.GetObjectType();
-                    }).ToArray());
-            }
-
-            return schemaType;
-        }
-
-        internal static object GetDefaultValue(this ISchemaField schemaField)
-        {
-            var declaringType = schemaField.DeclaringType;
-            var declaringTypeInfo = declaringType.GetTypeInfo();
-            var defaultAttribute = schemaField.GetAttribute<DefaultAttribute>(); 
-
-            // For interfaces determine member default value from the type and/or DefaultAttribute
-            if (declaringTypeInfo.IsInterface)
-            {
-                var schemaType = schemaField.GetSchemaType();
-
-                if (defaultAttribute != null)
-                {
-                    if (defaultAttribute.Value == null)
-                    {
-                        return null;
-                    }
-
-                    if (schemaType.IsBondNullable() || schemaType.IsBondStruct() || schemaType.IsBondContainer())
-                    {
-                        InvalidDefaultAttribute(schemaField, defaultAttribute.Value);
-                    }
-
-                    return defaultAttribute.Value;
-                }
-                else
-                {
-                    if (schemaType.IsBondNullable())
-                    {
-                        return null;
-                    }
-
-                    if (schemaType.IsBondStruct() || schemaType.IsBonded() || schemaType.IsBondContainer() || schemaType.IsBondBlob())
-                    {
-                        return Empty;
-                    }
-
-                    if (schemaType.IsBondString())
-                    {
-                        return string.Empty;
-                    }
-
-                    return Activator.CreateInstance(schemaField.MemberType);
-                }
-            }
-
-            if (defaultAttribute != null)
-            {
-                InvalidDefaultAttribute(schemaField, defaultAttribute.Value);
-            }
-            
-            // For classes create a default instance and get the actual default value of the member
-            var objectType = declaringType.GetObjectType();
-            var objectMemeber = objectType.GetSchemaFields().Single(m => m.Id == schemaField.Id);
-            var obj = Activator.CreateInstance(objectType);
-            var defaultValue = objectMemeber.GetValue(obj);
-            return defaultValue;
-        }
-
-        static void InvalidDefaultAttribute(ISchemaField schemaField, object value)
-        {
-            throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
-                "Invalid default value '{2}' specified by DefaultAttribute for {0}.{1}", 
-                schemaField.DeclaringType, schemaField.Name, value == null ? "null" : value.ToString()));
-        }
-
-        #endregion
     }
 }

--- a/cs/src/core/Comparer.cs
+++ b/cs/src/core/Comparer.cs
@@ -8,7 +8,7 @@ namespace Bond
     using System.Collections.Generic;
     using System.Linq.Expressions;
     using System.Reflection;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     /// <summary>
     /// Utility for comparing instances of Bond schemas for equality
@@ -31,9 +31,9 @@ namespace Bond
         {
             public static readonly Func<T, T, bool> Equal;
 
-            static readonly MethodInfo blobCompareData = BondReflection.MethodInfoOf(() => Blob.CompareData(default(ArraySegment<byte>), default(ArraySegment<byte>)));
-            static readonly MethodInfo moveNext =        BondReflection.MethodInfoOf((IEnumerator ie) => ie.MoveNext());
-            static readonly MethodInfo comparerEqual =   BondReflection.GenericMethodInfoOf(() => Comparer.Equal(default(T), default(T)));
+            static readonly MethodInfo blobCompareData = Reflection.MethodInfoOf(() => Blob.CompareData(default(ArraySegment<byte>), default(ArraySegment<byte>)));
+            static readonly MethodInfo moveNext =        Reflection.MethodInfoOf((IEnumerator ie) => ie.MoveNext());
+            static readonly MethodInfo comparerEqual =   Reflection.GenericMethodInfoOf(() => Comparer.Equal(default(T), default(T)));
 
             static Cache()
             {

--- a/cs/src/core/Deserializer.cs
+++ b/cs/src/core/Deserializer.cs
@@ -10,7 +10,7 @@ namespace Bond
     using System.Reflection;
     using Bond.Expressions;
     using Bond.IO;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     public static class Deserialize
     {

--- a/cs/src/core/GenericFactory.cs
+++ b/cs/src/core/GenericFactory.cs
@@ -6,7 +6,7 @@ namespace Bond
     using System;
     using System.Linq.Expressions;
     using Bond.Expressions;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     /// <summary>
     /// Generic object factory

--- a/cs/src/core/Property.cs
+++ b/cs/src/core/Property.cs
@@ -5,7 +5,7 @@ namespace Bond
 {
     using System;
     using System.Reflection;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     internal class Property : ISchemaField
     {

--- a/cs/src/core/Reflection.cs
+++ b/cs/src/core/Reflection.cs
@@ -1,0 +1,836 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Bond
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Reflection;
+    using System.Text;
+    using Bond.Internal.Reflection;
+
+    public static class Reflection
+    {
+        static readonly object Empty = new object();
+        static readonly Dictionary<BondDataType, string> bondTypeName = new Dictionary<BondDataType, string>
+        {
+            {BondDataType.BT_BOOL, "bool"},
+            {BondDataType.BT_UINT8, "uint8"},
+            {BondDataType.BT_UINT16, "uint16"},
+            {BondDataType.BT_UINT32, "uint32"},
+            {BondDataType.BT_UINT64, "uint64"},
+            {BondDataType.BT_FLOAT, "float"},
+            {BondDataType.BT_DOUBLE, "double"},
+            {BondDataType.BT_STRING, "string"},
+            {BondDataType.BT_LIST, "list"},
+            {BondDataType.BT_SET, "set"},
+            {BondDataType.BT_MAP, "map"},
+            {BondDataType.BT_INT8, "int8"},
+            {BondDataType.BT_INT16, "int16"},
+            {BondDataType.BT_INT32, "int32"},
+            {BondDataType.BT_INT64, "int64"},
+            {BondDataType.BT_WSTRING, "wstring"}
+        };
+
+        #region Public APIs
+
+        /// <summary>
+        /// Get list of fields for a Bond schema
+        /// </summary>
+        public static IEnumerable<ISchemaField> GetSchemaFields(this Type type)
+        {
+            var fields = from fieldInfo in type.GetDeclaredFields().Where(f => f.IsPublic)
+                         let idAttr = fieldInfo.GetAttribute<IdAttribute>()
+                         where idAttr != null
+                         select new Field(fieldInfo, idAttr.Value) as ISchemaField;
+
+            var properties =
+                from propertyInfo in type.GetDeclaredProperties()
+                let idAttr = propertyInfo.GetAttribute<IdAttribute>()
+                where idAttr != null
+                select new Property(propertyInfo, idAttr.Value) as ISchemaField;
+
+            var concatenated = fields.Concat(properties);
+            return concatenated.OrderBy(m => m.Id);
+        }
+
+        /// <summary>
+        /// Get the inner Type of composite/container types
+        /// </summary>
+        public static Type GetValueType(this Type type)
+        {
+            if (type.IsBondNullable() || type.IsBonded())
+                return type.GetGenericArguments()[0];
+
+            if (type.IsArray)
+                return type.GetElementType();
+
+            if (type.IsBondBlob())
+                return typeof(sbyte);
+
+            return type.GetMethod(typeof(IEnumerable<>), "GetEnumerator")
+                .ReturnType
+                .GetDeclaredProperty("Current")
+                .PropertyType;
+        }
+
+        /// <summary>
+        /// Get the key and value Type for a map
+        /// </summary>
+        public static KeyValuePair<Type, Type> GetKeyValueType(this Type type)
+        {
+            var types = GetValueType(type).GetGenericArguments();
+
+            if (types.Length != 2)
+            {
+                throw new InvalidOperationException("Expected generic type with 2 type arguments.");
+            }
+
+            return new KeyValuePair<Type, Type>(types[0], types[1]);
+        }
+
+        /// <summary>
+        /// Get a value indicating whether the Type is a Bond schema
+        /// </summary>
+        public static bool IsBondStruct(this Type type)
+        {
+            return null != type.GetAttribute<SchemaAttribute>();
+        }
+
+        /// <summary>
+        /// Get a value indicating whether the Type is a bonded&lt;T>
+        /// </summary>
+        public static bool IsBonded(this Type type)
+        {
+            if (type.IsGenericType())
+            {
+                var definition = type.GetGenericTypeDefinition();
+                return definition == typeof(IBonded<>) || definition == typeof(Tag.bonded<>);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Get a value indicating whether the Type is a Bond nullable type
+        /// </summary>
+        public static bool IsBondNullable(this Type type)
+        {
+            return type.IsGenericType() &&
+                   (type.GetGenericTypeDefinition() == typeof(Tag.nullable<>));
+        }
+
+        /// <summary>
+        /// Get a value indicating whether the Type is a Bond string
+        /// </summary>
+        public static bool IsBondString(this Type type)
+        {
+            return type == typeof(Tag.wstring) || type == typeof(string);
+        }
+
+        /// <summary>
+        /// Get a value indicating whether the Type is a Bond blob
+        /// </summary>
+        public static bool IsBondBlob(this Type type)
+        {
+            return type == typeof(Tag.blob) || type == typeof(ArraySegment<byte>);
+        }
+
+        /// <summary>
+        /// Get a value indicating whether the Type is a Bond list
+        /// or a Bond vector
+        /// </summary>
+        public static bool IsBondList(this Type type)
+        {
+            if (type.IsGenericType())
+            {
+                var genericType = type.GetGenericTypeDefinition();
+                if (genericType == typeof(IList<>) || genericType == typeof(ICollection<>))
+                    return true;
+            }
+
+            return typeof(IList).IsAssignableFrom(type) ||
+                   typeof(ICollection).IsAssignableFrom(type);
+        }
+
+        /// <summary>
+        /// Get a value indicating whether the Type is a Bond map
+        /// </summary>
+        public static bool IsBondMap(this Type type)
+        {
+            if (type.IsGenericType())
+            {
+                var genericType = type.GetGenericTypeDefinition();
+                if (genericType == typeof(IDictionary<,>))
+                    return true;
+            }
+
+            return typeof(IDictionary).IsAssignableFrom(type);
+        }
+
+        /// <summary>
+        /// Get a value indicating whether the Type is a Bond set
+        /// </summary>
+        public static bool IsBondSet(this Type type)
+        {
+            if (!type.IsGenericType())
+                return false;
+
+            return typeof(ISet<>).MakeGenericType(type.GetGenericArguments()[0]).IsAssignableFrom(type);
+        }
+
+        /// <summary>
+        /// Get a value indicating whether the Type is a Bond container
+        /// </summary>
+        public static bool IsBondContainer(this Type type)
+        {
+            return type.IsBondList() ||
+                   type.IsBondSet() ||
+                   type.IsBondMap() ||
+                   type.IsBondBlob();
+        }
+
+        /// <summary>
+        /// Get the BondDataType value for the Type
+        /// </summary>
+        public static BondDataType GetBondDataType(this Type type)
+        {
+            while (true)
+            {
+                if (type.IsBondStruct() || type.IsBonded())
+                    return BondDataType.BT_STRUCT;
+
+                if (type.IsBondNullable())
+                    return BondDataType.BT_LIST;
+
+                if (type.IsBondMap())
+                    return BondDataType.BT_MAP;
+
+                if (type.IsBondSet())
+                    return BondDataType.BT_SET;
+
+                if (type.IsBondList() || type.IsBondBlob())
+                    return BondDataType.BT_LIST;
+
+                if (type.IsEnum())
+                    return BondDataType.BT_INT32;
+
+                if (type == typeof(string))
+                    return BondDataType.BT_STRING;
+
+                if (type == typeof(Tag.wstring))
+                    return BondDataType.BT_WSTRING;
+
+                if (type == typeof(bool))
+                    return BondDataType.BT_BOOL;
+
+                if (type == typeof(byte))
+                    return BondDataType.BT_UINT8;
+
+                if (type == typeof(UInt16))
+                    return BondDataType.BT_UINT16;
+
+                if (type == typeof(UInt32))
+                    return BondDataType.BT_UINT32;
+
+                if (type == typeof(UInt64))
+                    return BondDataType.BT_UINT64;
+
+                if (type == typeof(float))
+                    return BondDataType.BT_FLOAT;
+
+                if (type == typeof(double))
+                    return BondDataType.BT_DOUBLE;
+
+                if (type == typeof(sbyte))
+                    return BondDataType.BT_INT8;
+
+                if (type == typeof(Int16))
+                    return BondDataType.BT_INT16;
+
+                if (type == typeof(Int32))
+                    return BondDataType.BT_INT32;
+
+                if (type == typeof(Int64))
+                    return BondDataType.BT_INT64;
+
+                if (type.IsGenericType() && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+                {
+                    type = type.GetValueType();
+                    continue;
+                }
+
+                return BondDataType.BT_UNAVAILABLE;
+            }
+        }
+
+        /// <summary>
+        /// Get the ListSubType value for the Type
+        /// </summary>
+        public static ListSubType GetBondListDataType(this Type type)
+        {
+            while (true)
+            {
+                if (type.IsBondNullable())
+                    return ListSubType.NULLABLE_SUBTYPE;
+
+                if (type.IsBondBlob())
+                    return ListSubType.BLOB_SUBTYPE;
+
+                if (type.IsBondList())
+                    return ListSubType.NO_SUBTYPE;
+
+                if (type.IsGenericType() && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+                {
+                    type = type.GetValueType();
+                    continue;
+                }
+
+                return ListSubType.NO_SUBTYPE;
+            }
+        }
+
+        /// <summary>
+        /// Get the Type representing the base schema or null if the schema has no base
+        /// </summary>
+        public static Type GetBaseSchemaType(this Type type)
+        {
+            if (type.IsClass())
+            {
+                var baseType = type.GetBaseType();
+                return baseType != null && baseType.GetAttribute<SchemaAttribute>() != null ? baseType : null;
+            }
+
+            if (type.IsInterface())
+            {
+                // Get all base interfaces. In case if an inheritance chain longer than 2, this returns all 
+                // the base interfaces flattened in no particular order, so we have to find the direct parent.
+                var baseInterfaces = type.GetInterfaces()
+                    .Where(t => t.GetAttribute<SchemaAttribute>() != null).ToArray();
+
+                for (var i = 0; i < baseInterfaces.Length; i++)
+                {
+                    var baseInterface = baseInterfaces[i];
+                    var indirectBaseInterfacesCount =
+                        baseInterface.GetInterfaces()
+                        .Count(t => t.GetAttribute<SchemaAttribute>() != null);
+
+                    if (indirectBaseInterfacesCount == baseInterfaces.Length - 1)
+                    {
+                        return baseInterface;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Get the Type of the schema field, including any type annotations from TypeAttribute
+        /// </summary>
+        /// <remarks>
+        /// In some cases this may not be the actual type of the property or field.
+        /// If the property or field has a TypeAttribute, this will be the attribute's value
+        /// and can provide schema information that is not available on the actual 
+        /// property/field type.
+        /// </remarks>
+        public static Type GetSchemaType(this ISchemaField schemaField)
+        {
+            var type = schemaField.MemberType;
+
+            var typeAttr = schemaField.GetAttribute<TypeAttribute>();
+            if (typeAttr != null)
+            {
+                type = ResolveTypeArgumentTags(type, typeAttr.Value);
+            }
+
+            return type;
+        }
+
+        #endregion
+
+        #region Internal
+
+        /// <summary>
+        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
+        /// </summary>
+        /// <typeparam name="T">Input type of the lambda.</typeparam>
+        /// <typeparam name="TResult">Return type of the lambda.</typeparam>
+        /// <param name="expression">Lambda expression to extract reflection information from</param>
+        /// <returns>Member information of the top-level node in the body of the lambda expression. An exception occurs if this node does not contain member information.</returns>
+        /// <example>
+        /// To obtain the MethodInfo for the "int Math::Abs(int)" overload, you can write:
+        /// <code>(MethodInfo)BondReflection.InfoOf((int x) => Math.Abs(x))</code>
+        /// </example>
+        static MemberInfo InfoOf<T, TResult>(Expression<Func<T, TResult>> expression)
+        {
+            if (expression == null)
+                throw new ArgumentNullException("expression");
+
+            return InfoOf(expression.Body);
+        }
+
+        /// <summary>
+        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
+        /// </summary>
+        /// <typeparam name="T">Input type of the lambda.</typeparam>
+        /// <typeparam name="TResult">Return type of the lambda.</typeparam>
+        /// <param name="expression">Lambda expression to extract reflection information from</param>
+        /// <returns>Member information of the top-level node in the body of the lambda expression. Return null if that member is not a method. An exception occurs if this node does not contain member information.</returns>
+        /// <example>
+        /// To obtain the MethodInfo for the "int Math::Abs(int)" overload, you can write:
+        /// <code>BondReflection.MethodInfoOf((int x) => Math.Abs(x))</code>
+        /// </example>
+        internal static MethodInfo MethodInfoOf<T, TResult>(Expression<Func<T, TResult>> expression)
+        {
+            return InfoOf(expression) as MethodInfo;
+        }
+
+        /// <summary>
+        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
+        /// </summary>
+        /// <typeparam name="T">Input type of the lambda.</typeparam>
+        /// <typeparam name="TResult">Return type of the lambda.</typeparam>
+        /// <param name="expression">Lambda expression to extract reflection information from</param>
+        /// <returns>Member information of the top-level node in the body of the lambda expression. Return null if the member is not a generic method definition. An exception occurs if this node does not contain member information.</returns>
+        /// <example>
+        /// To obtain the generic method definition for some "int Foo::Bar&lt;T>(T)" overload, you can write:
+        /// <code>BondReflection.GenericMethodInfoOf((int x) => Foo.Bar(x))</code>, which returns the definition Foo.Bar&lt;>
+        /// </example>
+        internal static MethodInfo GenericMethodInfoOf<T, TResult>(Expression<Func<T, TResult>> expression)
+        {
+            var methodInfo = MethodInfoOf(expression);
+            return methodInfo == null ? null : methodInfo.GetGenericMethodDefinition();
+        }
+
+        /// <summary>
+        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
+        /// </summary>
+        /// <typeparam name="T">Input type of the lambda.</typeparam>
+        /// <typeparam name="TResult">Return type of the lambda.</typeparam>
+        /// <param name="expression">Lambda expression to extract reflection information from</param>
+        /// <returns>Member information of the top-level node in the body of the lambda expression. Return null if the member is not a PropertyInfo. An exception occurs if this node does not contain member information.</returns>
+        /// <example>
+        /// To obtain the PropertyInfo for the "int Foo::SomeProperty", you can write:
+        /// <code>BondReflection.PropertyInfoOf((Foo f) => f.SomeProperty)</code>
+        /// </example>
+        internal static PropertyInfo PropertyInfoOf<T, TResult>(Expression<Func<T, TResult>> expression)
+        {
+            return InfoOf(expression) as PropertyInfo;
+        }
+
+        /// <summary>
+        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
+        /// </summary>
+        /// <typeparam name="T">Input type of the lambda.</typeparam>
+        /// <typeparam name="TResult">Return type of the lambda.</typeparam>
+        /// <param name="expression">Lambda expression to extract reflection information from</param>
+        /// <returns>Member information of the top-level node in the body of the lambda expression. Return null if the member is not a FieldInfo. An exception occurs if this node does not contain member information.</returns>
+        /// <example>
+        /// To obtain the FieldInfo for the "int Foo::someField" field, you can write:
+        /// <code>BondReflection.FieldInfoOf((Foo f) => f.someField)</code>
+        /// </example>
+        internal static FieldInfo FieldInfoOf<T, TResult>(Expression<Func<T, TResult>> expression)
+        {
+            return InfoOf(expression) as FieldInfo;
+        }
+
+        /// <summary>
+        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
+        /// </summary>
+        /// <typeparam name="TResult">Return type of the lambda.</typeparam>
+        /// <param name="expression">Lambda expression to extract reflection information from</param>
+        /// <returns>Member information of the top-level node in the body of the lambda expression. An exception occurs if this node does not contain member information.</returns>
+        /// <example>
+        /// To obtain the PropertyInfo of "DateTime DateTime::Now { get; }", you can write:
+        /// <code>(PropertyInfo)BondReflection.InfoOf(() => DateTime.Now)</code>
+        /// </example>
+        static MemberInfo InfoOf<TResult>(Expression<Func<TResult>> expression)
+        {
+            if (expression == null)
+                throw new ArgumentNullException("expression");
+
+            return InfoOf(expression.Body);
+        }
+
+        /// <summary>
+        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
+        /// </summary>
+        /// <typeparam name="TResult">Return type of the lambda.</typeparam>
+        /// <param name="expression">Lambda expression to extract reflection information from</param>
+        /// <returns>Member information of the top-level node in the body of the lambda expression. Return null if that member is not a method. An exception occurs if this node does not contain member information.</returns>
+        /// <example>
+        /// To obtain the MethodInfo for the "int Math::Abs(int)" overload, you can write:
+        /// <code>BondReflection.MethodInfoOf(() => Math.Abs(default(int)))</code>
+        /// </example>
+        internal static MethodInfo MethodInfoOf<TResult>(Expression<Func<TResult>> expression)
+        {
+            return InfoOf(expression) as MethodInfo;
+        }
+
+        /// <summary>
+        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
+        /// </summary>
+        /// <typeparam name="TResult">Return type of the lambda.</typeparam>
+        /// <param name="expression">Lambda expression to extract reflection information from</param>
+        /// <returns>Member information of the top-level node in the body of the lambda expression. Return null if the member is not a generic method definition. An exception occurs if this node does not contain member information.</returns>
+        /// <example>
+        /// To obtain the generic method definition for some "int Foo::Bar&lt;T>(T)" overload, you can write:
+        /// <code>BondReflection.GenericMethodInfoOf(() => Foo.Bar(default(int)))</code>, which returns the definition Foo.Bar&lt;>
+        /// </example>
+        internal static MethodInfo GenericMethodInfoOf<TResult>(Expression<Func<TResult>> expression)
+        {
+            var methodInfo = MethodInfoOf(expression);
+            return methodInfo == null ? null : methodInfo.GetGenericMethodDefinition();
+        }
+
+        /// <summary>
+        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
+        /// </summary>
+        /// <typeparam name="T">Input type of the lambda.</typeparam>
+        /// <param name="expression">Lambda expression to extract reflection information from</param>
+        /// <returns>Member information of the top-level node in the body of the lambda expression. An exception occurs if this node does not contain member information.</returns>
+        /// <example>
+        /// To obtain the MethodInfo for the "void Console::WriteLine(string)" overload, you can write:
+        /// <code>(MethodInfo)BondReflection.InfoOf((string s) => Console.WriteLine(s))</code>
+        /// </example>
+        static MemberInfo InfoOf<T>(Expression<Action<T>> expression)
+        {
+            if (expression == null)
+                throw new ArgumentNullException("expression");
+
+            return InfoOf(expression.Body);
+        }
+
+        /// <summary>
+        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
+        /// </summary>
+        /// <typeparam name="T">Input type of the lambda.</typeparam>
+        /// <param name="expression">Lambda expression to extract reflection information from</param>
+        /// <returns>Member information of the top-level node in the body of the lambda expression. Return null if that member is not a method. An exception occurs if this node does not contain member information.</returns>
+        /// <example>
+        /// To obtain the MethodInfo for the "void Foo::DoThing(int)" overload, you can write:
+        /// <code>BondReflection.MethodInfoOf(() => Foo.DoThing(default(int)))</code>
+        /// </example>
+        internal static MethodInfo MethodInfoOf<T>(Expression<Action<T>> expression)
+        {
+            return InfoOf(expression) as MethodInfo;
+        }
+
+        /// <summary>
+        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
+        /// </summary>
+        /// <typeparam name="T">Input type of the lambda.</typeparam>
+        /// <param name="expression">Lambda expression to extract reflection information from</param>
+        /// <returns>Member information of the top-level node in the body of the lambda expression. Return null if the member is not a generic method definition. An exception occurs if this node does not contain member information.</returns>
+        /// <example>
+        /// To obtain the generic method definition for some "void Foo::Bar&lt;T>(T)" overload, you can write:
+        /// <code>BondReflection.GenericMethodInfoOf(() => Foo.Bar(default(int)))</code>, which returns the definition Foo.Bar&lt;>
+        /// </example>
+        internal static MethodInfo GenericMethodInfoOf<T>(Expression<Action<T>> expression)
+        {
+            var methodInfo = MethodInfoOf(expression);
+            return methodInfo == null ? null : methodInfo.GetGenericMethodDefinition();
+        }
+
+        /// <summary>
+        /// Gets the reflection member information from the top-level node in the body of the given lambda expression.
+        /// </summary>
+        /// <param name="expression">Lambda expression to extract reflection information from</param>
+        /// <returns>Member information of the top-level node in the body of the lambda expression. An exception occurs if this node does not contain member information.</returns>
+        static MemberInfo InfoOf(Expression expression)
+        {
+            if (expression == null)
+                throw new ArgumentNullException("expression");
+
+            MethodCallExpression mce;
+            MemberExpression me;
+            NewExpression ne;
+            UnaryExpression ue;
+            BinaryExpression be;
+
+            if ((mce = expression as MethodCallExpression) != null)
+            {
+                return mce.Method;
+            }
+            else if ((me = expression as MemberExpression) != null)
+            {
+                return me.Member;
+            }
+            else if ((ne = expression as NewExpression) != null)
+            {
+                return ne.Constructor;
+            }
+            else if ((ue = expression as UnaryExpression) != null)
+            {
+                if (ue.Method != null)
+                {
+                    return ue.Method;
+                }
+            }
+            else if ((be = expression as BinaryExpression) != null)
+            {
+                if (be.Method != null)
+                {
+                    return be.Method;
+                }
+            }
+
+            throw new NotSupportedException("Expression tree type doesn't have an extractable MemberInfo object.");
+        }
+
+        internal static Modifier GetModifier(this ISchemaField schemaField)
+        {
+            return schemaField.GetAttribute<RequiredAttribute>() != null
+                ? Modifier.Required
+                : schemaField.GetAttribute<RequiredOptionalAttribute>() != null
+                ? Modifier.RequiredOptional
+                : Modifier.Optional;
+        }
+
+        internal static int GetHierarchyDepth(this RuntimeSchema schema)
+        {
+            if (!schema.IsStruct)
+                return 0;
+
+            var depth = 0;
+            for (var type = schema.TypeDef; type != null; type = schema.SchemaDef.structs[type.struct_def].base_def)
+                depth++;
+            return depth;
+        }
+
+        internal static int GetHierarchyDepth(this Type type)
+        {
+            var depth = 0;
+            for (; type != null; type = type.GetBaseSchemaType()) depth++;
+            return depth;
+        }
+
+        internal static string GetSchemaName(this Type type)
+        {
+            string name;
+
+            if (type.IsBondStruct() || type.IsEnum())
+            {
+                name = type.Name;
+                var n = name.IndexOf('`');
+                if (n >= 0)
+                    name = name.Remove(n);
+            }
+            else if (type.IsBondBlob())
+            {
+                return "blob";
+            }
+            else if (type.IsBonded())
+            {
+                name = "bonded";
+            }
+            else if (type.IsBondNullable())
+            {
+                name = "nullable";
+            }
+            else
+            {
+                name = bondTypeName[type.GetBondDataType()];
+            }
+
+            if (!type.IsGenericType())
+                return name;
+
+            var args = type.GetGenericArguments();
+            var builder = new StringBuilder(name, args.Length * 64);
+
+            builder.Append("<");
+            for (var i = 0; i < args.Length; ++i)
+            {
+                if (i != 0)
+                    builder.Append(", ");
+
+                builder.Append(args[i].GetSchemaFullName());
+            }
+            builder.Append(">");
+            return builder.ToString();
+        }
+
+        internal static string GetSchemaFullName(this Type type)
+        {
+            if (type.IsBondStruct() || type.IsEnum())
+                return type.GetSchemaNamespace() + "." + type.GetSchemaName();
+
+            return type.GetSchemaName();
+        }
+
+        static string GetSchemaNamespace(this Type type)
+        {
+            var attr = type.GetAttribute<NamespaceAttribute>();
+            if (attr != null)
+                return attr.Value;
+
+            return type.Namespace;
+        }
+
+        static T GetAttribute<T>(this MemberInfo type)
+            where T : class
+        {
+            return type.GetCustomAttributes(typeof(T), false).FirstOrDefault() as T;
+        }
+
+        internal static T GetAttribute<T>(this Type type)
+            where T : class
+        {
+            // ReSharper disable once RedundantCast
+            // This explicit cast is needed because when targeting non-portable runtime,
+            // type.GetTypeInfo returns an object which is also a Type, causing wrong call.
+            return GetAttribute<T>(type.GetTypeInfo() as MemberInfo);
+        }
+
+        static T GetAttribute<T>(this ISchemaField schemaField)
+            where T : class
+        {
+            return schemaField.MemberInfo.GetAttribute<T>();
+        }
+
+        static Type ResolveTypeArgumentTags(Type memberType, Type schemaType)
+        {
+            if (schemaType.IsGenericType())
+            {
+                Type[] memberTypeArguments;
+
+                var schemaGenericType = schemaType.GetGenericTypeDefinition();
+                var memberGenericType = memberType.IsGenericType() ? memberType.GetGenericTypeDefinition() : null;
+
+                if ((schemaGenericType == typeof(Tag.nullable<>) && memberGenericType != typeof(Nullable<>)) ||
+                    (schemaGenericType == typeof(Tag.bonded<>) && memberGenericType != typeof(IBonded<>)))
+                {
+                    memberTypeArguments = new[] { memberType };
+                }
+                else
+                {
+                    memberTypeArguments = memberType.GetGenericArguments();
+                }
+
+                return schemaGenericType.MakeGenericType(Enumerable.Zip(
+                    memberTypeArguments,
+                    schemaType.GetGenericArguments(), 
+                    ResolveTypeArgumentTags).ToArray());
+            }
+
+            return (schemaType == typeof(Tag.structT) || schemaType == typeof(Tag.classT)) ?
+                memberType : 
+                schemaType;
+        }
+
+        internal static Type GetObjectType(this Type schemaType)
+        {
+            if (schemaType == typeof(Tag.wstring))
+            {
+                return typeof(string);
+            }
+
+            if (schemaType == typeof(Tag.blob))
+            {
+                return typeof(ArraySegment<byte>);
+            }
+            
+            if (schemaType.IsGenericType())
+            {
+                return schemaType.GetGenericTypeDefinition().MakeGenericType(
+                    schemaType.GetGenericArguments().Select(type =>
+                    {
+                        if (type.IsGenericType())
+                        {
+                            var genericType = type.GetGenericTypeDefinition();
+                            if (genericType == typeof(Tag.nullable<>))
+                            {
+                                var nullableValue = type.GetGenericArguments()[0];
+                                return nullableValue.IsClass() || nullableValue.IsBondBlob()
+                                    ? nullableValue.GetObjectType()
+                                    : typeof(Nullable<>).MakeGenericType(nullableValue.GetObjectType());
+                            }
+
+                            if (genericType == typeof(Tag.bonded<>))
+                            {
+                                return typeof(IBonded<>).MakeGenericType(type.GetGenericArguments()[0].GetObjectType());
+                            }
+                        }
+
+                        return type.GetObjectType();
+                    }).ToArray());
+            }
+
+            return schemaType;
+        }
+
+        internal static object GetDefaultValue(this ISchemaField schemaField)
+        {
+            var declaringType = schemaField.DeclaringType;
+            var declaringTypeInfo = declaringType.GetTypeInfo();
+            var defaultAttribute = schemaField.GetAttribute<DefaultAttribute>(); 
+
+            // For interfaces determine member default value from the type and/or DefaultAttribute
+            if (declaringTypeInfo.IsInterface)
+            {
+                var schemaType = schemaField.GetSchemaType();
+
+                if (defaultAttribute != null)
+                {
+                    if (defaultAttribute.Value == null)
+                    {
+                        return null;
+                    }
+
+                    if (schemaType.IsBondNullable() || schemaType.IsBondStruct() || schemaType.IsBondContainer())
+                    {
+                        InvalidDefaultAttribute(schemaField, defaultAttribute.Value);
+                    }
+
+                    return defaultAttribute.Value;
+                }
+                else
+                {
+                    if (schemaType.IsBondNullable())
+                    {
+                        return null;
+                    }
+
+                    if (schemaType.IsBondStruct() || schemaType.IsBonded() || schemaType.IsBondContainer() || schemaType.IsBondBlob())
+                    {
+                        return Empty;
+                    }
+
+                    if (schemaType.IsBondString())
+                    {
+                        return string.Empty;
+                    }
+
+                    return Activator.CreateInstance(schemaField.MemberType);
+                }
+            }
+
+            if (defaultAttribute != null)
+            {
+                InvalidDefaultAttribute(schemaField, defaultAttribute.Value);
+            }
+            
+            // For classes create a default instance and get the actual default value of the member
+            var objectType = declaringType.GetObjectType();
+            var objectMemeber = objectType.GetSchemaFields().Single(m => m.Id == schemaField.Id);
+            var obj = Activator.CreateInstance(objectType);
+            var defaultValue = objectMemeber.GetValue(obj);
+            return defaultValue;
+        }
+
+        static void InvalidDefaultAttribute(ISchemaField schemaField, object value)
+        {
+            throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
+                "Invalid default value '{2}' specified by DefaultAttribute for {0}.{1}", 
+                schemaField.DeclaringType, schemaField.Name, value == null ? "null" : value.ToString()));
+        }
+
+        #endregion
+    }
+}

--- a/cs/src/core/Schema.cs
+++ b/cs/src/core/Schema.cs
@@ -8,7 +8,7 @@ namespace Bond
     using System.Diagnostics;
     using System.Linq;
     using System.Reflection;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     /// <summary>
     /// Utility to create runtime schema for dynamically specified Bond schema

--- a/cs/src/core/Serializer.cs
+++ b/cs/src/core/Serializer.cs
@@ -9,7 +9,7 @@ namespace Bond
 
     using Bond.Expressions;
     using Bond.Protocols;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     /// <summary>
     /// Serialize objects

--- a/cs/src/core/Transcoder.cs
+++ b/cs/src/core/Transcoder.cs
@@ -9,7 +9,7 @@ namespace Bond
     using Bond.Expressions;
     using Bond.IO;
     using Bond.Protocols;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     /// <summary>
     /// Transcode payload from one protocol into another

--- a/cs/src/core/expressions/DataExpression.cs
+++ b/cs/src/core/expressions/DataExpression.cs
@@ -4,7 +4,7 @@
 namespace Bond.Expressions
 {
     using System.Linq.Expressions;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     internal static class DataExpression
     {

--- a/cs/src/core/expressions/DeserializerTransform.cs
+++ b/cs/src/core/expressions/DeserializerTransform.cs
@@ -58,7 +58,7 @@ namespace Bond.Expressions
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     internal class DeserializerTransform<R>
     {
@@ -73,15 +73,15 @@ namespace Bond.Expressions
         readonly Dictionary<Type, int> deserializeIndex = new Dictionary<Type, int>();
         readonly Stack<Type> inProgress = new Stack<Type>();
         static readonly MethodInfo bondedConvert =
-            BondReflection.GenericMethodInfoOf((IBonded bonded) => bonded.Convert<object>());
+            Reflection.GenericMethodInfoOf((IBonded bonded) => bonded.Convert<object>());
         static readonly MethodInfo bondedDeserialize =
-            BondReflection.GenericMethodInfoOf((IBonded bonded) => bonded.Deserialize<object>());
+            Reflection.GenericMethodInfoOf((IBonded bonded) => bonded.Deserialize<object>());
         static readonly MethodInfo arrayResize =
-            BondReflection.GenericMethodInfoOf((object[] o) => Array.Resize(ref o, default(int)));
+            Reflection.GenericMethodInfoOf((object[] o) => Array.Resize(ref o, default(int)));
         static readonly ConstructorInfo arraySegmentCtor =
             typeof(ArraySegment<byte>).GetConstructor(typeof(byte[]), typeof(int), typeof(int));
         static readonly MethodInfo bufferBlockCopy =
-            BondReflection.MethodInfoOf((byte[] a) => Buffer.BlockCopy(a, default(int), a, default(int), default(int)));
+            Reflection.MethodInfoOf((byte[] a) => Buffer.BlockCopy(a, default(int), a, default(int), default(int)));
 
         public DeserializerTransform(
             Expression<Func<R, int, object>> deferredDeserialize,

--- a/cs/src/core/expressions/ObjectParser.cs
+++ b/cs/src/core/expressions/ObjectParser.cs
@@ -10,7 +10,7 @@ namespace Bond.Expressions
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     /// <summary>
     /// Creates expression of type <see cref="IBonded{T}"/> given a object type and value.
@@ -22,7 +22,7 @@ namespace Bond.Expressions
 
     public class ObjectParser : IParser
     {
-        static readonly MethodInfo moveNext = BondReflection.MethodInfoOf((IEnumerator e) => e.MoveNext());
+        static readonly MethodInfo moveNext = Reflection.MethodInfoOf((IEnumerator e) => e.MoveNext());
         static readonly ConstructorInfo arraySegmentCtor = typeof(ArraySegment<byte>).GetConstructor(typeof(byte[]));
         delegate Expression ContainerItemHandler(Expression value, Expression next, Expression count);
         readonly ParameterExpression objParam;

--- a/cs/src/core/expressions/ParserFactory.cs
+++ b/cs/src/core/expressions/ParserFactory.cs
@@ -7,7 +7,7 @@ namespace Bond.Expressions
     using System.Globalization;
     using System.Linq.Expressions;
     using Bond.Protocols;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     /// <summary>
     /// Creates expression of type <see cref="IBonded"/> given a reader and runtime schema.

--- a/cs/src/core/expressions/ProtocolWriter.cs
+++ b/cs/src/core/expressions/ProtocolWriter.cs
@@ -10,7 +10,7 @@ namespace Bond.Expressions
     using System.Linq.Expressions;
     using System.Reflection;
     using Bond.Protocols;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     /// <summary>
     /// Abstracts calling protocol writer methods via Expressions
@@ -21,40 +21,40 @@ namespace Bond.Expressions
     {
         readonly ParameterExpression writer = Expression.Parameter(typeof(W), "writer");
 
-        static readonly MethodInfo marshalBonded =   BondReflection.MethodInfoOf(() => Marshaler.Marshal(default(IBonded)));
-        static readonly MethodInfo serializeBonded = BondReflection.MethodInfoOf((IBonded bonded) => bonded.Serialize(default(W)));
-        static readonly MethodInfo writeBytes =      GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteBytes(default(ArraySegment<byte>))));
-        static readonly MethodInfo structBegin =     GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteStructBegin(default(Metadata))));
-        static readonly MethodInfo baseBegin =       GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteBaseBegin(default(Metadata))));
-        static readonly MethodInfo structEnd =       GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteStructEnd()));
-        static readonly MethodInfo baseEnd =         GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteBaseEnd()));
-        static readonly MethodInfo fieldBegin =      GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteFieldBegin(default(BondDataType), default(UInt16), default(Metadata))));
-        static readonly MethodInfo fieldEnd =        GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteFieldEnd()));
-        static readonly MethodInfo fieldOmitted =    GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteFieldOmitted(default(BondDataType), default(UInt16), default(Metadata))));
-        static readonly MethodInfo containerBegin =  GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteContainerBegin(default(int), default(BondDataType))));
-        static readonly MethodInfo containerBegin2 = GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteContainerBegin(default(int), default(BondDataType), default(BondDataType))));
-        static readonly MethodInfo containerEnd =    GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteContainerEnd()));
-        static readonly MethodInfo itemBegin =       GetMethod(BondReflection.MethodInfoOf((ITextProtocolWriter writer) => writer.WriteItemBegin()));
-        static readonly MethodInfo itemEnd =         GetMethod(BondReflection.MethodInfoOf((ITextProtocolWriter writer) => writer.WriteItemEnd()));
+        static readonly MethodInfo marshalBonded =   Reflection.MethodInfoOf(() => Marshaler.Marshal(default(IBonded)));
+        static readonly MethodInfo serializeBonded = Reflection.MethodInfoOf((IBonded bonded) => bonded.Serialize(default(W)));
+        static readonly MethodInfo writeBytes =      GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteBytes(default(ArraySegment<byte>))));
+        static readonly MethodInfo structBegin =     GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteStructBegin(default(Metadata))));
+        static readonly MethodInfo baseBegin =       GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteBaseBegin(default(Metadata))));
+        static readonly MethodInfo structEnd =       GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteStructEnd()));
+        static readonly MethodInfo baseEnd =         GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteBaseEnd()));
+        static readonly MethodInfo fieldBegin =      GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteFieldBegin(default(BondDataType), default(UInt16), default(Metadata))));
+        static readonly MethodInfo fieldEnd =        GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteFieldEnd()));
+        static readonly MethodInfo fieldOmitted =    GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteFieldOmitted(default(BondDataType), default(UInt16), default(Metadata))));
+        static readonly MethodInfo containerBegin =  GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteContainerBegin(default(int), default(BondDataType))));
+        static readonly MethodInfo containerBegin2 = GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteContainerBegin(default(int), default(BondDataType), default(BondDataType))));
+        static readonly MethodInfo containerEnd =    GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteContainerEnd()));
+        static readonly MethodInfo itemBegin =       GetMethod(Reflection.MethodInfoOf((ITextProtocolWriter writer) => writer.WriteItemBegin()));
+        static readonly MethodInfo itemEnd =         GetMethod(Reflection.MethodInfoOf((ITextProtocolWriter writer) => writer.WriteItemEnd()));
         
         static readonly bool untaggedProtocol =
             typeof(IUntaggedProtocolReader).IsAssignableFrom(typeof(W).GetAttribute<ReaderAttribute>().ReaderType);
 
         static readonly Dictionary<BondDataType, MethodInfo> write = new Dictionary<BondDataType, MethodInfo>
             {
-                { BondDataType.BT_BOOL,    GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteBool(default(bool)))) },
-                { BondDataType.BT_UINT8,   GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteUInt8(default(byte)))) },
-                { BondDataType.BT_UINT16,  GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteUInt16(default(UInt16)))) },
-                { BondDataType.BT_UINT32,  GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteUInt32(default(UInt32)))) },
-                { BondDataType.BT_UINT64,  GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteUInt64(default(UInt64)))) },
-                { BondDataType.BT_FLOAT,   GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteFloat(default(float)))) },
-                { BondDataType.BT_DOUBLE,  GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteDouble(default(double)))) },
-                { BondDataType.BT_STRING,  GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteString(default(string)))) },
-                { BondDataType.BT_INT8,    GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteInt8(default(sbyte)))) },
-                { BondDataType.BT_INT16,   GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteInt16(default(Int16)))) },
-                { BondDataType.BT_INT32,   GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteInt32(default(Int32)))) },
-                { BondDataType.BT_INT64,   GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteInt64(default(Int64)))) },
-                { BondDataType.BT_WSTRING, GetMethod(BondReflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteWString(default(string)))) },
+                { BondDataType.BT_BOOL,    GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteBool(default(bool)))) },
+                { BondDataType.BT_UINT8,   GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteUInt8(default(byte)))) },
+                { BondDataType.BT_UINT16,  GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteUInt16(default(UInt16)))) },
+                { BondDataType.BT_UINT32,  GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteUInt32(default(UInt32)))) },
+                { BondDataType.BT_UINT64,  GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteUInt64(default(UInt64)))) },
+                { BondDataType.BT_FLOAT,   GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteFloat(default(float)))) },
+                { BondDataType.BT_DOUBLE,  GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteDouble(default(double)))) },
+                { BondDataType.BT_STRING,  GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteString(default(string)))) },
+                { BondDataType.BT_INT8,    GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteInt8(default(sbyte)))) },
+                { BondDataType.BT_INT16,   GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteInt16(default(Int16)))) },
+                { BondDataType.BT_INT32,   GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteInt32(default(Int32)))) },
+                { BondDataType.BT_INT64,   GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteInt64(default(Int64)))) },
+                { BondDataType.BT_WSTRING, GetMethod(Reflection.MethodInfoOf((IProtocolWriter writer) => writer.WriteWString(default(string)))) },
             };
 
         static MethodInfo GetMethod(MethodInfo method)

--- a/cs/src/core/expressions/RequiredFields.cs
+++ b/cs/src/core/expressions/RequiredFields.cs
@@ -7,14 +7,14 @@ namespace Bond.Expressions
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     internal static class RequiredFields
     {
         static readonly ConstructorInfo ctor =  typeof(Bitmap).GetConstructor(typeof(int));
-        static readonly PropertyInfo isAnySet = BondReflection.PropertyInfoOf((Bitmap b) => b.IsAnySet);
-        static readonly PropertyInfo firstSet = BondReflection.PropertyInfoOf((Bitmap b) => b.FirstSet);
-        static readonly MethodInfo reset =      BondReflection.MethodInfoOf((Bitmap bitmap) => bitmap.Reset(default(int), default(long)));
+        static readonly PropertyInfo isAnySet = Reflection.PropertyInfoOf((Bitmap b) => b.IsAnySet);
+        static readonly PropertyInfo firstSet = Reflection.PropertyInfoOf((Bitmap b) => b.FirstSet);
+        static readonly MethodInfo reset =      Reflection.MethodInfoOf((Bitmap bitmap) => bitmap.Reset(default(int), default(long)));
 
         public static ParameterExpression Variable(string name)
         {

--- a/cs/src/core/expressions/SerializerGeneratorFactory.cs
+++ b/cs/src/core/expressions/SerializerGeneratorFactory.cs
@@ -6,7 +6,7 @@ namespace Bond.Expressions
     using System;
     using System.Globalization;
     using System.Linq.Expressions;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     internal static class SerializerGeneratorFactory<R, W>
     {

--- a/cs/src/core/expressions/SerializerTransform.cs
+++ b/cs/src/core/expressions/SerializerTransform.cs
@@ -9,7 +9,7 @@ namespace Bond.Expressions
     using System.Linq;
     using System.Linq.Expressions;
     using Bond.Protocols;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     public abstract class SerializerGenerator<R, W> : ISerializerGenerator<R, W>
     {

--- a/cs/src/core/expressions/StringExpression.cs
+++ b/cs/src/core/expressions/StringExpression.cs
@@ -15,25 +15,25 @@ namespace Bond.Expressions
     internal static class StringExpression
     {
         static readonly Expression invariantCulture = Expression.Property(null, typeof(CultureInfo), "InvariantCulture");
-        static readonly MethodInfo equals =      BondReflection.MethodInfoOf(() => string.Equals(default(string), default(string), default(StringComparison)));
-        static readonly MethodInfo format =      BondReflection.MethodInfoOf(() => string.Format(default(IFormatProvider), default(string), default(object[])));
-        static readonly MethodInfo getHashCode = BondReflection.MethodInfoOf((string s) => s.GetHashCode());
-        static readonly FieldInfo stringEmpty =  BondReflection.FieldInfoOf((string s) => string.Empty);
+        static readonly MethodInfo equals =      Reflection.MethodInfoOf(() => string.Equals(default(string), default(string), default(StringComparison)));
+        static readonly MethodInfo format =      Reflection.MethodInfoOf(() => string.Format(default(IFormatProvider), default(string), default(object[])));
+        static readonly MethodInfo getHashCode = Reflection.MethodInfoOf((string s) => s.GetHashCode());
+        static readonly FieldInfo stringEmpty =  Reflection.FieldInfoOf((string s) => string.Empty);
         
         static readonly IDictionary<BondDataType, MethodInfo> methods =
             new Dictionary<BondDataType, MethodInfo>
                 {
-                    { BondDataType.BT_BOOL,   BondReflection.MethodInfoOf(() => System.Convert.ToBoolean(default(string), default(IFormatProvider))) },
-                    { BondDataType.BT_UINT8,  BondReflection.MethodInfoOf(() => System.Convert.ToByte(default(string), default(IFormatProvider))) },
-                    { BondDataType.BT_UINT16, BondReflection.MethodInfoOf(() => System.Convert.ToUInt16(default(string), default(IFormatProvider))) },
-                    { BondDataType.BT_UINT32, BondReflection.MethodInfoOf(() => System.Convert.ToUInt32(default(string), default(IFormatProvider))) },
-                    { BondDataType.BT_UINT64, BondReflection.MethodInfoOf(() => System.Convert.ToUInt64(default(string), default(IFormatProvider))) },
-                    { BondDataType.BT_INT8,   BondReflection.MethodInfoOf(() => System.Convert.ToSByte(default(string), default(IFormatProvider))) },
-                    { BondDataType.BT_INT16,  BondReflection.MethodInfoOf(() => System.Convert.ToInt16(default(string), default(IFormatProvider))) },
-                    { BondDataType.BT_INT32,  BondReflection.MethodInfoOf(() => System.Convert.ToInt32(default(string), default(IFormatProvider))) },
-                    { BondDataType.BT_INT64,  BondReflection.MethodInfoOf(() => System.Convert.ToInt64(default(string), default(IFormatProvider))) },
-                    { BondDataType.BT_FLOAT,  BondReflection.MethodInfoOf(() => System.Convert.ToSingle(default(string), default(IFormatProvider))) },
-                    { BondDataType.BT_DOUBLE, BondReflection.MethodInfoOf(() => System.Convert.ToDouble(default(string), default(IFormatProvider))) }
+                    { BondDataType.BT_BOOL,   Reflection.MethodInfoOf(() => System.Convert.ToBoolean(default(string), default(IFormatProvider))) },
+                    { BondDataType.BT_UINT8,  Reflection.MethodInfoOf(() => System.Convert.ToByte(default(string), default(IFormatProvider))) },
+                    { BondDataType.BT_UINT16, Reflection.MethodInfoOf(() => System.Convert.ToUInt16(default(string), default(IFormatProvider))) },
+                    { BondDataType.BT_UINT32, Reflection.MethodInfoOf(() => System.Convert.ToUInt32(default(string), default(IFormatProvider))) },
+                    { BondDataType.BT_UINT64, Reflection.MethodInfoOf(() => System.Convert.ToUInt64(default(string), default(IFormatProvider))) },
+                    { BondDataType.BT_INT8,   Reflection.MethodInfoOf(() => System.Convert.ToSByte(default(string), default(IFormatProvider))) },
+                    { BondDataType.BT_INT16,  Reflection.MethodInfoOf(() => System.Convert.ToInt16(default(string), default(IFormatProvider))) },
+                    { BondDataType.BT_INT32,  Reflection.MethodInfoOf(() => System.Convert.ToInt32(default(string), default(IFormatProvider))) },
+                    { BondDataType.BT_INT64,  Reflection.MethodInfoOf(() => System.Convert.ToInt64(default(string), default(IFormatProvider))) },
+                    { BondDataType.BT_FLOAT,  Reflection.MethodInfoOf(() => System.Convert.ToSingle(default(string), default(IFormatProvider))) },
+                    { BondDataType.BT_DOUBLE, Reflection.MethodInfoOf(() => System.Convert.ToDouble(default(string), default(IFormatProvider))) }
                 };
 
         public static Expression Convert(Expression valueAsString, BondDataType type)

--- a/cs/src/core/expressions/TaggedParser.cs
+++ b/cs/src/core/expressions/TaggedParser.cs
@@ -7,7 +7,7 @@ namespace Bond.Expressions
     using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     public class TaggedParser<R> : IParser
     {

--- a/cs/src/core/expressions/TaggedReader.cs
+++ b/cs/src/core/expressions/TaggedReader.cs
@@ -10,39 +10,39 @@ namespace Bond.Expressions
     using System.Linq.Expressions;
     using System.Reflection;
     using Bond.Protocols;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     internal class TaggedReader<R>
     {
         readonly ParameterExpression reader = Expression.Parameter(typeof(R), "reader");
 
-        static readonly MethodInfo structBegin =     GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadStructBegin()));
-        static readonly MethodInfo baseBegin =       GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadBaseBegin()));
-        static readonly MethodInfo structEnd =       GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadStructEnd()));
-        static readonly MethodInfo baseEnd =         GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadBaseEnd()));
+        static readonly MethodInfo structBegin =     GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadStructBegin()));
+        static readonly MethodInfo baseBegin =       GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadBaseBegin()));
+        static readonly MethodInfo structEnd =       GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadStructEnd()));
+        static readonly MethodInfo baseEnd =         GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadBaseEnd()));
         static readonly MethodInfo fieldBegin =      GetMethod("ReadFieldBegin", typeof(BondDataType).MakeByRefType(), typeof(UInt16).MakeByRefType());
-        static readonly MethodInfo fieldEnd =        GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadFieldEnd()));
+        static readonly MethodInfo fieldEnd =        GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadFieldEnd()));
         static readonly MethodInfo containerBegin =  GetMethod("ReadContainerBegin", typeof(int).MakeByRefType(), typeof(BondDataType).MakeByRefType());
         static readonly MethodInfo containerBegin2 = GetMethod("ReadContainerBegin", typeof(int).MakeByRefType(), typeof(BondDataType).MakeByRefType(), typeof(BondDataType).MakeByRefType());
-        static readonly MethodInfo containerEnd =    GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadContainerEnd()));
-        static readonly MethodInfo readBytes =       GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadBytes(default(int))));
-        static readonly MethodInfo skip =            GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.Skip(default(BondDataType))));
+        static readonly MethodInfo containerEnd =    GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadContainerEnd()));
+        static readonly MethodInfo readBytes =       GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadBytes(default(int))));
+        static readonly MethodInfo skip =            GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.Skip(default(BondDataType))));
 
         static readonly Dictionary<BondDataType, MethodInfo> read = new Dictionary<BondDataType, MethodInfo>
             {
-                { BondDataType.BT_BOOL,    GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadBool())) },
-                { BondDataType.BT_UINT8,   GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadUInt8())) },
-                { BondDataType.BT_UINT16,  GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadUInt16())) },
-                { BondDataType.BT_UINT32,  GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadUInt32())) },
-                { BondDataType.BT_UINT64,  GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadUInt64())) },
-                { BondDataType.BT_FLOAT,   GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadFloat())) },
-                { BondDataType.BT_DOUBLE,  GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadDouble())) },
-                { BondDataType.BT_STRING,  GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadString())) },
-                { BondDataType.BT_INT8,    GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadInt8())) },
-                { BondDataType.BT_INT16,   GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadInt16())) },
-                { BondDataType.BT_INT32,   GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadInt32())) },
-                { BondDataType.BT_INT64,   GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadInt64())) },
-                { BondDataType.BT_WSTRING, GetMethod(BondReflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadWString())) }
+                { BondDataType.BT_BOOL,    GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadBool())) },
+                { BondDataType.BT_UINT8,   GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadUInt8())) },
+                { BondDataType.BT_UINT16,  GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadUInt16())) },
+                { BondDataType.BT_UINT32,  GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadUInt32())) },
+                { BondDataType.BT_UINT64,  GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadUInt64())) },
+                { BondDataType.BT_FLOAT,   GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadFloat())) },
+                { BondDataType.BT_DOUBLE,  GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadDouble())) },
+                { BondDataType.BT_STRING,  GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadString())) },
+                { BondDataType.BT_INT8,    GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadInt8())) },
+                { BondDataType.BT_INT16,   GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadInt16())) },
+                { BondDataType.BT_INT32,   GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadInt32())) },
+                { BondDataType.BT_INT64,   GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadInt64())) },
+                { BondDataType.BT_WSTRING, GetMethod(Reflection.MethodInfoOf((ITaggedProtocolReader reader) => reader.ReadWString())) }
             };
 
         static MethodInfo GetMethod(MethodInfo method)

--- a/cs/src/core/expressions/TypeAlias.cs
+++ b/cs/src/core/expressions/TypeAlias.cs
@@ -7,7 +7,7 @@ namespace Bond.Expressions
     using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     internal class TypeAlias
     {

--- a/cs/src/core/expressions/UntaggedParser.cs
+++ b/cs/src/core/expressions/UntaggedParser.cs
@@ -8,7 +8,7 @@ namespace Bond.Expressions
     using System.Diagnostics;
     using System.Linq;
     using System.Linq.Expressions;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     public class UntaggedParser<R> : IParser
     {

--- a/cs/src/core/expressions/UntaggedReader.cs
+++ b/cs/src/core/expressions/UntaggedReader.cs
@@ -9,49 +9,49 @@ namespace Bond.Expressions
     using System.Linq.Expressions;
     using System.Reflection;
     using Bond.Protocols;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     internal class UntaggedReader<R>
     {
-        static readonly MethodInfo unmarshalBonded = BondReflection.MethodInfoOf(() => Unmarshal.From(default(ArraySegment<byte>)));
-        static readonly MethodInfo fieldOmitted    = GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadFieldOmitted()));
-        static readonly MethodInfo containerBegin =  GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadContainerBegin()));
-        static readonly MethodInfo containerEnd =    GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadContainerEnd()));
-        static readonly MethodInfo readBytes =       GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadBytes(default(int))));
-        static readonly MethodInfo skipBytes =       GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipBytes(default(int))));
+        static readonly MethodInfo unmarshalBonded = Reflection.MethodInfoOf(() => Unmarshal.From(default(ArraySegment<byte>)));
+        static readonly MethodInfo fieldOmitted    = GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadFieldOmitted()));
+        static readonly MethodInfo containerBegin =  GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadContainerBegin()));
+        static readonly MethodInfo containerEnd =    GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadContainerEnd()));
+        static readonly MethodInfo readBytes =       GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadBytes(default(int))));
+        static readonly MethodInfo skipBytes =       GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipBytes(default(int))));
 
         static readonly Dictionary<BondDataType, MethodInfo> read = new Dictionary<BondDataType, MethodInfo>
             {
-                { BondDataType.BT_BOOL,    GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadBool())) },
-                { BondDataType.BT_UINT8,   GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadUInt8())) },
-                { BondDataType.BT_UINT16,  GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadUInt16())) },
-                { BondDataType.BT_UINT32,  GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadUInt32())) },
-                { BondDataType.BT_UINT64,  GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadUInt64())) },
-                { BondDataType.BT_FLOAT,   GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadFloat())) },
-                { BondDataType.BT_DOUBLE,  GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadDouble())) },
-                { BondDataType.BT_STRING,  GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadString())) },
-                { BondDataType.BT_INT8,    GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadInt8())) },
-                { BondDataType.BT_INT16,   GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadInt16())) },
-                { BondDataType.BT_INT32,   GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadInt32())) },
-                { BondDataType.BT_INT64,   GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadInt64())) },
-                { BondDataType.BT_WSTRING, GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadWString())) }
+                { BondDataType.BT_BOOL,    GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadBool())) },
+                { BondDataType.BT_UINT8,   GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadUInt8())) },
+                { BondDataType.BT_UINT16,  GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadUInt16())) },
+                { BondDataType.BT_UINT32,  GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadUInt32())) },
+                { BondDataType.BT_UINT64,  GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadUInt64())) },
+                { BondDataType.BT_FLOAT,   GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadFloat())) },
+                { BondDataType.BT_DOUBLE,  GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadDouble())) },
+                { BondDataType.BT_STRING,  GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadString())) },
+                { BondDataType.BT_INT8,    GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadInt8())) },
+                { BondDataType.BT_INT16,   GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadInt16())) },
+                { BondDataType.BT_INT32,   GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadInt32())) },
+                { BondDataType.BT_INT64,   GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadInt64())) },
+                { BondDataType.BT_WSTRING, GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.ReadWString())) }
             };
 
         static readonly Dictionary<BondDataType, MethodInfo> skip = new Dictionary<BondDataType, MethodInfo>
             {
-                { BondDataType.BT_BOOL,    GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipBool())) },
-                { BondDataType.BT_UINT8,   GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipUInt8())) },
-                { BondDataType.BT_UINT16,  GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipUInt16())) },
-                { BondDataType.BT_UINT32,  GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipUInt32())) },
-                { BondDataType.BT_UINT64,  GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipUInt64())) },
-                { BondDataType.BT_FLOAT,   GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipFloat())) },
-                { BondDataType.BT_DOUBLE,  GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipDouble())) },
-                { BondDataType.BT_STRING,  GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipString())) },
-                { BondDataType.BT_INT8,    GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipInt8())) },
-                { BondDataType.BT_INT16,   GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipInt16())) },
-                { BondDataType.BT_INT32,   GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipInt32())) },
-                { BondDataType.BT_INT64,   GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipInt64())) },
-                { BondDataType.BT_WSTRING, GetMethod(BondReflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipWString())) }
+                { BondDataType.BT_BOOL,    GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipBool())) },
+                { BondDataType.BT_UINT8,   GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipUInt8())) },
+                { BondDataType.BT_UINT16,  GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipUInt16())) },
+                { BondDataType.BT_UINT32,  GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipUInt32())) },
+                { BondDataType.BT_UINT64,  GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipUInt64())) },
+                { BondDataType.BT_FLOAT,   GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipFloat())) },
+                { BondDataType.BT_DOUBLE,  GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipDouble())) },
+                { BondDataType.BT_STRING,  GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipString())) },
+                { BondDataType.BT_INT8,    GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipInt8())) },
+                { BondDataType.BT_INT16,   GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipInt16())) },
+                { BondDataType.BT_INT32,   GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipInt32())) },
+                { BondDataType.BT_INT64,   GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipInt64())) },
+                { BondDataType.BT_WSTRING, GetMethod(Reflection.MethodInfoOf((IUntaggedProtocolReader reader) => reader.SkipWString())) }
             };
 
         static MethodInfo GetMethod(MethodInfo method)

--- a/cs/src/core/expressions/xml/XmlReader.cs
+++ b/cs/src/core/expressions/xml/XmlReader.cs
@@ -9,14 +9,14 @@ namespace Bond.Expressions.Xml
 
     public class XmlReader<R> where R : IXmlReader
     {
-        static readonly MethodInfo read = BondReflection.MethodInfoOf((IXmlReader r) => r.Read());
-        static readonly MethodInfo skip = BondReflection.MethodInfoOf((IXmlReader r) => r.Skip());
-        static readonly PropertyInfo eof = BondReflection.PropertyInfoOf((IXmlReader r) => r.EOF);
-        static readonly PropertyInfo nodeType = BondReflection.PropertyInfoOf((IXmlReader r) => r.NodeType);
-        static readonly PropertyInfo localName = BondReflection.PropertyInfoOf((IXmlReader r) => r.LocalName);
-        static readonly PropertyInfo namespaceUri = BondReflection.PropertyInfoOf((IXmlReader r) => r.NamespaceURI);
-        static readonly PropertyInfo isEmptyElement = BondReflection.PropertyInfoOf((IXmlReader r) => r.IsEmptyElement);
-        static readonly PropertyInfo value = BondReflection.PropertyInfoOf((IXmlReader r) => r.Value);
+        static readonly MethodInfo read = Reflection.MethodInfoOf((IXmlReader r) => r.Read());
+        static readonly MethodInfo skip = Reflection.MethodInfoOf((IXmlReader r) => r.Skip());
+        static readonly PropertyInfo eof = Reflection.PropertyInfoOf((IXmlReader r) => r.EOF);
+        static readonly PropertyInfo nodeType = Reflection.PropertyInfoOf((IXmlReader r) => r.NodeType);
+        static readonly PropertyInfo localName = Reflection.PropertyInfoOf((IXmlReader r) => r.LocalName);
+        static readonly PropertyInfo namespaceUri = Reflection.PropertyInfoOf((IXmlReader r) => r.NamespaceURI);
+        static readonly PropertyInfo isEmptyElement = Reflection.PropertyInfoOf((IXmlReader r) => r.IsEmptyElement);
+        static readonly PropertyInfo value = Reflection.PropertyInfoOf((IXmlReader r) => r.Value);
 
         readonly ParameterExpression reader = Expression.Parameter(typeof(R), "reader");
 

--- a/cs/src/json/expressions/json/JsonReader.cs
+++ b/cs/src/json/expressions/json/JsonReader.cs
@@ -9,13 +9,13 @@ namespace Bond.Expressions.Json
 
     public class JsonReader<R> where R : IJsonReader
     {
-        static readonly MethodInfo read = BondReflection.MethodInfoOf((IJsonReader r) => r.Read());
-        static readonly MethodInfo skip = BondReflection.MethodInfoOf((IJsonReader r) => r.Skip());
-        static readonly PropertyInfo eof = BondReflection.PropertyInfoOf((IJsonReader r) => r.EOF);
-        static readonly PropertyInfo tokenType = BondReflection.PropertyInfoOf((IJsonReader r) => r.TokenType);
-        static readonly PropertyInfo lineNumber = BondReflection.PropertyInfoOf((IJsonReader r) => r.LineNumber);
-        static readonly PropertyInfo linePosition = BondReflection.PropertyInfoOf((IJsonReader r) => r.LinePosition);
-        static readonly PropertyInfo value = BondReflection.PropertyInfoOf((IJsonReader r) => r.Value);
+        static readonly MethodInfo read = Reflection.MethodInfoOf((IJsonReader r) => r.Read());
+        static readonly MethodInfo skip = Reflection.MethodInfoOf((IJsonReader r) => r.Skip());
+        static readonly PropertyInfo eof = Reflection.PropertyInfoOf((IJsonReader r) => r.EOF);
+        static readonly PropertyInfo tokenType = Reflection.PropertyInfoOf((IJsonReader r) => r.TokenType);
+        static readonly PropertyInfo lineNumber = Reflection.PropertyInfoOf((IJsonReader r) => r.LineNumber);
+        static readonly PropertyInfo linePosition = Reflection.PropertyInfoOf((IJsonReader r) => r.LinePosition);
+        static readonly PropertyInfo value = Reflection.PropertyInfoOf((IJsonReader r) => r.Value);
         
         readonly ParameterExpression reader = Expression.Parameter(typeof(R), "reader");
 

--- a/cs/src/reflection/Reflection.cs
+++ b/cs/src/reflection/Reflection.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Bond.Reflection
+namespace Bond.Internal.Reflection
 {
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
 
-    internal static class Reflection
+    internal static class ReflectionExtensions
     {
         #region PCL compatibility
 

--- a/cs/src/reflection/Reflection40.cs
+++ b/cs/src/reflection/Reflection40.cs
@@ -4,7 +4,7 @@
 // Even though this file is compiled conditionally, the #if is necessary to unconfuse resharper
 #if NET40
 
-namespace Bond.Reflection
+namespace Bond.Internal.Reflection
 {
     using System;
     using System.Collections.Generic;

--- a/cs/src/reflection/Reflection45.cs
+++ b/cs/src/reflection/Reflection45.cs
@@ -4,7 +4,7 @@
 // Even though this file is compiled conditionally, the #if is necessary to unconfuse resharper
 #if !NET40
 
-namespace Bond.Reflection
+namespace Bond.Internal.Reflection
 {
     using System;
     using System.Collections.Generic;

--- a/cs/test/core/BondClass.cs
+++ b/cs/test/core/BondClass.cs
@@ -2,7 +2,7 @@
 {
     using System.Collections.Generic;
     using Bond;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     [Schema, Attribute("xmlns", "urn:UnitTest.BondClass")]
     class BondClass<T>

--- a/cs/test/core/BondedTests.cs
+++ b/cs/test/core/BondedTests.cs
@@ -7,7 +7,7 @@
     using Bond.Protocols;
     using Bond.IO;
     using Bond.IO.Unsafe;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     [TestFixture]
     public class BondedTests

--- a/cs/test/core/CustomBondedTests.cs
+++ b/cs/test/core/CustomBondedTests.cs
@@ -12,7 +12,7 @@ namespace UnitTest
     using Bond.IO;
     using Bond.IO.Unsafe;
     using Bond.Protocols;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
     using NUnit.Framework;
 
     [TestFixture]
@@ -290,7 +290,7 @@ namespace UnitTest
                     {
                         var arg = arguments[0]; // CustomBondedVoid<R>
 #if NETCOREAPP1_0
-                        Type[] genericArgs = Bond.Reflection.Reflection45.GetGenericArguments(type);
+                        Type[] genericArgs = Bond.Internal.Reflection.Reflection45.GetGenericArguments(type);
 #else
                         Type[] genericArgs = type.GetGenericArguments();
 #endif

--- a/cs/test/core/Equal.cs
+++ b/cs/test/core/Equal.cs
@@ -5,7 +5,7 @@
     using System.Linq;
     using System.Reflection;
     using Bond;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     public static class Equal
     {

--- a/cs/test/core/InterfaceTests.cs
+++ b/cs/test/core/InterfaceTests.cs
@@ -11,7 +11,7 @@
     using Bond.IO;
     using Bond.Protocols;
     using Bond.IO.Unsafe;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     [TestFixture]
     public class InterfaceTests

--- a/cs/test/core/SerializerGeneratorFactoryTests.cs
+++ b/cs/test/core/SerializerGeneratorFactoryTests.cs
@@ -8,7 +8,7 @@
     using Bond.Expressions;
     using Bond.Protocols;
     using Bond.IO.Unsafe;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     [TestFixture]
     public class SerializerGeneratorFactoryTests

--- a/cs/test/core/Util.cs
+++ b/cs/test/core/Util.cs
@@ -996,7 +996,7 @@ namespace UnitTest
                 streamTranscode(SerializeSP, TranscodeSPFB<From>, DeserializeFB<To>);
 
                 // Pull parser doesn't support bonded<T>
-                if (AnyField<From>(BondReflection.IsBonded))
+                if (AnyField<From>(Reflection.IsBonded))
                 {
                     streamTranscode(SerializeSP, TranscodeSPXml<From>, DeserializeXml<To>);
                 
@@ -1018,7 +1018,7 @@ namespace UnitTest
             }
 
             // Pull parser doesn't supprot bonded<T>
-            if (AnyField<From>(BondReflection.IsBonded))
+            if (AnyField<From>(Reflection.IsBonded))
             {
                 streamRoundtrip(SerializeXml, DeserializeXml<To>);
                 streamTranscode(SerializeCB, TranscodeCBXml<From>, DeserializeXml<To>);

--- a/cs/test/expressions/Program.cs
+++ b/cs/test/expressions/Program.cs
@@ -11,7 +11,7 @@
     using Bond.Expressions;
     using Bond.Protocols;
     using Bond.IO.Unsafe;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     internal static class DebugViewHelper
     {

--- a/cs/test/internal/ReflectionTests.cs
+++ b/cs/test/internal/ReflectionTests.cs
@@ -6,7 +6,7 @@
     using Bond;
     using NUnit.Framework;
     using Bond.Tag;
-    using Bond.Reflection;
+    using Bond.Internal.Reflection;
 
     [TestFixture]
     public class ReflectionTests
@@ -35,21 +35,21 @@
         [Test]
         public void FindMethodFromObject()
         {
-            Assert.AreEqual("ReadStructBegin", Reflection.FindMethod(typeof(ReaderA), "ReadStructBegin", new Type[0]).Name);
-            Assert.AreEqual(typeof(ReaderA), Reflection.FindMethod(typeof(ReaderA), "ReadStructBegin", new Type[0]).DeclaringType);
+            Assert.AreEqual("ReadStructBegin", ReflectionExtensions.FindMethod(typeof(ReaderA), "ReadStructBegin", new Type[0]).Name);
+            Assert.AreEqual(typeof(ReaderA), ReflectionExtensions.FindMethod(typeof(ReaderA), "ReadStructBegin", new Type[0]).DeclaringType);
         }
 
         [Test]
         public void FindMethodFromInterface()
         {
-            Assert.AreEqual("ReadStructBegin", Reflection.FindMethod(typeof(IReaderA), "ReadStructBegin", new Type[0]).Name);
-            Assert.AreEqual(typeof(IReaderA), Reflection.FindMethod(typeof(IReaderA), "ReadStructBegin", new Type[0]).DeclaringType);
+            Assert.AreEqual("ReadStructBegin", ReflectionExtensions.FindMethod(typeof(IReaderA), "ReadStructBegin", new Type[0]).Name);
+            Assert.AreEqual(typeof(IReaderA), ReflectionExtensions.FindMethod(typeof(IReaderA), "ReadStructBegin", new Type[0]).DeclaringType);
         }
 
         [Test]
         public void MultipleMethodsImplementedException()
         {
-            Assert.That(() => Reflection.FindMethod(typeof(IReaderAB), "ReadStructBegin", new Type[0]),
+            Assert.That(() => ReflectionExtensions.FindMethod(typeof(IReaderAB), "ReadStructBegin", new Type[0]),
                 Throws.TypeOf<System.Reflection.AmbiguousMatchException>()
                      .With.Message.Contains("FindMethod found more than one matching method"));
         }


### PR DESCRIPTION
In commit 9753e3be3, the type `Bond.Reflection` was renamed to
`Bond.BondReflection`. This inadvertently broke source- and
binary-compability.

`Bond.BondReflection` has been renamed back to `Bond.Reflection`. To
minimize breakage for anyone who took a dependency on the
`Bond.BondReflection` type in the interim, `Bond.BondReflection` is now
a shim that forwards to `Bond.Reflection`. The methods in
`Bond.BondReflection` are marked as obsolete (warning level,
suppressible).

The internal type `Bond.Reflection.Reflection` in `Bond.Reflection.dll`
has been renamed to `Bond.Internal.Reflection.ReflectionExtensions`.

This allows us to remove `Bond.BondReflection` during or after the
next major version of C# Bond.

Fixes https://github.com/Microsoft/bond/issues/369
