### PR TITLE
[C#] Fix Reflection.IsBonded for custom IBonded implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,12 @@ different versioning scheme, following the Haskell community's
 * IDL core version: TBD
 * IDL comm version: TBD
 * C++ version: TBD
-* C# NuGet version: TBD  (major bump needed)
+* C# NuGet version: TBD  (bug fix bump needed)
 * C# Comm NuGet version: TBD
 
 ### C# ###
 
-* **Breaking change** Reflection.IsBonded now recognizes custom IBonded
+* Reflection.IsBonded now recognizes custom IBonded
 implementations.
 
 ## 6.0.0: 2017-06-29  ##

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,24 @@ tag versions. The Bond compiler (`gbc`) and
 different versioning scheme, following the Haskell community's
 [package versioning policy](https://wiki.haskell.org/Package_versioning_policy).
 
+## Unreleased  ##
+* `gbc` & compiler library: TBD
+* IDL core version: TBD
+* IDL comm version: TBD
+* C++ version: TBD
+* C# NuGet version: TBD  (major bump needed)
+* C# Comm NuGet version: TBD
+
+### C# ###
+
+* **Breaking change** Reflection.IsBonded now recognizes custom IBonded
+implementations.
+
 ## 6.0.0: 2017-06-29  ##
 * `gbc` & compiler library: 0.10.0.0
 * IDL core version: 2.0
 * IDL comm version: 1.2
-* C++ version: TBD 6.0.0
+* C++ version: 6.0.0
 * C# NuGet version: 6.0.0
 * C# Comm NuGet version: 0.12.0
 

--- a/cs/src/core/Reflection.cs
+++ b/cs/src/core/Reflection.cs
@@ -110,7 +110,9 @@ namespace Bond
             if (type.IsGenericType())
             {
                 var definition = type.GetGenericTypeDefinition();
-                return definition == typeof(IBonded<>) || definition == typeof(Tag.bonded<>);
+                return definition == typeof(IBonded<>)
+                    || definition == typeof(Tag.bonded<>)
+                    || definition.GetTypeInfo().ImplementedInterfaces.Contains(typeof(IBonded));
             }
 
             return false;

--- a/cs/test/core/TypeAliasTests.cs
+++ b/cs/test/core/TypeAliasTests.cs
@@ -5,6 +5,7 @@
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
+    using System.Reflection;
     using Bond;
     using NUnit.Framework;
 
@@ -301,6 +302,7 @@
         public void AliasBonded()
         {
             var from = new BondedAlias {lazy = new Lazy<Foo>(UnitTest.Random.Init<Foo>())};
+            Assert.IsTrue(Reflection.IsBonded(typeof(Lazy<Foo>)));
             TestTypeAliases(from);
         }
 
@@ -308,6 +310,7 @@
         public void AliasGenericBonded()
         {
             var from = new GenericBondedAlias<Foo> { lazy = new Lazy<Foo>(UnitTest.Random.Init<Foo>()) };
+            Assert.IsTrue(Reflection.IsBonded(typeof(Lazy<Foo>)));
             TestTypeAliases(from);
         }
 

--- a/cs/test/core/Util.cs
+++ b/cs/test/core/Util.cs
@@ -996,7 +996,7 @@ namespace UnitTest
                 streamTranscode(SerializeSP, TranscodeSPFB<From>, DeserializeFB<To>);
 
                 // Pull parser doesn't support bonded<T>
-                if (AnyField<From>(Reflection.IsBonded))
+                if (!AnyField<From>(Reflection.IsBonded))
                 {
                     streamTranscode(SerializeSP, TranscodeSPXml<From>, DeserializeXml<To>);
                 
@@ -1017,8 +1017,8 @@ namespace UnitTest
                 streamMarshalSchema(MarshalSP);
             }
 
-            // Pull parser doesn't supprot bonded<T>
-            if (AnyField<From>(Reflection.IsBonded))
+            // Pull parser doesn't support bonded<T>
+            if (!AnyField<From>(Reflection.IsBonded))
             {
                 streamRoundtrip(SerializeXml, DeserializeXml<To>);
                 streamTranscode(SerializeCB, TranscodeCBXml<From>, DeserializeXml<To>);


### PR DESCRIPTION
Reflection.IsBonded now correctly returns true for custom IBonded
implementations. In addition, corrected reversed logic in test utility
code that was likely related to the incorrect predicate.