### PR TITLE
[c#] Always serialize DateTime as UTC

### DIFF
--- a/examples/cs/core/date_time/program.cs
+++ b/examples/cs/core/date_time/program.cs
@@ -10,12 +10,12 @@
     {
         public static long Convert(DateTime value, long unused)
         {
-            return value.Ticks;
+            return value.ToUniversalTime().Ticks;
         }
 
         public static DateTime Convert(long value, DateTime unused)
         {
-            return new DateTime(value);
+            return new DateTime(value, DateTimeKind.Utc);
         }
     }
 
@@ -25,8 +25,8 @@
         {
             var src = new Example
             {
-                Now = DateTime.Now,
-                Dates = { new DateTime(2017, 1, 29) }
+                Now = DateTime.UtcNow,
+                Dates = { new DateTime(2017, 1, 29, 0, 0, 0, DateTimeKind.Utc) }
             };
 
             var output = new OutputBuffer();


### PR DESCRIPTION
In order to avoid round-tripping problems due to changing local time
zones, the DateTime example now serializes and deserializes DateTime
instances as UTC.

This does mean, that if you have a Local DateTime that you round-trip,
you will get back a UTC DateTime instead. This is better expected
behavior than random time zone offset changes.