### PR TITLE
Fix Java StructDef full name to come from IDL

### DIFF
--- a/compiler/src/Language/Bond/Codegen/Java/Class_java.hs
+++ b/compiler/src/Language/Bond/Codegen/Java/Class_java.hs
@@ -470,7 +470,7 @@ package #{javaPackage};
         javaPackage = sepBy "." toText $ getNamespace java
 
         -- struct -> Java class
-        typeDefinition Struct {..} = [lt|
+        typeDefinition s@Struct {..} = [lt|
 #{generatedClassAnnotations}
 public class #{typeNameWithParams declName declParams}#{maybe interface baseClass structBase} {
     #{ifThenElse (null declParams) mempty (makeStructMember_GenericBondTypeBuilder declName declParams)}
@@ -483,6 +483,16 @@ public class #{typeNameWithParams declName declParams}#{maybe interface baseClas
             super(genericTypeSpecialization);
         }
         #{makeStructBondTypeMember_initialize java declParams structFields structBase}
+
+        @Override
+        public final String getName() {
+            return "#{declName}";
+        }
+
+        @Override
+        public final String getQualifiedName() {
+            return "#{qualifiedDeclaredTypeName java s}";
+        }
 
         @Override
         public final java.lang.Class<#{typeNameWithParams declName declParams}> getValueClass() {

--- a/compiler/tests/generated/aliases_concatenated.java
+++ b/compiler/tests/generated/aliases_concatenated.java
@@ -50,6 +50,16 @@ public class Foo<T> implements com.microsoft.bond.BondSerializable {
         }
 
         @Override
+        public final String getName() {
+            return "Foo";
+        }
+
+        @Override
+        public final String getQualifiedName() {
+            return "tests.Foo";
+        }
+
+        @Override
         public final java.lang.Class<Foo<T>> getValueClass() {
             return (java.lang.Class<Foo<T>>) (java.lang.Class) Foo.class;
         }
@@ -252,6 +262,16 @@ public class WrappingAnEnum implements com.microsoft.bond.BondSerializable {
         protected final void initialize() {
             this.aWrappedEnum = new com.microsoft.bond.StructBondType.EnumStructField<tests.EnumToWrap>(this, tests.EnumToWrap.BOND_TYPE, 0, "aWrappedEnum", com.microsoft.bond.Modifier.Optional);
             super.initializeBaseAndFields(null, this.aWrappedEnum);
+        }
+
+        @Override
+        public final String getName() {
+            return "WrappingAnEnum";
+        }
+
+        @Override
+        public final String getQualifiedName() {
+            return "tests.WrappingAnEnum";
         }
 
         @Override

--- a/compiler/tests/generated/attributes_concatenated.java
+++ b/compiler/tests/generated/attributes_concatenated.java
@@ -106,6 +106,16 @@ public class Foo implements com.microsoft.bond.BondSerializable {
         }
 
         @Override
+        public final String getName() {
+            return "Foo";
+        }
+
+        @Override
+        public final String getQualifiedName() {
+            return "tests.Foo";
+        }
+
+        @Override
         public final java.lang.Class<Foo> getValueClass() {
             return (java.lang.Class<Foo>) (java.lang.Class) Foo.class;
         }

--- a/compiler/tests/generated/basic_types_concatenated.java
+++ b/compiler/tests/generated/basic_types_concatenated.java
@@ -75,6 +75,16 @@ public class BasicTypes implements com.microsoft.bond.BondSerializable {
         }
 
         @Override
+        public final String getName() {
+            return "BasicTypes";
+        }
+
+        @Override
+        public final String getQualifiedName() {
+            return "tests.BasicTypes";
+        }
+
+        @Override
         public final java.lang.Class<BasicTypes> getValueClass() {
             return (java.lang.Class<BasicTypes>) (java.lang.Class) BasicTypes.class;
         }

--- a/compiler/tests/generated/bond_meta_concatenated.java
+++ b/compiler/tests/generated/bond_meta_concatenated.java
@@ -39,6 +39,16 @@ public class HasMetaFields implements com.microsoft.bond.BondSerializable {
         }
 
         @Override
+        public final String getName() {
+            return "HasMetaFields";
+        }
+
+        @Override
+        public final String getQualifiedName() {
+            return "deprecated.bondmeta.HasMetaFields";
+        }
+
+        @Override
         public final java.lang.Class<HasMetaFields> getValueClass() {
             return (java.lang.Class<HasMetaFields>) (java.lang.Class) HasMetaFields.class;
         }

--- a/compiler/tests/generated/complex_types_concatenated.java
+++ b/compiler/tests/generated/complex_types_concatenated.java
@@ -35,6 +35,16 @@ public class Foo implements com.microsoft.bond.BondSerializable {
         }
 
         @Override
+        public final String getName() {
+            return "Foo";
+        }
+
+        @Override
+        public final String getQualifiedName() {
+            return "tests.Foo";
+        }
+
+        @Override
         public final java.lang.Class<Foo> getValueClass() {
             return (java.lang.Class<Foo>) (java.lang.Class) Foo.class;
         }
@@ -164,6 +174,16 @@ public class ComplexTypes implements com.microsoft.bond.BondSerializable {
             this.bfoo = new com.microsoft.bond.StructBondType.ObjectStructField<com.microsoft.bond.Bonded<tests.Foo>>(this, bondedOf((com.microsoft.bond.StructBondType<tests.Foo>) getStructType(tests.Foo.class)), 5, "bfoo", com.microsoft.bond.Modifier.Optional);
             this.m = new com.microsoft.bond.StructBondType.ObjectStructField<java.util.Map<java.lang.Double, java.util.List<java.util.List<com.microsoft.bond.Bonded<tests.Bar>>>>>(this, mapOf(com.microsoft.bond.BondTypes.DOUBLE, listOf(vectorOf(nullableOf(bondedOf((com.microsoft.bond.StructBondType<tests.Bar>) getStructType(tests.Bar.class)))))), 6, "m", com.microsoft.bond.Modifier.Optional);
             super.initializeBaseAndFields(null, this.li8, this.sb, this.vb, this.nf, this.msws, this.bfoo, this.m);
+        }
+
+        @Override
+        public final String getName() {
+            return "ComplexTypes";
+        }
+
+        @Override
+        public final String getQualifiedName() {
+            return "tests.ComplexTypes";
         }
 
         @Override

--- a/compiler/tests/generated/defaults_concatenated.java
+++ b/compiler/tests/generated/defaults_concatenated.java
@@ -259,6 +259,16 @@ public class Foo implements com.microsoft.bond.BondSerializable {
         }
 
         @Override
+        public final String getName() {
+            return "Foo";
+        }
+
+        @Override
+        public final String getQualifiedName() {
+            return "tests.Foo";
+        }
+
+        @Override
         public final java.lang.Class<Foo> getValueClass() {
             return (java.lang.Class<Foo>) (java.lang.Class) Foo.class;
         }

--- a/compiler/tests/generated/field_modifiers_concatenated.java
+++ b/compiler/tests/generated/field_modifiers_concatenated.java
@@ -42,6 +42,16 @@ public class Foo implements com.microsoft.bond.BondSerializable {
         }
 
         @Override
+        public final String getName() {
+            return "Foo";
+        }
+
+        @Override
+        public final String getQualifiedName() {
+            return "tests.Foo";
+        }
+
+        @Override
         public final java.lang.Class<Foo> getValueClass() {
             return (java.lang.Class<Foo>) (java.lang.Class) Foo.class;
         }

--- a/compiler/tests/generated/generics_concatenated.java
+++ b/compiler/tests/generated/generics_concatenated.java
@@ -55,6 +55,16 @@ public class Foo<T1, T2> implements com.microsoft.bond.BondSerializable {
         }
 
         @Override
+        public final String getName() {
+            return "Foo";
+        }
+
+        @Override
+        public final String getQualifiedName() {
+            return "tests.Foo";
+        }
+
+        @Override
         public final java.lang.Class<Foo<T1, T2>> getValueClass() {
             return (java.lang.Class<Foo<T1, T2>>) (java.lang.Class) Foo.class;
         }

--- a/compiler/tests/generated/inheritance_concatenated.java
+++ b/compiler/tests/generated/inheritance_concatenated.java
@@ -36,6 +36,16 @@ public class Base implements com.microsoft.bond.BondSerializable {
         }
 
         @Override
+        public final String getName() {
+            return "Base";
+        }
+
+        @Override
+        public final String getQualifiedName() {
+            return "tests.Base";
+        }
+
+        @Override
         public final java.lang.Class<Base> getValueClass() {
             return (java.lang.Class<Base>) (java.lang.Class) Base.class;
         }
@@ -159,6 +169,16 @@ public class Foo extends tests.Base {
         protected final void initialize() {
             this.x = new com.microsoft.bond.StructBondType.Int32StructField(this, 0, "x", com.microsoft.bond.Modifier.Optional);
             super.initializeBaseAndFields((com.microsoft.bond.StructBondType<tests.Base>) getStructType(tests.Base.class), this.x);
+        }
+
+        @Override
+        public final String getName() {
+            return "Foo";
+        }
+
+        @Override
+        public final String getQualifiedName() {
+            return "tests.Foo";
         }
 
         @Override

--- a/cs/Compiler.vcxproj
+++ b/cs/Compiler.vcxproj
@@ -79,6 +79,9 @@ if %errorlevel% neq 0 goto :VCEnd
     <None Include="$(ProjectDir)..\compiler\src\Language\Bond\Codegen\Cs\Types_cs.hs" />
     <None Include="$(ProjectDir)..\compiler\src\Language\Bond\Codegen\Cs\Util.hs" />
     <None Include="$(ProjectDir)..\compiler\src\Language\Bond\Codegen\Cs\Grpc_cs.hs" />
+    <None Include="$(ProjectDir)..\compiler\src\Language\Bond\Codegen\Java\Class_java.hs" />
+    <None Include="$(ProjectDir)..\compiler\src\Language\Bond\Codegen\Java\Enum_java.hs" />
+    <None Include="$(ProjectDir)..\compiler\src\Language\Bond\Codegen\Java\Util.hs" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cs/Compiler.vcxproj.filters
+++ b/cs/Compiler.vcxproj.filters
@@ -89,6 +89,15 @@
     <None Include="$(ProjectDir)..\compiler\src\Language\Bond\Codegen\Cs\Grpc_cs.hs">
       <Filter>Bond\Codegen\Cs</Filter>
     </None>
+    <None Include="$(ProjectDir)..\compiler\src\Language\Bond\Codegen\Java\Class_java.hs">
+      <Filter>Bond\Codegen\Java</Filter>
+    </None>
+    <None Include="$(ProjectDir)..\compiler\src\Language\Bond\Codegen\Java\Enum_java.hs">
+      <Filter>Bond\Codegen\Java</Filter>
+    </None>
+    <None Include="$(ProjectDir)..\compiler\src\Language\Bond\Codegen\Java\Util.hs">
+      <Filter>Bond\Codegen\Java</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Bond">
@@ -107,6 +116,9 @@
     </Filter>
     <Filter Include="Bond\Syntax">
       <UniqueIdentifier>{905ABB36-088E-4045-8EA5-7316C8675D60}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Bond\Codegen\Java">
+      <UniqueIdentifier>{14da474f-b509-4d4b-88b2-8632ae8d4645}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/java/core/src/main/java/com/microsoft/bond/StructBondType.java
+++ b/java/core/src/main/java/com/microsoft/bond/StructBondType.java
@@ -246,18 +246,6 @@ public abstract class StructBondType<TStruct extends BondSerializable>
     }
 
     @Override
-    public final String getName() {
-        // rely on generated class
-        return this.getValueClass().getSimpleName();
-    }
-
-    @Override
-    public final String getQualifiedName() {
-        // rely on generated class
-        return this.getValueClass().getName();
-    }
-
-    @Override
     public final BondDataType getBondDataType() {
         return BondDataType.BT_STRUCT;
     }


### PR DESCRIPTION
This aligns with C++/C# implementations.

Also adds Java filter to compiler project in Visual Studio solution.