### PR TITLE
[c++] Only use /permissive- on VC++ 2017 and later

### DIFF
--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -42,7 +42,7 @@ if (MSVC)
     # Our minimum required version of CMake doesn't have GREATER_EQUAL, so
     # we invert a less-than comparison instead. CMake 3.7 added
     # GREATER_EQUAL.
-    if (NOT (MSVC_VERSION LESS 1900))
+    if (NOT (MSVC_VERSION LESS 1910))
       add_compile_options (/permissive-)
     endif()
 


### PR DESCRIPTION
The original condition (`NOT (MSVC_VERSION LESS 1900)`) was triggering
for Visual C++ 2015 as well.

* Visual C++ 2015 has a `MSVC_VERSION` of 1900.
* Visual C++ 2017 has a `MSVC_VERSION` of 1910.

The original error was not caught, as it was causing the _command line
warning_ "Command line warning D9002 : ignoring unknown option
'/permissive-'" to be emitted. The CI builds don't fail on these sort of
warnings. (The cl.exe switch `/WX` does not turn this warning into a
non-zero exit code.)