### PR TITLE
Improve MSBuild codegen handling of gbc changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ get a compiler error. To fix, remove the `<Writer>` part:
   [Issue #414](https://github.com/Microsoft/bond/issues/414)
     * The new public key for assemblies is now
       `00240000048000009400000006020000002400005253413100040000010001000d504ac18b4b149d2f7b0059b482f9b6d44d39059e6a96ff0a2a52678b5cfd8567cc67254132cd2debb5b95f6a1206a15c6f8ddac137c6c3ef4995f28c359acaa683a90995c8f08df7ce0aaa8836d331a344a514c443f112f80bf2ebed40ccb32d7df63c09b0d7bef80aecdc23ec200a458d4f8bafbcdeb9bf5ba111fbbd4787`
+* The codegen MSBuild targets will now re-run codegen if gbc itself has been
+  changed.
 
 ## 5.3.1: 2017-04-25 ##
 

--- a/cs/build/nuget/Common.targets
+++ b/cs/build/nuget/Common.targets
@@ -34,6 +34,8 @@
     </BondImportDirectory>
   </ItemDefinitionGroup>
 
+  <!-- Let Visual Studio know about the BondCodegen item so it can display
+       it in the UI as a potential action for files. -->
   <ItemGroup>
     <AvailableItemName Include="BondCodegen" />
   </ItemGroup>
@@ -53,17 +55,21 @@
     <UpToDateCheckInput Include="$(_BondExe)" />
   </ItemGroup>
 
-  <!--
+  <!-- BondCodegenCs - transform .bond files into .cs files
 
-    * BondCodegenCs - transform .bond files into .cs files
-    *    If we use output transforms from BondCodegen to the resulting targets we can get partial/minimal rebuilds
-    *    on change, but this doesn't reflect the internal import logic of bond.  A change to common.bond would
-    *    only rebuild common*cs, not all the others that import common.bond.  Without a bond parser prepass we
-    *    must rebuild all .bond files when any of them change.  We force that by putting a non-transform output
-    *    (bondcodegen.done) in the list so IFF any input changes, then all inputs rebuild since MSBuild can't
-    *    know what should create the unmapped output item and so can't be selective.
-    *    NOTE - this still won't catch changes to files outside declared BondCodegen elements.
-  -->
+       If we were to use an output transform from BondCodegen to the
+       resulting .cs files we could get partial/minimal rebuilds on changes,
+       but this behavior doesn't reflect the internal import logic of Bond.
+       A change to common.bond would only rebuild common*cs, not all the
+       other files that import common.bond. Without a Bond parser prepass we
+       must rebuild all .bond files when any of them change. We force that
+       by putting a non-transform output (bondcodegen.done) in the list so
+       if any input changes, then all inputs rebuild since MSBuild can't
+       know what should create the unmapped output item and so can't be
+       selective.
+
+       NOTE: This still won't catch changes to files imported outside the
+       BondCodegen item. -->
   <Target Name="BondCodegenCs"
           Inputs="$(_BondExe);@(BondCodegen)"
           Outputs="$(BondOutputDirectory)\bondcodegen.done;@(BondCodegen -> '$(BondOutputDirectory)\%(FileName)_types.cs')"

--- a/cs/build/nuget/Common.targets
+++ b/cs/build/nuget/Common.targets
@@ -38,7 +38,23 @@
     <AvailableItemName Include="BondCodegen" />
   </ItemGroup>
 
+  <!-- Attempt to find gbc in a platform-agnostic way. -->
+  <PropertyGroup>
+    <_BondExe>gbc</_BondExe>
+    <_BondExe Condition="Exists('$(BOND_COMPILER_PATH)\gbc.exe')">$(BOND_COMPILER_PATH)\gbc.exe</_BondExe>
+    <_BondExe Condition="Exists('$(BOND_COMPILER_PATH)\gbc')">$(BOND_COMPILER_PATH)\gbc</_BondExe>
+  </PropertyGroup>
+
+  <!-- Some versions of Visual Studio have an additional up-to-date check
+       that is performed on a subset of files before invoking MSBuild. We
+       need to add gbc as an input to the Visual Studio up-to-date check as
+       well. -->
+  <ItemGroup>
+    <UpToDateCheckInput Include="$(_BondExe)" />
+  </ItemGroup>
+
   <!--
+
     * BondCodegenCs - transform .bond files into .cs files
     *    If we use output transforms from BondCodegen to the resulting targets we can get partial/minimal rebuilds
     *    on change, but this doesn't reflect the internal import logic of bond.  A change to common.bond would
@@ -49,7 +65,7 @@
     *    NOTE - this still won't catch changes to files outside declared BondCodegen elements.
   -->
   <Target Name="BondCodegenCs"
-          Inputs="@(BondCodegen)"
+          Inputs="$(_BondExe);@(BondCodegen)"
           Outputs="$(BondOutputDirectory)\bondcodegen.done;@(BondCodegen -> '$(BondOutputDirectory)\%(FileName)_types.cs')"
           BeforeTargets="CoreCompile"
           Condition="'@(BondCodegen)' != ''">
@@ -61,11 +77,8 @@
 
     <!-- just for a simpler commandline read -->
     <PropertyGroup>
-      <_BondExe>gbc</_BondExe>
-      <_BondExe Condition="Exists('$(BOND_COMPILER_PATH)\gbc.exe')">"$(BOND_COMPILER_PATH)\gbc.exe"</_BondExe>
-      <_BondExe Condition="Exists('$(BOND_COMPILER_PATH)\gbc')">"$(BOND_COMPILER_PATH)\gbc"</_BondExe>
       <_BondImportDirs>--import-dir="$(BOND_INCLUDE_PATH)" @(BondImportDirectory -> '--import-dir=&quot;%(Identity)\.&quot;',' ')</_BondImportDirs>
-      <_BondCommand>$(_BondExe) $(BondCodegenMode) $(_BondImportDirs) --jobs=-2 --namespace=bond=Bond --output-dir="$(BondOutputDirectory)\."</_BondCommand>
+      <_BondCommand>&quot;$(_BondExe)&quot; $(BondCodegenMode) $(_BondImportDirs) --jobs=-2 --namespace=bond=Bond --output-dir="$(BondOutputDirectory)\."</_BondCommand>
     </PropertyGroup>
 
     <!-- We'll optimize to generate in a single command where possible -->


### PR DESCRIPTION
Two commits here:

* teach the MSBuild targets to rebuild when gbc itself is changed
* improve MSBuild targets comments

Please rebase when merging.