### PR TITLE
[c++] Fix some MSVC static analysis issues

### DIFF
--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -36,6 +36,12 @@ if (MSVC)
     # https://msdn.microsoft.com/en-us/library/ms175759.aspx
     add_definitions (-D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES=1 -D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT=1)
 
+    # Disable code analysis warnings about constant constant comparisons. A
+    # lot of our template functions trigger this when they do things like:
+    #
+    # if (T == traits<U>::some_value) { ... } else { ... }
+    add_compile_options(/wd6326)
+
     # Enable standards-conformance mode for MSVC compilers that support this
     # flag (Visual C++ 2017 and later).
     #

--- a/cpp/inc/bond/core/detail/cmdargs.h
+++ b/cpp/inc/bond/core/detail/cmdargs.h
@@ -535,10 +535,10 @@ protected:
 
         for (int begin = 0; i < static_cast<int>(formated.length()); begin += 80, i = begin + 79 - indent)
         {
-            while (i >= begin && !isspace(formated[i]))
+            while (i >= begin && !isspace(static_cast<int>(formated[i])))
                 --i;
 
-            while (i < static_cast<int>(formated.length()) && isspace(formated[i]))
+            while (i < static_cast<int>(formated.length()) && isspace(static_cast<int>(formated[i])))
                 ++i;
 
             formated.insert(i, begin + 80 - i, ' ');

--- a/cpp/test/compat/core/compat.cpp
+++ b/cpp/test/compat/core/compat.cpp
@@ -17,7 +17,7 @@
 #include <bond/protocol/simple_json_writer.h>
 #include <bond/stream/stdio_output_stream.h>
 
-void die(const char* fmt, ...)
+BOND_NORETURN void die(const char* fmt, ...)
 {
     va_list args;
     va_start(args, fmt);

--- a/cpp/test/core/metadata_tests.cpp
+++ b/cpp/test/core/metadata_tests.cpp
@@ -146,7 +146,7 @@ public:
         bond::Metadata  metadata_copy = metadata;
         char            name[100];
 
-        sprintf(name, "%s%d", _name, id);
+        sprintf(name, "%s%u", _name, id);
 
         UT_AssertIsTrue(metadata_copy.name == name);
         UT_AssertIsTrue(metadata_copy.name == metadata_copy.attributes["field_name"]);


### PR DESCRIPTION
* `isspace` takes ints, not chars, so promote.
* Instead of dealing with a potentially non-null terminated string when
  finding a field by ordinal in Simple JSON, attempt to parse the field
  ID and then compare the numeric values.
* Indicate that the `die` function never returns so that the analyzer
  can tell that we've checked for things like malloc returning null.
* The printf format string for unsigned ints is u, not d.
* Disable the code analysis warning C6326, "constant constant
  comparison". A lot of our template functions trigger this when they do
  things like: if (T == traits<U>::some_value) { ... } else { ... }