### PR TITLE
[Java] Fixed generic type parameters for set/map and bonded containers

### DIFF
--- a/java/core/src/main/java/org/bondlib/BondType.java
+++ b/java/core/src/main/java/org/bondlib/BondType.java
@@ -378,6 +378,35 @@ public abstract class BondType<T> {
     }
 
     /**
+     * Gets a type descriptor for the Bond "bonded" container type. Throws an exception
+     * if the value type is not a Bond struct. This method is intended for generated code.
+     * This method returns {@link BondType} instead of more specific {@link BondedBondType},
+     * due to the constraint on the latter's generic type parameter which must be a struct
+     * type (i.e. derive from {@link StructBondType}. Since the type parameter TStruct is not
+     * contrained in this method, that generic type constraint can't be satisfied. It shall be
+     * noted however, that this method returns only instances of {@link BondedBondType} with
+     * a valid Bond struct value underneath. All other cases result in throwing an exception.
+     *
+     * @param valueType a type descriptor for the underlying value class
+     * @param <TStruct> the class of the underlying struct value
+     * @return a type descriptor instance
+     * @exception IllegalArgumentException if the argument is not a Bond struct type
+     */
+    protected static <TStruct> BondType<Bonded<TStruct>> bondedOf(
+            BondType<TStruct> valueType) {
+        ArgumentHelper.ensureNotNull(valueType, "valueType");
+        if (!(valueType instanceof StructBondType)) {
+            Throw.raiseInvalidBondedValueTypeError(valueType);
+        }
+        // It's not possible to delegate to the public bondedOf method using a generic type, since that method
+        // constrains the TStruct type parameter. Thus, the call is made using non-generic type and the result
+        // is upcast to a generic type to match the method's return type.
+        @SuppressWarnings("unchecked")
+        BondType<Bonded<TStruct>> upcastBondedType = (BondType<Bonded<TStruct>>) bondedOf((StructBondType) valueType);
+        return upcastBondedType;
+    }
+
+    /**
      * Gets a type descriptor for the Bond "vector" container type.
      *
      * @param elementType a type descriptor for the element value class
@@ -417,6 +446,24 @@ public abstract class BondType<T> {
     }
 
     /**
+     * Gets a type descriptor for the Bond "set" container type. Throws an exception
+     * if the element type is not a primitive Bond type. This method is intended for generated code.
+     *
+     * @param elementType a type descriptor for the element value class
+     * @param <TElement>  the class of the element values
+     * @return a type descriptor instance
+     * @exception IllegalArgumentException if the argument is not a primitive Bond type
+     */
+    protected static <TElement> SetBondType<TElement> setOf(
+            BondType<TElement> elementType) {
+        ArgumentHelper.ensureNotNull(elementType, "elementType");
+        if (!(elementType instanceof PrimitiveBondType)) {
+            Throw.raiseInvalidSetElementTypeError(elementType);
+        }
+        return setOf((PrimitiveBondType<TElement>) elementType);
+    }
+
+    /**
      * Gets a type descriptor for the Bond "map" container type.
      *
      * @param keyType   a type descriptor for the map key class
@@ -430,6 +477,27 @@ public abstract class BondType<T> {
         ArgumentHelper.ensureNotNull(keyType, "keyType");
         ArgumentHelper.ensureNotNull(valueType, "valueType");
         return (MapBondType<TKey, TValue>) getCachedType(new MapBondType<TKey, TValue>(keyType, valueType));
+    }
+
+    /**
+     * Gets a type descriptor for the Bond "map" container type. Throws an exception
+     * if the key type is not a primitive Bond type. This method is intended for generated code.
+     *
+     * @param keyType   a type descriptor for the map key class
+     * @param valueType a type descriptor for the mapped values class
+     * @param <TKey>    the class of the map keys
+     * @param <TValue>  the class of the mapped values
+     * @return a type descriptor instance
+     * @exception IllegalArgumentException if the key type argument is not a primitive Bond type
+     */
+    public static <TKey, TValue> MapBondType<TKey, TValue> mapOf(
+            BondType<TKey> keyType, BondType<TValue> valueType) {
+        ArgumentHelper.ensureNotNull(keyType, "keyType");
+        ArgumentHelper.ensureNotNull(valueType, "valueType");
+        if (!(keyType instanceof PrimitiveBondType)) {
+            Throw.raiseInvalidMapKeyTypeError(keyType);
+        }
+        return mapOf((PrimitiveBondType<TKey>) keyType, valueType);
     }
 
     /**

--- a/java/core/src/main/java/org/bondlib/Bonded.java
+++ b/java/core/src/main/java/org/bondlib/Bonded.java
@@ -13,9 +13,15 @@ import java.io.IOException;
 /**
  * A construct representing a Bonded payload of some struct type.
  *
- * @param <T> the struct type of this Bonded instance
+ * The type parameter is expected to implement {@link BondSerializable} but this is not enforced at compile-time
+ * since the details of the type may not be known in advance (e.g. consider a generic type that contains a bonded
+ * field wrapping an instance of an unknown type specified through a type parameter). It shall be noted that
+ * although this class doesn't explicitly constrain its type parameter, all public API that creates {@link Bonded}
+ * instances does have this enforcement.
+ *
+ * @param <T> the struct type of this Bonded instance which is expected to implement {@link BondSerializable}
  */
