### PR TITLE
[gbc] Pin gbc-tests to ansi-terminal < 0.6.3

### DIFF
--- a/compiler/bond.cabal
+++ b/compiler/bond.cabal
@@ -87,6 +87,9 @@ test-suite gbc-tests
   build-depends:    bond,
                     aeson >= 0.7.0.6 && < 0.12.0.0,
                     aeson-pretty == 0.7.2,
+                    -- pinned to a lower version pending resolution of
+                    -- https://github.com/feuerbach/ansi-terminal/issues/22
+                    ansi-terminal < 0.6.3,
                     base >= 4.5 && < 5,
                     bytestring >= 0.10,
                     cmdargs >= 0.10.10,


### PR DESCRIPTION
The Hackage package ansi-terminal as of version 0.6.3 is no longer
building with GHC 7.8.3, which causes out CI builds to fail.

Issue https://github.com/feuerbach/ansi-terminal/issues/22 has been
opened about this, but until it is resolved, we need to use an earlier
version.