### PR TITLE
[C++] Don't build Comm by default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ before_script:
 script:
     - mkdir build && cd build
 
-    - if [ "$FLAVOR" == "cs" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DBOND_ENABLE_COMM=FALSE -DBOND_ENABLE_GRPC=FALSE ..; fi
+    - if [ "$FLAVOR" == "cs" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DBOND_ENABLE_GRPC=FALSE ..; fi
     - if [ "$FLAVOR" == "cs" ]; then make gbc; fi
     - if [ "$FLAVOR" == "cs" ]; then make DESTDIR=$HOME install; fi
     - if [ "$FLAVOR" == "cs" ]; then cd ..; fi
@@ -75,13 +75,13 @@ script:
     - if [ "$FLAVOR" == "cs" ]; then xbuild /p:Configuration=Debug cs/cs.sln; fi
     - if [ "$FLAVOR" == "cs" ]; then xbuild /p:Configuration=Fields cs/cs.sln; fi
     - if [ "$FLAVOR" == "cs" ]; then mono NUnit.Runners.2.6.4/tools/nunit-console.exe -framework=mono-4.5 -labels cs/test/core/bin/debug/net45/Properties/Bond.UnitTest.dll cs/test/core/bin/debug/net45/Fields/Bond.UnitTest.dll cs/test/internal/bin/debug/net45/Bond.InternalTest.dll; fi
-    - if [ "$FLAVOR" == "cpp-core" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_ENABLE_COMM=FALSE -DBOND_ENABLE_GRPC=FALSE ..; fi
+    - if [ "$FLAVOR" == "cpp-core" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_ENABLE_GRPC=FALSE ..; fi
     - if [ "$FLAVOR" == "cpp-core" ]; then make --jobs 2 check; fi
-    - if [ "$FLAVOR" == "cpp-comm" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DBOND_ENABLE_GRPC=FALSE ..; fi
+    - if [ "$FLAVOR" == "cpp-comm" ]; then cmake -DBOND_ENABLE_COMM=TRUE -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DBOND_ENABLE_GRPC=FALSE ..; fi
     - if [ "$FLAVOR" == "cpp-comm" ]; then make --jobs 2 check; fi
-    - if [ "$FLAVOR" == "cpp-grpc" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DBOND_ENABLE_COMM=FALSE -DgRPC_ZLIB_PROVIDER=package ..; fi
+    - if [ "$FLAVOR" == "cpp-grpc" ]; then cmake -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DgRPC_ZLIB_PROVIDER=package ..; fi
     - if [ "$FLAVOR" == "cpp-grpc" ]; then make --jobs 2 check; fi
-    - if [ "$FLAVOR" == "hs" ]; then cmake -DBOND_SKIP_CORE_TESTS=TRUE -DBOND_ENABLE_COMM=FALSE -DBOND_ENABLE_GRPC=FALSE ..; fi
+    - if [ "$FLAVOR" == "hs" ]; then cmake -DBOND_SKIP_CORE_TESTS=TRUE -DBOND_ENABLE_GRPC=FALSE ..; fi
     - if [ "$FLAVOR" == "hs" ]; then make gbc-tests; fi
     - if [ "$FLAVOR" == "hs" ]; then cd ../compiler; fi
     - if [ "$FLAVOR" == "hs" ]; then ../build/compiler/build/gbc-tests/gbc-tests; fi

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ In the root `bond` directory run:
 ```bash
 mkdir build
 cd build
-cmake .. -DBOND_ENABLE_GRPC=FALSE -DBOND_ENABLE_COMM=FALSE
+cmake .. -DBOND_ENABLE_GRPC=FALSE
 make
 sudo make install
 ```
@@ -80,8 +80,8 @@ The `build` directory is just an example. Any directory can be used as the build
 destination.
 
 In order to build all the C++ and Python tests and examples, as well as
-Bond-over-gRPC and Bond Comm, a few more packages are needed, and CMake
-needs to be run with different options:
+Bond-over-gRPC, a few more packages are needed, and CMake needs to be run with
+different options:
 
 ```bash
 sudo apt-get install \
@@ -94,7 +94,7 @@ sudo apt-get install \
     python2.7-dev
 
 cd build # or wherever you ran CMake before
-cmake .. -DBOND_ENABLE_GRPC=TRUE -DBOND_ENABLE_COMM=TRUE -DgRPC_ZLIB_PROVIDER=package
+cmake .. -DBOND_ENABLE_GRPC=TRUE -DgRPC_ZLIB_PROVIDER=package
 ```
 
 Running the following command in the build directory will build and execute all
@@ -218,7 +218,7 @@ Studio 2015 run the following commands from the root `bond` directory:
 mkdir build
 cd build
 set PreferredToolArchitecture=x64
-cmake -DBOND_ENABLE_GRPC=FALSE -DBOND_ENABLE_COMM=FALSE -G "Visual Studio 14 2015 Win64" ..
+cmake -DBOND_ENABLE_GRPC=FALSE -G "Visual Studio 14 2015 Win64" ..
 ```
 
 Setting `PreferredToolArchitecture=x64` selects the 64-bit toolchain which
@@ -253,7 +253,7 @@ You will also need to enable gRPC in the `cmake` configuration step by running t
 in the `build` directory from above and then following the other `cmake` commands above:
 
 ```bash
-cmake -DBOND_ENABLE_GRPC=TRUE -DBOND_ENABLE_COMM=FALSE -G "Visual Studio 14 2015 Win64" ..
+cmake -DBOND_ENABLE_GRPC=TRUE -G "Visual Studio 14 2015 Win64" ..
 ```
 
 ## Contributing

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,14 +32,14 @@
               BOND_VS_NUM: 12
               BOND_ARCH: 32
               BOND_BOOST: 58
-              BOND_CMAKE_FLAGS: "-DBOND_ENABLE_COMM=FALSE;-DBOND_ENABLE_GRPC=FALSE;-DBOND_SKIP_GBC_TESTS=TRUE"
+              BOND_CMAKE_FLAGS: "-DBOND_ENABLE_GRPC=FALSE;-DBOND_SKIP_GBC_TESTS=TRUE"
               # C++ Core build and tests
             - BOND_BUILD: C++
               BOND_VS: "Visual Studio 14 2015"
               BOND_VS_NUM: 14
               BOND_ARCH: 64
               BOND_BOOST: 60
-              BOND_CMAKE_FLAGS: "-DBOND_ENABLE_COMM=FALSE;-DBOND_ENABLE_GRPC=FALSE"
+              BOND_CMAKE_FLAGS: "-DBOND_ENABLE_GRPC=FALSE"
             - BOND_BUILD: C#
               BOND_OUTPUT: Properties
               BOND_CONFIG: Debug
@@ -54,34 +54,34 @@
               BOND_VS_NUM: 14
               BOND_ARCH: 32
               BOND_BOOST: 60
-              BOND_CMAKE_FLAGS: "-DBOND_ENABLE_COMM=FALSE;-DBOND_ENABLE_GRPC=FALSE"
+              BOND_CMAKE_FLAGS: "-DBOND_ENABLE_GRPC=FALSE"
             - BOND_BUILD: Python
               BOND_VS: "Visual Studio 14 2015"
               BOND_VS_NUM: 14
               BOND_ARCH: 64
               BOND_BOOST: 63
-              BOND_CMAKE_FLAGS: "-DBOND_ENABLE_COMM=FALSE;-DBOND_ENABLE_GRPC=FALSE"
+              BOND_CMAKE_FLAGS: "-DBOND_ENABLE_GRPC=FALSE"
               # C++ Comm build and tests
             - BOND_BUILD: C++
               BOND_VS: "Visual Studio 14 2015"
               BOND_VS_NUM: 14
               BOND_ARCH: 64
               BOND_BOOST: 63
-              BOND_CMAKE_FLAGS: "-DBOND_ENABLE_GRPC=FALSE;-DBOND_SKIP_CORE_TESTS=TRUE;-DBOND_SKIP_GBC_TESTS=TRUE"
+              BOND_CMAKE_FLAGS: "-DBOND_ENABLE_COMM=TRUE;-DBOND_ENABLE_GRPC=FALSE;-DBOND_SKIP_CORE_TESTS=TRUE;-DBOND_SKIP_GBC_TESTS=TRUE"
               # C++ gRPC build and tests
             - BOND_BUILD: C++
               BOND_VS: "Visual Studio 14 2015"
               BOND_VS_NUM: 14
               BOND_ARCH: 64
               BOND_BOOST: 63
-              BOND_CMAKE_FLAGS: "-DBOND_ENABLE_COMM=FALSE;-DBOND_SKIP_CORE_TESTS=TRUE;-DBOND_SKIP_GBC_TESTS=TRUE"
+              BOND_CMAKE_FLAGS: "-DBOND_SKIP_CORE_TESTS=TRUE;-DBOND_SKIP_GBC_TESTS=TRUE"
               # C++ Comm build and tests (Visual C++ 2013)
             - BOND_BUILD: C++
               BOND_VS: "Visual Studio 12 2013"
               BOND_VS_NUM: 12
               BOND_ARCH: 64
               BOND_BOOST: 58
-              BOND_CMAKE_FLAGS: "-DBOND_ENABLE_GRPC=FALSE;-DBOND_SKIP_CORE_TESTS=TRUE;-DBOND_SKIP_GBC_TESTS=TRUE"
+              BOND_CMAKE_FLAGS: "-DBOND_ENABLE_COMM=TRUE;-DBOND_ENABLE_GRPC=FALSE;-DBOND_SKIP_CORE_TESTS=TRUE;-DBOND_SKIP_GBC_TESTS=TRUE"
     install:
         - ps: >-
             if (($env:BOND_BUILD -eq 'C++') -or ($env:BOND_BUILD -eq 'Python')) {

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -179,7 +179,7 @@ set (BOND_LIBRARIES_INSTALL_CPP
     CACHE BOOL "If TRUE, the generated .cpp files for the Bond libraries will be installed under src/ as part of the INSTALL target.")
 
 set (BOND_ENABLE_COMM
-    "TRUE"
+    "FALSE"
     CACHE BOOL "If FALSE, then do not build Comm")
 
 set (BOND_SKIP_GBC_TESTS


### PR DESCRIPTION
Need to check that CI not only passes, but that each flavor includes or does not include Comm, as appropriate.