### PR TITLE
ClientContext lifetime improvements (WIP)

### DIFF
--- a/compiler/src/Language/Bond/Codegen/Cpp/Grpc_h.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Grpc_h.hs
@@ -28,6 +28,7 @@ grpc_h _ cpp file imports declarations = ("_grpc.h", [lt|
 #{newlineSep 0 includeImport imports}
 #include <bond/core/bonded.h>
 #include <bond/ext/grpc/bond_utils.h>
+#include <bond/ext/grpc/client_callback.h>
 #include <bond/ext/grpc/io_manager.h>
 #include <bond/ext/grpc/thread_pool.h>
 #include <bond/ext/grpc/unary_call.h>
@@ -153,21 +154,21 @@ inline #{className}::#{proxyName}<TThreadPool>::#{proxyName}(
         serviceMethodsWithIndex :: [(Integer,Method)]
         serviceMethodsWithIndex = zip [0..] serviceMethods
 
-        publicProxyMethodDecl Function{methodInput = Nothing, ..} = [lt|void Async#{methodName}(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(const #{bonded methodResult}&, const ::grpc::Status&)>& cb);
-        void Async#{methodName}(const std::function<void(const #{bonded methodResult}&, const ::grpc::Status&)>& cb)
+        publicProxyMethodDecl Function{methodInput = Nothing, ..} = [lt|void Async#{methodName}(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< #{payload methodResult}>>)>& cb);
+        void Async#{methodName}(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< #{payload methodResult}>>)>& cb)
         {
             Async#{methodName}(::std::make_shared< ::grpc::ClientContext>(), cb);
         }|]
-        publicProxyMethodDecl Function{..} = [lt|void Async#{methodName}(::std::shared_ptr< ::grpc::ClientContext> context, const #{bonded methodInput}& request, const std::function<void(const #{bonded methodResult}&, const ::grpc::Status&)>& cb);
-        void Async#{methodName}(::std::shared_ptr< ::grpc::ClientContext> context, const #{payload methodInput}& request, const std::function<void(const #{bonded methodResult}&, const ::grpc::Status&)>& cb)
+        publicProxyMethodDecl Function{..} = [lt|void Async#{methodName}(::std::shared_ptr< ::grpc::ClientContext> context, const #{bonded methodInput}& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< #{payload methodResult}>>)>& cb);
+        void Async#{methodName}(::std::shared_ptr< ::grpc::ClientContext> context, const #{payload methodInput}& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< #{payload methodResult}>>)>& cb)
         {
             Async#{methodName}(context, #{bonded methodInput}{request}, cb);
         }
-        void Async#{methodName}(const #{bonded methodInput}& request, const std::function<void(const #{bonded methodResult}&, const ::grpc::Status&)>& cb)
+        void Async#{methodName}(const #{bonded methodInput}& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< #{payload methodResult}>>)>& cb)
         {
             Async#{methodName}(::std::make_shared< ::grpc::ClientContext>(), request, cb);
         }
-        void Async#{methodName}(const #{payload methodInput}& request, const std::function<void(const #{bonded methodResult}&, const ::grpc::Status&)>& cb)
+        void Async#{methodName}(const #{payload methodInput}& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< #{payload methodResult}>>)>& cb)
         {
             Async#{methodName}(::std::make_shared< ::grpc::ClientContext>(), #{bonded methodInput}{request}, cb);
         }|]
@@ -200,10 +201,10 @@ inline #{className}::#{proxyName}<TThreadPool>::#{proxyName}(
 inline void #{className}::#{proxyName}<TThreadPool>::Async#{methodName}(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     #{voidParam methodInput}
-    const std::function<void(const #{bonded methodResult}&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< #{payload methodResult}>>)>& cb)
 {
     #{voidRequest methodInput}
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< #{bonded methodInput}, #{bonded methodResult}, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< #{payload methodInput}, #{payload methodResult}, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -223,7 +224,7 @@ inline void #{className}::#{proxyName}<TThreadPool>::Async#{methodName}(
     #{voidParam methodInput})
 {
     #{voidRequest methodInput}
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< #{bonded methodInput}, #{bonded Nothing}, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< #{payload methodInput}, #{payload Nothing}, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,

--- a/compiler/tests/generated/generic_service_grpc.h
+++ b/compiler/tests/generated/generic_service_grpc.h
@@ -6,6 +6,7 @@
 
 #include <bond/core/bonded.h>
 #include <bond/ext/grpc/bond_utils.h>
+#include <bond/ext/grpc/client_callback.h>
 #include <bond/ext/grpc/io_manager.h>
 #include <bond/ext/grpc/thread_pool.h>
 #include <bond/ext/grpc/unary_call.h>
@@ -48,36 +49,36 @@ public:
             std::shared_ptr< ::bond::ext::gRPC::io_manager> ioManager,
             std::shared_ptr<TThreadPool> threadPool);
 
-        void Asyncfoo31(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded<Payload>& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo31(::std::shared_ptr< ::grpc::ClientContext> context, const Payload& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo31(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded<Payload>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb);
+        void Asyncfoo31(::std::shared_ptr< ::grpc::ClientContext> context, const Payload& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb)
         {
             Asyncfoo31(context, ::bond::bonded<Payload>{request}, cb);
         }
-        void Asyncfoo31(const ::bond::bonded<Payload>& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo31(const ::bond::bonded<Payload>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb)
         {
             Asyncfoo31(::std::make_shared< ::grpc::ClientContext>(), request, cb);
         }
-        void Asyncfoo31(const Payload& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo31(const Payload& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb)
         {
             Asyncfoo31(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded<Payload>{request}, cb);
         }
 
-        void Asyncfoo32(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo32(const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo32(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< Payload>>)>& cb);
+        void Asyncfoo32(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< Payload>>)>& cb)
         {
             Asyncfoo32(::std::make_shared< ::grpc::ClientContext>(), cb);
         }
 
-        void Asyncfoo33(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded<Payload>& request, const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo33(::std::shared_ptr< ::grpc::ClientContext> context, const Payload& request, const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo33(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded<Payload>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< Payload>>)>& cb);
+        void Asyncfoo33(::std::shared_ptr< ::grpc::ClientContext> context, const Payload& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< Payload>>)>& cb)
         {
             Asyncfoo33(context, ::bond::bonded<Payload>{request}, cb);
         }
-        void Asyncfoo33(const ::bond::bonded<Payload>& request, const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo33(const ::bond::bonded<Payload>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< Payload>>)>& cb)
         {
             Asyncfoo33(::std::make_shared< ::grpc::ClientContext>(), request, cb);
         }
-        void Asyncfoo33(const Payload& request, const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo33(const Payload& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< Payload>>)>& cb)
         {
             Asyncfoo33(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded<Payload>{request}, cb);
         }
@@ -195,10 +196,10 @@ template <typename Payload>
 inline void Foo<Payload>::ClientCore<TThreadPool>::Asyncfoo31(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded<Payload>& request,
-    const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<Payload>, ::bond::bonded< ::bond::Void>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< Payload, ::bond::Void, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -212,10 +213,10 @@ template <typename Payload>
 inline void Foo<Payload>::ClientCore<TThreadPool>::Asyncfoo32(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     
-    const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< Payload>>)>& cb)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded<Payload>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::Void, Payload, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -229,10 +230,10 @@ template <typename Payload>
 inline void Foo<Payload>::ClientCore<TThreadPool>::Asyncfoo33(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded<Payload>& request,
-    const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< Payload>>)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<Payload>, ::bond::bonded<Payload>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< Payload, Payload, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,

--- a/compiler/tests/generated/generic_service_grpc.h
+++ b/compiler/tests/generated/generic_service_grpc.h
@@ -48,18 +48,38 @@ public:
             std::shared_ptr< ::bond::ext::gRPC::io_manager> ioManager,
             std::shared_ptr<TThreadPool> threadPool);
 
-        void Asyncfoo31(::grpc::ClientContext* context, const ::bond::bonded<Payload>& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo31(::grpc::ClientContext* context, const Payload& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo31(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded<Payload>& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo31(::std::shared_ptr< ::grpc::ClientContext> context, const Payload& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
         {
             Asyncfoo31(context, ::bond::bonded<Payload>{request}, cb);
         }
+        void Asyncfoo31(const ::bond::bonded<Payload>& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo31(::std::make_shared< ::grpc::ClientContext>(), request, cb);
+        }
+        void Asyncfoo31(const Payload& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo31(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded<Payload>{request}, cb);
+        }
 
-        void Asyncfoo32(::grpc::ClientContext* context, const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo32(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo32(const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo32(::std::make_shared< ::grpc::ClientContext>(), cb);
+        }
 
-        void Asyncfoo33(::grpc::ClientContext* context, const ::bond::bonded<Payload>& request, const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo33(::grpc::ClientContext* context, const Payload& request, const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo33(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded<Payload>& request, const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo33(::std::shared_ptr< ::grpc::ClientContext> context, const Payload& request, const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb)
         {
             Asyncfoo33(context, ::bond::bonded<Payload>{request}, cb);
+        }
+        void Asyncfoo33(const ::bond::bonded<Payload>& request, const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo33(::std::make_shared< ::grpc::ClientContext>(), request, cb);
+        }
+        void Asyncfoo33(const Payload& request, const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo33(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded<Payload>{request}, cb);
         }
 
         ClientCore(const ClientCore&) = delete;
@@ -173,49 +193,52 @@ inline Foo<Payload>::ClientCore<TThreadPool>::ClientCore(
 template <typename Payload>
     template <typename TThreadPool>
 inline void Foo<Payload>::ClientCore<TThreadPool>::Asyncfoo31(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded<Payload>& request,
     const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<Payload>, ::bond::bonded< ::bond::Void>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<Payload>, ::bond::bonded< ::bond::Void>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod_foo31_, context, request);
+    calldata->dispatch(rpcmethod_foo31_, request);
 }
 
 template <typename Payload>
     template <typename TThreadPool>
 inline void Foo<Payload>::ClientCore<TThreadPool>::Asyncfoo32(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     
     const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded<Payload>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded<Payload>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod_foo32_, context, request);
+    calldata->dispatch(rpcmethod_foo32_, request);
 }
 
 template <typename Payload>
     template <typename TThreadPool>
 inline void Foo<Payload>::ClientCore<TThreadPool>::Asyncfoo33(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded<Payload>& request,
     const std::function<void(const ::bond::bonded<Payload>&, const ::grpc::Status&)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<Payload>, ::bond::bonded<Payload>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded<Payload>, ::bond::bonded<Payload>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod_foo33_, context, request);
+    calldata->dispatch(rpcmethod_foo33_, request);
 }
 
 

--- a/compiler/tests/generated/service_attributes_grpc.h
+++ b/compiler/tests/generated/service_attributes_grpc.h
@@ -6,6 +6,7 @@
 
 #include <bond/core/bonded.h>
 #include <bond/ext/grpc/bond_utils.h>
+#include <bond/ext/grpc/client_callback.h>
 #include <bond/ext/grpc/io_manager.h>
 #include <bond/ext/grpc/thread_pool.h>
 #include <bond/ext/grpc/unary_call.h>
@@ -47,16 +48,16 @@ public:
             std::shared_ptr< ::bond::ext::gRPC::io_manager> ioManager,
             std::shared_ptr<TThreadPool> threadPool);
 
-        void Asyncfoo(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::Param>& request, const std::function<void(const ::bond::bonded< ::tests::Result>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::Param& request, const std::function<void(const ::bond::bonded< ::tests::Result>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::Param>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::Result>>)>& cb);
+        void Asyncfoo(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::Param& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::Result>>)>& cb)
         {
             Asyncfoo(context, ::bond::bonded< ::tests::Param>{request}, cb);
         }
-        void Asyncfoo(const ::bond::bonded< ::tests::Param>& request, const std::function<void(const ::bond::bonded< ::tests::Result>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo(const ::bond::bonded< ::tests::Param>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::Result>>)>& cb)
         {
             Asyncfoo(::std::make_shared< ::grpc::ClientContext>(), request, cb);
         }
-        void Asyncfoo(const ::tests::Param& request, const std::function<void(const ::bond::bonded< ::tests::Result>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo(const ::tests::Param& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::Result>>)>& cb)
         {
             Asyncfoo(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::Param>{request}, cb);
         }
@@ -134,10 +135,10 @@ template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded< ::tests::Param>& request,
-    const std::function<void(const ::bond::bonded< ::tests::Result>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::Result>>)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::Param>, ::bond::bonded< ::tests::Result>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::tests::Param, ::tests::Result, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,

--- a/compiler/tests/generated/service_attributes_grpc.h
+++ b/compiler/tests/generated/service_attributes_grpc.h
@@ -47,10 +47,18 @@ public:
             std::shared_ptr< ::bond::ext::gRPC::io_manager> ioManager,
             std::shared_ptr<TThreadPool> threadPool);
 
-        void Asyncfoo(::grpc::ClientContext* context, const ::bond::bonded< ::tests::Param>& request, const std::function<void(const ::bond::bonded< ::tests::Result>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo(::grpc::ClientContext* context, const ::tests::Param& request, const std::function<void(const ::bond::bonded< ::tests::Result>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::Param>& request, const std::function<void(const ::bond::bonded< ::tests::Result>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::Param& request, const std::function<void(const ::bond::bonded< ::tests::Result>&, const ::grpc::Status&)>& cb)
         {
             Asyncfoo(context, ::bond::bonded< ::tests::Param>{request}, cb);
+        }
+        void Asyncfoo(const ::bond::bonded< ::tests::Param>& request, const std::function<void(const ::bond::bonded< ::tests::Result>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo(::std::make_shared< ::grpc::ClientContext>(), request, cb);
+        }
+        void Asyncfoo(const ::tests::Param& request, const std::function<void(const ::bond::bonded< ::tests::Result>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::Param>{request}, cb);
         }
 
         ClientCore(const ClientCore&) = delete;
@@ -124,17 +132,18 @@ inline Foo::ClientCore<TThreadPool>::ClientCore(
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded< ::tests::Param>& request,
     const std::function<void(const ::bond::bonded< ::tests::Result>&, const ::grpc::Status&)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::Param>, ::bond::bonded< ::tests::Result>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::Param>, ::bond::bonded< ::tests::Result>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod_foo_, context, request);
+    calldata->dispatch(rpcmethod_foo_, request);
 }
 
 

--- a/compiler/tests/generated/service_grpc.h
+++ b/compiler/tests/generated/service_grpc.h
@@ -48,85 +48,205 @@ public:
             std::shared_ptr< ::bond::ext::gRPC::io_manager> ioManager,
             std::shared_ptr<TThreadPool> threadPool);
 
-        void Asyncfoo11(::grpc::ClientContext* context);
+        void Asyncfoo11(::std::shared_ptr< ::grpc::ClientContext> context);
+        void Asyncfoo11()
+        {
+            Asyncfoo11(::std::make_shared< ::grpc::ClientContext>());
+        }
 
-        void Asyncfoo12(::grpc::ClientContext* context);
+        void Asyncfoo12(::std::shared_ptr< ::grpc::ClientContext> context);
+        void Asyncfoo12()
+        {
+            Asyncfoo12(::std::make_shared< ::grpc::ClientContext>());
+        }
 
-        void Asyncfoo12_impl(::grpc::ClientContext* context);
+        void Asyncfoo12_impl(::std::shared_ptr< ::grpc::ClientContext> context);
+        void Asyncfoo12_impl()
+        {
+            Asyncfoo12_impl(::std::make_shared< ::grpc::ClientContext>());
+        }
 
-        void Asyncfoo13(::grpc::ClientContext* context, const ::bond::bonded< ::tests::BasicTypes>& request);
-        void Asyncfoo13(::grpc::ClientContext* context, const ::tests::BasicTypes& request)
+        void Asyncfoo13(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::BasicTypes>& request);
+        void Asyncfoo13(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::BasicTypes& request)
         {
             Asyncfoo13(context, ::bond::bonded< ::tests::BasicTypes>{request});
         }
+        void Asyncfoo13(const ::bond::bonded< ::tests::BasicTypes>& request)
+        {
+            Asyncfoo13(::std::make_shared< ::grpc::ClientContext>(), request);
+        }
+        void Asyncfoo13(const ::tests::BasicTypes& request)
+        {
+            Asyncfoo13(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::BasicTypes>{request});
+        }
 
-        void Asyncfoo14(::grpc::ClientContext* context, const ::bond::bonded< ::tests::dummy>& request);
-        void Asyncfoo14(::grpc::ClientContext* context, const ::tests::dummy& request)
+        void Asyncfoo14(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::dummy>& request);
+        void Asyncfoo14(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::dummy& request)
         {
             Asyncfoo14(context, ::bond::bonded< ::tests::dummy>{request});
         }
+        void Asyncfoo14(const ::bond::bonded< ::tests::dummy>& request)
+        {
+            Asyncfoo14(::std::make_shared< ::grpc::ClientContext>(), request);
+        }
+        void Asyncfoo14(const ::tests::dummy& request)
+        {
+            Asyncfoo14(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::dummy>{request});
+        }
 
-        void Asyncfoo15(::grpc::ClientContext* context, const ::bond::bonded< ::tests2::OtherBasicTypes>& request);
-        void Asyncfoo15(::grpc::ClientContext* context, const ::tests2::OtherBasicTypes& request)
+        void Asyncfoo15(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests2::OtherBasicTypes>& request);
+        void Asyncfoo15(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests2::OtherBasicTypes& request)
         {
             Asyncfoo15(context, ::bond::bonded< ::tests2::OtherBasicTypes>{request});
         }
+        void Asyncfoo15(const ::bond::bonded< ::tests2::OtherBasicTypes>& request)
+        {
+            Asyncfoo15(::std::make_shared< ::grpc::ClientContext>(), request);
+        }
+        void Asyncfoo15(const ::tests2::OtherBasicTypes& request)
+        {
+            Asyncfoo15(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests2::OtherBasicTypes>{request});
+        }
 
-        void Asyncfoo21(::grpc::ClientContext* context, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo21(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo21(const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo21(::std::make_shared< ::grpc::ClientContext>(), cb);
+        }
 
-        void Asyncfoo22(::grpc::ClientContext* context, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo22(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo22(const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo22(::std::make_shared< ::grpc::ClientContext>(), cb);
+        }
 
-        void Asyncfoo23(::grpc::ClientContext* context, const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo23(::grpc::ClientContext* context, const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo23(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo23(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
         {
             Asyncfoo23(context, ::bond::bonded< ::tests::BasicTypes>{request}, cb);
         }
+        void Asyncfoo23(const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo23(::std::make_shared< ::grpc::ClientContext>(), request, cb);
+        }
+        void Asyncfoo23(const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo23(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::BasicTypes>{request}, cb);
+        }
 
-        void Asyncfoo24(::grpc::ClientContext* context, const ::bond::bonded< ::tests::dummy>& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo24(::grpc::ClientContext* context, const ::tests::dummy& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo24(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::dummy>& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo24(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::dummy& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
         {
             Asyncfoo24(context, ::bond::bonded< ::tests::dummy>{request}, cb);
         }
+        void Asyncfoo24(const ::bond::bonded< ::tests::dummy>& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo24(::std::make_shared< ::grpc::ClientContext>(), request, cb);
+        }
+        void Asyncfoo24(const ::tests::dummy& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo24(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::dummy>{request}, cb);
+        }
 
-        void Asyncfoo31(::grpc::ClientContext* context, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo31(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo31(const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo31(::std::make_shared< ::grpc::ClientContext>(), cb);
+        }
 
-        void Asyncfoo32(::grpc::ClientContext* context, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo32(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo32(const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo32(::std::make_shared< ::grpc::ClientContext>(), cb);
+        }
 
-        void Asyncfoo33(::grpc::ClientContext* context, const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo33(::grpc::ClientContext* context, const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo33(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo33(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
         {
             Asyncfoo33(context, ::bond::bonded< ::tests::BasicTypes>{request}, cb);
         }
+        void Asyncfoo33(const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo33(::std::make_shared< ::grpc::ClientContext>(), request, cb);
+        }
+        void Asyncfoo33(const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo33(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::BasicTypes>{request}, cb);
+        }
 
-        void Async_rd_foo33(::grpc::ClientContext* context, const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
-        void Async_rd_foo33(::grpc::ClientContext* context, const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        void Async_rd_foo33(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
+        void Async_rd_foo33(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
         {
             Async_rd_foo33(context, ::bond::bonded< ::tests::BasicTypes>{request}, cb);
         }
+        void Async_rd_foo33(const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        {
+            Async_rd_foo33(::std::make_shared< ::grpc::ClientContext>(), request, cb);
+        }
+        void Async_rd_foo33(const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        {
+            Async_rd_foo33(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::BasicTypes>{request}, cb);
+        }
 
-        void Asyncfoo34(::grpc::ClientContext* context, const ::bond::bonded< ::tests::dummy>& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo34(::grpc::ClientContext* context, const ::tests::dummy& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo34(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::dummy>& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo34(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::dummy& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
         {
             Asyncfoo34(context, ::bond::bonded< ::tests::dummy>{request}, cb);
         }
+        void Asyncfoo34(const ::bond::bonded< ::tests::dummy>& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo34(::std::make_shared< ::grpc::ClientContext>(), request, cb);
+        }
+        void Asyncfoo34(const ::tests::dummy& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo34(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::dummy>{request}, cb);
+        }
 
-        void Asyncfoo41(::grpc::ClientContext* context, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo41(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo41(const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo41(::std::make_shared< ::grpc::ClientContext>(), cb);
+        }
 
-        void Asyncfoo42(::grpc::ClientContext* context, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo42(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo42(const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo42(::std::make_shared< ::grpc::ClientContext>(), cb);
+        }
 
-        void Asyncfoo43(::grpc::ClientContext* context, const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo43(::grpc::ClientContext* context, const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo43(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo43(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
         {
             Asyncfoo43(context, ::bond::bonded< ::tests::BasicTypes>{request}, cb);
         }
+        void Asyncfoo43(const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo43(::std::make_shared< ::grpc::ClientContext>(), request, cb);
+        }
+        void Asyncfoo43(const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo43(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::BasicTypes>{request}, cb);
+        }
 
-        void Asyncfoo44(::grpc::ClientContext* context, const ::bond::bonded< ::tests::dummy>& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo44(::grpc::ClientContext* context, const ::tests::dummy& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo44(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::dummy>& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb);
+        void Asyncfoo44(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::dummy& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
         {
             Asyncfoo44(context, ::bond::bonded< ::tests::dummy>{request}, cb);
         }
+        void Asyncfoo44(const ::bond::bonded< ::tests::dummy>& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo44(::std::make_shared< ::grpc::ClientContext>(), request, cb);
+        }
+        void Asyncfoo44(const ::tests::dummy& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+        {
+            Asyncfoo44(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::dummy>{request}, cb);
+        }
 
-        void Asynccq(::grpc::ClientContext* context, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
+        void Asynccq(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
+        void Asynccq(const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        {
+            Asynccq(::std::make_shared< ::grpc::ClientContext>(), cb);
+        }
 
         ClientCore(const ClientCore&) = delete;
         ClientCore& operator=(const ClientCore&) = delete;
@@ -560,290 +680,310 @@ inline Foo::ClientCore<TThreadPool>::ClientCore(
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo11(
-    ::grpc::ClientContext* context
+    ::std::shared_ptr< ::grpc::ClientContext> context
     )
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::bond::Void>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::bond::Void>, TThreadPool>(
         _channel,
         _ioManager,
-        _threadPool);
-    calldata->dispatch(rpcmethod_foo11_, context, request);
+        _threadPool,
+        context);
+    calldata->dispatch(rpcmethod_foo11_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo12(
-    ::grpc::ClientContext* context
+    ::std::shared_ptr< ::grpc::ClientContext> context
     )
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::bond::Void>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::bond::Void>, TThreadPool>(
         _channel,
         _ioManager,
-        _threadPool);
-    calldata->dispatch(rpcmethod_foo12_, context, request);
+        _threadPool,
+        context);
+    calldata->dispatch(rpcmethod_foo12_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo12_impl(
-    ::grpc::ClientContext* context
+    ::std::shared_ptr< ::grpc::ClientContext> context
     )
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::bond::Void>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::bond::Void>, TThreadPool>(
         _channel,
         _ioManager,
-        _threadPool);
-    calldata->dispatch(rpcmethod_foo12_impl_, context, request);
+        _threadPool,
+        context);
+    calldata->dispatch(rpcmethod_foo12_impl_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo13(
-    ::grpc::ClientContext* context
+    ::std::shared_ptr< ::grpc::ClientContext> context
     , const ::bond::bonded< ::tests::BasicTypes>& request)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::bond::Void>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::bond::Void>, TThreadPool>(
         _channel,
         _ioManager,
-        _threadPool);
-    calldata->dispatch(rpcmethod_foo13_, context, request);
+        _threadPool,
+        context);
+    calldata->dispatch(rpcmethod_foo13_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo14(
-    ::grpc::ClientContext* context
+    ::std::shared_ptr< ::grpc::ClientContext> context
     , const ::bond::bonded< ::tests::dummy>& request)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded< ::bond::Void>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded< ::bond::Void>, TThreadPool>(
         _channel,
         _ioManager,
-        _threadPool);
-    calldata->dispatch(rpcmethod_foo14_, context, request);
+        _threadPool,
+        context);
+    calldata->dispatch(rpcmethod_foo14_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo15(
-    ::grpc::ClientContext* context
+    ::std::shared_ptr< ::grpc::ClientContext> context
     , const ::bond::bonded< ::tests2::OtherBasicTypes>& request)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests2::OtherBasicTypes>, ::bond::bonded< ::bond::Void>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests2::OtherBasicTypes>, ::bond::bonded< ::bond::Void>, TThreadPool>(
         _channel,
         _ioManager,
-        _threadPool);
-    calldata->dispatch(rpcmethod_foo15_, context, request);
+        _threadPool,
+        context);
+    calldata->dispatch(rpcmethod_foo15_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo21(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     
     const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::bond::Void>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::bond::Void>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod_foo21_, context, request);
+    calldata->dispatch(rpcmethod_foo21_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo22(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     
     const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::bond::Void>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::bond::Void>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod_foo22_, context, request);
+    calldata->dispatch(rpcmethod_foo22_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo23(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded< ::tests::BasicTypes>& request,
     const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::bond::Void>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::bond::Void>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod_foo23_, context, request);
+    calldata->dispatch(rpcmethod_foo23_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo24(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded< ::tests::dummy>& request,
     const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded< ::bond::Void>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded< ::bond::Void>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod_foo24_, context, request);
+    calldata->dispatch(rpcmethod_foo24_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo31(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     
     const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod_foo31_, context, request);
+    calldata->dispatch(rpcmethod_foo31_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo32(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     
     const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod_foo32_, context, request);
+    calldata->dispatch(rpcmethod_foo32_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo33(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded< ::tests::BasicTypes>& request,
     const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod_foo33_, context, request);
+    calldata->dispatch(rpcmethod_foo33_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Async_rd_foo33(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded< ::tests::BasicTypes>& request,
     const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod__rd_foo33_, context, request);
+    calldata->dispatch(rpcmethod__rd_foo33_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo34(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded< ::tests::dummy>& request,
     const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod_foo34_, context, request);
+    calldata->dispatch(rpcmethod_foo34_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo41(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     
     const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::tests::dummy>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::tests::dummy>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod_foo41_, context, request);
+    calldata->dispatch(rpcmethod_foo41_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo42(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     
     const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::tests::dummy>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::tests::dummy>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod_foo42_, context, request);
+    calldata->dispatch(rpcmethod_foo42_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo43(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded< ::tests::BasicTypes>& request,
     const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::dummy>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::dummy>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod_foo43_, context, request);
+    calldata->dispatch(rpcmethod_foo43_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo44(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded< ::tests::dummy>& request,
     const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded< ::tests::dummy>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded< ::tests::dummy>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod_foo44_, context, request);
+    calldata->dispatch(rpcmethod_foo44_, request);
 }
 
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asynccq(
-    ::grpc::ClientContext* context,
+    ::std::shared_ptr< ::grpc::ClientContext> context,
     
     const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool >(
+    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool>(
         _channel,
         _ioManager,
         _threadPool,
+        context,
         cb);
-    calldata->dispatch(rpcmethod_cq_, context, request);
+    calldata->dispatch(rpcmethod_cq_, request);
 }
 
 

--- a/compiler/tests/generated/service_grpc.h
+++ b/compiler/tests/generated/service_grpc.h
@@ -7,6 +7,7 @@
 #include "namespace_basic_types_grpc.h"
 #include <bond/core/bonded.h>
 #include <bond/ext/grpc/bond_utils.h>
+#include <bond/ext/grpc/client_callback.h>
 #include <bond/ext/grpc/io_manager.h>
 #include <bond/ext/grpc/thread_pool.h>
 #include <bond/ext/grpc/unary_call.h>
@@ -108,142 +109,142 @@ public:
             Asyncfoo15(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests2::OtherBasicTypes>{request});
         }
 
-        void Asyncfoo21(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo21(const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo21(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb);
+        void Asyncfoo21(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb)
         {
             Asyncfoo21(::std::make_shared< ::grpc::ClientContext>(), cb);
         }
 
-        void Asyncfoo22(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo22(const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo22(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb);
+        void Asyncfoo22(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb)
         {
             Asyncfoo22(::std::make_shared< ::grpc::ClientContext>(), cb);
         }
 
-        void Asyncfoo23(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo23(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo23(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb);
+        void Asyncfoo23(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::BasicTypes& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb)
         {
             Asyncfoo23(context, ::bond::bonded< ::tests::BasicTypes>{request}, cb);
         }
-        void Asyncfoo23(const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo23(const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb)
         {
             Asyncfoo23(::std::make_shared< ::grpc::ClientContext>(), request, cb);
         }
-        void Asyncfoo23(const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo23(const ::tests::BasicTypes& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb)
         {
             Asyncfoo23(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::BasicTypes>{request}, cb);
         }
 
-        void Asyncfoo24(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::dummy>& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo24(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::dummy& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo24(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::dummy>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb);
+        void Asyncfoo24(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::dummy& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb)
         {
             Asyncfoo24(context, ::bond::bonded< ::tests::dummy>{request}, cb);
         }
-        void Asyncfoo24(const ::bond::bonded< ::tests::dummy>& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo24(const ::bond::bonded< ::tests::dummy>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb)
         {
             Asyncfoo24(::std::make_shared< ::grpc::ClientContext>(), request, cb);
         }
-        void Asyncfoo24(const ::tests::dummy& request, const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo24(const ::tests::dummy& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb)
         {
             Asyncfoo24(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::dummy>{request}, cb);
         }
 
-        void Asyncfoo31(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo31(const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo31(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb);
+        void Asyncfoo31(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
         {
             Asyncfoo31(::std::make_shared< ::grpc::ClientContext>(), cb);
         }
 
-        void Asyncfoo32(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo32(const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo32(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb);
+        void Asyncfoo32(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
         {
             Asyncfoo32(::std::make_shared< ::grpc::ClientContext>(), cb);
         }
 
-        void Asyncfoo33(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo33(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo33(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb);
+        void Asyncfoo33(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::BasicTypes& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
         {
             Asyncfoo33(context, ::bond::bonded< ::tests::BasicTypes>{request}, cb);
         }
-        void Asyncfoo33(const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo33(const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
         {
             Asyncfoo33(::std::make_shared< ::grpc::ClientContext>(), request, cb);
         }
-        void Asyncfoo33(const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo33(const ::tests::BasicTypes& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
         {
             Asyncfoo33(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::BasicTypes>{request}, cb);
         }
 
-        void Async_rd_foo33(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
-        void Async_rd_foo33(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        void Async_rd_foo33(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb);
+        void Async_rd_foo33(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::BasicTypes& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
         {
             Async_rd_foo33(context, ::bond::bonded< ::tests::BasicTypes>{request}, cb);
         }
-        void Async_rd_foo33(const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        void Async_rd_foo33(const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
         {
             Async_rd_foo33(::std::make_shared< ::grpc::ClientContext>(), request, cb);
         }
-        void Async_rd_foo33(const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        void Async_rd_foo33(const ::tests::BasicTypes& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
         {
             Async_rd_foo33(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::BasicTypes>{request}, cb);
         }
 
-        void Asyncfoo34(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::dummy>& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo34(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::dummy& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo34(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::dummy>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb);
+        void Asyncfoo34(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::dummy& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
         {
             Asyncfoo34(context, ::bond::bonded< ::tests::dummy>{request}, cb);
         }
-        void Asyncfoo34(const ::bond::bonded< ::tests::dummy>& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo34(const ::bond::bonded< ::tests::dummy>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
         {
             Asyncfoo34(::std::make_shared< ::grpc::ClientContext>(), request, cb);
         }
-        void Asyncfoo34(const ::tests::dummy& request, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo34(const ::tests::dummy& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
         {
             Asyncfoo34(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::dummy>{request}, cb);
         }
 
-        void Asyncfoo41(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo41(const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo41(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb);
+        void Asyncfoo41(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb)
         {
             Asyncfoo41(::std::make_shared< ::grpc::ClientContext>(), cb);
         }
 
-        void Asyncfoo42(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo42(const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo42(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb);
+        void Asyncfoo42(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb)
         {
             Asyncfoo42(::std::make_shared< ::grpc::ClientContext>(), cb);
         }
 
-        void Asyncfoo43(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo43(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo43(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb);
+        void Asyncfoo43(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::BasicTypes& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb)
         {
             Asyncfoo43(context, ::bond::bonded< ::tests::BasicTypes>{request}, cb);
         }
-        void Asyncfoo43(const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo43(const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb)
         {
             Asyncfoo43(::std::make_shared< ::grpc::ClientContext>(), request, cb);
         }
-        void Asyncfoo43(const ::tests::BasicTypes& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo43(const ::tests::BasicTypes& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb)
         {
             Asyncfoo43(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::BasicTypes>{request}, cb);
         }
 
-        void Asyncfoo44(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::dummy>& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb);
-        void Asyncfoo44(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::dummy& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo44(::std::shared_ptr< ::grpc::ClientContext> context, const ::bond::bonded< ::tests::dummy>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb);
+        void Asyncfoo44(::std::shared_ptr< ::grpc::ClientContext> context, const ::tests::dummy& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb)
         {
             Asyncfoo44(context, ::bond::bonded< ::tests::dummy>{request}, cb);
         }
-        void Asyncfoo44(const ::bond::bonded< ::tests::dummy>& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo44(const ::bond::bonded< ::tests::dummy>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb)
         {
             Asyncfoo44(::std::make_shared< ::grpc::ClientContext>(), request, cb);
         }
-        void Asyncfoo44(const ::tests::dummy& request, const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+        void Asyncfoo44(const ::tests::dummy& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb)
         {
             Asyncfoo44(::std::make_shared< ::grpc::ClientContext>(), ::bond::bonded< ::tests::dummy>{request}, cb);
         }
 
-        void Asynccq(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb);
-        void Asynccq(const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+        void Asynccq(::std::shared_ptr< ::grpc::ClientContext> context, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb);
+        void Asynccq(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
         {
             Asynccq(::std::make_shared< ::grpc::ClientContext>(), cb);
         }
@@ -684,7 +685,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo11(
     )
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::bond::Void>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::Void, ::bond::Void, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -698,7 +699,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo12(
     )
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::bond::Void>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::Void, ::bond::Void, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -712,7 +713,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo12_impl(
     )
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::bond::Void>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::Void, ::bond::Void, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -726,7 +727,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo13(
     , const ::bond::bonded< ::tests::BasicTypes>& request)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::bond::Void>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::tests::BasicTypes, ::bond::Void, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -740,7 +741,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo14(
     , const ::bond::bonded< ::tests::dummy>& request)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded< ::bond::Void>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::tests::dummy, ::bond::Void, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -754,7 +755,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo15(
     , const ::bond::bonded< ::tests2::OtherBasicTypes>& request)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests2::OtherBasicTypes>, ::bond::bonded< ::bond::Void>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::tests2::OtherBasicTypes, ::bond::Void, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -766,10 +767,10 @@ template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo21(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     
-    const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::bond::Void>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::Void, ::bond::Void, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -782,10 +783,10 @@ template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo22(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     
-    const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::bond::Void>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::Void, ::bond::Void, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -798,10 +799,10 @@ template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo23(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded< ::tests::BasicTypes>& request,
-    const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::bond::Void>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::tests::BasicTypes, ::bond::Void, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -814,10 +815,10 @@ template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo24(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded< ::tests::dummy>& request,
-    const std::function<void(const ::bond::bonded< ::bond::Void>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded< ::bond::Void>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::tests::dummy, ::bond::Void, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -830,10 +831,10 @@ template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo31(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     
-    const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::Void, ::tests::BasicTypes, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -846,10 +847,10 @@ template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo32(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     
-    const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::Void, ::tests::BasicTypes, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -862,10 +863,10 @@ template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo33(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded< ::tests::BasicTypes>& request,
-    const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::tests::BasicTypes, ::tests::BasicTypes, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -878,10 +879,10 @@ template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Async_rd_foo33(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded< ::tests::BasicTypes>& request,
-    const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::tests::BasicTypes, ::tests::BasicTypes, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -894,10 +895,10 @@ template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo34(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded< ::tests::dummy>& request,
-    const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::tests::dummy, ::tests::BasicTypes, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -910,10 +911,10 @@ template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo41(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     
-    const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::tests::dummy>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::Void, ::tests::dummy, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -926,10 +927,10 @@ template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo42(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     
-    const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::tests::dummy>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::Void, ::tests::dummy, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -942,10 +943,10 @@ template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo43(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded< ::tests::BasicTypes>& request,
-    const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::BasicTypes>, ::bond::bonded< ::tests::dummy>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::tests::BasicTypes, ::tests::dummy, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -958,10 +959,10 @@ template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo44(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     const ::bond::bonded< ::tests::dummy>& request,
-    const std::function<void(const ::bond::bonded< ::tests::dummy>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb)
 {
     
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::tests::dummy>, ::bond::bonded< ::tests::dummy>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::tests::dummy, ::tests::dummy, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,
@@ -974,10 +975,10 @@ template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asynccq(
     ::std::shared_ptr< ::grpc::ClientContext> context,
     
-    const std::function<void(const ::bond::bonded< ::tests::BasicTypes>&, const ::grpc::Status&)>& cb)
+    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
-    auto calldata = new ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::bonded< ::bond::Void>, ::bond::bonded< ::tests::BasicTypes>, TThreadPool>(
+    auto calldata = std::make_shared< ::bond::ext::gRPC::detail::client_unary_call_data< ::bond::Void, ::tests::BasicTypes, TThreadPool>>(
         _channel,
         _ioManager,
         _threadPool,

--- a/cpp/inc/bond/ext/grpc/client_callback.h
+++ b/cpp/inc/bond/ext/grpc/client_callback.h
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include <grpc++/impl/codegen/status.h>
+#include <grpc++/client_context.h>
+
+#include <bond/core/bonded.h>
+
+#include <memory>
+#include <utility>
+
+namespace bond { namespace ext { namespace gRPC {
+
+    /// @brief The client-side results of a unary call.
+    template <typename TResponse>
+    struct unary_call_result
+    {
+        /// @brief The response received from the service.
+        ///
+        /// @note Depending on the implementation of the service, this may or
+        /// may not contain an actual response. Consult the documentation for
+        /// the service to determine under what conditions it sends back a
+        /// response.
+        bond::bonded<TResponse> response;
+        /// @brief The status of the request.
+        grpc::Status status;
+        /// @brief The client context underwhich the request was executed.
+        std::shared_ptr<grpc::ClientContext> context;
+
+        /// @brief Create a unary_call_result with the given context and
+        /// empty \ref response and \ref status members.
+        ///
+        /// @param context the context underwhich the request is being
+        /// executed.
+        explicit unary_call_result(std::shared_ptr<grpc::ClientContext> context)
+            : response(),
+              status(),
+              context(std::move(context))
+        { }
+
+        /// @brief Create a unary_call_result with the given values.
+        ///
+        /// @param response The response.
+        /// @param status The status.
+        /// @param context the context underwhich the request is being executed.
+        unary_call_result(
+            const bond::bonded<TResponse>& response,
+            const grpc::Status& status,
+            std::shared_ptr<grpc::ClientContext> context)
+            : response(response),
+              status(status),
+              context(std::move(context))
+        { }
+
+        unary_call_result(const unary_call_result&) = default;
+        unary_call_result(unary_call_result&&) = default;
+        unary_call_result& operator=(const unary_call_result&) = default;
+        unary_call_result& operator=(unary_call_result&&) = default;
+    };
+
+} } } // namespace bond::ext::gRPC

--- a/cpp/test/compat/grpc/pingpong_client.cpp
+++ b/cpp/test/compat/grpc/pingpong_client.cpp
@@ -17,7 +17,6 @@
 #include <thread>
 
 using grpc::Channel;
-using grpc::ClientContext;
 using grpc::Status;
 
 using namespace PingPongNS;
@@ -32,7 +31,6 @@ int main()
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
-    
     PingPong::Client client(channel, ioManager, threadPool);
 
     printf("Start client\n");
@@ -42,7 +40,6 @@ int main()
     {
         for (int i = 0; i < NumRequests; i++)
         {
-            ClientContext context;
             PingRequest request;
 
             request.Payload = "request" + std::to_string(i);
@@ -52,7 +49,7 @@ int main()
             fflush(stdout);
 
             bond::ext::gRPC::wait_callback<PingResponse> cb;
-            client.AsyncPing(&context, bond::bonded<PingRequest>{ request }, cb);
+            client.AsyncPing(request, cb);
             bool gotResponse = cb.wait_for(std::chrono::seconds(1));
 
             if (!gotResponse)
@@ -83,14 +80,13 @@ int main()
 
         for (int i = 0; i < NumErrors; i++)
         {
-            ClientContext context;
             PingRequest request;
 
             request.Payload = "error" + std::to_string(i);
             request.Action = PingAction::Error;
 
             bond::ext::gRPC::wait_callback<PingResponse> cb;
-            client.AsyncPing(&context, bond::bonded<PingRequest> { request }, cb);
+            client.AsyncPing(request, cb);
             bool gotResponse = cb.wait_for(std::chrono::seconds(1));
 
             if (!gotResponse)

--- a/cpp/test/grpc/io_manager.cpp
+++ b/cpp/test/grpc/io_manager.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #ifdef _MSC_VER
+    #pragma warning(push)
     #pragma warning(disable : 4100) // disable "unreferenced formal parameter" warning
     #pragma warning(disable : 4505) // disable "unreferenced local function has been removed" warning
 #endif
@@ -12,6 +13,10 @@
 #include <grpc++/impl/grpc_library.h>
 #include <grpc/grpc.h>
 #include <grpc/support/time.h>
+
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif
 
 #include <bond/ext/grpc/io_manager.h>
 #include <bond/ext/grpc/detail/io_manager_tag.h>

--- a/doc/src/bond_over_grpc.md
+++ b/doc/src/bond_over_grpc.md
@@ -163,7 +163,7 @@ implementation by subclassing the server base and supplying the business logic:
                 ExampleResponse> call) override
         {
             ExampleRequest request = call.request().Deserialize();
-            ExampleResponse reply;
+            ExampleResponse response;
 
             // Service business logic goes here
 
@@ -204,7 +204,7 @@ The proxy stub can then be used to make calls to the server as follows:
     // Fill in request fields here
 
     bond::ext::gRPC::wait_callback<ExampleResponse> cb;
-    client.AsyncExampleMethod(&context, request, callback);
+    client.AsyncExampleMethod(request, callback);
 
     callback.wait();
     ExampleResponse response = callback.response().Deserialize();
@@ -213,14 +213,23 @@ The proxy stub can then be used to make calls to the server as follows:
 Note these APIs are significantly different from the APIs presented in the
 gRPC documentation; Bond-over-gRPC is attempting to provide a more
 straightforward API for aynchronous communication than gRPC currently
-presents in C++. The use of [`wait_callback<T>`][wait_callback_reference]
-here is for illustrative purposes; any callback implementation with the same
-signature can be used. Note also the use of `bonded<T>` to wrap the request
-and response objects in several places; this allows for better control over
-the time of deserialization and also helps prevent slicing when using
-polymorphic Bond types. Convenience APIs are provided in some places to hide
-the use `bonded<T>` where possible. Finally, note that Bond-over-gRPC does
-not provide synchronous APIs in C++ by design.
+presents in C++. Bond-over-gRPC does not provide synchronous APIs in C++ by
+design. The use of [`wait_callback<T>`][wait_callback_reference] here is for
+illustrative purposes; any callback implementation with the same signature
+can be used. `wait_callback` satisfies the signature and provides a `wait()`
+method to adapt the asynchronous proxy method into an effectively
+synchronous call.
+
+The proxy stub has a number of overloads for each method. The simplest is
+demonstrated above, and there are ones that take `bonded<T>` and
+`grpc::ClientContext` arguments.
+
+Using `bonded<T>` to wrap the request and response objects allows for better
+control over the time of deserialization and also helps prevent slicing when
+using polymorphic Bond types. As demonstrated above, convenience APIs are
+provided in some places to hide the use `bonded<T>` where possible. For use
+of `bonded` request objects and `ClientContext` arguments, see the pingpong
+example.
 
 For more information about gRPC in C++, take a look at the
 [gRPC C++ tutorial](http://www.grpc.io/docs/tutorials/basic/c.html);
@@ -230,5 +239,6 @@ from those documented there.
 See also the following example:
 
 - `examples/cpp/grpc/helloworld`
+- `examples/cpp/grpc/pingpong`
 
 [wait_callback_reference]: ../reference/cpp/classbond_1_1ext_1_1g_r_p_c_1_1wait__callback.html

--- a/examples/cpp/grpc/grpc_dll/using_grpc_dll.cpp
+++ b/examples/cpp/grpc/grpc_dll/using_grpc_dll.cpp
@@ -34,9 +34,6 @@
 #include <memory>
 
 using grpc::Channel;
-using grpc::ClientContext;
-using grpc::Status;
-using grpc::StatusCode;
 
 using grpc::Server;
 using grpc::ServerBuilder;

--- a/examples/cpp/grpc/grpc_static_library/client/grpc_static_library_client.cpp
+++ b/examples/cpp/grpc/grpc_static_library/client/grpc_static_library_client.cpp
@@ -27,8 +27,6 @@
 #include <memory>
 
 using grpc::Channel;
-using grpc::ClientContext;
-using grpc::Status;
 
 using namespace examples::grpc_static_library;
 

--- a/examples/cpp/grpc/helloworld/helloworld.cpp
+++ b/examples/cpp/grpc/helloworld/helloworld.cpp
@@ -15,7 +15,6 @@
 #include <string>
 
 using grpc::Channel;
-using grpc::ClientContext;
 using grpc::ServerBuilder;
 using grpc::Status;
 
@@ -57,15 +56,13 @@ int main()
         ioManager,
         threadPool);
 
-    ClientContext context;
-
     const std::string user("world");
 
     HelloRequest request;
     request.name = user;
 
     bond::ext::gRPC::wait_callback<HelloReply> cb;
-    greeter.AsyncSayHello(&context, request, cb);
+    greeter.AsyncSayHello(request, cb);
 
     bool waitResult = cb.wait_for(std::chrono::seconds(10));
 


### PR DESCRIPTION
Here's a checkpoint of some work to improve the ClientContext lifetime management that @chadwalters  and I've been working on. This PR is here to get Travis and AppVeyor runs and as a place to collect comments. I expect it will be reworked heavily before being merged.

Current improvements:

* take ClientContext via shared pointer in the proxy methods so the context can be kept alive for the duration of the client call. Before, this was the client's responsibility, and failure to do so resulted in crashes.
* include the ClientContext in what's passed back to the callback so that the caller can "forget" about the context if they don't need it in the interim
* minimize copies by reading the response and status into a client_callback_args that we then move into the callback

Potential future improvements:

* add overloads that create a client context so callers who don't need to muck with the context don't even need to worry about one at all
* adjust naming to reflect that this is only what unary client calls will use