### PR TITLE
[c++] Fixing a regression in pre-compiled Apply functions

### DIFF
--- a/cpp/inc/bond/core/apply.h
+++ b/cpp/inc/bond/core/apply.h
@@ -77,16 +77,14 @@ ApplyTransform(const Transform& transform, const T& value)
 } // namespace detail
 
 
-template <typename Transform, typename T>
-typename boost::enable_if<is_modifying_transform<Transform>, bool>::type
-Apply(const Transform& transform, T& value)
+template <typename Transform, typename T, typename boost::enable_if<is_modifying_transform<Transform> >::type* = nullptr>
+bool Apply(const Transform& transform, T& value)
 {
     return detail::ApplyTransform(transform, value);
 }
 
 template <typename Transform, typename T>
-typename boost::disable_if<is_modifying_transform<Transform>, bool>::type
-Apply(const Transform& transform, const T& value)
+bool Apply(const Transform& transform, const T& value)
 {
     return detail::ApplyTransform(transform, value);
 }

--- a/cpp/inc/bond/core/apply.h
+++ b/cpp/inc/bond/core/apply.h
@@ -78,13 +78,15 @@ ApplyTransform(const Transform& transform, const T& value)
 
 
 template <typename Transform, typename T>
-bool Apply(const Transform& transform, T& value)
+typename boost::enable_if<is_modifying_transform<Transform>, bool>::type
+Apply(const Transform& transform, T& value)
 {
     return detail::ApplyTransform(transform, value);
 }
 
 template <typename Transform, typename T>
-bool Apply(const Transform& transform, const T& value)
+typename boost::disable_if<is_modifying_transform<Transform>, bool>::type
+Apply(const Transform& transform, const T& value)
 {
     return detail::ApplyTransform(transform, value);
 }

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -1,6 +1,6 @@
 #include "precompiled.h"
 #include "apply_tests.h"
-#include "apply_test_reflection.h"
+#include "apply_test_apply.h"   // The _reflection.h should not be included.
 
 void Init(unittest::apply::Struct& obj)
 {

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -1,6 +1,7 @@
 #include "precompiled.h"
 #include "apply_tests.h"
-#include "apply_test_apply.h"   // The _reflection.h should not be included.
+#include "apply_test_apply.h"   // Note that we don't want to include apply_test_reflection.h so that
+                                // we only see pre-generated Apply overloads.
 
 void Init(unittest::apply::Struct& obj)
 {


### PR DESCRIPTION
After introducing the two simpler overloads of `Apply` in #411 the case when passing a non-`const` reference to `bonded` selects an overload that takes non-`const T&` while corresponding `_apply.cpp` compiles it with `const` argument. This change fixes it by making sure that `Apply` accepting `T&` participates in overload resolution only for modifying transforms.