### PR TITLE
[c++] Use simplified uniform signature for bond::Apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ different versioning scheme, following the Haskell community's
     * Clang 3.4 or newer
     * GNU C++ 4.7 or newer
     * Microsoft Visual C++ 2013 or newer
+* The `bond::Apply` now has a uniform signature. Users who were calling
+  the overload for `Marshaler<Writer>` transform and were _mistakenly_
+  passing `Writer` explicitly (i.e. `bond::Apply<Writer>(marshaler, value)`)
+  they will get a compile error. To fix, please remove the `<Writer>` part.
 
 ## 5.3.0: 2017-04-12 ##
 * `gbc` & compiler library: 0.9.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,11 @@ different versioning scheme, following the Haskell community's
     * Clang 3.4 or newer
     * GNU C++ 4.7 or newer
     * Microsoft Visual C++ 2013 or newer
-* The `bond::Apply` now has a uniform signature. Users who were calling
-  the overload for `Marshaler<Writer>` transform and were _mistakenly_
-  passing `Writer` explicitly (i.e. `bond::Apply<Writer>(marshaler, value)`)
-  they will get a compile error. To fix, please remove the `<Writer>` part.
+* The `bond::Apply` function now has a uniform signature. Call sites for
+the `Marshaler<Writer>` transform overload that were _mistakenly_ passing
+`Writer` explicitly (e.g. `bond::Apply<Writer>(marshaler, value)`) will now
+get a compiler error. To fix, remove the `<Writer>` part:
+`bond::Apply(marshaler, value)`.
 
 ## 5.3.0: 2017-04-12 ##
 * `gbc` & compiler library: 0.9.0.0

--- a/cpp/inc/bond/core/apply.h
+++ b/cpp/inc/bond/core/apply.h
@@ -12,12 +12,13 @@
 
 namespace bond
 {
-
+namespace detail
+{
 
 /// @brief Apply transform to serialized struct wrapped in bonded<T>
 template <typename Transform, typename T, typename Reader>
-typename boost::disable_if<detail::need_double_pass<Transform>, bool>::type inline
-Apply(const Transform& transform, const bonded<T, Reader>& bonded)
+typename boost::disable_if<need_double_pass<Transform>, bool>::type inline
+ApplyTransform(const Transform& transform, const bonded<T, Reader>& bonded)
 {
     return bonded._Apply(transform);
 }
@@ -25,17 +26,18 @@ Apply(const Transform& transform, const bonded<T, Reader>& bonded)
 
 /// @brief Apply transform to serialized container wrapped in value<T, Reader>
 template <typename Transform, typename T, typename Reader>
-void inline
-Apply(const Transform& transform, const value<T, Reader>& value)
+bool inline
+ApplyTransform(const Transform& transform, const value<T, Reader>& value)
 {
     value._Apply(transform);
+    return true;
 }
 
 
 /// @brief Apply transform to an instance of a struct
 template <typename Transform, typename T>
-typename boost::disable_if<detail::need_double_pass<Transform>, bool>::type inline
-Apply(const Transform& transform, const T& value)
+typename boost::disable_if<need_double_pass<Transform>, bool>::type inline
+ApplyTransform(const Transform& transform, const T& value)
 {
     return StaticParser<const T&>(value).Apply(transform, typename schema<T>::type());
 }
@@ -44,7 +46,7 @@ Apply(const Transform& transform, const T& value)
 /// @brief Apply transform which can modify an instance of a struct
 template <typename Transform, typename T>
 typename boost::enable_if<is_modifying_transform<Transform>, bool>::type inline
-Apply(const Transform& transform, T& value)
+ApplyTransform(const Transform& transform, T& value)
 {
     return StaticParser<T&>(value).Apply(transform, typename schema<T>::type());
 }
@@ -52,26 +54,40 @@ Apply(const Transform& transform, T& value)
 
 // Specializations for transform requiring double-pass
 template <typename Transform, typename T, typename Reader>
-typename boost::enable_if<detail::need_double_pass<Transform>, bool>::type inline
-Apply(const Transform& transform, const bonded<T, Reader>& bonded)
+typename boost::enable_if<need_double_pass<Transform>, bool>::type inline
+ApplyTransform(const Transform& transform, const bonded<T, Reader>& bonded)
 {
     if (transform.NeedPass0())
-        return detail::DoublePassApply(transform, bonded);
+        return DoublePassApply(transform, bonded);
     else
         return bonded._Apply(transform);
 }
 
 
 template <typename Transform, typename T>
-typename boost::enable_if<detail::need_double_pass<Transform>, bool>::type inline
-Apply(const Transform& transform, const T& value)
+typename boost::enable_if<need_double_pass<Transform>, bool>::type inline
+ApplyTransform(const Transform& transform, const T& value)
 {
     if (transform.NeedPass0())
-        return detail::DoublePassApply(transform, value);
+        return DoublePassApply(transform, value);
     else
         return StaticParser<const T&>(value).Apply(transform, typename schema<T>::type());
 }
 
+} // namespace detail
+
+
+template <typename Transform, typename T>
+bool inline Apply(const Transform& transform, T& value)
+{
+    return detail::ApplyTransform(transform, value);
+}
+
+template <typename Transform, typename T>
+bool inline Apply(const Transform& transform, const T& value)
+{
+    return detail::ApplyTransform(transform, value);
+}
 
 } // namespace bond
 

