### PR TITLE
[c++] Fix G++ 5.4 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ different versioning scheme, following the Haskell community's
   bond::CoreException is now thrown.
 * When SimpleJSON deserializes a map key of non-primitive type, a
   bond::CoreException is now thrown.
+* Errors from some versions of G++ like "non-template type `Deserialize`
+  used as a template" have been fixed.
+  [Issue #538](https://github.com/Microsoft/bond/issues/538)
 
 ### C# ###
 

--- a/cpp/inc/bond/core/value.h
+++ b/cpp/inc/bond/core/value.h
@@ -633,9 +633,9 @@ template <typename Protocols, typename X, typename I, typename T>
 typename boost::enable_if<require_modify_element<X> >::type
 inline DeserializeElement(X& var, const I& item, const T& element)
 {
-    struct Deserialize
+    struct DeserializeImpl
     {
-        Deserialize(const T& element)
+        DeserializeImpl(const T& element)
             : element(element)
         {}
 
@@ -647,7 +647,7 @@ inline DeserializeElement(X& var, const I& item, const T& element)
         const T& element;
     };
 
-    modify_element(var, item, Deserialize(element));
+    modify_element(var, item, DeserializeImpl(element));
 }
 
 

--- a/cpp/test/core/marshal.cpp
+++ b/cpp/test/core/marshal.cpp
@@ -116,7 +116,7 @@ TEST_CASE_BEGIN(MapTo)
         To to;
 
         bond::InputBuffer input(output_buffer.GetBuffer());
-        bond::SelectProtocolAndApply<From>(input, bond::MapTo<To>(to, mappings));
+        bond::SelectProtocolAndApply<From, bond::BuiltInProtocols>(input, bond::MapTo<To>(to, mappings));
 
         UT_Compare(from, to);
     }


### PR DESCRIPTION
* Deserialize was used as the name for both a struct and a member
  function. This causes some versions of G++ to emit errors, so rename
  the helper struct. Fixes https://github.com/Microsoft/bond/issues/538
* The Protocols template argument could not be deduced in one place
  where bond::SelectProtocolAndApply was called. It is now explicitly
  specified.