### PR TITLE
[C++] Adding GetBuffer overloads

### DIFF
--- a/cpp/inc/bond/protocol/compact_binary.h
+++ b/cpp/inc/bond/protocol/compact_binary.h
@@ -178,7 +178,7 @@ public:
     }
 
 
-    /// @brief Access to underlaying buffer
+    /// @brief Access to underlying buffer
     typename boost::call_traits<Buffer>::const_reference
     GetBuffer() const
     {
@@ -186,7 +186,7 @@ public:
     }
 
 
-    /// @brief Access to underlaying buffer
+    /// @brief Access to underlying buffer
     typename boost::call_traits<Buffer>::reference
     GetBuffer()
     {
@@ -562,7 +562,7 @@ public:
     {}
 
 
-    /// @brief Access to underlaying buffer
+    /// @brief Access to underlying buffer
     typename boost::call_traits<Buffer>::reference
     GetBuffer()
     {

--- a/cpp/inc/bond/protocol/compact_binary.h
+++ b/cpp/inc/bond/protocol/compact_binary.h
@@ -186,6 +186,14 @@ public:
     }
 
 
+    /// @brief Access to underlaying buffer
+    typename boost::call_traits<Buffer>::reference
+    GetBuffer()
+    {
+        return _input;
+    }
+
+
     bool ReadVersion()
     {
         uint16_t magic_value;
@@ -552,6 +560,14 @@ public:
         : _output(output),
           _version(pass1._version)
     {}
+
+
+    /// @brief Access to underlaying buffer
+    typename boost::call_traits<Buffer>::reference
+    GetBuffer()
+    {
+        return _output;
+    }
 
 
     bool NeedPass0()

--- a/cpp/inc/bond/protocol/fast_binary.h
+++ b/cpp/inc/bond/protocol/fast_binary.h
@@ -126,7 +126,7 @@ public:
     }
 
 
-    /// @brief Access to underlaying buffer
+    /// @brief Access to underlying buffer
     typename boost::call_traits<Buffer>::const_reference
     GetBuffer() const
     {
@@ -134,7 +134,7 @@ public:
     }
 
 
-    /// @brief Access to underlaying buffer
+    /// @brief Access to underlying buffer
     typename boost::call_traits<Buffer>::reference
     GetBuffer()
     {
@@ -392,7 +392,7 @@ public:
     {
     }
 
-    /// @brief Access to underlaying buffer
+    /// @brief Access to underlying buffer
     typename boost::call_traits<Buffer>::reference
     GetBuffer()
     {

--- a/cpp/inc/bond/protocol/fast_binary.h
+++ b/cpp/inc/bond/protocol/fast_binary.h
@@ -134,6 +134,14 @@ public:
     }
 
 
+    /// @brief Access to underlaying buffer
+    typename boost::call_traits<Buffer>::reference
+    GetBuffer()
+    {
+        return _input;
+    }
+
+
     bool ReadVersion()
     {
         uint16_t magic_value, version_value;
@@ -382,6 +390,13 @@ public:
     FastBinaryWriter(Buffer& buffer)
         : _output(buffer)
     {
+    }
+
+    /// @brief Access to underlaying buffer
+    typename boost::call_traits<Buffer>::reference
+    GetBuffer()
+    {
+        return _output;
     }
 
     void WriteVersion()

--- a/cpp/inc/bond/protocol/simple_binary.h
+++ b/cpp/inc/bond/protocol/simple_binary.h
@@ -57,7 +57,7 @@ public:
     }
 
 
-    /// @brief Access to underlaying buffer
+    /// @brief Access to underlying buffer
     typename boost::call_traits<Buffer>::const_reference
     GetBuffer() const
     {
@@ -65,7 +65,7 @@ public:
     }
 
 
-    /// @brief Access to underlaying buffer
+    /// @brief Access to underlying buffer
     typename boost::call_traits<Buffer>::reference
     GetBuffer()
     {
@@ -236,7 +236,7 @@ public:
         BOOST_ASSERT(_version <= Reader::version);
     }
 
-    /// @brief Access to underlaying buffer
+    /// @brief Access to underlying buffer
     typename boost::call_traits<Buffer>::reference
     GetBuffer()
     {

--- a/cpp/inc/bond/protocol/simple_binary.h
+++ b/cpp/inc/bond/protocol/simple_binary.h
@@ -65,6 +65,14 @@ public:
     }
 
 
+    /// @brief Access to underlaying buffer
+    typename boost::call_traits<Buffer>::reference
+    GetBuffer()
+    {
+        return _input;
+    }
+
+
     bool ReadVersion()
     {
         uint16_t magic_value;
@@ -226,6 +234,13 @@ public:
           _version(version)
     {
         BOOST_ASSERT(_version <= Reader::version);
+    }
+
+    /// @brief Access to underlaying buffer
+    typename boost::call_traits<Buffer>::reference
+    GetBuffer()
+    {
+        return _output;
     }
 
     void WriteVersion()

--- a/cpp/inc/bond/protocol/simple_json_reader.h
+++ b/cpp/inc/bond/protocol/simple_json_reader.h
@@ -110,6 +110,13 @@ public:
     }
 
     /// @brief Access to underlying buffer
+    typename boost::call_traits<Buffer>::const_reference
+    GetBuffer() const
+    {
+        return _input;
+    }
+
+    /// @brief Access to underlying buffer
     typename boost::call_traits<Buffer>::reference
     GetBuffer()
     {

--- a/cpp/inc/bond/protocol/simple_json_reader.h
+++ b/cpp/inc/bond/protocol/simple_json_reader.h
@@ -109,7 +109,7 @@ public:
         return _value == rhs._value;
     }
 
-    /// @brief Access to underlaying buffer
+    /// @brief Access to underlying buffer
     typename boost::call_traits<Buffer>::reference
     GetBuffer()
     {

--- a/cpp/inc/bond/protocol/simple_json_reader.h
+++ b/cpp/inc/bond/protocol/simple_json_reader.h
@@ -108,6 +108,13 @@ public:
     {
         return _value == rhs._value;
     }
+
+    /// @brief Access to underlaying buffer
+    typename boost::call_traits<Buffer>::reference
+    GetBuffer()
+    {
+        return _input;
+    }
     
 private:
     rapidjson::Value::ConstMemberIterator MemberBegin() const

--- a/cpp/inc/bond/protocol/simple_json_writer.h
+++ b/cpp/inc/bond/protocol/simple_json_writer.h
@@ -40,6 +40,13 @@ public:
           _all_fields(all_fields)
     {}
 
+    /// @brief Access to underlaying buffer
+    typename boost::call_traits<Buffer>::reference
+    GetBuffer()
+    {
+        return _output;
+    }
+
     void WriteVersion()
     {}
     

--- a/cpp/inc/bond/protocol/simple_json_writer.h
+++ b/cpp/inc/bond/protocol/simple_json_writer.h
@@ -40,7 +40,7 @@ public:
           _all_fields(all_fields)
     {}
 
-    /// @brief Access to underlaying buffer
+    /// @brief Access to underlying buffer
     typename boost::call_traits<Buffer>::reference
     GetBuffer()
     {


### PR DESCRIPTION
This change adds non-`const` overloads of `GetBuffer` function in protocol readers and writers which helps make it possible to refactor the handling of buffers to remove the hard-coded built-in buffers.
