### PR TITLE
c++ clang: Compile -Wno-null-dereference.

### DIFF
--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -152,6 +152,7 @@ cxx_add_compile_options(Clang
     --std=c++11
     -Wall
     -Werror
+    -Wno-null-dereference
     -Wno-unknown-warning-option
     -Wno-unused-local-typedefs)
 
@@ -161,6 +162,7 @@ cxx_add_compile_options(AppleClang
     --std=c++11
     -Wall
     -Werror
+    -Wno-null-dereference
     -Wno-unknown-warning-option
     -Wno-unused-local-typedefs)
 


### PR DESCRIPTION
#536 is now breaking travis CI. The right answer is probably a change to the underlying code, but this will suppress what are, for now, spurious build failures.