### PR TITLE
[C#] Add support for uint64 in JSON when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ different versioning scheme, following the Haskell community's
 ### C# ###
 
 * Reflection.IsBonded now recognizes custom IBonded implementations.
+* Use Newtonsoft's JSON.NET BigInteger support -- when available -- to
+  handle the full range of uint64 values in the SimpleJson protocol (.NET
+  4.5 or greater, .NET Standard 1.6 or greater).
 
 ## 6.0.0: 2017-06-29  ##
 * `gbc` & compiler library: 0.10.0.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -298,6 +298,9 @@
                 nunit-console-x86 /framework:net-4.5 /labels "cs\test\core\bin\debug\net45\${env:BOND_OUTPUT}\Bond.UnitTest.dll" cs\test\internal\bin\debug\net45\Bond.InternalTest.dll
                 if (-not $?) { throw "tests failed" }
 
+                nunit-console-x86 /framework:net-4.5 /labels "cs\test\core\bin\debug\net45-nonportable\${env:BOND_OUTPUT}\Bond.UnitTest.dll"
+                if (-not $?) { throw "tests failed" }
+
                 & examples\cs\grpc\pingpong\bin\Debug\pingpong.exe
                 if (-not $?) { throw "tests failed" }
 

--- a/cs/Compiler.vcxproj
+++ b/cs/Compiler.vcxproj
@@ -33,8 +33,6 @@ call cmake $(ProjectDir)\..\compiler -Wno-dev
 if %errorlevel% neq 0 goto :cmEnd
 call cmake --build $(OutDir) --target gbc
 if %errorlevel% neq 0 goto :cmEnd
-copy $(OutDir)\build\gbc\gbc.exe $(ProjectDir)\tools\
-if %errorlevel% neq 0 goto :cmEnd
 :cmEnd
 endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
 :cmErrorLevel
@@ -81,4 +79,7 @@ if %errorlevel% neq 0 goto :VCEnd
     <None Include="$(ProjectDir)..\compiler\src\Language\Bond\Codegen\Cs\Grpc_cs.hs" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="AfterBuild">
+    <Copy SourceFiles="$(OutDir)\build\gbc\gbc.exe" DestinationFolder="$(ProjectDir)\tools\" />
+  </Target>
 </Project>

--- a/cs/build/internal/Common.Internal.props
+++ b/cs/build/internal/Common.Internal.props
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <Import Project="..\nuget\Common.props" />
   <PropertyGroup Condition="'$(BuildFramework)' == ''">
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <BuildFramework>net45</BuildFramework>
   </PropertyGroup>
   <PropertyGroup>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <OutputPath>bin\$(BuildType)\$(BuildFramework)</OutputPath>
     <IntermediateOutputPath>obj\$(BuildType)\$(BuildFramework)</IntermediateOutputPath>
     <FileAlignment>512</FileAlignment>

--- a/cs/build/internal/Common.Internal.targets
+++ b/cs/build/internal/Common.Internal.targets
@@ -18,5 +18,6 @@
   </ItemGroup>
   <Target Name="AfterBuild">
     <Copy SourceFiles="$(TargetPath);@(FileToCopy)" DestinationFolder="$(BOND_BINARY_PATH)\$(BuildFramework)" Condition="'$(BondRedistributable)' == 'true'" />
+    <MSBuild Condition="'$(BuildFramework)' == 'net45' and ('$(HasNonportableVersion)' == 'true')" Projects="$(MSBuildProjectFile)" Properties="BuildNonportable=true" RunEachTargetSeparately="true"  />
   </Target>
 </Project>

--- a/cs/build/internal/Portable.Internal.props
+++ b/cs/build/internal/Portable.Internal.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)\Common.Internal.props" />
-  <PropertyGroup Condition="'$(BuildFramework)' == 'net45'">
+  <PropertyGroup>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
   </PropertyGroup>

--- a/cs/dnc/src/json/project.json
+++ b/cs/dnc/src/json/project.json
@@ -37,10 +37,10 @@
     "dependencies": {
         "attributes": "1.0.0-*",
         "core": "1.0.0-*",
+        "reflection": "1.0.0-*",
         "Newtonsoft.Json": {
             "version": "9.0.1"
-        },
-        "reflection": "1.0.0-*"
+        }
     },
     "frameworks": {
         "netstandard1.0": {
@@ -49,6 +49,11 @@
             }
         },
         "netstandard1.6": {
+            "buildOptions": {
+                "define": [
+                    "SUPPORTS_BIGINTEGER"
+                ]
+            },
             "dependencies": {
                 "NETStandard.Library": "1.6.0"
             }

--- a/cs/dnc/test/core.tests/project.json
+++ b/cs/dnc/test/core.tests/project.json
@@ -9,7 +9,7 @@
                 "gen/*.cs"
             ]
         },
-        "debugType": "portable",
+        "debugType": "net45",
         "nowarn": [
             "CS1591"
         ],