-public abstract class Bonded<T extends BondSerializable> {
+public abstract class Bonded<T> {
 
     /**
      * Creates a new Bonded instance from a tagged protocol reader that is constrained to a given struct type.

--- a/java/core/src/main/java/org/bondlib/EnumBondType.java
+++ b/java/core/src/main/java/org/bondlib/EnumBondType.java
@@ -13,16 +13,10 @@ import java.io.IOException;
  */
 public abstract class EnumBondType<TEnum extends BondEnum<TEnum>> extends PrimitiveBondType<TEnum> {
 
-    // the default value of the enum type is cached inside the singleton class descriptor,
-    // since the generated enum class may not cache it if there is no declared constant for it
-    private final TEnum defaultValue;
-
     /**
      * Used by generated subclasses (and only by generated subclasses) to instantiate the type descriptor.
      */
     protected EnumBondType() {
-        // a default for enum type is the enum value with the underlying integer set to 0
-        this.defaultValue = this.getEnumValue(0);
     }
 
     @Override
@@ -50,7 +44,8 @@ public abstract class EnumBondType<TEnum extends BondEnum<TEnum>> extends Primit
 
     @Override
     protected final TEnum newDefaultValue() {
-        return this.defaultValue;
+        // a default for enum type is the enum value with the underlying integer set to 0
+        return this.getEnumValue(0);
     }
 
     /**

--- a/java/core/src/main/java/org/bondlib/Throw.java
+++ b/java/core/src/main/java/org/bondlib/Throw.java
@@ -179,4 +179,25 @@ final class Throw {
                 field.getId(),
                 field.getFieldType().getFullName());
     }
+
+    // raised when trying to instantiate a map container with an invalid key type
+    static void raiseInvalidMapKeyTypeError(BondType<?> keyType) {
+        throw new IllegalArgumentException(String.format(
+                "Invalid map key type: '%s', must be a Bond primitive data type.",
+                keyType.getFullName()));
+    }
+
+    // raised when trying to instantiate a set container with an invalid element type
+    static void raiseInvalidSetElementTypeError(BondType<?> elementType) {
+        throw new IllegalArgumentException(String.format(
+                "Invalid set element type: '%s', must be a Bond primitive data type.",
+                elementType.getFullName()));
+    }
+
+    // raised when trying to instantiate a Bonded container with an invalid element type
+    static void raiseInvalidBondedValueTypeError(BondType<?> valueType) {
+        throw new IllegalArgumentException(String.format(
+                "Invalid bonded value type: '%s', must be a Bond struct data type.",
+                valueType.getFullName()));
+    }
 }

--- a/java/core/src/test/bond/common.bond
+++ b/java/core/src/test/bond/common.bond
@@ -1,5 +1,20 @@
 namespace org.bondlib.test
 
+enum MonthOfYear {
+    January = 1,
+    February,
+    March,
+    April,
+    May,
+    June,
+    July,
+    August,
+    September,
+    October,
+    November,
+    December
+}
+
 struct Empty {}
 
 struct Base {

--- a/java/core/src/test/bond/generic.bond
+++ b/java/core/src/test/bond/generic.bond
@@ -1,0 +1,29 @@
+namespace org.bondlib.test
+
+struct GenericValueContainer<T> {
+    0: T valueField;
+}
+
+struct GenericNullableContainer<T> {
+    0: nullable<T> nullableField;
+}
+
+struct GenericVectorContainer<T> {
+    0: vector<T> vectorField;
+}
+
+struct GenericListContainer<T> {
+    0: list<T> listField;
+}
+
+struct GenericSetContainer<T> {
+    0: set<T> setField;
+}
+
+struct GenericMapContainer<T> {
+    0: map<T, T> mapField;
+}
+
+struct GenericBondedContainer<T> {
+    0: bonded<T> bondedField;
+}

--- a/java/core/src/test/java/org/bondlib/GenericContainerTest.java
+++ b/java/core/src/test/java/org/bondlib/GenericContainerTest.java
@@ -1,0 +1,312 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package org.bondlib;
+
+import org.bondlib.test.*;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class GenericContainerTest {
+
+    @Test
+    public void testGenericValueContainer() {
+        genericValueContainerTestHelper(BondTypes.STRING, "test");
+        genericValueContainerTestHelper(BondTypes.BOOL, true);
+        genericValueContainerTestHelper(BondTypes.INT8, (byte)1);
+        genericValueContainerTestHelper(BondTypes.INT32, Integer.MIN_VALUE);
+        genericValueContainerTestHelper(BondTypes.UINT64, Long.MAX_VALUE);
+        genericValueContainerTestHelper(BondTypes.DOUBLE, 3.14);
+
+        genericValueContainerTestHelper(MonthOfYear.BOND_TYPE, MonthOfYear.August);
+        genericValueContainerTestHelper(MonthOfYear.BOND_TYPE, MonthOfYear.get(100));
+
+        Empty empty = new Empty();
+        genericValueContainerTestHelper(Empty.BOND_TYPE, empty);
+
+        Derived derived = new Derived();
+        derived.baseInt = 123;
+        derived.derivedInt = 456;
+        genericValueContainerTestHelper(Derived.BOND_TYPE, derived);
+    }
+
+    private static <T> void genericValueContainerTestHelper(BondType<T> elementBondType, T elementValue) {
+        StructBondType<GenericValueContainer<T>> containerBondType =
+                GenericValueContainer.BOND_TYPE.makeGenericType(elementBondType);
+        GenericValueContainer<T> container = new GenericValueContainer<T>(containerBondType);
+        Assert.assertEquals(elementBondType.newDefaultValue(), container.valueField);
+        container.valueField = elementValue;
+        Assert.assertEquals(elementValue, container.valueField);
+        marshalUnmarshalAndCompareUsingMultipleProtocols(container);
+    }
+
+    @Test
+    public void testGenericNullableContainer() {
+        genericNullableContainerTestHelper(BondTypes.STRING, "test");
+        genericNullableContainerTestHelper(BondTypes.BOOL, true);
+        genericNullableContainerTestHelper(BondTypes.INT8, (byte)1);
+        genericNullableContainerTestHelper(BondTypes.INT32, Integer.MIN_VALUE);
+        genericNullableContainerTestHelper(BondTypes.UINT64, Long.MAX_VALUE);
+        genericNullableContainerTestHelper(BondTypes.DOUBLE, 3.14);
+
+        genericNullableContainerTestHelper(MonthOfYear.BOND_TYPE, MonthOfYear.August);
+        genericNullableContainerTestHelper(MonthOfYear.BOND_TYPE, MonthOfYear.get(100));
+
+        Empty empty = new Empty();
+        genericNullableContainerTestHelper(Empty.BOND_TYPE, empty);
+
+        Derived derived = new Derived();
+        derived.baseInt = 123;
+        derived.derivedInt = 456;
+        genericNullableContainerTestHelper(Derived.BOND_TYPE, derived);
+    }
+
+    private static <T> void genericNullableContainerTestHelper(BondType<T> elementBondType, T elementValue) {
+        StructBondType<GenericNullableContainer<T>> containerBondType =
+                GenericNullableContainer.BOND_TYPE.makeGenericType(elementBondType);
+        GenericNullableContainer<T> container = new GenericNullableContainer<T>(containerBondType);
+        Assert.assertEquals(null, container.nullableField);
+        container.nullableField = elementValue;
+        Assert.assertEquals(elementValue, container.nullableField);
+        marshalUnmarshalAndCompareUsingMultipleProtocols(container);
+    }
+
+    @Test
+    public void testGenericVectorContainer() {
+        genericVectorContainerTestHelper(BondTypes.STRING, "test");
+        genericVectorContainerTestHelper(BondTypes.BOOL, true);
+        genericVectorContainerTestHelper(BondTypes.INT8, (byte)1);
+        genericVectorContainerTestHelper(BondTypes.INT32, Integer.MIN_VALUE);
+        genericVectorContainerTestHelper(BondTypes.UINT64, Long.MAX_VALUE);
+        genericVectorContainerTestHelper(BondTypes.DOUBLE, 3.14);
+
+        genericVectorContainerTestHelper(MonthOfYear.BOND_TYPE, MonthOfYear.August);
+        genericVectorContainerTestHelper(MonthOfYear.BOND_TYPE, MonthOfYear.get(100));
+
+        Empty empty = new Empty();
+        genericVectorContainerTestHelper(Empty.BOND_TYPE, empty);
+
+        Derived derived = new Derived();
+        derived.baseInt = 123;
+        derived.derivedInt = 456;
+        genericVectorContainerTestHelper(Derived.BOND_TYPE, derived);
+    }
+
+    private static <T> void genericVectorContainerTestHelper(BondType<T> elementBondType, T elementValue) {
+        StructBondType<GenericVectorContainer<T>> containerBondType =
+                GenericVectorContainer.BOND_TYPE.makeGenericType(elementBondType);
+        GenericVectorContainer<T> container = new GenericVectorContainer<T>(containerBondType);
+        Assert.assertEquals(0, container.vectorField.size());
+        container.vectorField.add(elementValue);
+        Assert.assertEquals(1, container.vectorField.size());
+        Assert.assertEquals(elementValue, container.vectorField.get(0));
+        marshalUnmarshalAndCompareUsingMultipleProtocols(container);
+    }
+
+    @Test
+    public void testGenericListContainer() {
+        genericListContainerTestHelper(BondTypes.STRING, "test");
+        genericListContainerTestHelper(BondTypes.BOOL, true);
+        genericListContainerTestHelper(BondTypes.INT8, (byte)1);
+        genericListContainerTestHelper(BondTypes.INT32, Integer.MIN_VALUE);
+        genericListContainerTestHelper(BondTypes.UINT64, Long.MAX_VALUE);
+        genericListContainerTestHelper(BondTypes.DOUBLE, 3.14);
+
+        genericListContainerTestHelper(MonthOfYear.BOND_TYPE, MonthOfYear.August);
+        genericListContainerTestHelper(MonthOfYear.BOND_TYPE, MonthOfYear.get(100));
+
+        Empty empty = new Empty();
+        genericListContainerTestHelper(Empty.BOND_TYPE, empty);
+
+        Derived derived = new Derived();
+        derived.baseInt = 123;
+        derived.derivedInt = 456;
+        genericListContainerTestHelper(Derived.BOND_TYPE, derived);
+    }
+
+    private static <T> void genericListContainerTestHelper(BondType<T> elementBondType, T elementValue) {
+        StructBondType<GenericListContainer<T>> containerBondType =
+                GenericListContainer.BOND_TYPE.makeGenericType(elementBondType);
+        GenericListContainer<T> container = new GenericListContainer<T>(containerBondType);
+        Assert.assertEquals(0, container.listField.size());
+        container.listField.add(elementValue);
+        Assert.assertEquals(1, container.listField.size());
+        Assert.assertEquals(elementValue, container.listField.get(0));
+        marshalUnmarshalAndCompareUsingMultipleProtocols(container);
+    }
+
+    @Test
+    public void testGenericSetContainer() {
+        genericSetContainerTestHelper(BondTypes.STRING, "test");
+        genericSetContainerTestHelper(BondTypes.BOOL, true);
+        genericSetContainerTestHelper(BondTypes.INT8, (byte)1);
+        genericSetContainerTestHelper(BondTypes.INT32, Integer.MIN_VALUE);
+        genericSetContainerTestHelper(BondTypes.UINT64, Long.MAX_VALUE);
+        genericSetContainerTestHelper(BondTypes.DOUBLE, 3.14);
+
+        genericSetContainerTestHelper(MonthOfYear.BOND_TYPE, MonthOfYear.August);
+        genericSetContainerTestHelper(MonthOfYear.BOND_TYPE, MonthOfYear.get(100));
+    }
+
+    private static <T> void genericSetContainerTestHelper(BondType<T> elementBondType, T elementValue) {
+        StructBondType<GenericSetContainer<T>> containerBondType =
+                GenericSetContainer.BOND_TYPE.makeGenericType(elementBondType);
+        GenericSetContainer<T> container = new GenericSetContainer<T>(containerBondType);
+        Assert.assertEquals(0, container.setField.size());
+        container.setField.add(elementValue);
+        Assert.assertEquals(1, container.setField.size());
+        Assert.assertTrue(container.setField.contains(elementValue));
+        marshalUnmarshalAndCompareUsingMultipleProtocols(container);
+    }
+
+    @Test
+    public void testGenericSetContainerWithInvalidElementType() {
+        try {
+            StructBondType<GenericSetContainer<Derived>> containerBondType =
+                    GenericSetContainer.BOND_TYPE.makeGenericType(Derived.BOND_TYPE);
+            Assert.fail("Bond type must not be created");
+        } catch (IllegalArgumentException e) {
+            // success
+        }
+
+        try {
+            StructBondType<GenericSetContainer<List<Integer>>> containerBondType =
+                    GenericSetContainer.BOND_TYPE.makeGenericType(BondType.listOf(BondTypes.INT32));
+            Assert.fail("Bond type must not be created");
+        } catch (IllegalArgumentException e) {
+            // success
+        }
+
+        try {
+            StructBondType<GenericSetContainer<Integer>> containerBondType =
+                    GenericSetContainer.BOND_TYPE.makeGenericType(BondType.nullableOf(BondTypes.INT32));
+            Assert.fail("Bond type must not be created");
+        } catch (IllegalArgumentException e) {
+            // success
+        }
+    }
+
+    @Test
+    public void testGenericMapContainer() {
+        genericMapContainerTestHelper(BondTypes.STRING, "test");
+        genericMapContainerTestHelper(BondTypes.BOOL, true);
+        genericMapContainerTestHelper(BondTypes.INT8, (byte)1);
+        genericMapContainerTestHelper(BondTypes.INT32, Integer.MIN_VALUE);
+        genericMapContainerTestHelper(BondTypes.UINT64, Long.MAX_VALUE);
+        genericMapContainerTestHelper(BondTypes.DOUBLE, 3.14);
+
+        genericMapContainerTestHelper(MonthOfYear.BOND_TYPE, MonthOfYear.August);
+        genericMapContainerTestHelper(MonthOfYear.BOND_TYPE, MonthOfYear.get(100));
+    }
+
+    private static <T> void genericMapContainerTestHelper(BondType<T> elementBondType, T elementValue) {
+        StructBondType<GenericMapContainer<T>> containerBondType =
+                GenericMapContainer.BOND_TYPE.makeGenericType(elementBondType);
+        GenericMapContainer<T> container = new GenericMapContainer<T>(containerBondType);
+        Assert.assertEquals(0, container.mapField.size());
+        container.mapField.put(elementValue, elementValue);
+        Assert.assertEquals(1, container.mapField.size());
+        Assert.assertTrue(container.mapField.containsKey(elementValue));
+        Assert.assertTrue(container.mapField.containsValue(elementValue));
+        marshalUnmarshalAndCompareUsingMultipleProtocols(container);
+    }
+
+    @Test
+    public void testGenericMapContainerWithInvalidKeyType() {
+        try {
+            StructBondType<GenericMapContainer<Derived>> containerBondType =
+                    GenericMapContainer.BOND_TYPE.makeGenericType(Derived.BOND_TYPE);
+            Assert.fail("Bond type must not be created");
+        } catch (IllegalArgumentException e) {
+            // success
+        }
+
+        try {
+            StructBondType<GenericMapContainer<List<Integer>>> containerBondType =
+                    GenericMapContainer.BOND_TYPE.makeGenericType(BondType.listOf(BondTypes.INT32));
+            Assert.fail("Bond type must not be created");
+        } catch (IllegalArgumentException e) {
+            // success
+        }
+
+        try {
+            StructBondType<GenericMapContainer<Integer>> containerBondType =
+                    GenericMapContainer.BOND_TYPE.makeGenericType(BondType.nullableOf(BondTypes.INT32));
+            Assert.fail("Bond type must not be created");
+        } catch (IllegalArgumentException e) {
+            // success
+        }
+    }
+
+    @Test
+    public void testGenericBondedContainer() {
+        Empty empty = new Empty();
+        genericBondedContainerTestHelper(Empty.BOND_TYPE, empty);
+
+        Derived derived = new Derived();
+        derived.baseInt = 123;
+        derived.derivedInt = 456;
+        genericBondedContainerTestHelper(Derived.BOND_TYPE, derived);
+    }
+
+    private static <T extends BondSerializable> void genericBondedContainerTestHelper(
+            StructBondType<T> elementBondType, T elementValue) {
+        StructBondType<GenericBondedContainer<T>> containerBondType =
+                GenericBondedContainer.BOND_TYPE.makeGenericType(elementBondType);
+        GenericBondedContainer<T> container = new GenericBondedContainer<T>(containerBondType);
+        try {
+            Assert.assertEquals(elementBondType.newDefaultValue(), container.bondedField.deserialize());
+            container.bondedField = Bonded.fromObject(elementValue, elementBondType);
+            Assert.assertEquals(elementValue, container.bondedField.deserialize());
+            // can't compare marshal/unmarshal results due to lack of proper Bonded.equals
+            // TODO: implement a way to compare bonded fields and use it in this method
+        } catch (IOException e) {
+            Assert.fail(e.toString());
+        }
+    }
+
+    @Test
+    public void testGenericBondedContainerWithInvalidValueType() {
+        try {
+            StructBondType<GenericBondedContainer<Integer>> containerBondType =
+                    GenericBondedContainer.BOND_TYPE.makeGenericType(BondTypes.INT32);
+            Assert.fail("Bond type must not be created");
+        } catch (IllegalArgumentException e) {
+            // success
+        }
+
+        try {
+            StructBondType<GenericBondedContainer<List<Integer>>> containerBondType =
+                    GenericBondedContainer.BOND_TYPE.makeGenericType(BondType.listOf(BondTypes.INT32));
+            Assert.fail("Bond type must not be created");
+        } catch (IllegalArgumentException e) {
+            // success
+        }
+
+        try {
+            StructBondType<GenericMapContainer<Integer>> containerBondType =
+                    GenericMapContainer.BOND_TYPE.makeGenericType(BondType.nullableOf(BondTypes.INT32));
+            Assert.fail("Bond type must not be created");
+        } catch (IllegalArgumentException e) {
+            // success
+        }
+    }
+
+    private static void marshalUnmarshalAndCompareUsingMultipleProtocols(BondSerializable obj) {
+        try {
+            TestHelper.marshalUnmarshalAndCompare(obj, ProtocolType.FAST_PROTOCOL, 1);
+            TestHelper.marshalUnmarshalAndCompare(obj, ProtocolType.COMPACT_PROTOCOL, 1);
+            TestHelper.marshalUnmarshalAndCompare(obj, ProtocolType.COMPACT_PROTOCOL, 2);
+            TestHelper.marshalUnmarshalAndCompare(obj, ProtocolType.SIMPLE_PROTOCOL, 1);
+            TestHelper.marshalUnmarshalAndCompare(obj, ProtocolType.SIMPLE_PROTOCOL, 2);
+        } catch (IOException e) {
+            // shouldn't happen
+            Assert.fail(e.toString());
+        }
+    }
+}


### PR DESCRIPTION
In this change:

1. Fixed generic type parameters for set/map and bonded containers.
2. Added tests for the above, as well as testing generic containers in general.
3. Added a unit test helper to marshal/unmarshal and compare results. This is currently broken for Bonded due to lack of proper test for equality.
4. Identified and fixed a bug in EnumBondType triggered when a generic Enum type parameter was serialized

The fix for generic type parameters doesn't require any codegen changes. It involves overloading setOf/mapOf/bondedOf methods to take plain BondType (instead of PrimitiveBondType or StructBondType), which is what generated code will call from now on. The methods are protected since they are intended for generated code use only. The original public methods are unmodified and should be used when the user needs to create a set/map/bonded Bond Type explicitly (in which case the user must make sure the element constraint is satisfied and pass PrimitiveBondType for set/map or StructBondType for bonded).