### PR TITLE
[c++] Suppress MSVC warning 4310 locally

### DIFF
--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -1,6 +1,3 @@
-# warning C4310: cast truncates constant value
-cxx_add_compile_options(MSVC /wd4310)
-
 # Core unit tests don't build under VS2013 without this.
 cxx_add_compile_options(MSVC /EHa)
 

--- a/cpp/test/compat/core/serialization.cpp
+++ b/cpp/test/compat/core/serialization.cpp
@@ -52,12 +52,25 @@ void Init(std::list<T>& x)
     }
     else
     {
+#ifdef _MSC_VER
+    #pragma warning (push)
+    // warning C4310: cast truncates constant value
+    //
+    // There are golden data files with the truncated values, so we need to
+    // truncate when T is not large enough for the value.
+    #pragma warning (disable: 4310)
+#endif
+
         static std::vector<T> constants = boost::assign::list_of
             ((T)-1)((T)0)((T)1)((T)2)((T)3)((T)4)((T)5)((T)6)((T)7)((T)8)((T)9)
             ((T)SCHAR_MAX)((T)SCHAR_MIN)((T)UCHAR_MAX)
             ((T)SHRT_MIN)((T)SHRT_MAX)((T)USHRT_MAX)
             ((T)INT_MIN)((T)INT_MAX)((T)UINT_MAX)
             ((T)LLONG_MAX)((T)LLONG_MIN)((T)ULLONG_MAX);
+
+#ifdef _MSC_VER
+    #pragma warning (pop)
+#endif
 
         std::copy(constants.begin(), constants.end(), std::back_inserter(x));
     }

--- a/cpp/test/core/unit_test_util.h
+++ b/cpp/test/core/unit_test_util.h
@@ -26,13 +26,13 @@ using boost::mpl::_;
 typedef boost::mpl::list
     <
 #ifndef UNIT_TEST_TYPE_SUBSET
-        uint8_t, uint16_t, uint32_t, uint64_t, 
+        uint8_t, uint16_t, uint32_t, uint64_t,
         int8_t,   int16_t,  int32_t,  int64_t,
         bool, float, double
 #else
         int32_t, double
 #endif
-    > 
+    >
     NumericTypes;
 
 typedef boost::mpl::list
@@ -47,8 +47,8 @@ typedef boost::mpl::list
 typedef boost::mpl::copy
     <
         StringTypes,
-        boost::mpl::front_inserter<NumericTypes> 
-    >::type 
+        boost::mpl::front_inserter<NumericTypes>
+    >::type
     SortableTypes;
 
 typedef boost::mpl::push_front
@@ -65,7 +65,7 @@ struct ListTypes
     typedef boost::mpl::list
     <
 #ifndef UNIT_TEST_TYPE_SUBSET
-        list<T>, 
+        list<T>,
         vector<T>
 #else
         vector<T>
@@ -80,12 +80,12 @@ struct SkipTypes
     typedef boost::mpl::list
     <
 #ifndef UNIT_TEST_TYPE_SUBSET
-        BondStruct<T>, 
+        BondStruct<T>,
         vector<list<T> >,
         //list<T>,
         set<T>,
-        map<string, T>, 
-        //BondStruct<list<T> >, 
+        map<string, T>,
+        //BondStruct<list<T> >,
         bond::nullable<T>,
         bond::nullable<BondStruct<T> >,
         vector<BondStruct<list<T> > >
@@ -112,19 +112,29 @@ is_protocols<bond::BuiltInProtocols>
 template <typename T>
 const std::vector<T>& IntegerConstants()
 {
+#ifdef _MSC_VER
+    #pragma warning (push)
+    // warning C4310: cast truncates constant value
+    #pragma warning (disable: 4310)
+#endif
+
     static std::vector<T> constants = boost::assign::list_of
         ((T)-1)((T)0)((T)1)((T)2)((T)3)((T)4)((T)5)((T)6)((T)7)((T)8)((T)9)
         ((T)SCHAR_MAX)((T)SCHAR_MIN)((T)UCHAR_MAX)
-        ((T)SHRT_MIN)((T)SHRT_MAX)((T)USHRT_MAX)  
-        ((T)INT_MIN)((T)INT_MAX)((T)UINT_MAX)     
+        ((T)SHRT_MIN)((T)SHRT_MAX)((T)USHRT_MAX)
+        ((T)INT_MIN)((T)INT_MAX)((T)UINT_MAX)
         ((T)LLONG_MAX)((T)LLONG_MIN)((T)ULLONG_MAX);
+
+#ifdef _MSC_VER
+    #pragma warning (pop)
+#endif
 
     return constants;
 }
 
 
 // CreateSelfMappings creates mappings compatible with MapTo<T> transform
-// for every field of the specified bond structure. 
+// for every field of the specified bond structure.
 template <typename Protocols>
 class CreateSelfMappings
     : public bond::SerializingTransform
@@ -172,7 +182,7 @@ public:
         _path.push_back(id);
         bond::Apply<Protocols>(CreateSelfMappings(_mappings[id].fields, _path), value);
         _path.pop_back();
-        
+
         return false;
     }
 
@@ -182,7 +192,7 @@ public:
         _path.push_back(id);
         _mappings[id].path = _path;
         _path.pop_back();
-        
+
         return false;
     }
 
