### PR TITLE
[c++] Mark custom stream interface BOND_NORETURN

### DIFF
--- a/cpp/inc/bond/stream/stream_interface.h
+++ b/cpp/inc/bond/stream/stream_interface.h
@@ -56,7 +56,7 @@ public:
 // Return type is not required to be specifically bond::blob.
 // See GetBufferRange for more details.
 template <typename InputBuffer>
-inline blob GetCurrentBuffer(const InputBuffer& /*input*/)
+BOND_NORETURN inline blob GetCurrentBuffer(const InputBuffer& /*input*/)
 {
     BOOST_STATIC_ASSERT_MSG(detail::always_false<InputBuffer>::value, "GetCurrentBuffer is undefined.");
 }
@@ -69,7 +69,7 @@ inline blob GetCurrentBuffer(const InputBuffer& /*input*/)
 // output buffer associated with the writer (i.e. there is an overloaded Write
 // function that accepts it).
 template <typename Blob>
-inline Blob GetBufferRange(const Blob& /*begin*/, const Blob& /*end*/)
+BOND_NORETURN inline Blob GetBufferRange(const Blob& /*begin*/, const Blob& /*end*/)
 {
     BOOST_STATIC_ASSERT_MSG(detail::always_false<Blob>::value, "GetBufferRange is undefined.");
 }
@@ -107,7 +107,7 @@ public:
 // compatible properties as the original one (e.g. while serializing
 // bonded<T> for untagged protocols).
 template <typename OutputBuffer>
-inline OutputBuffer CreateOutputBuffer(const OutputBuffer& /*other*/)
+BOND_NORETURN inline OutputBuffer CreateOutputBuffer(const OutputBuffer& /*other*/)
 {
     BOOST_STATIC_ASSERT_MSG(detail::always_false<OutputBuffer>::value, "CreateOutputBuffer is undefined.");
 }


### PR DESCRIPTION
The unspecialized custom stream inferface functions that exist solely to
describe the interface have static asserts that are always false.
However, they are also non-void functions that have no return
statements. g++ 5.4.0 emits a warning about the lack of a return
statement. It apparently cannot see that the static assert is always
false. BOND_NORETURN is used to indicate that these methods don't
actually ever return anything.