### PR TITLE
gradle plugin: Initial commit.

### DIFF
--- a/java/.gitignore
+++ b/java/.gitignore
@@ -1,0 +1,7 @@
+*/.gradle/
+*/gradle/
+*/gradlew
+*/gradlew.bat
+*/.idea/libraries
+*/.idea/workspace.xml
+*/build/

--- a/java/compat/.gitignore
+++ b/java/compat/.gitignore
@@ -1,4 +1,0 @@
-/.gradle/
-/.idea/libraries
-/.idea/workspace.xml
-/build/

--- a/java/compat/build.gradle
+++ b/java/compat/build.gradle
@@ -1,7 +1,19 @@
 group 'com.microsoft.bond'
 version '1.0'
 
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.microsoft.bond:gradle:+'
+    }
+}
+
 apply plugin: 'java'
+apply plugin: 'com.microsoft.bond.gradle'
 
 sourceCompatibility = 1.8
 
@@ -14,27 +26,10 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 
-def gbcOutputPath = "$buildDir/generated-src"
-def gbcOutputDir = file("$gbcOutputPath")
-def bondRoot = "../.."
-
-allprojects {
-    task compatCodegen(type:Exec) {
-        commandLine "$bondRoot/build/compiler/build/gbc/gbc", 'java',
-            "$bondRoot/test/compat/core/schemas/compat.bond",
-            "$bondRoot/test/compat/core/schemas/compat2.bond",
-            "$bondRoot/test/compat/core/schemas/compat_common.bond",
-            '--output', "$gbcOutputPath"
-    }
-    compileJava.dependsOn compatCodegen
-}
-
-sourceSets {
-    main {
-        java {
-            srcDirs += gbcOutputDir
-        }
-    }
+bondCodegen {
+    bondfiles '../../test/compat/core/schemas/compat.bond',
+              '../../test/compat/core/schemas/compat2.bond',
+              '../../test/compat/core/schemas/compat_common.bond'
 }
 
 jar {

--- a/java/core/.gitignore
+++ b/java/core/.gitignore
@@ -1,4 +1,0 @@
-/.gradle/
-/.idea/libraries
-/.idea/workspace.xml
-/build/

--- a/java/core/build.gradle
+++ b/java/core/build.gradle
@@ -1,15 +1,23 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+group 'com.microsoft.bond'
+version = '5.0.0'
+
 buildscript {
     repositories {
+        mavenLocal()
         mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.microsoft.bond:gradle:+'
     }
 }
 
 apply plugin: 'java'
+apply plugin: 'com.microsoft.bond.gradle'
 
-version = '5.0.0'
 sourceCompatibility = 1.6
 
 repositories {
@@ -20,25 +28,8 @@ dependencies {
     testCompile 'junit:junit:4.12'
 }
 
-def gbcOutputPath = "$buildDir/generated-src"
-def gbcOutputDir = file("$gbcOutputPath")
-def bondRoot = '../..'
-
-allprojects {
-    task coreCodegen(type:Exec) {
-        commandLine "$bondRoot/build/compiler/build/gbc/gbc", 'java',
-            '-n', 'bond=com.microsoft.bond',
-            "$bondRoot/idl/bond/core/bond.bond",
-            "$bondRoot/idl/bond/core/bond_const.bond",
-            '--output', "$gbcOutputPath"
-    }
-    compileJava.dependsOn coreCodegen
-}
-
-sourceSets {
-    main {
-        java {
-            srcDirs += gbcOutputDir
-        }
-    }
+bondCodegen {
+    bondfiles '../../idl/bond/core/bond.bond',
+              '../../idl/bond/core/bond_const.bond'
+    options '-n', 'bond=com.microsoft.bond'
 }

--- a/java/gradle-plugin/.idea/.name
+++ b/java/gradle-plugin/.idea/.name
@@ -1,0 +1,1 @@
+bond-gradle

--- a/java/gradle-plugin/.idea/compiler.xml
+++ b/java/gradle-plugin/.idea/compiler.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <wildcardResourcePatterns>
+      <entry name="!?*.java" />
+      <entry name="!?*.form" />
+      <entry name="!?*.class" />
+      <entry name="!?*.groovy" />
+      <entry name="!?*.scala" />
+      <entry name="!?*.flex" />
+      <entry name="!?*.kt" />
+      <entry name="!?*.clj" />
+    </wildcardResourcePatterns>
+  </component>
+</project>

--- a/java/gradle-plugin/.idea/encodings.xml
+++ b/java/gradle-plugin/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="PROJECT" charset="UTF-8" />
+  </component>
+</project>

--- a/java/gradle-plugin/.idea/gradle.xml
+++ b/java/gradle-plugin/.idea/gradle.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="distributionType" value="LOCAL" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleHome" value="/usr/local/Cellar/gradle/3.5/libexec" />
+        <option name="gradleJvm" value="1.8" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+          </set>
+        </option>
+        <option name="resolveModulePerSourceSet" value="false" />
+        <option name="useAutoImport" value="true" />
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/java/gradle-plugin/.idea/misc.xml
+++ b/java/gradle-plugin/.idea/misc.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/classes" />
+  </component>
+  <component name="masterDetails">
+    <states>
+      <state key="ProjectJDKs.UI">
+        <settings>
+          <last-edited>1.8</last-edited>
+          <splitter-proportions>
+            <option name="proportions">
+              <list>
+                <option value="0.2" />
+              </list>
+            </option>
+          </splitter-proportions>
+        </settings>
+      </state>
+    </states>
+  </component>
+</project>

--- a/java/gradle-plugin/.idea/modules.xml
+++ b/java/gradle-plugin/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/bond-gradle.iml" filepath="$PROJECT_DIR$/.idea/modules/bond-gradle.iml" />
+    </modules>
+  </component>
+</project>

--- a/java/gradle-plugin/.idea/modules/bond-gradle.iml
+++ b/java/gradle-plugin/.idea/modules/bond-gradle.iml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id="bond-gradle" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="com.microsoft.bond" external.system.module.version="1.0" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <output url="file://$MODULE_DIR$/../../build/classes/main" />
+    <output-test url="file://$MODULE_DIR$/../../build/classes/test" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../..">
+      <sourceFolder url="file://$MODULE_DIR$/../../src/main/groovy" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../src/test/groovy" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../../src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../../src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../../src/test/resources" type="java-test-resource" />
+      <excludeFolder url="file://$MODULE_DIR$/../../.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/../../build" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module-library" scope="PROVIDED">
+      <library name="Gradle: groovy-all-2.4.10">
+        <CLASSES>
+          <root url="jar:///usr/local/Cellar/gradle/3.5/libexec/lib/groovy-all-2.4.10.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library name="Gradle: gradle-installation-beacon-3.5">
+        <CLASSES>
+          <root url="jar:///usr/local/Cellar/gradle/3.5/libexec/lib/gradle-installation-beacon-3.5.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library name="Gradle: gradle-api-3.5">
+        <CLASSES>
+          <root url="jar://$USER_HOME$/.gradle/caches/3.5/generated-gradle-jars/gradle-api-3.5.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library name="Gradle: groovy-all-2.4.10">
+        <CLASSES>
+          <root url="jar:///usr/local/Cellar/gradle/3.5/libexec/lib/groovy-all-2.4.10.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="RUNTIME">
+      <library name="Gradle: gradle-installation-beacon-3.5">
+        <CLASSES>
+          <root url="jar:///usr/local/Cellar/gradle/3.5/libexec/lib/gradle-installation-beacon-3.5.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="RUNTIME">
+      <library name="Gradle: gradle-api-3.5">
+        <CLASSES>
+          <root url="jar://$USER_HOME$/.gradle/caches/3.5/generated-gradle-jars/gradle-api-3.5.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="RUNTIME">
+      <library name="Gradle: groovy-all-2.4.10">
+        <CLASSES>
+          <root url="jar:///usr/local/Cellar/gradle/3.5/libexec/lib/groovy-all-2.4.10.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="PROVIDED">
+      <library name="Gradle: gradle-installation-beacon-3.5">
+        <CLASSES>
+          <root url="jar:///usr/local/Cellar/gradle/3.5/libexec/lib/gradle-installation-beacon-3.5.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="PROVIDED">
+      <library name="Gradle: gradle-api-3.5">
+        <CLASSES>
+          <root url="jar://$USER_HOME$/.gradle/caches/3.5/generated-gradle-jars/gradle-api-3.5.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+  </component>
+</module>

--- a/java/gradle-plugin/.idea/vcs.xml
+++ b/java/gradle-plugin/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
+  </component>
+</project>

--- a/java/gradle-plugin/README.md
+++ b/java/gradle-plugin/README.md
@@ -1,0 +1,6 @@
+To build with a development version of this plugin, repeat as follows:
+* make changes
+* gradle build
+* mvn install:install-file -Dfile=${BOND_JAVA_ROOT}/gradle-plugin/build/libs/bond-gradle-1.0.jar -DgroupId=com.microsoft.bond -DartifactId=gradle -Dversion=1.0 -Dpackaging=jar
+This will install the plugin to your local maven repository, which the other
+Java projects' build.gradles will use in preference to maven central.

--- a/java/gradle-plugin/build.gradle
+++ b/java/gradle-plugin/build.gradle
@@ -1,0 +1,12 @@
+apply plugin: 'groovy'
+
+group 'com.microsoft.bond'
+version '1.0'
+
+dependencies {
+    compile localGroovy()
+    compile gradleApi()
+}
+
+jar {
+}

--- a/java/gradle-plugin/settings.gradle
+++ b/java/gradle-plugin/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'bond-gradle'

--- a/java/gradle-plugin/src/main/groovy/com/microsoft/bond/gradle/BondCodegen.groovy
+++ b/java/gradle-plugin/src/main/groovy/com/microsoft/bond/gradle/BondCodegen.groovy
@@ -1,0 +1,87 @@
+package com.microsoft.bond.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+class BondCodegen extends DefaultTask {
+    List<String> gbcBaseArgv = ['gbc', 'java']
+    File defaultBondRoot = project.file('src/main/bond')
+
+    @Input
+    List<String> gbcOptions = []
+
+    @InputFiles
+    Set<File> allBondfiles = defaultBondfiles()
+
+    @OutputDirectory
+    File outputDir = project.file("${project.buildDir.canonicalPath}/generated-bond-src")
+
+    BondCodegen() {
+        // Assumes we are being called from a Java or Java-inherited
+        // (e.g., Kotlin) context.
+        project.tasks.getByName(JavaPlugin.COMPILE_JAVA_TASK_NAME).dependsOn this
+
+        // Needs to happen regardless of whether gradle decides we're up-to-date.
+        // We can do this in the constructor for now, but if we expose the
+        // ability to change our output dir, this has to happen there.
+        project.sourceSets.main.java.srcDir outputDir.canonicalPath
+    }
+
+    def options(Object... optionList) {
+        optionList.each { option ->
+            gbcOptions << option.toString()
+        }
+    }
+
+    private def defaultBondfiles() {
+        Set<File> defaultBondfiles = []
+
+        if (defaultBondRoot.exists()) {
+            project.fileTree(defaultBondRoot) {
+                include '**/*.bond'
+            }.each { bondfile ->
+                defaultBondfiles.add(bondfile)
+            }
+        }
+
+        return defaultBondfiles
+    }
+
+    def bondfiles(Object... bondfileList) {
+        bondfileList.each { bondfile ->
+            allBondfiles << project.file(bondfile)
+        }
+    }
+
+    @TaskAction
+    def codegen() {
+        if (allBondfiles.empty) {
+            project.logger.warn("bond codegen enabled, but no bondfiles detected or configured")
+            return
+        }
+
+        def gbcArgv = gbcBaseArgv.clone()
+        gbcArgv += ['--output-dir', outputDir.canonicalPath]
+        gbcArgv += gbcOptions
+
+        allBondfiles.each { bondfile ->
+            gbcArgv << bondfile.canonicalPath
+        }
+
+        project.logger.info("BondCodegen: executing gbc argv ${gbcArgv}")
+        def result = project.exec {
+            commandLine gbcArgv
+        }
+
+        if (result.exitValue != 0) {
+            def errmsg = "gbc returned ${result.exitValue}"
+            project.logger.error(errmsg)
+            throw new GradleException(errmsg)
+        }
+    }
+}

--- a/java/gradle-plugin/src/main/groovy/com/microsoft/bond/gradle/BondPlugin.groovy
+++ b/java/gradle-plugin/src/main/groovy/com/microsoft/bond/gradle/BondPlugin.groovy
@@ -1,0 +1,11 @@
+package com.microsoft.bond.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class BondPlugin implements Plugin<Project> {
+    @Override
+    void apply(Project project) {
+        project.tasks.create("bondCodegen", BondCodegen)
+    }
+}

--- a/java/gradle-plugin/src/main/resources/META-INF/gradle-plugins/com.microsoft.bond.gradle.properties
+++ b/java/gradle-plugin/src/main/resources/META-INF/gradle-plugins/com.microsoft.bond.gradle.properties
@@ -1,0 +1,1 @@
+implementation-class = com.microsoft.bond.gradle.BondPlugin


### PR DESCRIPTION
The initial version of the gradle plugin permits a single pass per project, compiles all files in `src/main/bond` plus any specified in the build file, and exposes its inputs and outputs in the way gradle needs to determine whether gbc needs to be run. The `src/main/bond` functionality isn't demonstrated here because `core` and `compat` only use bond files located elsewhere in the tree, but I've tested it by hand. We'll be exercising it in all future Java examples.

There's an escape hatch for passing arbitrary options to gbc. This can be abused - if you add a bondfile here, gradle won't be able to track it as an input; if you change the output directory, gradle won't be able to add it to Java source directories. I think we need to keep it around, but should consider any use of it as a sign that we need to change something. 

Obvious next steps:
* Compile bond files in `src/test/bond` and make them available exclusively to test code.
* Add properties for gbc options to avoid the need for the escape hatch. (e.g., `alias 'bond' 'com.bond.microsoft'`)
* Metadata, etc. for publishing to Maven Central.