### PR TITLE
gradle plugin: Support src/test/bond.

### DIFF
--- a/java/compat/build.gradle
+++ b/java/compat/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 
-bondCodegen {
+compileBond {
     bondfiles '../../test/compat/core/schemas/compat.bond',
               '../../test/compat/core/schemas/compat2.bond',
               '../../test/compat/core/schemas/compat_common.bond'

--- a/java/core/.idea/modules/bond.iml
+++ b/java/core/.idea/modules/bond.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="bond" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="" external.system.module.version="5.0.0" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="bond" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="com.microsoft.bond" external.system.module.version="5.0.0" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager">
     <output url="file://$MODULE_DIR$/../../build/classes/main" />
     <output-test url="file://$MODULE_DIR$/../../build/classes/test" />
@@ -12,8 +12,11 @@
       <excludeFolder url="file://$MODULE_DIR$/../../.gradle" />
       <excludeFolder url="file://$MODULE_DIR$/../../build" />
     </content>
-    <content url="file://$MODULE_DIR$/../../build/generated-src">
-      <sourceFolder url="file://$MODULE_DIR$/../../build/generated-src" isTestSource="false" />
+    <content url="file://$MODULE_DIR$/../../build/generated-bond-main-src">
+      <sourceFolder url="file://$MODULE_DIR$/../../build/generated-bond-main-src" isTestSource="false" />
+    </content>
+    <content url="file://$MODULE_DIR$/../../build/generated-bond-test-src">
+      <sourceFolder url="file://$MODULE_DIR$/../../build/generated-bond-test-src" isTestSource="true" />
     </content>
     <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/java/core/.idea/modules/bond.iml
+++ b/java/core/.idea/modules/bond.iml
@@ -20,7 +20,6 @@
     </content>
     <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: junit:junit:4.12" level="project" />
   </component>
 </module>

--- a/java/core/build.gradle
+++ b/java/core/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
 }
 
-bondCodegen {
+compileBond {
     bondfiles '../../idl/bond/core/bond.bond',
               '../../idl/bond/core/bond_const.bond'
     options '-n', 'bond=com.microsoft.bond'

--- a/java/gradle-plugin/.idea/misc.xml
+++ b/java/gradle-plugin/.idea/misc.xml
@@ -3,20 +3,4 @@
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/classes" />
   </component>
-  <component name="masterDetails">
-    <states>
-      <state key="ProjectJDKs.UI">
-        <settings>
-          <last-edited>1.8</last-edited>
-          <splitter-proportions>
-            <option name="proportions">
-              <list>
-                <option value="0.2" />
-              </list>
-            </option>
-          </splitter-proportions>
-        </settings>
-      </state>
-    </states>
-  </component>
 </project>

--- a/java/gradle-plugin/.idea/modules/bond-gradle.iml
+++ b/java/gradle-plugin/.idea/modules/bond-gradle.iml
@@ -25,55 +25,10 @@
         <SOURCES />
       </library>
     </orderEntry>
-    <orderEntry type="module-library" scope="TEST">
-      <library name="Gradle: gradle-installation-beacon-3.5">
-        <CLASSES>
-          <root url="jar:///usr/local/Cellar/gradle/3.5/libexec/lib/gradle-installation-beacon-3.5.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" scope="TEST">
+    <orderEntry type="module-library" scope="PROVIDED">
       <library name="Gradle: gradle-api-3.5">
         <CLASSES>
           <root url="jar://$USER_HOME$/.gradle/caches/3.5/generated-gradle-jars/gradle-api-3.5.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" scope="TEST">
-      <library name="Gradle: groovy-all-2.4.10">
-        <CLASSES>
-          <root url="jar:///usr/local/Cellar/gradle/3.5/libexec/lib/groovy-all-2.4.10.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" scope="RUNTIME">
-      <library name="Gradle: gradle-installation-beacon-3.5">
-        <CLASSES>
-          <root url="jar:///usr/local/Cellar/gradle/3.5/libexec/lib/gradle-installation-beacon-3.5.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" scope="RUNTIME">
-      <library name="Gradle: gradle-api-3.5">
-        <CLASSES>
-          <root url="jar://$USER_HOME$/.gradle/caches/3.5/generated-gradle-jars/gradle-api-3.5.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" scope="RUNTIME">
-      <library name="Gradle: groovy-all-2.4.10">
-        <CLASSES>
-          <root url="jar:///usr/local/Cellar/gradle/3.5/libexec/lib/groovy-all-2.4.10.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />
@@ -88,10 +43,55 @@
         <SOURCES />
       </library>
     </orderEntry>
-    <orderEntry type="module-library" scope="PROVIDED">
+    <orderEntry type="module-library" scope="RUNTIME">
+      <library name="Gradle: groovy-all-2.4.10">
+        <CLASSES>
+          <root url="jar:///usr/local/Cellar/gradle/3.5/libexec/lib/groovy-all-2.4.10.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="RUNTIME">
       <library name="Gradle: gradle-api-3.5">
         <CLASSES>
           <root url="jar://$USER_HOME$/.gradle/caches/3.5/generated-gradle-jars/gradle-api-3.5.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="RUNTIME">
+      <library name="Gradle: gradle-installation-beacon-3.5">
+        <CLASSES>
+          <root url="jar:///usr/local/Cellar/gradle/3.5/libexec/lib/gradle-installation-beacon-3.5.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library name="Gradle: groovy-all-2.4.10">
+        <CLASSES>
+          <root url="jar:///usr/local/Cellar/gradle/3.5/libexec/lib/groovy-all-2.4.10.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library name="Gradle: gradle-api-3.5">
+        <CLASSES>
+          <root url="jar://$USER_HOME$/.gradle/caches/3.5/generated-gradle-jars/gradle-api-3.5.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library name="Gradle: gradle-installation-beacon-3.5">
+        <CLASSES>
+          <root url="jar:///usr/local/Cellar/gradle/3.5/libexec/lib/gradle-installation-beacon-3.5.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/java/gradle-plugin/.idea/modules/bond-gradle.iml
+++ b/java/gradle-plugin/.idea/modules/bond-gradle.iml
@@ -34,15 +34,6 @@
         <SOURCES />
       </library>
     </orderEntry>
-    <orderEntry type="module-library" scope="PROVIDED">
-      <library name="Gradle: gradle-installation-beacon-3.5">
-        <CLASSES>
-          <root url="jar:///usr/local/Cellar/gradle/3.5/libexec/lib/gradle-installation-beacon-3.5.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
     <orderEntry type="module-library" scope="RUNTIME">
       <library name="Gradle: groovy-all-2.4.10">
         <CLASSES>
@@ -61,15 +52,6 @@
         <SOURCES />
       </library>
     </orderEntry>
-    <orderEntry type="module-library" scope="RUNTIME">
-      <library name="Gradle: gradle-installation-beacon-3.5">
-        <CLASSES>
-          <root url="jar:///usr/local/Cellar/gradle/3.5/libexec/lib/gradle-installation-beacon-3.5.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library name="Gradle: groovy-all-2.4.10">
         <CLASSES>
@@ -83,15 +65,6 @@
       <library name="Gradle: gradle-api-3.5">
         <CLASSES>
           <root url="jar://$USER_HOME$/.gradle/caches/3.5/generated-gradle-jars/gradle-api-3.5.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" scope="TEST">
-      <library name="Gradle: gradle-installation-beacon-3.5">
-        <CLASSES>
-          <root url="jar:///usr/local/Cellar/gradle/3.5/libexec/lib/gradle-installation-beacon-3.5.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/java/gradle-plugin/src/main/groovy/com/microsoft/bond/gradle/BondPlugin.groovy
+++ b/java/gradle-plugin/src/main/groovy/com/microsoft/bond/gradle/BondPlugin.groovy
@@ -6,6 +6,7 @@ import org.gradle.api.Project
 class BondPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        project.tasks.create("bondCodegen", BondCodegen)
+        project.tasks.create("compileBond", BondProdCodegen)
+        project.tasks.create("compileTestBond", BondTestCodegen)
     }
 }

--- a/java/gradle-plugin/src/main/groovy/com/microsoft/bond/gradle/BondProdCodegen.groovy
+++ b/java/gradle-plugin/src/main/groovy/com/microsoft/bond/gradle/BondProdCodegen.groovy
@@ -1,0 +1,26 @@
+package com.microsoft.bond.gradle
+
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.tasks.SourceSet
+
+class BondProdCodegen extends BondCodegen {
+    @Override
+    String dependentTaskName() {
+        return JavaPlugin.COMPILE_JAVA_TASK_NAME
+    }
+
+    @Override
+    SourceSet dependentSourceSet() {
+        return project.sourceSets.main
+    }
+
+    @Override
+    String bondSrcRootPath() {
+        return "src/main/bond"
+    }
+
+    @Override
+    String outputDirName() {
+        return "generated-bond-main-src"
+    }
+}

--- a/java/gradle-plugin/src/main/groovy/com/microsoft/bond/gradle/BondTestCodegen.groovy
+++ b/java/gradle-plugin/src/main/groovy/com/microsoft/bond/gradle/BondTestCodegen.groovy
@@ -1,0 +1,26 @@
+package com.microsoft.bond.gradle
+
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.tasks.SourceSet
+
+class BondTestCodegen extends BondCodegen {
+    @Override
+    String dependentTaskName() {
+        return JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME
+    }
+
+    @Override
+    SourceSet dependentSourceSet() {
+        return project.sourceSets.test
+    }
+
+    @Override
+    String bondSrcRootPath() {
+        return "src/test/bond"
+    }
+
+    @Override
+    String outputDirName() {
+        return "generated-bond-test-src"
+    }
+}


### PR DESCRIPTION
This also renames the bond codegen tasks to mirror their Java counterparts. The second commit cleans up some stray libraries that were automatically added, some of which come from the first.

A fresh build on core now looks like this:
```
[ted@pike 16:21]{3}\% gradle build
:compileBond
:compileJava
warning: [options] bootstrap class path not set in conjunction with -source 1.6
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 warning
:processResources NO-SOURCE
:classes
:jar
:assemble
:compileTestBond
:compileTestJava
warning: [options] bootstrap class path not set in conjunction with -source 1.6
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 warning
:processTestResources
:testClasses
:test
:check
:build

BUILD SUCCESSFUL

Total time: 3.075 secs
```

Note that `compileTestBond` runs even though core has no configuration or bondfiles for it. Both `compileBond` and `compileTestBond` will be wired up and will run with defaults even if you don't have a stanza for them in your build file, so if you don't need to pass options to gbc or include bondfiles outside default locations, you can get bond codegen just by applying the plugin. (i.e., the one line `apply plugin: 'com.microsoft.bond.gradle'` in `{core,compat}/build.gradle`)