### PR TITLE
[c++] Fix potential simultaneous codegen

### DIFF
--- a/cpp/test/comm/CMakeLists.txt
+++ b/cpp/test/comm/CMakeLists.txt
@@ -28,18 +28,36 @@ function (add_unit_test)
     cxx_target_compile_options (AppleClang ${name} PRIVATE -DBOOST_ASIO_HAS_STD_CHRONO)
 endfunction()
 
-
 # Build common code into its own library.
-add_library (comm_test_common EXCLUDE_FROM_ALL "main.cpp" "idl.cpp")
+add_bond_codegen (
+    TARGET comm_test_codegen
+    COMM
+    comm_test_common.bond
+    generic.bond)
+
+add_library (comm_test_common EXCLUDE_FROM_ALL
+    STATIC
+    "main.cpp"
+    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/comm_test_common_apply.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/comm_test_common_comm.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/comm_test_common_types.cpp
+    # There's nothing in generic_apply.cpp to build, so we omit it.
+    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/generic_comm.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/generic_types.cpp)
 add_target_to_folder (comm_test_common)
 add_dependencies(comm_test_common comm_test_codegen)
 target_include_directories (comm_test_common PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR})
-target_link_libraries (comm_test_common PRIVATE
+target_compile_definitions (comm_test_common PUBLIC
+        -DBOND_COMPACT_BINARY_PROTOCOL
+        -DBOND_SIMPLE_BINARY_PROTOCOL
+        -DBOND_FAST_BINARY_PROTOCOL)
+target_link_libraries (comm_test_common
+    PUBLIC
+    bond
+    PRIVATE
     ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
-
-add_bond_codegen (TARGET comm_test_codegen comm_test_common.bond COMM)
 
 add_unit_test (async.cpp)
 add_unit_test (basic.cpp)
@@ -47,8 +65,8 @@ add_unit_test (core.cpp)
 add_unit_test (error.cpp)
 add_unit_test (event.cpp event.bond)
 add_unit_test (forward.cpp)
-add_unit_test (generic_service.cpp generic.bond)
-add_unit_test (generic_type.cpp generic.bond)
+add_unit_test (generic_service.cpp)
+add_unit_test (generic_type.cpp)
 add_unit_test (jumbo.cpp)
 add_unit_test (layers.cpp)
 add_unit_test (protocol.cpp)

--- a/cpp/test/comm/basic.cpp
+++ b/cpp/test/comm/basic.cpp
@@ -5,6 +5,7 @@
     #pragma warning(disable : 4505) // disable "unreferenced local function has been removed" warning
 #endif
 
+#include <comm_test_common_apply.h>
 #include <comm_test_common_reflection.h>
 #include <comm_test_common_comm.h>
 

--- a/cpp/test/comm/core.cpp
+++ b/cpp/test/comm/core.cpp
@@ -2,6 +2,7 @@
     #pragma warning(disable : 4505) // disable "unreferenced local function has been removed" warning
 #endif
 
+#include <comm_test_common_apply.h>
 #include <comm_test_common_reflection.h>
 #include <comm_test_common_comm.h>
 

--- a/cpp/test/comm/error.cpp
+++ b/cpp/test/comm/error.cpp
@@ -5,6 +5,7 @@
     #pragma warning(disable : 4505) // disable "unreferenced local function has been removed" warning
 #endif
 
+#include <comm_test_common_apply.h>
 #include <comm_test_common_reflection.h>
 #include <comm_test_common_comm.h>
 

--- a/cpp/test/comm/forward.cpp
+++ b/cpp/test/comm/forward.cpp
@@ -5,6 +5,7 @@
     #pragma warning(disable : 4505) // disable "unreferenced local function has been removed" warning
 #endif
 
+#include <comm_test_common_apply.h>
 #include <comm_test_common_reflection.h>
 #include <comm_test_common_comm.h>
 

--- a/cpp/test/comm/generic_service.cpp
+++ b/cpp/test/comm/generic_service.cpp
@@ -5,6 +5,7 @@
     #pragma warning(disable : 4505) // disable "unreferenced local function has been removed" warning
 #endif
 
+#include <generic_apply.h>
 #include <generic_reflection.h>
 #include <generic_comm.h>
 

--- a/cpp/test/comm/generic_type.cpp
+++ b/cpp/test/comm/generic_type.cpp
@@ -5,6 +5,7 @@
     #pragma warning(disable : 4505) // disable "unreferenced local function has been removed" warning
 #endif
 
+#include <generic_apply.h>
 #include <generic_reflection.h>
 #include <generic_comm.h>
 

--- a/cpp/test/comm/idl.cpp
+++ b/cpp/test/comm/idl.cpp
@@ -1,3 +1,0 @@
-#include "comm_test_common_apply.cpp"
-#include "comm_test_common_comm.cpp"
-#include "comm_test_common_types.cpp"

--- a/cpp/test/comm/jumbo.cpp
+++ b/cpp/test/comm/jumbo.cpp
@@ -5,6 +5,7 @@
     #pragma warning(disable : 4505) // disable "unreferenced local function has been removed" warning
 #endif
 
+#include <comm_test_common_apply.h>
 #include <comm_test_common_reflection.h>
 #include <comm_test_common_comm.h>
 

--- a/cpp/test/comm/layers.cpp
+++ b/cpp/test/comm/layers.cpp
@@ -5,6 +5,7 @@
     #pragma warning(disable : 4505) // disable "unreferenced local function has been removed" warning
 #endif
 
+#include <comm_test_common_apply.h>
 #include <comm_test_common_reflection.h>
 #include <comm_test_common_comm.h>
 

--- a/cpp/test/comm/protocol.cpp
+++ b/cpp/test/comm/protocol.cpp
@@ -5,6 +5,7 @@
     #pragma warning(disable : 4505) // disable "unreferenced local function has been removed" warning
 #endif
 
+#include <comm_test_common_apply.h>
 #include <comm_test_common_reflection.h>
 #include <comm_test_common_comm.h>
 

--- a/cpp/test/comm/timeout.cpp
+++ b/cpp/test/comm/timeout.cpp
@@ -5,6 +5,7 @@
     #pragma warning(disable : 4505) // disable "unreferenced local function has been removed" warning
 #endif
 
+#include <comm_test_common_apply.h>
 #include <comm_test_common_reflection.h>
 #include <comm_test_common_comm.h>
 

--- a/cpp/test/compat/comm/CMakeLists.txt
+++ b/cpp/test/compat/comm/CMakeLists.txt
@@ -1,11 +1,28 @@
 cxx_add_compile_options(Clang -Wno-unused-value)
 
+# driver executable
 add_bond_executable (comm_compatibility_test EXCLUDE_FROM_ALL
     commcmd_arg.bond
     commcompat.cpp)
 
+# shared generated code
+add_bond_codegen(TARGET cpp_comm_compat_codegen
+    COMM
+    ${BOND_COMPAT_TEST_DIR}/comm/pingpong.bond)
+add_library(cpp_comm_compat_codegen_lib EXCLUDE_FROM_ALL
+    STATIC
+    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/pingpong_apply.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/pingpong_comm.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/pingpong_types.cpp)
+add_target_to_folder(cpp_comm_compat_codegen_lib)
+target_link_libraries(cpp_comm_compat_codegen_lib PUBLIC bond)
+add_dependencies(cpp_comm_compat_codegen_lib cpp_comm_compat_codegen)
+target_compile_definitions (cpp_comm_compat_codegen_lib PUBLIC
+    -DBOND_COMPACT_BINARY_PROTOCOL
+    -DBOND_FAST_BINARY_PROTOCOL)
+
+# server and client executables
 add_bond_executable (cpp_comm_compat_server COMM EXCLUDE_FROM_ALL
-    ${BOND_COMPAT_TEST_DIR}/comm/pingpong.bond
     pingpong_server.cpp)
 
 add_bond_executable (cpp_comm_compat_client COMM EXCLUDE_FROM_ALL
@@ -16,17 +33,15 @@ add_dependencies (comm_compatibility_test cpp_comm_compat_server)
 add_dependencies (comm_compatibility_test cpp_comm_compat_client)
 add_dependencies (check comm_compatibility_test)
 
-target_compile_definitions (cpp_comm_compat_server PRIVATE
-    -DBOND_COMPACT_BINARY_PROTOCOL
-    -DBOND_FAST_BINARY_PROTOCOL)
-target_compile_definitions (cpp_comm_compat_client PRIVATE
-    -DBOND_COMPACT_BINARY_PROTOCOL
-    -DBOND_FAST_BINARY_PROTOCOL)
 target_compile_definitions (comm_compatibility_test PRIVATE
     -DBOND_COMPACT_BINARY_PROTOCOL
     -DBOND_FAST_BINARY_PROTOCOL)
 
+target_link_libraries (cpp_comm_compat_server PRIVATE
+    cpp_comm_compat_codegen_lib)
+
 target_link_libraries (cpp_comm_compat_client PRIVATE
+    cpp_comm_compat_codegen_lib
     ${Boost_CHRONO_LIBRARY})
 
 # disable generation of debug symbols to speed up build

--- a/cpp/test/compat/comm/pingpong_client.cpp
+++ b/cpp/test/compat/comm/pingpong_client.cpp
@@ -11,6 +11,7 @@
 #include <bond/comm/transport/epoxy.h>
 
 // Include auto-generated files
+#include "pingpong_apply.h"
 #include "pingpong_reflection.h"
 #include "pingpong_comm.h"
 

--- a/cpp/test/compat/comm/pingpong_server.cpp
+++ b/cpp/test/compat/comm/pingpong_server.cpp
@@ -10,6 +10,7 @@
 #include <bond/comm/transport/epoxy.h>
 
 // Include auto-generated files
+#include "pingpong_apply.h"
 #include "pingpong_reflection.h"
 #include "pingpong_comm.h"
 

--- a/cpp/test/compat/grpc/CMakeLists.txt
+++ b/cpp/test/compat/grpc/CMakeLists.txt
@@ -1,31 +1,38 @@
 cxx_add_compile_options(Clang -Wno-unused-value)
 
+# driver executable
 add_bond_executable (grpc_compatibility_test EXCLUDE_FROM_ALL
     grpccmd_arg.bond
     grpccompat.cpp)
 
+# shared generated code
+add_bond_codegen(TARGET cpp_grpc_compat_codegen
+    GRPC
+    ${BOND_COMPAT_TEST_DIR}/grpc/pingpong.bond)
+add_library(cpp_grpc_compat_codegen_lib EXCLUDE_FROM_ALL
+    STATIC
+    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/pingpong_apply.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/pingpong_types.cpp)
+add_target_to_folder(cpp_grpc_compat_codegen_lib)
+target_link_libraries(cpp_grpc_compat_codegen_lib PUBLIC bond)
+add_dependencies(cpp_grpc_compat_codegen_lib cpp_grpc_compat_codegen)
+target_compile_definitions (cpp_grpc_compat_codegen_lib PUBLIC
+    -DBOND_COMPACT_BINARY_PROTOCOL
+    -DBOND_FAST_BINARY_PROTOCOL)
+
+# server and client executables
 add_bond_executable (cpp_grpc_compat_server GRPC EXCLUDE_FROM_ALL
-    ${BOND_COMPAT_TEST_DIR}/grpc/pingpong.bond
     pingpong_server.cpp)
 
 add_bond_executable (cpp_grpc_compat_client GRPC EXCLUDE_FROM_ALL
-    ${BOND_COMPAT_TEST_DIR}/grpc/pingpong.bond
     pingpong_client.cpp)
 
 add_dependencies (grpc_compatibility_test cpp_grpc_compat_server)
 add_dependencies (grpc_compatibility_test cpp_grpc_compat_client)
 add_dependencies (check grpc_compatibility_test)
 
-target_compile_definitions (cpp_grpc_compat_server PRIVATE
-    -DBOND_COMPACT_BINARY_PROTOCOL
-    -DBOND_FAST_BINARY_PROTOCOL)
-
 cxx_target_compile_definitions (MSVC cpp_grpc_compat_server PRIVATE
     -D_WIN32_WINNT=0x0600)
-
-target_compile_definitions (cpp_grpc_compat_client PRIVATE
-    -DBOND_COMPACT_BINARY_PROTOCOL
-    -DBOND_FAST_BINARY_PROTOCOL)
 
 cxx_target_compile_definitions (MSVC cpp_grpc_compat_client PRIVATE
     -D_WIN32_WINNT=0x0600)
@@ -35,8 +42,10 @@ target_compile_definitions (grpc_compatibility_test PRIVATE
     -DBOND_FAST_BINARY_PROTOCOL)
 
 target_link_libraries (cpp_grpc_compat_server PRIVATE
+    cpp_grpc_compat_codegen_lib
     grpc++)
 target_link_libraries (cpp_grpc_compat_client PRIVATE
+    cpp_grpc_compat_codegen_lib
     grpc++
     ${Boost_CHRONO_LIBRARY})
 

--- a/cpp/test/compat/grpc/pingpong_client.cpp
+++ b/cpp/test/compat/grpc/pingpong_client.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // Include auto-generated files
+#include "pingpong_apply.h"
 #include "pingpong_grpc.h"
 #include "pingpong_reflection.h"
 #include "pingpong_types.h"

--- a/cpp/test/compat/grpc/pingpong_server.cpp
+++ b/cpp/test/compat/grpc/pingpong_server.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // Include auto-generated files
+#include "pingpong_apply.h"
 #include "pingpong_grpc.h"
 #include "pingpong_reflection.h"
 #include "pingpong_types.h"


### PR DESCRIPTION
In some CMakeLists.txt files, codegen was being run on the same .bond
files multiple times. Depending on build scheduling, this could result
in build failures (if the generation were to happen at the same time) or
spurious rebuilds (due to spurious rewrites of the generated files).

Now, .bond files that are shared across targets within the same
directory are generated once and compiled into a static library that is
then linked into all the consumers.

Since we're compiling the .bond files into a static library, we can take
advantage of the _apply.cpp precompilation as well.