### PR TITLE
[c++] Upgrade RapidJSON dependency to v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ get a compiler error. To fix, remove the `<Writer>` part:
 * Fixed a bug that caused serialization using
   `CompactBinaryWriter<OutputCounter>` (to get the expected length of
   serializing with compact binary) to produced bogus results.
+* For Visual C++ 2017 compability, RapidJSON v1.0.0 or newer is now
+  required. The RapidJSON submodule that Bond uses by default has been
+  updated to v1.0.0.
 
 ## 5.3.0: 2017-04-12 ##
 * `gbc` & compiler library: 0.9.0.0


### PR DESCRIPTION
To build with Visual C++ 2017, we need a [fix from RapidJSON for the
_umul128 intrinsic][1]. This fix was first included in the v1.0.0
release of RapidJSON.

Fixes https://github.com/Microsoft/bond/issues/340

[1]: https://github.com/miloyip/rapidjson/commit/4b4f726dd810967498b81ef05f8ed62f04384968