--- a/cpp/inc/bond/core/bonded.h
+++ b/cpp/inc/bond/core/bonded.h
@@ -12,6 +12,18 @@
 
 namespace bond
 {
+namespace detail
+{
+
+template <typename Transform, typename T, typename Reader>
+typename boost::disable_if<need_double_pass<Transform>, bool>::type inline
+ApplyTransform(const Transform& transform, const bonded<T, Reader>& bonded);
+
+template <typename Transform, typename T, typename Reader>
+typename boost::enable_if<need_double_pass<Transform>, bool>::type inline
+ApplyTransform(const Transform& transform, const bonded<T, Reader>& bonded);
+
+} // namespace detail
 
 
 template <typename T, typename Reader, typename Unused = void> struct
@@ -216,11 +228,11 @@ public:
 
     template <typename Transform, typename U, typename ReaderT>
     friend typename boost::disable_if<detail::need_double_pass<Transform>, bool>::type inline
-    Apply(const Transform& transform, const bonded<U, ReaderT>& bonded);
+    detail::ApplyTransform(const Transform& transform, const bonded<U, ReaderT>& bonded);
 
     template <typename Transform, typename U, typename ReaderT>
     friend typename boost::enable_if<detail::need_double_pass<Transform>, bool>::type inline
-    Apply(const Transform& transform, const bonded<U, ReaderT>& bonded);
+    detail::ApplyTransform(const Transform& transform, const bonded<U, ReaderT>& bonded);
 
     template <typename U, typename ReaderT>
     friend class bonded;

--- a/cpp/inc/bond/core/bonded_void.h
+++ b/cpp/inc/bond/core/bonded_void.h
@@ -141,11 +141,11 @@ public:
 
     template <typename Transform, typename U, typename ReaderT>
     friend typename boost::disable_if<detail::need_double_pass<Transform>, bool>::type inline
-    Apply(const Transform& transform, const bonded<U, ReaderT>& bonded);
+    detail::ApplyTransform(const Transform& transform, const bonded<U, ReaderT>& bonded);
 
     template <typename Transform, typename U, typename ReaderT>
     friend typename boost::enable_if<detail::need_double_pass<Transform>, bool>::type inline
-    Apply(const Transform& transform, const bonded<U, ReaderT>& bonded);
+    detail::ApplyTransform(const Transform& transform, const bonded<U, ReaderT>& bonded);
 
     template <typename T, typename ReaderT>
     friend class bonded;

--- a/cpp/inc/bond/core/transforms.h
+++ b/cpp/inc/bond/core/transforms.h
@@ -316,9 +316,12 @@ public:
 };
 
 
+namespace detail
+{
+
 template <typename Writer, typename T, typename Reader>
 bool inline
-Apply(const Marshaler<Writer>& marshaler, const bonded<T, Reader>& bonded)
+ApplyTransform(const Marshaler<Writer>& marshaler, const bonded<T, Reader>& bonded)
 {
     return marshaler.Marshal(bonded);
 }
@@ -326,10 +329,12 @@ Apply(const Marshaler<Writer>& marshaler, const bonded<T, Reader>& bonded)
 
 template <typename Writer, typename T>
 bool inline 
-Apply(const Marshaler<Writer>& marshaler, const T& value)
+ApplyTransform(const Marshaler<Writer>& marshaler, const T& value)
 {
     return marshaler.Marshal(value);
 }
+
+} // namespace detail
 
 
 // MarshalTo

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -1,6 +1,7 @@
 #include "precompiled.h"
 #include "apply_tests.h"
 #include "apply_test_apply.h"
+#include "apply_test_reflection.h"
 
 void Init(unittest::apply::Struct& obj)
 {


### PR DESCRIPTION
The `bond::Apply` function has multiple overloads with [SFINAE](http://en.cppreference.com/w/cpp/language/sfinae) checks which are invoked from multiple places. This change moves them to `bond::detail::ApplyTransform` and replaces with only two simple ones without those checks. It reduces compilers' memory consumption and improves build time and also avoids some compiler crashes (primarily on MSVC).