### PR TITLE
c++/c# simple binary documentation fixes

### DIFF
--- a/cpp/inc/bond/protocol/simple_binary.h
+++ b/cpp/inc/bond/protocol/simple_binary.h
@@ -60,6 +60,12 @@
 
                             key, mapped     each item encoded according to its type
 
+                                           .-------. .-----------.
+                    bonded                 | count | | marshaled |
+                                           '-------' '-----------'
+                            count           uint32 count of bytes (always fixed-width, even in v2)
+
+                            marshaled       a marshaled payload
 */
 
 namespace bond

--- a/cpp/inc/bond/protocol/simple_binary.h
+++ b/cpp/inc/bond/protocol/simple_binary.h
@@ -36,8 +36,8 @@
                      string, wstring        | count | characters |
                                             '-------'------------'
 
-                           count            variable encoded uint32 count of 1-byte (for
-                                            string) or 2-byte (for wstring) Unicode code
+                           count            uint32 count of 1-byte (for string)
+                                            or 2-byte (for wstring) Unicode code
                                             units (variable encoded in v2)
 
                            characters       1-byte UTF-8 code units (for string) or 2-byte

--- a/cs/src/core/protocols/SimpleBinary.cs
+++ b/cs/src/core/protocols/SimpleBinary.cs
@@ -29,8 +29,8 @@
                      string, wstring        | count | characters |
                                             '-------'------------'
 
-                           count            variable encoded uint32 count of 1-byte (for
-                                            string) or 2-byte (for wstring) Unicode code
+                           count            uint32 count of 1-byte (for string)
+                                            or 2-byte (for wstring) Unicode code
                                             units (variable encoded in v2)
 
                            characters       1-byte UTF-8 code units (for string) or 2-byte

--- a/cs/src/core/protocols/SimpleBinary.cs
+++ b/cs/src/core/protocols/SimpleBinary.cs
@@ -53,6 +53,13 @@
 
                             key, mapped     each item encoded according to its type
 
+                                           .-------. .-----------.
+                    bonded                 | count | | marshaled |
+                                           '-------' '-----------'
+                            count           uint32 count of bytes (always fixed-width, even in v2)
+
+                            marshaled       a marshaled payload
+
 */
 #endregion
 


### PR DESCRIPTION
This cherry-picks the fixes I made to `simple_binary.h` in `jvm` and applies them to `SimpleBinary.cs`, too.