@@ -39,7 +39,10 @@
         "io": "1.0.0-*",
         "json": "1.0.0-*",
         "NUnit": "3.4.0",
-        "reflection": "1.0.0-*"
+        "reflection": "1.0.0-*",
+        "Newtonsoft.Json": {
+            "version": "10.0.1"
+        }
     },
     "frameworks": {
         "netcoreapp1.0": {
@@ -47,6 +50,11 @@
                 "netcoreapp1.0",
                 "portable-net45+win8"
             ],
+            "buildOptions": {
+                "define": [
+                    "SUPPORTS_BIGINTEGER"
+                ]
+            },
             "dependencies": {
                 "Microsoft.NETCore.App": {
                     "version": "1.0.0-*",

--- a/cs/nuget/bond.csharp.test.csproj
+++ b/cs/nuget/bond.csharp.test.csproj
@@ -121,7 +121,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>

--- a/cs/nuget/bond.runtime.csharp.nuspec
+++ b/cs/nuget/bond.runtime.csharp.nuspec
@@ -28,9 +28,9 @@
         </dependencies>
     </metadata>
     <files>
-        <file target="lib\net45" src="net45\Bond.JSON.dll" />
-        <file target="lib\net45" src="net45\Bond.JSON.pdb" />
-        <file target="lib\net45" src="net45\Bond.JSON.xml" />
+        <file target="lib\net45" src="net45-nonportable\Bond.JSON.dll" />
+        <file target="lib\net45" src="net45-nonportable\Bond.JSON.pdb" />
+        <file target="lib\net45" src="net45-nonportable\Bond.JSON.xml" />
 
         <file target="lib\netstandard1.0" src="netstandard1.0\Bond.JSON.dll" />
         <file target="lib\netstandard1.0" src="netstandard1.0\Bond.JSON.pdb" />

--- a/cs/nuget/packages.config
+++ b/cs/nuget/packages.config
@@ -3,7 +3,7 @@
   <package id="Bond.Core.CSharp" version="6.0.0" targetFramework="net45" />
   <package id="Bond.CSharp" version="6.0.0" targetFramework="net45" />
   <package id="Bond.Runtime.CSharp" version="6.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="portable-net45+wp80+win8+wpa81" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="portable-net45+wp80+win" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/cs/src/json/JSON.csproj
+++ b/cs/src/json/JSON.csproj
@@ -1,7 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath32)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath32)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="$(MSBuildThisFileDirectory)\..\..\build\internal\Portable.Internal.props" />
+  <PropertyGroup Condition="'$(BuildNonportable)' == 'true'">
+    <BuildFramework>net45-nonportable</BuildFramework>
+    <DefineConstants>$(DefineConstants);SUPPORTS_BIGINTEGER</DefineConstants>
+  </PropertyGroup>
+  <Import Condition="'$(BuildNonportable)' == 'true'" Project="$(MSBuildThisFileDirectory)\..\..\build\internal\Common.Internal.props" />
+  <Import Condition="'$(BuildNonportable)' != 'true'" Project="$(MSBuildThisFileDirectory)\..\..\build\internal\Portable.Internal.props" />
   <PropertyGroup>
     <ProjectGuid>{C001C79F-D289-4CF3-BB59-5F5A72F70D0E}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -9,6 +14,8 @@
     <RootNamespace>Bond</RootNamespace>
     <AssemblyName>Bond.JSON</AssemblyName>
     <BondRedistributable>true</BondRedistributable>
+    <DependentOutputPath>bin\$(BuildType)\net45</DependentOutputPath>
+    <HasNonportableVersion>true</HasNonportableVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="expressions\json\JsonParser.cs" />
@@ -20,14 +27,18 @@
     <Compile Include="protocols\SimpleJsonWriter.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Numerics" Condition="'$(BuildFramework)' == 'net45-nonportable'" />
     <Reference Include="Bond">
-      <HintPath>..\core\$(OutputPath)\Bond.dll</HintPath>
+      <HintPath>..\core\$(DependentOutputPath)\Bond.dll</HintPath>
     </Reference>
     <Reference Include="Bond.Attributes">
-      <HintPath>..\attributes\$(OutputPath)\Bond.Attributes.dll</HintPath>
+      <HintPath>..\attributes\$(DependentOutputPath)\Bond.Attributes.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json" Condition="'$(TargetFrameworkVersion)' == 'v4.5'">
+    <Reference Include="Newtonsoft.Json" Condition="'$(BuildFramework)' == 'net45'">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json" Condition="'$(BuildFramework)' == 'net45-nonportable'">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/cs/test/core/Core.csproj
+++ b/cs/test/core/Core.csproj
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <BuildFramework Condition="'$(Configuration)' == 'Net45'">net45</BuildFramework>
-  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath32)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath32)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup Condition="'$(BuildNonportable)' == 'true'">
+    <BuildFramework>net45-nonportable</BuildFramework>
+    <DefineConstants>$(DefineConstants);SUPPORTS_BIGINTEGER</DefineConstants>
+  </PropertyGroup>
   <Import Project="$(MSBuildThisFileDirectory)\..\..\build\internal\Common.Internal.props" />
   <PropertyGroup>
     <ProjectGuid>{FF056B62-225A-47BC-B177-550FADDA4B41}</ProjectGuid>
