### PR TITLE
[c++ grpc] Rename sync objects' wait to wait_for

### DIFF
--- a/cpp/inc/bond/ext/detail/barrier.h
+++ b/cpp/inc/bond/ext/detail/barrier.h
@@ -73,9 +73,9 @@ public:
     /// @return \p true if the event was signaled. \p false if the timeout
     /// occured.
     template <typename Rep, typename Period>
-    bool wait(const std::chrono::duration<Rep, Period>& timeout)
+    bool wait_for(const std::chrono::duration<Rep, Period>& timeout)
     {
-        return _e.wait(timeout);
+        return _e.wait_for(timeout);
     }
 
 private:

--- a/cpp/inc/bond/ext/detail/countdown_event.h
+++ b/cpp/inc/bond/ext/detail/countdown_event.h
@@ -60,9 +60,9 @@ public:
     /// @return \p true if the event was signaled. \p false if the timeout
     /// occured.
     template <typename Rep, typename Period>
-    bool wait(const std::chrono::duration<Rep, Period>& timeout)
+    bool wait_for(const std::chrono::duration<Rep, Period>& timeout)
     {
-        return _e.wait(timeout);
+        return _e.wait_for(timeout);
     }
 
 private:

--- a/cpp/inc/bond/ext/detail/event.h
+++ b/cpp/inc/bond/ext/detail/event.h
@@ -53,7 +53,7 @@ namespace bond { namespace ext { namespace detail {
         /// @return \p true if the event was signaled. \p false if the
         /// timeout occured.
         template <typename Rep, typename Period>
-        bool wait(const std::chrono::duration<Rep, Period>& timeout)
+        bool wait_for(const std::chrono::duration<Rep, Period>& timeout)
         {
             std::unique_lock<std::mutex> lock(_m);
             return _cv.wait_for(lock, timeout, [this]() {return _isSet;});

--- a/cpp/test/compat/comm/pingpong_server.cpp
+++ b/cpp/test/compat/comm/pingpong_server.cpp
@@ -101,7 +101,7 @@ int main()
     printf("Server ready\n");
     fflush(stdout);
 
-    bool countdownSet = Countdown.wait(std::chrono::seconds(30));
+    bool countdownSet = Countdown.wait_for(std::chrono::seconds(30));
 
     if (!countdownSet ||
         (NumRequestsReceived != NumRequests) ||

--- a/cpp/test/compat/grpc/pingpong_server.cpp
+++ b/cpp/test/compat/grpc/pingpong_server.cpp
@@ -104,7 +104,7 @@ int main()
     printf("Server ready\n");
     fflush(stdout);
 
-    bool countdownSet = Countdown.wait(std::chrono::seconds(30));
+    bool countdownSet = Countdown.wait_for(std::chrono::seconds(30));
 
     if (!countdownSet ||
         (NumRequestsReceived != NumRequests) ||

--- a/cpp/test/grpc/io_manager.cpp
+++ b/cpp/test/grpc/io_manager.cpp
@@ -58,7 +58,7 @@ class io_managerTests
         gpr_timespec deadline = gpr_time_0(GPR_CLOCK_MONOTONIC);
         grpc::Alarm alarm(ioManager.cq(), deadline, &act);
 
-        bool wasSet = act.completion_event.wait(std::chrono::seconds(30));
+        bool wasSet = act.completion_event.wait_for(std::chrono::seconds(30));
         UT_AssertIsTrue(wasSet);
     }
 
@@ -79,7 +79,7 @@ class io_managerTests
             alarms.emplace_back(ioManager.cq(), deadline, &act);
         }
 
-        bool wasSet = act.completion_event.wait(std::chrono::seconds(30));
+        bool wasSet = act.completion_event.wait_for(std::chrono::seconds(30));
         UT_AssertIsTrue(wasSet);
     }
 
@@ -119,10 +119,10 @@ class io_managerTests
             });
         }
 
-        bool wasSet = threadsStarted.wait(std::chrono::seconds(30));
+        bool wasSet = threadsStarted.wait_for(std::chrono::seconds(30));
         UT_AssertIsTrue(wasSet); // all the threads took too long to get started
 
-        wasSet = threadsObservedShutdown.wait(std::chrono::seconds(30));
+        wasSet = threadsObservedShutdown.wait_for(std::chrono::seconds(30));
         UT_AssertIsTrue(wasSet); // took too long to see the io_manager shutdown
 
         for (auto& thread : threads)
@@ -143,7 +143,7 @@ class io_managerTests
         gpr_timespec deadline = gpr_time_0(GPR_CLOCK_MONOTONIC);
         grpc::Alarm alarm(ioManager.cq(), deadline, &act);
 
-        bool wasSet = act.completion_event.wait(std::chrono::milliseconds(1250));
+        bool wasSet = act.completion_event.wait_for(std::chrono::milliseconds(1250));
         UT_AssertIsTrue(!wasSet);
 
         // since we've put something into the completion queue, we need to
@@ -153,7 +153,7 @@ class io_managerTests
         // test that we can call start multiple times
         ioManager.start();
 
-        wasSet = act.completion_event.wait(std::chrono::seconds(30));
+        wasSet = act.completion_event.wait_for(std::chrono::seconds(30));
         UT_AssertIsTrue(wasSet);
     }
 

--- a/cpp/test/grpc/thread_pool.cpp
+++ b/cpp/test/grpc/thread_pool.cpp
@@ -38,7 +38,7 @@ class BasicThreadPoolTests
 
         threads.schedule(std::bind(f_addOne, &sum, &sum_event));
 
-        bool waitResult = sum_event.wait(std::chrono::seconds(30));
+        bool waitResult = sum_event.wait_for(std::chrono::seconds(30));
 
         UT_AssertIsTrue(waitResult);
         UT_AssertIsTrue(sum == 1);
@@ -56,7 +56,7 @@ class BasicThreadPoolTests
             sum_event.set();
         });
 
-        bool waitResult = sum_event.wait(std::chrono::seconds(30));
+        bool waitResult = sum_event.wait_for(std::chrono::seconds(30));
 
         UT_AssertIsTrue(waitResult);
         UT_AssertIsTrue(sum == 1);

--- a/cpp/test/grpc/wait_callback.cpp
+++ b/cpp/test/grpc/wait_callback.cpp
@@ -134,7 +134,7 @@ namespace wait_callback_tests
 
         // This is a clumsy attempt to get the thread into the wait_for method
         // before invoking the callback.
-        bool wasStarted = threadStarted.wait(std::chrono::seconds(30));
+        bool wasStarted = threadStarted.wait_for(std::chrono::seconds(30));
         UT_AssertIsTrue(wasStarted);
 
         cb(anyBondedValue, anyStatus);

--- a/examples/cpp/grpc/pingpong/pingpong.cpp
+++ b/examples/cpp/grpc/pingpong/pingpong.cpp
@@ -257,8 +257,8 @@ int main()
         pingPong.AsyncPing(&pingGenericContext, req, f_print);
     }
 
-    bool waitResult = ping_event.wait(std::chrono::seconds(10));
-    waitResult &= pingNoResponse_event.wait(std::chrono::seconds(10));
+    bool waitResult = ping_event.wait_for(std::chrono::seconds(10));
+    waitResult &= pingNoResponse_event.wait_for(std::chrono::seconds(10));
 
     if (!waitResult)
     {


### PR DESCRIPTION
The wait member function of barrier, countdown_event, and event that
takes a timeout has been renamed to wait_for to match
std::condition_variable.