### PR TITLE
[c#] Append to list in serialization example

### DIFF
--- a/examples/cs/core/serialization/program.cs
+++ b/examples/cs/core/serialization/program.cs
@@ -1,6 +1,5 @@
 ﻿namespace Examples
 {
-    using System.Collections.Generic;
     using System.Diagnostics;
     using Bond;
     using Bond.Protocols;
@@ -16,7 +15,7 @@
             {
                 n = 0x1000,
                 str = "test",
-                items = new List<double> { 3.14, 0}
+                items = { 3.14, 0 }
             };
 
             // OutputBuffer implements the Bond output stream interface on top

--- a/examples/cs/core/serialization/serialization.csproj
+++ b/examples/cs/core/serialization/serialization.csproj
@@ -30,10 +30,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="program.cs" />


### PR DESCRIPTION
The previous code in the serialization example created a new
List<double> for the vector<double> field `items`, implying that the
field was not initialized to an empty List<double>.

Since the `items` field is initialized to an empty list, we now just
append to the existing list.