### PR TITLE
java core: Add regression test for CBv2 double bonded bug.

### DIFF
--- a/java/compat/.idea/modules/compat.iml
+++ b/java/compat/.idea/modules/compat.iml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module external.linked.project.id="compat" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.bondlib" external.system.module.version="1.0" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager">
-    <output url="file://$MODULE_DIR$/../../build/classes/java/main" />
-    <output-test url="file://$MODULE_DIR$/../../build/classes/java/test" />
+    <output url="file://$MODULE_DIR$/../../out/production/classes" />
+    <output-test url="file://$MODULE_DIR$/../../out/test/classes" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../..">
       <sourceFolder url="file://$MODULE_DIR$/../../src/main/java" isTestSource="false" />

--- a/java/core/.idea/modules/bond.iml
+++ b/java/core/.idea/modules/bond.iml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module external.linked.project.id="bond" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.bondlib" external.system.module.version="5.0.0" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager">
-    <output url="file://$MODULE_DIR$/../../build/classes/main" />
-    <output-test url="file://$MODULE_DIR$/../../build/classes/test" />
+    <output url="file://$MODULE_DIR$/../../out/production/classes" />
+    <output-test url="file://$MODULE_DIR$/../../out/test/classes" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../..">
       <sourceFolder url="file://$MODULE_DIR$/../../src/main/java" isTestSource="false" />

--- a/java/core/src/test/bond/bonded.bond
+++ b/java/core/src/test/bond/bonded.bond
@@ -2,6 +2,10 @@ import "common.bond"
 
 namespace org.bondlib.test
 
+struct HasBondedField {
+    0: bonded<Base> bondedField;
+}
+
 struct BondedCollection {
     0: list<bonded<Base>> bondeds;
 }


### PR DESCRIPTION
Locally reverted the bug fix from 8a608fbe and confirmed that the test fails with an `InvalidBondDataException`.

Additionally, accept IDEA's insistence on `out/` in a separate commit.