### PR TITLE
[c++] Remove last boost::integral_constant uses

### DIFF
--- a/cpp/inc/bond/core/reflection.h
+++ b/cpp/inc/bond/core/reflection.h
@@ -782,7 +782,7 @@ get_type_id<int16_t>
 
 template <> struct
 get_type_id<int32_t>
-    : boost::integral_constant<BondDataType, BT_INT32> {};
+    : std::integral_constant<BondDataType, BT_INT32> {};
 
 template <> struct
 get_type_id<int64_t>
@@ -794,7 +794,7 @@ get_type_id<float>
 
 template <> struct
 get_type_id<double>
-    : boost::integral_constant<BondDataType, BT_DOUBLE> {};
+    : std::integral_constant<BondDataType, BT_DOUBLE> {};
 
 template <> struct
 get_type_id<void>


### PR DESCRIPTION
Commit fd9a186676cf switched from boost::integral_constant to
std::integral_constant, but didn't make a clean break. With this change,
everything now uses std::integral_constant.

CC: @jdubrule