### PR TITLE
[c++ grpc] Upgrade to gRPC v1.3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ before_script:
 script:
     - mkdir build && cd build
 
-    - if [ "$FLAVOR" == "cs" ]; then cmake ..; fi
+    - if [ "$FLAVOR" == "cs" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DBOND_ENABLE_COMM=FALSE -DBOND_ENABLE_GRPC=FALSE ..; fi
     - if [ "$FLAVOR" == "cs" ]; then make --jobs 2 DESTDIR=$HOME install; fi
     - if [ "$FLAVOR" == "cs" ]; then cd ..; fi
     - if [ "$FLAVOR" == "cs" ]; then export BOND_COMPILER_PATH=$HOME/usr/local/bin; fi
@@ -86,7 +86,7 @@ script:
     - if [ "$FLAVOR" == "cpp-comm" ]; then make --jobs 2 check; fi
     - if [ "$FLAVOR" == "cpp-grpc" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DBOND_ENABLE_COMM=FALSE -DgRPC_ZLIB_PROVIDER=package ..; fi
     - if [ "$FLAVOR" == "cpp-grpc" ]; then make --jobs 2 check; fi
-    - if [ "$FLAVOR" == "hs" ]; then cmake ..; fi
+    - if [ "$FLAVOR" == "hs" ]; then cmake -DBOND_SKIP_CORE_TESTS=TRUE -DBOND_ENABLE_COMM=FALSE -DBOND_ENABLE_GRPC=FALSE ..; fi
     - if [ "$FLAVOR" == "hs" ]; then make gbc-tests; fi
     - if [ "$FLAVOR" == "hs" ]; then cd ../compiler; fi
     - if [ "$FLAVOR" == "hs" ]; then ../build/compiler/build/gbc-tests/gbc-tests; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ script:
     - if [ "$FLAVOR" == "cpp-core" ]; then make --jobs 2 check; fi
     - if [ "$FLAVOR" == "cpp-comm" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DBOND_ENABLE_GRPC=FALSE ..; fi
     - if [ "$FLAVOR" == "cpp-comm" ]; then make --jobs 2 check; fi
-    - if [ "$FLAVOR" == "cpp-grpc" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DBOND_ENABLE_COMM=FALSE ..; fi
+    - if [ "$FLAVOR" == "cpp-grpc" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DBOND_ENABLE_COMM=FALSE -DgRPC_ZLIB_PROVIDER=package ..; fi
     - if [ "$FLAVOR" == "cpp-grpc" ]; then make --jobs 2 check; fi
     - if [ "$FLAVOR" == "hs" ]; then cmake ..; fi
     - if [ "$FLAVOR" == "hs" ]; then make gbc-tests; fi

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ In the root `bond` directory run:
 ```bash
 mkdir build
 cd build
-cmake ..
+cmake .. -DBOND_ENABLE_COMM=FALSE -DBOND_ENABLE_GRPC=FALSE
 make
 sudo make install
 ```
@@ -86,7 +86,8 @@ The `build` directory is just an example. Any directory can be used as the build
 destination.
 
 In order to build all the C++ and Python tests and examples, as well as
-Bond-over-gRPC and Bond Comm, a few more packages are needed:
+Bond-over-gRPC and Bond Comm, a few more packages are needed, and CMake
+needs to be run with different options:
 
 ```bash
 sudo apt-get install \
@@ -99,6 +100,9 @@ sudo apt-get install \
     python2.7-dev
 
 cabal install happy
+
+cd build # or wherever you ran CMake before
+cmake .. -DBOND_ENABLE_COMM=TRUE -DBOND_ENABLE_GRPC=TRUE -DgRPC_ZLIB_PROVIDER=package
 ```
 
 Running the following command in the build directory will build and execute all

--- a/cpp/inc/bond/ext/grpc/detail/client_call_data.h
+++ b/cpp/inc/bond/ext/grpc/detail/client_call_data.h
@@ -77,7 +77,7 @@ struct client_unary_call_data : io_manager_tag
         const TRequest& request)
     {
         _responseReader = std::unique_ptr<grpc::ClientAsyncResponseReader<TResponse>>(
-            new ::grpc::ClientAsyncResponseReader<TResponse>(
+            ::grpc::ClientAsyncResponseReader<TResponse>::Create(
                 _channel.get(),
                 _ioManager->cq(),
                 method,


### PR DESCRIPTION
ClientAsyncResponseReader had a breaking API change that we needed to
adjust to.

The gRPC zlib submodule is now conflicting with the system-wide zlib.
When using CMake inside of Travis, we prefer the system-wide zlib
package over the submodule.

There also appears to be a bug with ClientAsyncResponseReader's
placement new and placement delete operators, so we're consuming a
slightly patched version (see
https://github.com/chwarr/grpc/commit/8bd0fb92ec for the delta).
Upstream issue https://github.com/grpc/grpc/issues/11301 has been opened
about this problem.

This PR supersedes #467, which was closed with the underlying grpc++ branch was merged into master and deleted.