### PR TITLE
[c++] Switch to std::to_string in string_stream

### DIFF
--- a/cpp/inc/bond/core/detail/string_stream.h
+++ b/cpp/inc/bond/core/detail/string_stream.h
@@ -13,7 +13,7 @@ namespace bond
 
 namespace detail
 {
-    
+
 template<uint16_t Size, typename Allocator = std::allocator<char> >
 class basic_string_stream
 {
@@ -32,7 +32,7 @@ public:
     }
 
     basic_string_stream& operator<<(const char* str)
-    {        
+    {
         while (*str)
         {
             write(*str++);
@@ -54,67 +54,10 @@ public:
         return *this;
     }
 
-    basic_string_stream& operator<<(int value)
+    template <typename T>
+    basic_string_stream& operator<<(const T& value)
     {
-        char str[256];
-        *str = '\0';
-
-        ::sprintf(str, "%d", value);
-        return *this << str;
-    }
-
-    basic_string_stream& operator<<(unsigned int value)
-    {
-        char str[256];
-        *str = '\0';
-
-        ::sprintf(str, "%u", value);
-        return *this << str;
-    }
-
-    basic_string_stream& operator<<(long value)
-    {
-        char str[256];
-        *str = '\0';
-
-        ::sprintf(str, "%ld", value);
-        return *this << str;
-    }
-
-    basic_string_stream& operator<<(unsigned long value)
-    {
-        char str[256];
-        *str = '\0';
-
-        ::sprintf(str, "%lu", value);
-        return *this << str;
-    }
-
-    basic_string_stream& operator<<(long long value)
-    {
-        char str[256];
-        *str = '\0';
-
-        ::sprintf(str, "%lld", value);
-        return *this << str;
-    }
-
-    basic_string_stream& operator<<(unsigned long long value)
-    {
-        char str[256];
-        *str = '\0';
-        
-        ::sprintf(str, "%llu", value);
-        return *this << str;
-    }
-
-    basic_string_stream& operator<<(double value)
-    {
-        char str[256];
-        *str = '\0';
-
-        ::sprintf(str, "%f", value);
-        return *this << str;
+        return *this << std::to_string(value);
     }
 
     std::string str() const
@@ -127,7 +70,7 @@ public:
         return &buffer[0];
     }
 
-private:    
+private:
     void write(char ch)
     {
         buffer.back() = ch;
@@ -137,12 +80,12 @@ private:
     template<typename I>
     void write(I begin, I end)
     {
-        for ( ; begin != end; ++begin) 
+        for ( ; begin != end; ++begin)
         {
             write(*begin);
         }
     }
-    
+
     std::vector<char, Allocator> buffer;
 };
 


### PR DESCRIPTION
When using MSVC, even with _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES and
_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT enabled, sometimes the
non-sprint_s overload is chosen when a stack buffer is used (the
array-to-pointer decay and the array-of-size-N template are competing
with each other, and the char* overload wins instead of the template).

To avoid, switch to using std::to_string to format things in the
string_stream that is used to compute exception messages.