### PR TITLE
Address race condition in gRPC compat tests

### DIFF
--- a/cpp/test/compat/grpc/pingpong_server.cpp
+++ b/cpp/test/compat/grpc/pingpong_server.cpp
@@ -54,9 +54,9 @@ public:
                 response.Payload = request.Payload;
 
                 NumRequestsReceived++;
-                Countdown.set();
 
                 call.Finish(bond::bonded<PingResponse>{ response }, Status::OK);
+                Countdown.set();
                 break;
             }
 
@@ -66,10 +66,10 @@ public:
                 fflush(stdout);
 
                 NumErrorsReceived++;
-                Countdown.set();
 
                 Status error(StatusCode::UNIMPLEMENTED, "Application Exception");
                 call.FinishWithError(error);
+                Countdown.set();
                 break;
             }
 
@@ -78,10 +78,9 @@ public:
                 printf("Received unknown request \"%s\"\n", request.Payload.c_str());
                 fflush(stdout);
 
-                Countdown.set();
-
                 Status error(StatusCode::UNIMPLEMENTED, "Unknown PingAction");
                 call.FinishWithError(error);
+                Countdown.set();
                 break;
             }
         }
@@ -105,6 +104,9 @@ int main()
     fflush(stdout);
 
     bool countdownSet = Countdown.wait(std::chrono::seconds(30));
+
+    server->Shutdown();
+    server->Wait();
 
     if (!countdownSet ||
         (NumRequestsReceived != NumRequests) ||

--- a/cpp/test/compat/grpc/pingpong_server.cpp
+++ b/cpp/test/compat/grpc/pingpong_server.cpp
@@ -105,7 +105,7 @@ int main()
 
     bool countdownSet = Countdown.wait(std::chrono::seconds(30));
 
-    server->Shutdown();
+    server->Shutdown(std::chrono::system_clock::now() + std::chrono::seconds(30));
     server->Wait();
 
     if (!countdownSet ||

--- a/cs/test/compat/grpc/server/Program.cs
+++ b/cs/test/compat/grpc/server/Program.cs
@@ -76,9 +76,10 @@ namespace PingPongServer
 
             bool countdownSet = Countdown.Wait(30000);
 
-            pingServer.ShutdownAsync().GetAwaiter().GetResult();
+            bool shutdownCompleted = pingServer.ShutdownAsync().Wait(30000);
 
             if (!countdownSet ||
+                !shutdownCompleted ||
                 (NumRequestsReceived != (int)PingConstants.NumRequests) ||
                 (NumErrorsReceived != (int)PingConstants.NumErrors))
             {

--- a/cs/test/compat/grpc/server/Program.cs
+++ b/cs/test/compat/grpc/server/Program.cs
@@ -76,6 +76,8 @@ namespace PingPongServer
 
             bool countdownSet = Countdown.Wait(30000);
 
+            pingServer.ShutdownAsync().GetAwaiter().GetResult();
+
             if (!countdownSet ||
                 (NumRequestsReceived != (int)PingConstants.NumRequests) ||
                 (NumErrorsReceived != (int)PingConstants.NumErrors))


### PR DESCRIPTION
Ensure that the server has shutdown once all the expected requests have
been received and response have been queued up.