### PR TITLE
[C++] Upgrade rapidjson to v1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ get a compiler error. To fix, remove the `<Writer>` part:
   support which was broken for some scenarios.
 * For Visual C++ 2017 compability, RapidJSON v1.0.0 or newer is now
   required. The RapidJSON submodule that Bond uses by default has been
-  updated to v1.0.0.
+  updated to v1.1.0 due to a warning from clang in earlier versions.
 * C++ codegen hides FieldTemplate details, shortening symbol names.
 
 ### C# ###

--- a/cpp/inc/bond/comm/wire_protocol.h
+++ b/cpp/inc/bond/comm/wire_protocol.h
@@ -98,7 +98,7 @@ public:
     {
         auto stream = StreamFactory::Create();
 
-        ::bond::Apply< ::bond::Marshaler>(payload, stream, requestProtocol);
+        ::bond::Apply< ::bond::Marshaler>(payload, stream, static_cast<uint16_t>(requestProtocol));
 
         std::vector<blob> buffers;
         stream.GetBuffers(buffers);

--- a/cpp/inc/bond/core/detail/validate.h
+++ b/cpp/inc/bond/core/detail/validate.h
@@ -234,10 +234,9 @@ public:
     }
 
     template <typename T>
-    bool UnknownField(uint16_t id, const T&) const
+    BOND_NORETURN bool UnknownField(uint16_t id, const T&) const
     {
         UnknownSchemaDefException(id);
-        return false;
     }
 
     template <typename T>

--- a/cpp/inc/bond/protocol/detail/rapidjson_helper.h
+++ b/cpp/inc/bond/protocol/detail/rapidjson_helper.h
@@ -13,9 +13,34 @@
 #include <boost/call_traits.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/locale.hpp>
+
 #include "rapidjson/rapidjson.h"
 #include "rapidjson/error/en.h"
+
+// rapidjson/document.h v1.1 uses std::min/max in ways that conflict
+// with macros defined in windows. This works around the issue.
+#ifdef _MSC_VER
+#if defined(_WINDEF_) || defined(_MINWINDEF_)
+#ifndef NOMINMAX
+  #pragma push_macro("min")
+  #pragma push_macro("max")
+#undef min
+#undef max
+#endif
+#endif
+#endif
+
 #include "rapidjson/document.h"
+
+#ifdef _MSC_VER
+#if defined(_WINDEF_) || defined(_MINWINDEF_)
+#ifndef NOMINMAX
+  #pragma pop_macro("min")
+  #pragma pop_macro("max")
+#endif
+#endif
+#endif
+
 #include "rapidjson/writer.h"
 #include <algorithm>
 


### PR DESCRIPTION
v1.1 addresses warning from clang. Also, fix some issues in VC++ that the
upgrade exposed, specifically:
* Unreachable code warnings in several places
* Conflicts due to mix/max macros in windef.h
* Warning due to converting enum to uint16_t

Resolves https://github.com/Microsoft/bond/issues/485