### PR TITLE
[C#] Fix interaction with CBv2 and bonded fields 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ different versioning scheme, following the Haskell community's
   [Issue #498](https://github.com/Microsoft/bond/issues/498)
     * Such streams are detected by inspecting
       [`Stream.CanSeek`][msdn-stream-canseek].
+* Fix a bug in CompactBinaryWriter when using v2 that repeated first pass
+  when a bonded field was serailized, resulting in extra work and extra
+  state left in the CompactBinaryWriter.
 
 [msdn-gzipstream]: https://msdn.microsoft.com/en-us/library/system.io.compression.gzipstream(v=vs.110).aspx
 [msdn-stream-canseek]: https://msdn.microsoft.com/en-us/library/system.io.stream.canseek(v=vs.110).aspx

--- a/cs/src/core/protocols/CompactBinary.cs
+++ b/cs/src/core/protocols/CompactBinary.cs
@@ -176,7 +176,11 @@ namespace Bond.Protocols
         {
             if (version == 2)
             {
-                return firstPassWriter.Value;
+                // Only return first pass if not in middle of second pass
+                if (lengths.Count == 0)
+                {
+                    return firstPassWriter.Value;
+                }
             }
 
             return null;

--- a/cs/test/core/BondedTests.cs
+++ b/cs/test/core/BondedTests.cs
@@ -438,5 +438,15 @@
             Assert.IsTrue(Comparer.Equal(poly1, obj.poly[1].Deserialize()));
             Assert.IsTrue(Comparer.Equal(poly2, obj.poly[2].Deserialize<Derived>()));
         }
+
+        [Test]
+        public void SerializeBondedCB2Multiple()
+        {
+            var obj = new StructWithBonded();
+
+            var stream = new MemoryStream();
+            stream.SetLength(0);
+            Util.SerializeCB2Multiple(obj, stream, 2);
+        }
     }
 }

--- a/cs/test/core/Util.cs
+++ b/cs/test/core/Util.cs
@@ -393,6 +393,8 @@ namespace UnitTest
             for (uint i = 0; i < times; i++)
             {
                 Serialize.To(writer, obj);
+
+                // Verify that CBv2 writer has an active FirstPassWriter before the next top-level serialization
                 Assert.NotNull(writer.GetFirstPassWriter());
             }
             output.Flush();

--- a/cs/test/core/Util.cs
+++ b/cs/test/core/Util.cs
@@ -385,6 +385,19 @@ namespace UnitTest
             output.Flush();
         }
 
+        public static void SerializeCB2Multiple<T>(T obj, Stream stream, uint times)
+        {
+            var output = new OutputStream(stream, 11);
+            var writer = new CompactBinaryWriter<OutputStream>(output, 2);
+
+            for (uint i = 0; i < times; i++)
+            {
+                Serialize.To(writer, obj);
+                Assert.NotNull(writer.GetFirstPassWriter());
+            }
+            output.Flush();
+        }
+
         public static void MarshalCB2<T>(T obj, Stream stream)
         {
             var output = new OutputStream(stream, 11);


### PR DESCRIPTION
Serialization of bonded fields was interacting with the state in the CompactBinaryWriter because it triggered first-pass again. This fix prevents the first-pass writer from being returened in the middle of the
second pass.