### PR TITLE
[gbc c++] Generate extern templates of bond::Apply instead of overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ different versioning scheme, following the Haskell community's
     * Microsoft Visual C++ 2013 or newer
 * **Breaking change** The generated apply.h/.cpp files now contain
   [extern templates](http://en.cppreference.com/w/cpp/language/function_template)
-  of `bond::Apply` instead of overload implementations.
+  of `bond::Apply` instead of overload implementations. Calls to bare `Apply`
+  or `TypeNamespace::Apply` must be changed to `bond::Apply`.
 * The `bond::Apply` function now has a uniform signature. Call sites for
 the `Marshaler<Writer>` transform overload that were _mistakenly_ passing
 `Writer` explicitly (e.g. `bond::Apply<Writer>(marshaler, value)`) will now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ the `Marshaler<Writer>` transform overload that were _mistakenly_ passing
 `Writer` explicitly (e.g. `bond::Apply<Writer>(marshaler, value)`) will now
 get a compiler error. To fix, remove the `<Writer>` part:
 `bond::Apply(marshaler, value)`.
+* C++ codegen now generates [extern templates](http://en.cppreference.com/w/cpp/language/function_template) of `bond::Apply` instead of overloads.
 
 ## 5.3.0: 2017-04-12 ##
 * `gbc` & compiler library: 0.9.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ different versioning scheme, following the Haskell community's
 * C# NuGet version: TBD
 * C# Comm NuGet version: TBD
 
+### `gbc` and Bond compiler library ###
+
+* C++ codegen now generates [extern templates](http://en.cppreference.com/w/cpp/language/function_template) of `bond::Apply` instead of overloads.
+
 ### C++ ###
 
 * **Breaking change** A C++11 compiler is now required. The minimum
@@ -31,7 +35,8 @@ the `Marshaler<Writer>` transform overload that were _mistakenly_ passing
 `Writer` explicitly (e.g. `bond::Apply<Writer>(marshaler, value)`) will now
 get a compiler error. To fix, remove the `<Writer>` part:
 `bond::Apply(marshaler, value)`.
-* C++ codegen now generates [extern templates](http://en.cppreference.com/w/cpp/language/function_template) of `bond::Apply` instead of overloads.
+* **Breaking change** Generated *_apply.h/.cpp files now contain [extern templates](http://en.cppreference.com/w/cpp/language/function_template)
+  of `bond::Apply` instead of overload implementations.
 
 ## 5.3.0: 2017-04-12 ##
 * `gbc` & compiler library: 0.9.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ different versioning scheme, following the Haskell community's
 
 ### `gbc` and Bond compiler library ###
 
-* C++ codegen now generates [extern templates](http://en.cppreference.com/w/cpp/language/function_template) of `bond::Apply` instead of overloads.
+* C++ codegen now generates
+  [extern templates](http://en.cppreference.com/w/cpp/language/function_template)
+  of `bond::Apply` instead of overloads.
 
 ### C++ ###
 
@@ -30,6 +32,9 @@ different versioning scheme, following the Haskell community's
     * Clang 3.4 or newer
     * GNU C++ 4.7 or newer
     * Microsoft Visual C++ 2013 or newer
+* **Breaking change** The generated apply.h/.cpp files now contain
+  [extern templates](http://en.cppreference.com/w/cpp/language/function_template)
+  of `bond::Apply` instead of overload implementations.
 * The `bond::Apply` function now has a uniform signature. Call sites for
 the `Marshaler<Writer>` transform overload that were _mistakenly_ passing
 `Writer` explicitly (e.g. `bond::Apply<Writer>(marshaler, value)`) will now
@@ -38,8 +43,6 @@ get a compiler error. To fix, remove the `<Writer>` part:
 * Fixed a bug that caused serialization using
   `CompactBinaryWriter<OutputCounter>` (to get the expected length of
   serializing with compact binary) to produced bogus results.
-* **Breaking change** Generated *_apply.h/.cpp files now contain [extern templates](http://en.cppreference.com/w/cpp/language/function_template)
-  of `bond::Apply` instead of overload implementations.
 
 ## 5.3.0: 2017-04-12 ##
 * `gbc` & compiler library: 0.9.0.0

--- a/compiler/src/Language/Bond/Codegen/Cpp/ApplyOverloads.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/ApplyOverloads.hs
@@ -28,16 +28,16 @@ applyOverloads protocols cpp attr extern s@Struct {..} | null declParams = [lt|
     // transforms for #{declName}.
     //
 
-    #{extern}template
-    #{attr}bool Apply(const ::bond::To< #{qualifiedName}>& transform,
+    #{extern}template #{attr}
+    bool Apply(const ::bond::To< #{qualifiedName}>& transform,
                const ::bond::bonded< #{qualifiedName}>& value);
 
-    #{extern}template
-    #{attr}bool Apply(const ::bond::InitSchemaDef& transform,
+    #{extern}template #{attr}
+    bool Apply(const ::bond::InitSchemaDef& transform,
                const #{qualifiedName}& value);
 
-    #{extern}template
-    #{attr}bool Apply(const ::bond::Null& transform,
+    #{extern}template #{attr}
+    bool Apply(const ::bond::Null& transform,
                const ::bond::bonded< #{qualifiedName}, ::bond::SimpleBinaryReader< ::bond::InputBuffer>&>& value);
     #{newlineSep 1 applyOverloads' protocols}|]
   where
@@ -52,29 +52,29 @@ applyOverloads protocols cpp attr extern s@Struct {..} | null declParams = [lt|
 
     deserialization (ProtocolWriter _) = mempty
     deserialization (ProtocolReader protocolReader) = [lt|
-    #{extern}template
-    #{attr}bool Apply(const ::bond::To< #{qualifiedName}>& transform,
+    #{extern}template #{attr}
+    bool Apply(const ::bond::To< #{qualifiedName}>& transform,
                const ::bond::bonded< #{qualifiedName}, #{protocolReader}&>& value);
 
-    #{extern}template
-    #{attr}bool Apply(const ::bond::To< #{qualifiedName}>& transform,
+    #{extern}template #{attr}
+    bool Apply(const ::bond::To< #{qualifiedName}>& transform,
                const ::bond::bonded<void, #{protocolReader}&>& value);|]
 
     serialization (ProtocolReader _) _ = mempty
     serialization (ProtocolWriter protocolWriter) transform = [lt|
-    #{extern}template
-    #{attr}bool Apply(const ::bond::#{transform}<#{protocolWriter} >& transform,
+    #{extern}template #{attr}
+    bool Apply(const ::bond::#{transform}<#{protocolWriter} >& transform,
                const #{qualifiedName}& value);
 
-    #{extern}template
-    #{attr}bool Apply(const ::bond::#{transform}<#{protocolWriter} >& transform,
+    #{extern}template #{attr}
+    bool Apply(const ::bond::#{transform}<#{protocolWriter} >& transform,
                const ::bond::bonded< #{qualifiedName}>& value);
     #{newlineSep 1 transcoding protocols}|]
       where
         transcoding (ProtocolWriter _) = mempty
         transcoding (ProtocolReader protocolReader) = [lt|
-    #{extern}template
-    #{attr}bool Apply(const ::bond::#{transform}<#{protocolWriter} >& transform,
+    #{extern}template #{attr}
+    bool Apply(const ::bond::#{transform}<#{protocolWriter} >& transform,
                const ::bond::bonded< #{qualifiedName}, #{protocolReader}&>& value);|]
 
 applyOverloads _ _ _ _ _ = mempty

--- a/compiler/src/Language/Bond/Codegen/Cpp/ApplyOverloads.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/ApplyOverloads.hs
@@ -28,15 +28,15 @@ applyOverloads protocols cpp attr extern s@Struct {..} | null declParams = [lt|
     // transforms for #{declName}.
     //
 
-    #{extern}
+    #{extern}template
     #{attr}bool Apply(const ::bond::To< #{qualifiedName}>& transform,
                const ::bond::bonded< #{qualifiedName}>& value);
 
-    #{extern}
+    #{extern}template
     #{attr}bool Apply(const ::bond::InitSchemaDef& transform,
                const #{qualifiedName}& value);
 
-    #{extern}
+    #{extern}template
     #{attr}bool Apply(const ::bond::Null& transform,
                const ::bond::bonded< #{qualifiedName}, ::bond::SimpleBinaryReader< ::bond::InputBuffer>&>& value);
     #{newlineSep 1 applyOverloads' protocols}|]
@@ -52,28 +52,28 @@ applyOverloads protocols cpp attr extern s@Struct {..} | null declParams = [lt|
 
     deserialization (ProtocolWriter _) = mempty
     deserialization (ProtocolReader protocolReader) = [lt|
-    #{extern}
+    #{extern}template
     #{attr}bool Apply(const ::bond::To< #{qualifiedName}>& transform,
                const ::bond::bonded< #{qualifiedName}, #{protocolReader}&>& value);
 
-    #{extern}
+    #{extern}template
     #{attr}bool Apply(const ::bond::To< #{qualifiedName}>& transform,
                const ::bond::bonded<void, #{protocolReader}&>& value);|]
 
     serialization (ProtocolReader _) _ = mempty
     serialization (ProtocolWriter protocolWriter) transform = [lt|
-    #{extern}
+    #{extern}template
     #{attr}bool Apply(const ::bond::#{transform}<#{protocolWriter} >& transform,
                const #{qualifiedName}& value);
 
-    #{extern}
+    #{extern}template
     #{attr}bool Apply(const ::bond::#{transform}<#{protocolWriter} >& transform,
                const ::bond::bonded< #{qualifiedName}>& value);
     #{newlineSep 1 transcoding protocols}|]
       where
         transcoding (ProtocolWriter _) = mempty
         transcoding (ProtocolReader protocolReader) = [lt|
-    #{extern}
+    #{extern}template
     #{attr}bool Apply(const ::bond::#{transform}<#{protocolWriter} >& transform,
                const ::bond::bonded< #{qualifiedName}, #{protocolReader}&>& value);|]
 

--- a/compiler/src/Language/Bond/Codegen/Cpp/ApplyOverloads.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/ApplyOverloads.hs
@@ -22,20 +22,23 @@ data Protocol =
 
 -- Apply overloads
 applyOverloads :: [Protocol] -> MappingContext -> Text -> Text -> Declaration -> Text
-applyOverloads protocols cpp attr body s@Struct {..} | null declParams = [lt|
+applyOverloads protocols cpp attr extern s@Struct {..} | null declParams = [lt|
     //
-    // Overloads of Apply function with common transforms for #{declName}.
-    // These overloads will be selected using argument dependent lookup
-    // before ::bond::Apply function templates.
+    // Extern template specializations of Apply function with common
+    // transforms for #{declName}.
     //
+
+    #{extern}
     #{attr}bool Apply(const ::bond::To< #{qualifiedName}>& transform,
-               const ::bond::bonded< #{qualifiedName}>& value)#{body}
+               const ::bond::bonded< #{qualifiedName}>& value);
 
+    #{extern}
     #{attr}bool Apply(const ::bond::InitSchemaDef& transform,
-               const #{qualifiedName}& value)#{body}
+               const #{qualifiedName}& value);
 
+    #{extern}
     #{attr}bool Apply(const ::bond::Null& transform,
-               const ::bond::bonded< #{qualifiedName}, ::bond::SimpleBinaryReader< ::bond::InputBuffer>&>& value)#{body}
+               const ::bond::bonded< #{qualifiedName}, ::bond::SimpleBinaryReader< ::bond::InputBuffer>&>& value);
     #{newlineSep 1 applyOverloads' protocols}|]
   where
     qualifiedName = getDeclTypeName cpp s
@@ -49,24 +52,29 @@ applyOverloads protocols cpp attr body s@Struct {..} | null declParams = [lt|
 
     deserialization (ProtocolWriter _) = mempty
     deserialization (ProtocolReader protocolReader) = [lt|
+    #{extern}
     #{attr}bool Apply(const ::bond::To< #{qualifiedName}>& transform,
-               const ::bond::bonded< #{qualifiedName}, #{protocolReader}&>& value)#{body}
+               const ::bond::bonded< #{qualifiedName}, #{protocolReader}&>& value);
 
+    #{extern}
     #{attr}bool Apply(const ::bond::To< #{qualifiedName}>& transform,
-               const ::bond::bonded<void, #{protocolReader}&>& value)#{body}|]
+               const ::bond::bonded<void, #{protocolReader}&>& value);|]
 
     serialization (ProtocolReader _) _ = mempty
     serialization (ProtocolWriter protocolWriter) transform = [lt|
+    #{extern}
     #{attr}bool Apply(const ::bond::#{transform}<#{protocolWriter} >& transform,
-               const #{qualifiedName}& value)#{body}
+               const #{qualifiedName}& value);
 
+    #{extern}
     #{attr}bool Apply(const ::bond::#{transform}<#{protocolWriter} >& transform,
-               const ::bond::bonded< #{qualifiedName}>& value)#{body}
+               const ::bond::bonded< #{qualifiedName}>& value);
     #{newlineSep 1 transcoding protocols}|]
       where
         transcoding (ProtocolWriter _) = mempty
         transcoding (ProtocolReader protocolReader) = [lt|
+    #{extern}
     #{attr}bool Apply(const ::bond::#{transform}<#{protocolWriter} >& transform,
-               const ::bond::bonded< #{qualifiedName}, #{protocolReader}&>& value)#{body}|]
+               const ::bond::bonded< #{qualifiedName}, #{protocolReader}&>& value);|]
 
 applyOverloads _ _ _ _ _ = mempty

--- a/compiler/src/Language/Bond/Codegen/Cpp/Apply_cpp.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Apply_cpp.hs
@@ -28,5 +28,5 @@ namespace bond
   where
     attr = [lt||]
 
-    extern = [lt|template|]
+    extern = [lt||]
 

--- a/compiler/src/Language/Bond/Codegen/Cpp/Apply_cpp.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Apply_cpp.hs
@@ -11,7 +11,6 @@ import Language.Bond.Syntax.Types
 import Language.Bond.Codegen.TypeMapping
 import Language.Bond.Codegen.Util
 import Language.Bond.Codegen.Cpp.ApplyOverloads
-import qualified Language.Bond.Codegen.Cpp.Util as CPP
 
 -- | Codegen template for generating /base_name/_apply.cpp containing
 -- definitions of the @Apply@ function overloads for the specified protocols.
@@ -21,15 +20,13 @@ apply_cpp protocols cpp file _imports declarations = ("_apply.cpp", [lt|
 #include "#{file}_apply.h"
 #include "#{file}_reflection.h"
 
-#{CPP.openNamespace cpp}
-    #{newlineSepEnd 1 (applyOverloads protocols cpp attr body) declarations}
-#{CPP.closeNamespace cpp}
+namespace bond
+{
+    #{newlineSepEnd 1 (applyOverloads protocols cpp attr extern) declarations}
+} // namespace bond
 |])
   where
-    body = [lt|
-    {
-        return ::bond::Apply<>(transform, value);
-    }|]
-
     attr = [lt||]
+
+    extern = [lt|template|]
 

--- a/compiler/src/Language/Bond/Codegen/Cpp/Apply_cpp.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Apply_cpp.hs
@@ -26,7 +26,6 @@ namespace bond
 } // namespace bond
 |])
   where
-    attr = [lt||]
-
-    extern = [lt||]
+    attr = ""
+    extern = ""
 

--- a/compiler/src/Language/Bond/Codegen/Cpp/Apply_h.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Apply_h.hs
@@ -37,8 +37,7 @@ namespace bond
   where
     includeImport (Import path) = [lt|#include "#{dropExtension path}_apply.h"|]
 
-    export_attr = optional (\a -> [lt|#{a}
-    |]) export_attribute
+    export_attr = optional (\a -> [lt|#{a}|]) export_attribute
 
     extern = "extern "
 

--- a/compiler/src/Language/Bond/Codegen/Cpp/Apply_h.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Apply_h.hs
@@ -40,5 +40,5 @@ namespace bond
     export_attr = optional (\a -> [lt|#{a}
     |]) export_attribute
 
-    extern = [lt|extern |]
+    extern = "extern "
 

--- a/compiler/src/Language/Bond/Codegen/Cpp/Apply_h.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Apply_h.hs
@@ -40,5 +40,5 @@ namespace bond
     export_attr = optional (\a -> [lt|#{a}
     |]) export_attribute
 
-    extern = [lt|extern template |]
+    extern = [lt|extern |]
 

--- a/compiler/src/Language/Bond/Codegen/Cpp/Apply_h.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Apply_h.hs
@@ -14,7 +14,6 @@ import Language.Bond.Util
 import Language.Bond.Codegen.Util
 import Language.Bond.Codegen.TypeMapping
 import Language.Bond.Codegen.Cpp.ApplyOverloads
-import qualified Language.Bond.Codegen.Cpp.Util as CPP
 
 -- | Codegen template for generating /base_name/_apply.h containing declarations of
 -- <https://microsoft.github.io/bond/manual/bond_cpp.html#optimizing-build-time Apply>
@@ -30,9 +29,10 @@ apply_h protocols export_attribute cpp file imports declarations = ("_apply.h", 
 #include <bond/stream/output_buffer.h>
 #{newlineSep 0 includeImport imports}
 
-#{CPP.openNamespace cpp}
-    #{newlineSepEnd 1 (applyOverloads protocols cpp export_attr semi) declarations}
-#{CPP.closeNamespace cpp}
+namespace bond
+{
+    #{newlineSepEnd 1 (applyOverloads protocols cpp export_attr extern) declarations}
+} // namespace bond
 |])
   where
     includeImport (Import path) = [lt|#include "#{dropExtension path}_apply.h"|]
@@ -40,5 +40,5 @@ apply_h protocols export_attribute cpp file imports declarations = ("_apply.h", 
     export_attr = optional (\a -> [lt|#{a}
     |]) export_attribute
 
-    semi = [lt|;|]
+    extern = [lt|extern template |]
 

--- a/compiler/tests/generated/apply/basic_types_apply.cpp
+++ b/compiler/tests/generated/apply/basic_types_apply.cpp
@@ -10,199 +10,199 @@ namespace bond
     // transforms for BasicTypes.
     //
 
-    template
+    template 
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
 
-    template
+    template 
     bool Apply(const ::bond::InitSchemaDef& transform,
                const ::tests::BasicTypes& value);
 
-    template
+    template 
     bool Apply(const ::bond::Null& transform,
                const ::bond::bonded< ::tests::BasicTypes, ::bond::SimpleBinaryReader< ::bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
 
-    template
+    template 
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded<void, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::tests::BasicTypes& value);
 
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::tests::BasicTypes& value);
 
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
 
-    template
+    template 
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded<void, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
 
-    template
+    template 
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded<void, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    template
+    template 
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     

--- a/compiler/tests/generated/apply/basic_types_apply.cpp
+++ b/compiler/tests/generated/apply/basic_types_apply.cpp
@@ -2,306 +2,208 @@
 #include "basic_types_apply.h"
 #include "basic_types_reflection.h"
 
-namespace tests
+namespace bond
 {
     
     //
-    // Overloads of Apply function with common transforms for BasicTypes.
-    // These overloads will be selected using argument dependent lookup
-    // before ::bond::Apply function templates.
+    // Extern template specializations of Apply function with common
+    // transforms for BasicTypes.
     //
-    bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
-               const ::bond::bonded< ::tests::BasicTypes>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
 
+    template
+    bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
+               const ::bond::bonded< ::tests::BasicTypes>& value);
+
+    template
     bool Apply(const ::bond::InitSchemaDef& transform,
-               const ::tests::BasicTypes& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::tests::BasicTypes& value);
 
+    template
     bool Apply(const ::bond::Null& transform,
-               const ::bond::bonded< ::tests::BasicTypes, ::bond::SimpleBinaryReader< ::bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, ::bond::SimpleBinaryReader< ::bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
 
+    template
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
-               const ::bond::bonded<void, bond::CompactBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded<void, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::tests::BasicTypes& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::tests::BasicTypes& value);
 
+    template
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes>& value);
     
+    template
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::tests::BasicTypes& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::tests::BasicTypes& value);
 
+    template
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes>& value);
     
+    template
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
-               const ::tests::BasicTypes& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::tests::BasicTypes& value);
 
+    template
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes>& value);
     
+    template
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
-               const ::tests::BasicTypes& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::tests::BasicTypes& value);
 
+    template
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes>& value);
     
+    template
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
 
+    template
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
-               const ::bond::bonded<void, bond::FastBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded<void, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::tests::BasicTypes& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::tests::BasicTypes& value);
 
+    template
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes>& value);
     
+    template
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::tests::BasicTypes& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::tests::BasicTypes& value);
 
+    template
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes>& value);
     
+    template
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
 
+    template
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
-               const ::bond::bonded<void, bond::SimpleBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded<void, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::tests::BasicTypes& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::tests::BasicTypes& value);
 
+    template
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes>& value);
     
+    template
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::tests::BasicTypes& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::tests::BasicTypes& value);
 
+    template
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes>& value);
     
+    template
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    template
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
-               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value)
-    {
-        return ::bond::Apply<>(transform, value);
-    }
+               const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-} // namespace tests
+} // namespace bond

--- a/compiler/tests/generated/apply/basic_types_apply.h
+++ b/compiler/tests/generated/apply/basic_types_apply.h
@@ -14,248 +14,199 @@ namespace bond
     // transforms for BasicTypes.
     //
 
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
 
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::InitSchemaDef& transform,
                const ::tests::BasicTypes& value);
 
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Null& transform,
                const ::bond::bonded< ::tests::BasicTypes, ::bond::SimpleBinaryReader< ::bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
 
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded<void, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::tests::BasicTypes& value);
 
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::tests::BasicTypes& value);
 
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
 
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded<void, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
 
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded<void, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template
-    DllExport
+    extern template DllExport
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     

--- a/compiler/tests/generated/apply/basic_types_apply.h
+++ b/compiler/tests/generated/apply/basic_types_apply.h
@@ -14,247 +14,247 @@ namespace bond
     // transforms for BasicTypes.
     //
 
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
 
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::InitSchemaDef& transform,
                const ::tests::BasicTypes& value);
 
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Null& transform,
                const ::bond::bonded< ::tests::BasicTypes, ::bond::SimpleBinaryReader< ::bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
 
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded<void, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::tests::BasicTypes& value);
 
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::tests::BasicTypes& value);
 
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
 
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded<void, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
 
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded<void, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
-    extern template 
+    extern template
     DllExport
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);

--- a/compiler/tests/generated/apply/basic_types_apply.h
+++ b/compiler/tests/generated/apply/basic_types_apply.h
@@ -6,208 +6,257 @@
 #include <bond/stream/output_buffer.h>
 
 
-namespace tests
+namespace bond
 {
     
     //
-    // Overloads of Apply function with common transforms for BasicTypes.
-    // These overloads will be selected using argument dependent lookup
-    // before ::bond::Apply function templates.
+    // Extern template specializations of Apply function with common
+    // transforms for BasicTypes.
     //
+
+    extern template 
     DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
 
+    extern template 
     DllExport
     bool Apply(const ::bond::InitSchemaDef& transform,
                const ::tests::BasicTypes& value);
 
+    extern template 
     DllExport
     bool Apply(const ::bond::Null& transform,
                const ::bond::bonded< ::tests::BasicTypes, ::bond::SimpleBinaryReader< ::bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
 
+    extern template 
     DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded<void, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::tests::BasicTypes& value);
 
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::tests::BasicTypes& value);
 
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::CompactBinaryWriter<bond::OutputCounter> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
 
+    extern template 
     DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded<void, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::FastBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
 
+    extern template 
     DllExport
     bool Apply(const ::bond::To< ::tests::BasicTypes>& transform,
                const ::bond::bonded<void, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Serializer<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::tests::BasicTypes& value);
 
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::CompactBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::FastBinaryReader<bond::InputBuffer>&>& value);
     
+    extern template 
     DllExport
     bool Apply(const ::bond::Marshaler<bond::SimpleBinaryWriter<bond::OutputBuffer> >& transform,
                const ::bond::bonded< ::tests::BasicTypes, bond::SimpleBinaryReader<bond::InputBuffer>&>& value);
     
-} // namespace tests
+} // namespace bond

--- a/cpp/inc/bond/core/apply.h
+++ b/cpp/inc/bond/core/apply.h
@@ -78,13 +78,13 @@ ApplyTransform(const Transform& transform, const T& value)
 
 
 template <typename Transform, typename T>
-bool inline Apply(const Transform& transform, T& value)
+bool Apply(const Transform& transform, T& value)
 {
     return detail::ApplyTransform(transform, value);
 }
 
 template <typename Transform, typename T>
-bool inline Apply(const Transform& transform, const T& value)
+bool Apply(const Transform& transform, const T& value)
 {
     return detail::ApplyTransform(transform, value);
 }


### PR DESCRIPTION
Currently code-generated *_apply.h/.cpp files are achieving build time improvements by declaring additional overloads of `bond::Apply` function for predefined set of transforms and a given user-defined struct(s) which are then selected, thanks to [ADL](http://en.cppreference.com/w/cpp/language/adl). With C++11 the same can be achieved in a more idiomatic way by using [extern templates](http://en.cppreference.com/w/cpp/language/function_template).