### PR TITLE
ByteArrayInputStream cloning + misc

### DIFF
--- a/java/core/.idea/runConfigurations/all_tests.xml
+++ b/java/core/.idea/runConfigurations/all_tests.xml
@@ -1,0 +1,29 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="all tests" type="JUnit" factoryName="JUnit">
+    <extension name="coverage" enabled="true" merge="false" runner="idea">
+      <pattern>
+        <option name="PATTERN" value="com.microsoft.bond.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <module name="bond" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+    <option name="ALTERNATIVE_JRE_PATH" />
+    <option name="PACKAGE_NAME" />
+    <option name="MAIN_CLASS_NAME" value="" />
+    <option name="METHOD_NAME" value="" />
+    <option name="TEST_OBJECT" value="directory" />
+    <option name="VM_PARAMETERS" value="-ea" />
+    <option name="PARAMETERS" value="" />
+    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$" />
+    <option name="ENV_VARIABLES" />
+    <option name="PASS_PARENT_ENVS" value="true" />
+    <option name="TEST_SEARCH_SCOPE">
+      <value defaultName="singleModule" />
+    </option>
+    <envs />
+    <dir value="$PROJECT_DIR$/src/test" />
+    <patterns />
+    <method />
+  </configuration>
+</component>

--- a/java/core/src/main/java/com/microsoft/bond/protocol/Cloning.java
+++ b/java/core/src/main/java/com/microsoft/bond/protocol/Cloning.java
@@ -1,0 +1,54 @@
+package com.microsoft.bond.protocol;
+
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.Field;
+
+class Cloning {
+    static ByteArrayInputStream clone(ByteArrayInputStream stream) {
+        // A ByteArrayInputStream can be duplicated with the three pieces of
+        // state that are passed to its long-form constructor. Unfortunately,
+        // they are hidden in protected members after construction, so we need
+        // to reflect to get them out.
+        //
+        // There's one more piece of state inside that class - mark. We don't
+        // use mark()/reset(), and cloned streams shouldn't leak out of the
+        // library, so we ignore it here.
+
+        final Field bufField;
+        final Field posField;
+        final Field countField;
+        try {
+            bufField = ByteArrayInputStream.class.getDeclaredField("buf");
+            posField = ByteArrayInputStream.class.getDeclaredField("pos");
+            countField = ByteArrayInputStream.class.getDeclaredField("count");
+        } catch (final NoSuchFieldException e) {
+            // This should never happen. ByteArrayInputStream has been in the
+            // JDK and has had these fields since 1.0.
+            throw new RuntimeException(e);
+        }
+
+        bufField.setAccessible(true);
+        posField.setAccessible(true);
+        countField.setAccessible(true);
+
+        final byte[] buf;
+        final int pos;
+        final int count;
+        try {
+            buf = (byte[]) bufField.get(stream);
+            pos = posField.getInt(stream);
+            count = countField.getInt(stream);
+        } catch (final IllegalAccessException e) {
+            // This should never happen. We just made those fields accessible.
+            throw new RuntimeException(e);
+        }
+
+        bufField.setAccessible(false);
+        posField.setAccessible(false);
+        countField.setAccessible(false);
+
+        final ByteArrayInputStream cloned = new ByteArrayInputStream(buf, 0, count);
+        cloned.skip(pos);
+        return cloned;
+    }
+}

