### PR TITLE
[c++] Use boost::format instead of sprintf in tests

### DIFF
--- a/cpp/test/core/metadata_tests.cpp
+++ b/cpp/test/core/metadata_tests.cpp
@@ -1,6 +1,7 @@
 #include "precompiled.h"
 #include "metadata_tests.h"
 
+#include <boost/format.hpp>
 
 class DefaultValueVerifier
     : public bond::SerializingTransform
@@ -111,10 +112,9 @@ public:
 
     void Begin(const bond::Metadata& metadata) const
     {
-        char name[100], qualified_name[100];
-
-        sprintf(name, "%sWithMetadata", _name);
-        sprintf(qualified_name, "unittest.%sWithMetadata", _name);
+        std::string name = boost::str(boost::format("%sWithMetadata") % _name);
+        std::string qualified_name =
+            boost::str(boost::format("unittest.%sWithMetadata") % _name);
 
         UT_AssertIsTrue(metadata.name == name);
         UT_AssertIsTrue(metadata.qualified_name == qualified_name);
@@ -144,9 +144,8 @@ public:
     bool Field(uint16_t id, const bond::Metadata& metadata, const T& value) const
     {
         bond::Metadata  metadata_copy = metadata;
-        char            name[100];
 
-        sprintf(name, "%s%u", _name, id);
+        std::string name = boost::str(boost::format("%s%u") % _name % id);
 
         UT_AssertIsTrue(metadata_copy.name == name);
         UT_AssertIsTrue(metadata_copy.name == metadata_copy.attributes["field_name"]);
@@ -306,4 +305,3 @@ bool init_unit_test()
     MetadataTest::Initialize();
     return true;
 }
-

--- a/cpp/test/core/unit_test_framework.h
+++ b/cpp/test/core/unit_test_framework.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <boost/format.hpp>
 #include <boost/version.hpp>
 #include <boost/test/unit_test.hpp>
 
-#define UT_AssertIsTrue(...) BOOST_CHECK((__VA_ARGS__)) 
+#define UT_AssertIsTrue(...) BOOST_CHECK((__VA_ARGS__))
 
 #define UT_AssertIsFalse(...) BOOST_CHECK(!(__VA_ARGS__))
 
@@ -49,7 +50,7 @@
 // parameters) which in turn let's us disable individual test cases at compile
 // time such that they are not compiled at all.
 // The drawback is that we need to wrap test case definition in two macros (one
-// macro would be enough for non-generic tests but not for generic ones). 
+// macro would be enough for non-generic tests but not for generic ones).
 #define TEST_CASE_BEGIN(name) struct name{static void Run()
 #define TEST_CASE_END };
 
@@ -61,7 +62,7 @@
 // Test cases can be also defined conditionally based on a compile-time boolean
 // constant (usually derived from a condition on type parameters).
 #define KEY(x) ((x << 16) | __COUNTER__)
-#define TEST_ID(x) (true),KEY(x) 
+#define TEST_ID(x) (true),KEY(x)
 #define COND_TEST_ID(x, cond) (cond),KEY(x)
 
 #ifndef ENABLE_TEST_CASE
@@ -90,9 +91,9 @@ public:
 
     void Add(void (*func)(), uint32_t key, const std::string& test)
     {
-        char id[20];    
-        sprintf(id, "0x%x ", key);
-        AddTestCase(func, id + test);
+        AddTestCase(
+            func,
+            boost::str(boost::format("%#x %s") % key % test));
     }
 
     void AddTestCase(void (*func)(), const std::string& test)
@@ -100,7 +101,7 @@ public:
         if (!suite)
         {
             suite = BOOST_TEST_SUITE(name);
-            parent.add(suite);    
+            parent.add(suite);
         }
 
         suite->add(MAKE_BOOST_TEST_CASE(func, test));


### PR DESCRIPTION
When using MSVC, even with _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES and
_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT enabled, sometimes the
non-sprint_s overload is chosen when a stack buffer is used (the
array-to-pointer decay and the array-of-size-N template are competing
with each other, and the char* overload wins instead of the template).

To avoid, switch to using boost::format to format string in tests.