@@ -14,13 +15,13 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <DependentOutputPath>$(OutputPath)</DependentOutputPath>
+    <OrigOutputPath>$(OutputPath)</OrigOutputPath>
+    <DependentOutputPath>bin\$(BuildType)\net45</DependentOutputPath>
+    <HasNonportableVersion>true</HasNonportableVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <IntermediateOutputPath>$(IntermediateOutputPath)\Properties\</IntermediateOutputPath>
     <OutputPath>$(OutputPath)\Properties\</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Net45' ">
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Fields' ">
     <IntermediateOutputPath>$(IntermediateOutputPath)\Fields\</IntermediateOutputPath>
@@ -91,8 +92,11 @@
     <Reference Include="nunit.framework">
       <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json" Condition="'$(TargetFrameworkVersion)' == 'v4.5'">
+    <Reference Include="Newtonsoft.Json" Condition="'$(BuildFramework)' == 'net45'">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json" Condition="'$(BuildFramework)' == 'net45-nonportable'">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -109,7 +113,7 @@
       <HintPath>..\..\src\io\$(DependentOutputPath)\Bond.IO.dll</HintPath>
     </Reference>
     <Reference Include="Bond.JSON">
-      <HintPath>..\..\src\json\$(DependentOutputPath)\Bond.JSON.dll</HintPath>
+      <HintPath>..\..\src\json\$(OrigOutputPath)\Bond.JSON.dll</HintPath> <!-- Intentionally not DependentOutputPath to match BuildFramework-->
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/cs/test/core/SerializationTests.cs
+++ b/cs/test/core/SerializationTests.cs
@@ -49,7 +49,7 @@
                 _uint8 = byte.MaxValue,
                 _uint16 = ushort.MaxValue,
                 _uint32 = uint.MaxValue,
-                // Note: not ulong.MaxValue because NewtonSoft JSON doesn't support it
+                // Note: not ulong.MaxValue because NewtonSoft JSON doesn't support it in portable profile
                 _uint64 = long.MaxValue
             });
 

--- a/cs/test/core/Util.cs
+++ b/cs/test/core/Util.cs
@@ -976,6 +976,12 @@ namespace UnitTest
                 return DeserializeTagged<To>(reader);
             });
 
+#if SUPPORTS_BIGINTEGER
+            const bool hasBigInteger = true;
+#else
+            const bool hasBigInteger = false;
+#endif
+
             // Simple doesn't support omitting fields
             if (typeof(From) != typeof(Nothing) && typeof(From) != typeof(GenericsWithNothing))
             {
@@ -999,9 +1005,10 @@ namespace UnitTest
                 if (!AnyField<From>(Reflection.IsBonded))
                 {
                     streamTranscode(SerializeSP, TranscodeSPXml<From>, DeserializeXml<To>);
-                
-                    // NewtonSoft JSON doesn't support uint64
-                    if (typeof (From) != typeof (MaxUInt64))
+
+                    // NewtonSoft JSON doesn't fully support uint64 in portable profile, so we skip
+                    // MaxUInt64 type where BigInteger isn't avaiable
+                    if (hasBigInteger || (typeof(From) != typeof (MaxUInt64)))
                     {
                         streamTranscode(SerializeSP, TranscodeSPJson<From>, DeserializeJson<To>);
                     }
@@ -1024,8 +1031,9 @@ namespace UnitTest
                 streamTranscode(SerializeCB, TranscodeCBXml<From>, DeserializeXml<To>);
                 streamTranscode(SerializeFB, TranscodeFBXml<From>, DeserializeXml<To>);
 
-                // NewtonSoft JSON doesn't support uint64
-                if (typeof (From) != typeof (MaxUInt64))
+                // NewtonSoft JSON doesn't fully support uint64 in portable profile, so we skip
+                // MaxUInt64 type where BigInteger isn't avaiable
+                if (hasBigInteger || (typeof (From) != typeof (MaxUInt64)))
                 {
                     streamRoundtrip(SerializeJson, DeserializeJson<To>);
                     streamTranscode(SerializeCB, TranscodeCBJson<From>, DeserializeJson<To>);

--- a/examples/cs/core/simple_json/simple_json.csproj
+++ b/examples/cs/core/simple_json/simple_json.csproj
@@ -58,7 +58,7 @@
       <HintPath>$(BOND_BINARY_PATH)\net45\Bond.JSON.dll</HintPath>
     </Reference>    
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\cs\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\..\..\cs\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Newtonsoft JSON.NET supports uint64 where BigInteger is supported. This pull request allows Bond's SimpleJsonProtocol to leverage that support.