### PR TITLE
[C++] Address issues encountered in fuzz testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ different versioning scheme, following the Haskell community's
 
 * When Unicode conversion fails during JSON deserialization to wstring, throw a 
   Bond CoreException instead of a Boost exception.
+* Throw Bond CoreException when SimpleJSON deserializes map key with no matching value.
+* Throw Bond CoreException when SimpleJSON deserializes map key of non-primitive type.
 
 ### C# ###
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,14 @@ different versioning scheme, following the Haskell community's
 * `gbc` & compiler library: TBD
 * IDL core version: TBD
 * IDL comm version: TBD
-* C++ version: TBD
+* C++ version: TBD (bug fix bump needed)
 * C# NuGet version: TBD  (bug fix bump needed)
 * C# Comm NuGet version: TBD
+
+### C++ ###
+
+* When Unicode conversion fails during JSON deserialization to wstring, throw a 
+  Bond CoreException instead of a Boost exception.
 
 ### C# ###
 

--- a/cpp/inc/bond/core/detail/string_stream.h
+++ b/cpp/inc/bond/core/detail/string_stream.h
@@ -41,7 +41,8 @@ public:
         return *this;
     }
 
-    basic_string_stream& operator<<(const std::string& str)
+    template<typename T, typename A>
+    basic_string_stream& operator<<(const std::basic_string<char, T, A>& str)
     {
         write(str.begin(), str.end());
         return *this;

--- a/cpp/inc/bond/core/exception.h
+++ b/cpp/inc/bond/core/exception.h
@@ -5,6 +5,8 @@
 
 #include "detail/string_stream.h"
 #include <bond/core/bond_types.h>
+#include <boost/locale/encoding_utf.hpp>
+#include <boost/utility/enable_if.hpp>
 
 #define BOND_THROW(x, y)  throw x((::bond::detail::basic_string_stream<1024>() << y).content());
 
@@ -55,11 +57,43 @@ BOND_NORETURN inline void MergerContainerException(uint32_t payload, uint32_t ob
 }
 
 
+BOND_NORETURN inline void InvalidKeyTypeException()
+{
+    BOND_THROW(CoreException,
+        "Map key type not valid");
+}
+
+
+namespace detail
+{
+    template <typename Key>
+    BOND_NORETURN inline void ElementNotFoundExceptionHelper(const Key& key, typename boost::enable_if<is_wstring<Key>>::type* = nullptr)
+    {
+        try
+        {
+            BOND_THROW(CoreException,
+                "Map element not found: key: " <<
+                    boost::locale::conv::utf_to_utf<char>(string_data(key), string_data(key) +string_length(key),  boost::locale::conv::stop));
+        }
+        catch (boost::locale::conv::conversion_error &)
+        {
+            BOND_THROW(CoreException, "Map element not found: key: <bad wstring>");
+        }
+    }
+
+    template <typename Key>
+    BOND_NORETURN inline void ElementNotFoundExceptionHelper(const Key& key, typename boost::disable_if<is_wstring<Key>>::type* = nullptr)
+    {
+        BOND_THROW(CoreException,
+            "Map element not found: key: " << key);
+    }
+}
+
+
 template <typename Key>
 BOND_NORETURN inline void ElementNotFoundException(const Key& key)
 {
-    BOND_THROW(CoreException,
-          "Map element not found: key: " << key);
+    detail::ElementNotFoundExceptionHelper(key);
 }
 
 
@@ -106,7 +140,7 @@ BOND_NORETURN inline void RapidJsonException(const char* error, size_t offset)
 }
 
 
-BOND_NORETURN inline void UnicodeConversionException(void)
+BOND_NORETURN inline void UnicodeConversionException()
 {
     BOND_THROW(CoreException,
         "Unicode conversion exception");

--- a/cpp/inc/bond/core/exception.h
+++ b/cpp/inc/bond/core/exception.h
@@ -105,7 +105,14 @@ BOND_NORETURN inline void RapidJsonException(const char* error, size_t offset)
         "JSON parser error: " << error << " at offset " << offset);
 }
 
- 
+
+BOND_NORETURN inline void UnicodeConversionException(void)
+{
+    BOND_THROW(CoreException,
+        "Unicode conversion exception");
+}
+
+
 struct StreamException
     : Exception
 {

--- a/cpp/inc/bond/protocol/detail/rapidjson_helper.h
+++ b/cpp/inc/bond/protocol/detail/rapidjson_helper.h
@@ -279,19 +279,26 @@ template <typename T>
 typename boost::enable_if<is_wstring<T> >::type
 Read(const rapidjson::Value& value, T& var)
 {
-    const std::basic_string<uint16_t> str =
-        boost::locale::conv::utf_to_utf<uint16_t>(
-            value.GetString(),
-            value.GetString() + value.GetStringLength(),
-            boost::locale::conv::stop);
+    try
+    {
+        const std::basic_string<uint16_t> str =
+            boost::locale::conv::utf_to_utf<uint16_t>(
+                value.GetString(),
+                value.GetString() + value.GetStringLength(),
+                boost::locale::conv::stop);
 
-    const size_t length = str.size();
-    resize_string(var, static_cast<uint32_t>(length));
+        const size_t length = str.size();
+        resize_string(var, static_cast<uint32_t>(length));
 
-    std::copy(
-        str.begin(),
-        str.end(),
-        make_checked_array_iterator(string_data(var), length));
+        std::copy(
+            str.begin(),
+            str.end(),
+            make_checked_array_iterator(string_data(var), length));
+    }
+    catch (const boost::locale::conv::conversion_error &)
+    {
+        UnicodeConversionException();
+    }
 }
 
 

--- a/cpp/inc/bond/protocol/simple_json_reader_impl.h
+++ b/cpp/inc/bond/protocol/simple_json_reader_impl.h
@@ -150,8 +150,19 @@ DeserializeMap(X& var, BondDataType keyType, const T& element, SimpleJsonReader<
         {
             detail::Read(*it, key);
         }
+        else
+        {
+            bond::InvalidKeyTypeException();
+        }
 
-        SimpleJsonReader<Buffer> input(reader, *++it);
+        ++it;
+
+        if (it == end)
+        {
+            bond::ElementNotFoundException(key);
+        }
+
+        SimpleJsonReader<Buffer> input(reader, *it);
 
         if (value_type.ComplexTypeMatch(*it))
             detail::MakeValue(input, element).template Deserialize<Protocols>(mapped_at(var, key));


### PR DESCRIPTION
Addresses several issues identified in fuzz testing:
- SimpleJSON: map deserialization throws exception if every key doesn't have a corresponding value
- SimpleJSON: map deserialization throws exception if key type is not primitive 
- SimpleJSON: Boost Unicode conversion exception caught and rethrown as Bond UnicodeConversionException