@@ -265,7 +275,7 @@ template <typename Reader, typename Writer, typename Protocols = bond::BuiltInPr
 Reader Serialize(const T& x, uint16_t version = bond::v1)
 {
     typename Writer::Buffer output_buffer(4096);
-    
+
     // serialize value to output
     Factory<Writer>::Call(output_buffer, version, boost::bind(
         bond::Serialize<Protocols, T, Writer>, x, _1));
@@ -302,7 +312,7 @@ Reader Merge(const Payload& payload, const T& x, uint16_t version = bond::v1)
         bond::Merge<Protocols, T, Reader, Writer>, x, Serialize<Reader, Writer, Protocols>(payload, version), _1));
 
     typename Reader::Buffer input_buffer(output_buffer.GetBuffer());
-    
+
     return Factory<Reader>::Create(input_buffer, version);
  }
 
@@ -321,7 +331,7 @@ void InitRandom(T& x, uint32_t max_string_length = c_max_string_length, uint32_t
     // we transcode from Random protocol to Fast protocol and then deserialize
     // the Fast protocol payload into the instance of T. This obvioulsy take longer
     // at runtime, but it compiles faster; build time is the bottleneck for unit tests.
-    
+
     bond::RandomProtocolReader                      random_reader(max_string_length, max_list_size);
     bond::bonded<void, bond::RandomProtocolReader&> random(random_reader, bond::GetRuntimeSchema<T>());
 
@@ -368,12 +378,12 @@ is_optional_field
 
 template <typename Protocols = bond::BuiltInProtocols, typename T>
 void CopyAndMove(const T& src)
-{        
+{
     T x(src);
     UT_Equal_P(x, src, Protocols);
 
 #ifndef BOND_NO_CXX11_RVALUE_REFERENCES
-    T y(std::move(x)); 
+    T y(std::move(x));
     UT_Equal_P(y, src, Protocols);
     UT_AssertIsTrue(moved(x));
 #endif
@@ -383,7 +393,7 @@ void CopyAndMove(const T& src)
 template <typename Reader, typename Writer, typename From, typename To, typename BondedType, typename Protocols = bond::BuiltInProtocols>
 void Binding(const From& from, uint16_t version = bond::v1)
 {
-    BOOST_STATIC_ASSERT((std::is_same<BondedType, From>::value 
+    BOOST_STATIC_ASSERT((std::is_same<BondedType, From>::value
                       || !bond::uses_static_parser<Reader>::value));
 
     // Compile-time schema
@@ -463,9 +473,9 @@ template <typename Reader, typename Writer, typename From, typename To, typename
 void Mapping(const From& from, uint16_t version = bond::v1)
 {
 #ifdef UNIT_TEST_MAPPING
-    BOOST_STATIC_ASSERT((std::is_same<BondedType, From>::value 
+    BOOST_STATIC_ASSERT((std::is_same<BondedType, From>::value
                       || !bond::uses_static_parser<Reader>::value));
-    
+
     bond::Mappings mappings;
 
     InitMappings<To, BondedType>(mappings);
@@ -475,7 +485,7 @@ void Mapping(const From& from, uint16_t version = bond::v1)
         bond::bonded<BondedType> bonded(GetBonded<Reader, Writer, BondedType, Protocols>(from, version));
 
         To to;
-        
+
         if (boost::mpl::count_if<From::Schema::fields, is_optional_field<_> >::value == 0)
         {
             to = InitRandom<To, Protocols>();
@@ -492,7 +502,7 @@ void Mapping(const From& from, uint16_t version = bond::v1)
         bond::bonded<void> bonded(GetBonded<Reader, Writer, BondedType, Protocols>(from, version));
 
         To to;
-        
+
         if (boost::mpl::count_if<From::Schema::fields, is_optional_field<_> >::value == 0)
         {
             to = InitRandom<To, Protocols>();
@@ -516,7 +526,7 @@ void AllBinding()
     // default value
     Binding<Reader, Writer, From, To, BondedType, Protocols>(From());
     Binding<Reader, Writer, From, To, BondedType, Protocols>(From(), Reader::version);
-    
+
     // random values
     for (uint32_t i = 0; i < c_iterations; ++i)
     {
@@ -532,7 +542,7 @@ void AllMapping()
     // default value
     Mapping<Reader, Writer, From, To, BondedType, Protocols>(From());
     Mapping<Reader, Writer, From, To, BondedType, Protocols>(From(), Reader::version);
-    
+
     // random values
     for (uint32_t i = 0; i < c_iterations; ++i)
     {
@@ -548,7 +558,7 @@ BindingAndMapping(const From& from)
 {
     Binding<Reader, Writer, From, To, From, Protocols>(from);
     Mapping<Reader, Writer, From, To, From, Protocols>(from);
-    
+
     // For dynamic parser the schema doesn't have to exactly match the payload
     Binding<Reader, Writer, From, To, To, Protocols>(from);
     Mapping<Reader, Writer, From, To, To, Protocols>(from);
@@ -579,7 +589,7 @@ AllBindingAndMapping()
 {
     AllBinding<Reader, Writer, From, To, From, Protocols>();
     AllMapping<Reader, Writer, From, To, From, Protocols>();
-    
+
     // For dynamic parser the schema doesn't have to exactly match the payload
     AllBinding<Reader, Writer, From, To, To, Protocols>();
     AllMapping<Reader, Writer, From, To, To, Protocols>();
@@ -610,7 +620,7 @@ AllBindingAndMapping()
 {
     // This function is noop for static parser.
     // Calling it with BondedType equal to From or To is most likely unintended
-    BOOST_STATIC_ASSERT((!std::is_same<BondedType, From>::value 
+    BOOST_STATIC_ASSERT((!std::is_same<BondedType, From>::value
                       && !std::is_same<BondedType, To>::value));
 }
 


### PR DESCRIPTION
Instead of suppressing warning C4310 on the command line, we now
suppress it just where we need the truncation behavior.