### PR TITLE
boost-builder: Set -u in scripts.

### DIFF
--- a/tools/boost-builder/build_boosts.zsh
+++ b/tools/boost-builder/build_boosts.zsh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 
-set -ex
+set -eux
 
 BOOST_VERSIONS=(1.58.0 1.59.0 1.60.0 1.61.0 1.62.0 1.63.0)
 BOOST_LIBRARIES="chrono,date_time,python,system,test,thread"

--- a/tools/boost-builder/upload_boosts.zsh
+++ b/tools/boost-builder/upload_boosts.zsh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 
-set -ex
+set -eux
 
 # Define AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_KEY in this file.
 source ~/.azure/bondboostbinaries.sh


### PR DESCRIPTION
Was advising a friend on shell scripting and realized I missed an important option here. -u causes the shell script to terminate if you try to expand an undefined variable.