### PR TITLE
[c++ grpc] Take durations by const reference

### DIFF
--- a/cpp/inc/bond/ext/detail/barrier.h
+++ b/cpp/inc/bond/ext/detail/barrier.h
@@ -73,7 +73,7 @@ public:
     /// @return \p true if the event was signaled. \p false if the timeout
     /// occured.
     template <typename Rep, typename Period>
-    bool wait(std::chrono::duration<Rep, Period> timeout)
+    bool wait(const std::chrono::duration<Rep, Period>& timeout)
     {
         return _e.wait(timeout);
     }

--- a/cpp/inc/bond/ext/detail/countdown_event.h
+++ b/cpp/inc/bond/ext/detail/countdown_event.h
@@ -60,7 +60,7 @@ public:
     /// @return \p true if the event was signaled. \p false if the timeout
     /// occured.
     template <typename Rep, typename Period>
-    bool wait(std::chrono::duration<Rep, Period> timeout)
+    bool wait(const std::chrono::duration<Rep, Period>& timeout)
     {
         return _e.wait(timeout);
     }

--- a/cpp/inc/bond/ext/detail/event.h
+++ b/cpp/inc/bond/ext/detail/event.h
@@ -53,7 +53,7 @@ namespace bond { namespace ext { namespace detail {
         /// @return \p true if the event was signaled. \p false if the
         /// timeout occured.
         template <typename Rep, typename Period>
-        bool wait(std::chrono::duration<Rep, Period> timeout)
+        bool wait(const std::chrono::duration<Rep, Period>& timeout)
         {
             std::unique_lock<std::mutex> lock(_m);
             return _cv.wait_for(lock, timeout, [this]() {return _isSet;});


### PR DESCRIPTION
For wait()-like functions we now take std::chrono::duration arguments by
const reference, just like std::condition_variable does.