--- a/java/core/src/main/java/com/microsoft/bond/protocol/Cloning.java
+++ b/java/core/src/main/java/com/microsoft/bond/protocol/Cloning.java
@@ -4,6 +4,23 @@ import java.io.ByteArrayInputStream;
 import java.lang.reflect.Field;
 
 class Cloning {
+    private static final Object byteArrayInputStreamLock = new Object();
+    private static final Field byteArrayInputStream_buf;
+    private static final Field byteArrayInputStream_pos;
+    private static final Field byteArrayInputStream_count;
+
+    static {
+        try {
+            byteArrayInputStream_buf = ByteArrayInputStream.class.getDeclaredField("buf");
+            byteArrayInputStream_pos = ByteArrayInputStream.class.getDeclaredField("pos");
+            byteArrayInputStream_count = ByteArrayInputStream.class.getDeclaredField("count");
+        } catch (final NoSuchFieldException e) {
+            // This should never happen. ByteArrayInputStream has had these
+            // fields since JDK 1.0.
+            throw new RuntimeException(e);
+        }
+    }
+
     static ByteArrayInputStream clone(ByteArrayInputStream stream) {
         // A ByteArrayInputStream can be duplicated with the three pieces of
         // state that are passed to its long-form constructor. Unfortunately,
@@ -13,42 +30,41 @@ class Cloning {
         // There's one more piece of state inside that class - mark. We don't
         // use mark()/reset(), and cloned streams shouldn't leak out of the
         // library, so we ignore it here.
-
-        final Field bufField;
-        final Field posField;
-        final Field countField;
-        try {
-            bufField = ByteArrayInputStream.class.getDeclaredField("buf");
-            posField = ByteArrayInputStream.class.getDeclaredField("pos");
-            countField = ByteArrayInputStream.class.getDeclaredField("count");
-        } catch (final NoSuchFieldException e) {
-            // This should never happen. ByteArrayInputStream has been in the
-            // JDK and has had these fields since 1.0.
-            throw new RuntimeException(e);
-        }
-
-        bufField.setAccessible(true);
-        posField.setAccessible(true);
-        countField.setAccessible(true);
-
         final byte[] buf;
         final int pos;
         final int count;
-        try {
-            buf = (byte[]) bufField.get(stream);
-            pos = posField.getInt(stream);
-            count = countField.getInt(stream);
-        } catch (final IllegalAccessException e) {
-            // This should never happen. We just made those fields accessible.
-            throw new RuntimeException(e);
+
+        synchronized (byteArrayInputStreamLock) {
+            byteArrayInputStream_buf.setAccessible(true);
+            byteArrayInputStream_pos.setAccessible(true);
+            byteArrayInputStream_count.setAccessible(true);
+
+            try {
+                buf = (byte[]) byteArrayInputStream_buf.get(stream);
+                pos = byteArrayInputStream_pos.getInt(stream);
+                count = byteArrayInputStream_count.getInt(stream);
+            } catch (final IllegalAccessException e) {
+                // This synchronized block makes this expose/access/hide
+                // operation safe to call concurrently, but there's no way to
+                // guarantee unrelated code isn't modifying these fields'
+                // accessibility. In that unlikely event, there's nothing
+                // sensible we can do to recover.
+                throw new RuntimeException(e);
+            }
+
+            // The RuntimeException caused by an IllegalAccessException thrown
+            // above indicates a serious incompatibility between this part of
+            // Bond and some other component and cannot be resolved
+            // programmatically.
+            //
+            // We can't even clean up without a risk of causing the same
+            // problem to the other component, so we do this outside the try,
+            // not in a finally {}.
+            byteArrayInputStream_buf.setAccessible(false);
+            byteArrayInputStream_pos.setAccessible(false);
+            byteArrayInputStream_count.setAccessible(false);
         }
 
-        bufField.setAccessible(false);
-        posField.setAccessible(false);
-        countField.setAccessible(false);
-
-        final ByteArrayInputStream cloned = new ByteArrayInputStream(buf, 0, count);
-        cloned.skip(pos);
-        return cloned;
+        return new ByteArrayInputStream(buf, pos, count - pos);
     }
 }

--- a/java/core/src/test/java/com/microsoft/bond/protocol/CloningTest.java
+++ b/java/core/src/test/java/com/microsoft/bond/protocol/CloningTest.java
@@ -1,0 +1,101 @@
+package com.microsoft.bond.protocol;
+
+import org.junit.Assert;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class CloningTest {
+    private final byte[] bytes = new byte[] {
+            0x01, 0x02, 0x03,
+            0x04, 0x05, 0x06,
+            0x07, 0x08, 0x09,
+            0x0a, 0x0b, 0x0c
+    };
+
+    private void byteArrayInput(final int readFirst, final int offset, final int length) {
+        final ByteArrayInputStream original = new ByteArrayInputStream(bytes, offset, length);
+
+        // Skip zero or more bytes before cloning.
+        int i = 0;
+        for (; i < readFirst; i++) {
+            try {
+                StreamHelper.readByte(original);
+            } catch (final IOException ignored) {
+                fail("original stream hit end-of-stream while skipping initial bytes");
+            }
+        }
+
+        // original and cloned should see the same sequence of bytes from here.
+        final ByteArrayInputStream cloned = Cloning.clone(original);
+        for (; i < length; i++) {
+            // readByte() converts the underlying representation of end-of-stream
+            // to an IOException. A byte[]-backed stream shouldn't throw for any
+            // other reason.
+            byte originalByte = 0;
+            try {
+                originalByte = StreamHelper.readByte(original);
+            } catch (final IOException ignored) {
+                fail(String.format("original stream hit end-of-stream at index %d", i));
+            }
+
+            byte clonedByte = 0;
+            try {
+                clonedByte = StreamHelper.readByte(cloned);
+            } catch (final IOException ignored) {
+                fail(String.format("cloned stream hit end-of-stream at index %d", i));
+            }
+
+            final byte expectedByte = bytes[offset + i];
+            Assert.assertEquals(String.format("original stream read the wrong value at index %d", i),
+                    expectedByte, originalByte);
+            Assert.assertEquals(String.format("cloned stream read the wrong value at index %d", i),
+                    expectedByte, clonedByte);
+        }
+
+        // original and cloned should both signal end-of-stream on their next reads.
+        boolean originalThrewEof = false;
+        try {
+            StreamHelper.readByte(original);
+        } catch (final IOException ignored) {
+            originalThrewEof = true;
+        }
+        Assert.assertTrue("original stream read past the end of its segment", originalThrewEof);
+
+        boolean clonedThrewEof = false;
+        try {
+            StreamHelper.readByte(cloned);
+        } catch (final IOException ignored) {
+            clonedThrewEof = true;
+        }
+        Assert.assertTrue("cloned stream read past the end of its segment", clonedThrewEof);
+    }
+
+    @Test
+    public void byteArrayInput() {
+        // stream consumes entire array
+        byteArrayInput(0, 0, bytes.length);
+        byteArrayInput(bytes.length / 2, 0, bytes.length);
+        byteArrayInput(bytes.length, 0, bytes.length);
+
+        final int segmentLength = bytes.length / 2;
+
+        // stream consumes prefix of array
+        byteArrayInput(0, 0, segmentLength);
+        byteArrayInput(segmentLength / 2, 0, segmentLength);
+        byteArrayInput(segmentLength, 0, segmentLength);
+
+        // stream consumes suffix of array
+        byteArrayInput(0, bytes.length - segmentLength, segmentLength);
+        byteArrayInput(segmentLength / 2, bytes.length - segmentLength, segmentLength);
+        byteArrayInput(segmentLength, bytes.length - segmentLength, segmentLength);
+
+        // stream consumes middle of array
+        final int middleSegmentOffset = segmentLength / 2;
+        byteArrayInput(0, middleSegmentOffset, segmentLength);
+        byteArrayInput(segmentLength / 2, middleSegmentOffset, segmentLength);
+        byteArrayInput(segmentLength, middleSegmentOffset, segmentLength);
+    }
+}


### PR DESCRIPTION
9f07440 adds functionality that should be sufficient for `bonded` in memory streams.
1badec2 fixes a mistake from my earlier reorg into `java/core`.
bda0607 adds a shared test runner (configured for line coverage), which will make it a little easier to get new copies of the repo up and running.