### PR TITLE
[Java] Replaced field/struct metadata interfaces with SchemaDef's metadata

### DIFF
--- a/java/core/src/main/java/org/bondlib/BlobBondType.java
+++ b/java/core/src/main/java/org/bondlib/BlobBondType.java
@@ -123,9 +123,9 @@ public final class BlobBondType extends BondType<Blob> {
             StructBondType.StructField<Blob> field) throws IOException {
         this.verifySerializedNonNullableFieldIsNotSetToNull(value, field);
         if (value.getData().length == 0 && field.isOptional()) {
-            context.writer.writeFieldOmitted(BondDataType.BT_LIST, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_LIST, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_LIST, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_LIST, field.getId(), field.getFieldDef().metadata);
             try {
                 this.serializeValue(context, value);
             } catch (InvalidBondDataException e) {

--- a/java/core/src/main/java/org/bondlib/BondedBondType.java
+++ b/java/core/src/main/java/org/bondlib/BondedBondType.java
@@ -143,7 +143,7 @@ public final class BondedBondType<TStruct extends BondSerializable> extends Bond
             Bonded<TStruct> value,
             StructBondType.StructField<Bonded<TStruct>> field) throws IOException {
         // struct (bonded) fields are never omitted
-        context.writer.writeFieldBegin(BondDataType.BT_STRUCT, field.getId(), field);
+        context.writer.writeFieldBegin(BondDataType.BT_STRUCT, field.getId(), field.getFieldDef().metadata);
         try {
             this.serializeValue(context, value);
         } catch (InvalidBondDataException e) {

--- a/java/core/src/main/java/org/bondlib/BoolBondType.java
+++ b/java/core/src/main/java/org/bondlib/BoolBondType.java
@@ -148,9 +148,9 @@ public final class BoolBondType extends PrimitiveBondType<Boolean> {
             boolean value,
             StructBondType.StructField<Boolean> field) throws IOException {
         if (!field.isDefaultNothing() && field.isOptional() && (value == field.getDefaultValue())) {
-            context.writer.writeFieldOmitted(BondDataType.BT_BOOL, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_BOOL, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_BOOL, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_BOOL, field.getId(), field.getFieldDef().metadata);
             context.writer.writeBool(value);
             context.writer.writeFieldEnd();
         }

--- a/java/core/src/main/java/org/bondlib/DoubleBondType.java
+++ b/java/core/src/main/java/org/bondlib/DoubleBondType.java
@@ -151,9 +151,9 @@ public final class DoubleBondType extends PrimitiveBondType<Double> {
             StructBondType.StructField<Double> field) throws IOException {
         if (!field.isDefaultNothing() && field.isOptional() &&
                 FloatingPointHelper.doubleEquals(value, field.getDefaultValue())) {
-            context.writer.writeFieldOmitted(BondDataType.BT_DOUBLE, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_DOUBLE, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_DOUBLE, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_DOUBLE, field.getId(), field.getFieldDef().metadata);
             context.writer.writeDouble(value);
             context.writer.writeFieldEnd();
         }

--- a/java/core/src/main/java/org/bondlib/EnumBondType.java
+++ b/java/core/src/main/java/org/bondlib/EnumBondType.java
@@ -83,9 +83,9 @@ public abstract class EnumBondType<TEnum extends BondEnum<TEnum>> extends Primit
         int intValueToSerialize = value.getValue();
         if (!field.isDefaultNothing() && field.isOptional() &&
                 intValueToSerialize == field.getDefaultValue().getValue()) {
-            context.writer.writeFieldOmitted(BondDataType.BT_INT32, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_INT32, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_INT32, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_INT32, field.getId(), field.getFieldDef().metadata);
             context.writer.writeInt32(intValueToSerialize);
             context.writer.writeFieldEnd();
         }

--- a/java/core/src/main/java/org/bondlib/FloatBondType.java
+++ b/java/core/src/main/java/org/bondlib/FloatBondType.java
@@ -151,9 +151,9 @@ public final class FloatBondType extends PrimitiveBondType<Float> {
             StructBondType.StructField<Float> field) throws IOException {
         if (!field.isDefaultNothing() && field.isOptional() &&
                 FloatingPointHelper.floatEquals(value, field.getDefaultValue())) {
-            context.writer.writeFieldOmitted(BondDataType.BT_FLOAT, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_FLOAT, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_FLOAT, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_FLOAT, field.getId(), field.getFieldDef().metadata);
             context.writer.writeFloat(value);
             context.writer.writeFieldEnd();
         }

--- a/java/core/src/main/java/org/bondlib/Int16BondType.java
+++ b/java/core/src/main/java/org/bondlib/Int16BondType.java
@@ -148,9 +148,9 @@ public final class Int16BondType extends PrimitiveBondType<Short> {
             short value,
             StructBondType.StructField<Short> field) throws IOException {
         if (!field.isDefaultNothing() && field.isOptional() && (value == field.getDefaultValue())) {
-            context.writer.writeFieldOmitted(BondDataType.BT_INT16, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_INT16, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_INT16, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_INT16, field.getId(), field.getFieldDef().metadata);
             context.writer.writeInt16(value);
             context.writer.writeFieldEnd();
         }

--- a/java/core/src/main/java/org/bondlib/Int32BondType.java
+++ b/java/core/src/main/java/org/bondlib/Int32BondType.java
@@ -148,9 +148,9 @@ public final class Int32BondType extends PrimitiveBondType<Integer> {
             int value,
             StructBondType.StructField<Integer> field) throws IOException {
         if (!field.isDefaultNothing() && field.isOptional() && (value == field.getDefaultValue())) {
-            context.writer.writeFieldOmitted(BondDataType.BT_INT32, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_INT32, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_INT32, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_INT32, field.getId(), field.getFieldDef().metadata);
             context.writer.writeInt32(value);
             context.writer.writeFieldEnd();
         }

--- a/java/core/src/main/java/org/bondlib/Int64BondType.java
+++ b/java/core/src/main/java/org/bondlib/Int64BondType.java
@@ -148,9 +148,9 @@ public final class Int64BondType extends PrimitiveBondType<Long> {
             long value,
             StructBondType.StructField<Long> field) throws IOException {
         if (!field.isDefaultNothing() && field.isOptional() && (value == field.getDefaultValue())) {
-            context.writer.writeFieldOmitted(BondDataType.BT_INT64, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_INT64, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_INT64, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_INT64, field.getId(), field.getFieldDef().metadata);
             context.writer.writeInt64(value);
             context.writer.writeFieldEnd();
         }

--- a/java/core/src/main/java/org/bondlib/Int8BondType.java
+++ b/java/core/src/main/java/org/bondlib/Int8BondType.java
@@ -148,9 +148,9 @@ public final class Int8BondType extends PrimitiveBondType<Byte> {
             byte value,
             StructBondType.StructField<Byte> field) throws IOException {
         if (!field.isDefaultNothing() && field.isOptional() && (value == field.getDefaultValue())) {
-            context.writer.writeFieldOmitted(BondDataType.BT_INT8, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_INT8, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_INT8, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_INT8, field.getId(), field.getFieldDef().metadata);
             context.writer.writeInt8(value);
             context.writer.writeFieldEnd();
         }

--- a/java/core/src/main/java/org/bondlib/ListBondType.java
+++ b/java/core/src/main/java/org/bondlib/ListBondType.java
@@ -174,9 +174,9 @@ public final class ListBondType<TElement> extends BondType<List<TElement>> {
         this.verifySerializedNonNullableFieldIsNotSetToNull(value, field);
         final int count = value.size();
         if (!field.isDefaultNothing() && count == 0 && field.isOptional()) {
-            context.writer.writeFieldOmitted(BondDataType.BT_LIST, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_LIST, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_LIST, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_LIST, field.getId(), field.getFieldDef().metadata);
             try {
                 this.serializeValue(context, value);
             } catch (InvalidBondDataException e) {

--- a/java/core/src/main/java/org/bondlib/MapBondType.java
+++ b/java/core/src/main/java/org/bondlib/MapBondType.java
@@ -215,9 +215,9 @@ public final class MapBondType<TKey, TValue> extends BondType<Map<TKey, TValue>>
         this.verifySerializedNonNullableFieldIsNotSetToNull(value, field);
         final int count = value.size();
         if (!field.isDefaultNothing() && count == 0 && field.isOptional()) {
-            context.writer.writeFieldOmitted(BondDataType.BT_MAP, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_MAP, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_MAP, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_MAP, field.getId(), field.getFieldDef().metadata);
             try {
                 this.serializeValue(context, value);
             } catch (InvalidBondDataException e) {

--- a/java/core/src/main/java/org/bondlib/NullableBondType.java
+++ b/java/core/src/main/java/org/bondlib/NullableBondType.java
@@ -142,9 +142,9 @@ public final class NullableBondType<TValue> extends BondType<TValue> {
             TValue value,
             StructBondType.StructField<TValue> field) throws IOException {
         if (!field.isDefaultNothing() && value == null && field.isOptional()) {
-            context.writer.writeFieldOmitted(BondDataType.BT_LIST, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_LIST, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_LIST, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_LIST, field.getId(), field.getFieldDef().metadata);
             try {
                 this.serializeValue(context, value);
             } catch (InvalidBondDataException e) {

--- a/java/core/src/main/java/org/bondlib/SetBondType.java
+++ b/java/core/src/main/java/org/bondlib/SetBondType.java
@@ -174,9 +174,9 @@ public final class SetBondType<TElement> extends BondType<Set<TElement>> {
         this.verifySerializedNonNullableFieldIsNotSetToNull(value, field);
         final int count = value.size();
         if (!field.isDefaultNothing() && count == 0 && field.isOptional()) {
-            context.writer.writeFieldOmitted(BondDataType.BT_SET, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_SET, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_SET, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_SET, field.getId(), field.getFieldDef().metadata);
             try {
                 this.serializeValue(context, value);
             } catch (InvalidBondDataException e) {

--- a/java/core/src/main/java/org/bondlib/StringBondType.java
+++ b/java/core/src/main/java/org/bondlib/StringBondType.java
@@ -83,9 +83,9 @@ public final class StringBondType extends PrimitiveBondType<String> {
             StructBondType.StructField<String> field) throws IOException {
         this.verifySerializedNonNullableFieldIsNotSetToNull(value, field);
         if (field.isOptional() && value.equals(field.getDefaultValue())) {
-            context.writer.writeFieldOmitted(BondDataType.BT_STRING, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_STRING, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_STRING, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_STRING, field.getId(), field.getFieldDef().metadata);
             context.writer.writeString(value);
             context.writer.writeFieldEnd();
         }

--- a/java/core/src/main/java/org/bondlib/UInt16BondType.java
+++ b/java/core/src/main/java/org/bondlib/UInt16BondType.java
@@ -148,9 +148,9 @@ public final class UInt16BondType extends PrimitiveBondType<Short> {
             short value,
             StructBondType.StructField<Short> field) throws IOException {
         if (!field.isDefaultNothing() && field.isOptional() && (value == field.getDefaultValue())) {
-            context.writer.writeFieldOmitted(BondDataType.BT_UINT16, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_UINT16, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_UINT16, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_UINT16, field.getId(), field.getFieldDef().metadata);
             context.writer.writeUInt16(value);
             context.writer.writeFieldEnd();
         }

--- a/java/core/src/main/java/org/bondlib/UInt32BondType.java
+++ b/java/core/src/main/java/org/bondlib/UInt32BondType.java
@@ -148,9 +148,9 @@ public final class UInt32BondType extends PrimitiveBondType<Integer> {
         int value,
         StructBondType.StructField<Integer> field) throws IOException {
         if (!field.isDefaultNothing() && field.isOptional() && (value == field.getDefaultValue())) {
-            context.writer.writeFieldOmitted(BondDataType.BT_UINT32, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_UINT32, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_UINT32, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_UINT32, field.getId(), field.getFieldDef().metadata);
             context.writer.writeUInt32(value);
             context.writer.writeFieldEnd();
         }

--- a/java/core/src/main/java/org/bondlib/UInt64BondType.java
+++ b/java/core/src/main/java/org/bondlib/UInt64BondType.java
@@ -148,9 +148,9 @@ public final class UInt64BondType extends PrimitiveBondType<Long> {
             long value,
             StructBondType.StructField<Long> field) throws IOException {
         if (!field.isDefaultNothing() && field.isOptional() && (value == field.getDefaultValue())) {
-            context.writer.writeFieldOmitted(BondDataType.BT_UINT64, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_UINT64, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_UINT64, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_UINT64, field.getId(), field.getFieldDef().metadata);
             context.writer.writeUInt64(value);
             context.writer.writeFieldEnd();
         }

--- a/java/core/src/main/java/org/bondlib/UInt8BondType.java
+++ b/java/core/src/main/java/org/bondlib/UInt8BondType.java
@@ -148,9 +148,9 @@ public final class UInt8BondType extends PrimitiveBondType<Byte> {
             byte value,
             StructBondType.StructField<Byte> field) throws IOException {
         if (!field.isDefaultNothing() && field.isOptional() && (value == field.getDefaultValue())) {
-            context.writer.writeFieldOmitted(BondDataType.BT_UINT8, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_UINT8, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_UINT8, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_UINT8, field.getId(), field.getFieldDef().metadata);
             context.writer.writeUInt8(value);
             context.writer.writeFieldEnd();
         }

--- a/java/core/src/main/java/org/bondlib/VectorBondType.java
+++ b/java/core/src/main/java/org/bondlib/VectorBondType.java
@@ -180,9 +180,9 @@ public final class VectorBondType<TElement> extends BondType<List<TElement>> {
         this.verifySerializedNonNullableFieldIsNotSetToNull(value, field);
         final int count = value.size();
         if (!field.isDefaultNothing() && count == 0 && field.isOptional()) {
-            context.writer.writeFieldOmitted(BondDataType.BT_LIST, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_LIST, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_LIST, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_LIST, field.getId(), field.getFieldDef().metadata);
             try {
                 this.serializeValue(context, value);
             } catch (InvalidBondDataException e) {

--- a/java/core/src/main/java/org/bondlib/WStringBondType.java
+++ b/java/core/src/main/java/org/bondlib/WStringBondType.java
@@ -83,9 +83,9 @@ public final class WStringBondType extends PrimitiveBondType<String> {
             StructBondType.StructField<String> field) throws IOException {
         this.verifySerializedNonNullableFieldIsNotSetToNull(value, field);
         if (field.isOptional() && value.equals(field.getDefaultValue())) {
-            context.writer.writeFieldOmitted(BondDataType.BT_WSTRING, field.getId(), field);
+            context.writer.writeFieldOmitted(BondDataType.BT_WSTRING, field.getId(), field.getFieldDef().metadata);
         } else {
-            context.writer.writeFieldBegin(BondDataType.BT_WSTRING, field.getId(), field);
+            context.writer.writeFieldBegin(BondDataType.BT_WSTRING, field.getId(), field.getFieldDef().metadata);
             context.writer.writeWString(value);
             context.writer.writeFieldEnd();
         }

--- a/java/core/src/main/java/org/bondlib/protocol/CompactBinaryWriter.java
+++ b/java/core/src/main/java/org/bondlib/protocol/CompactBinaryWriter.java
@@ -4,6 +4,7 @@
 package org.bondlib.protocol;
 
 import org.bondlib.BondDataType;
+import org.bondlib.Metadata;
 import org.bondlib.ProtocolType;
 
 import java.io.IOException;
@@ -60,7 +61,7 @@ public final class CompactBinaryWriter implements TwoPassProtocolWriter {
     }
 
     @Override
-    public void writeStructBegin(final StructMetadata metadata) throws IOException {
+    public void writeStructBegin(final Metadata metadata) throws IOException {
         if (this.protocolVersion == 2) {
             int structLength = this.structLengths.removeFirst().length;
             this.writer.writeVarUInt32(structLength);
@@ -73,7 +74,7 @@ public final class CompactBinaryWriter implements TwoPassProtocolWriter {
     }
 
     @Override
-    public void writeBaseBegin(final StructMetadata metadata) throws IOException {
+    public void writeBaseBegin(final Metadata metadata) throws IOException {
     }
 
     @Override
@@ -83,7 +84,7 @@ public final class CompactBinaryWriter implements TwoPassProtocolWriter {
 
     @Override
     public void writeFieldBegin(
-            final BondDataType type, final int id, final FieldMetadata metadata) throws IOException {
+            final BondDataType type, final int id, final Metadata metadata) throws IOException {
         if (id <= 5) {
             this.writer.writeInt8((byte) (type.value | (id << 5)));
         } else if (id <= 0xFF) {
@@ -101,7 +102,7 @@ public final class CompactBinaryWriter implements TwoPassProtocolWriter {
 
     @Override
     public void writeFieldOmitted(
-            final BondDataType type, final int id, final FieldMetadata metadata) throws IOException {
+            final BondDataType type, final int id, final Metadata metadata) throws IOException {
     }
 
     @Override
@@ -230,7 +231,7 @@ public final class CompactBinaryWriter implements TwoPassProtocolWriter {
         }
 
         @Override
-        public void writeStructBegin(final StructMetadata metadata) throws IOException {
+        public void writeStructBegin(final Metadata metadata) throws IOException {
             // start new stack frame for the struct
             StructLength stackFrame = new StructLength();
             this.workingStack.push(stackFrame);
@@ -238,7 +239,7 @@ public final class CompactBinaryWriter implements TwoPassProtocolWriter {
         }
 
         @Override
-        public void writeBaseBegin(final StructMetadata metadata) throws IOException {
+        public void writeBaseBegin(final Metadata metadata) throws IOException {
         }
 
         @Override
@@ -261,7 +262,7 @@ public final class CompactBinaryWriter implements TwoPassProtocolWriter {
 
         @Override
         public void writeFieldBegin(
-                final BondDataType type, final int id, final FieldMetadata metadata) throws IOException {
+                final BondDataType type, final int id, final Metadata metadata) throws IOException {
             if (id <= 5) {
                 this.addBytes(1);
             } else if (id <= 0xFF) {
@@ -277,7 +278,7 @@ public final class CompactBinaryWriter implements TwoPassProtocolWriter {
 
         @Override
         public void writeFieldOmitted(
-                final BondDataType type, final int id, final FieldMetadata metadata) throws IOException {
+                final BondDataType type, final int id, final Metadata metadata) throws IOException {
         }
 
         @Override

--- a/java/core/src/main/java/org/bondlib/protocol/FastBinaryWriter.java
+++ b/java/core/src/main/java/org/bondlib/protocol/FastBinaryWriter.java
@@ -4,6 +4,7 @@
 package org.bondlib.protocol;
 
 import org.bondlib.BondDataType;
+import org.bondlib.Metadata;
 import org.bondlib.ProtocolType;
 
 import java.io.IOException;
@@ -46,7 +47,7 @@ public final class FastBinaryWriter implements ProtocolWriter {
     }
 
     @Override
-    public void writeStructBegin(final StructMetadata metadata) throws IOException {
+    public void writeStructBegin(final Metadata metadata) throws IOException {
     }
 
     @Override
@@ -55,7 +56,7 @@ public final class FastBinaryWriter implements ProtocolWriter {
     }
 
     @Override
-    public void writeBaseBegin(final StructMetadata metadata) throws IOException {
+    public void writeBaseBegin(final Metadata metadata) throws IOException {
     }
 
     @Override
@@ -65,7 +66,7 @@ public final class FastBinaryWriter implements ProtocolWriter {
 
     @Override
     public void writeFieldBegin(
-            final BondDataType type, final int id, final FieldMetadata metadata) throws IOException {
+            final BondDataType type, final int id, final Metadata metadata) throws IOException {
         writer.writeInt8((byte) type.value);
         writer.writeInt16((short) id);
     }
@@ -76,7 +77,7 @@ public final class FastBinaryWriter implements ProtocolWriter {
 
     @Override
     public void writeFieldOmitted(
-            final BondDataType type, final int id, final FieldMetadata metadata) throws IOException {
+            final BondDataType type, final int id, final Metadata metadata) throws IOException {
     }
 
     @Override

--- a/java/core/src/main/java/org/bondlib/protocol/ProtocolWriter.java
+++ b/java/core/src/main/java/org/bondlib/protocol/ProtocolWriter.java
@@ -4,6 +4,7 @@
 package org.bondlib.protocol;
 
 import org.bondlib.BondDataType;
+import org.bondlib.Metadata;
 
 import java.io.IOException;
 
@@ -28,7 +29,7 @@ public interface ProtocolWriter {
      *
      * @param metadata struct metadata
      */
-    void writeStructBegin(StructMetadata metadata) throws IOException;
+    void writeStructBegin(Metadata metadata) throws IOException;
 
     /**
      * End writing a struct.
@@ -40,7 +41,7 @@ public interface ProtocolWriter {
      *
      * @param metadata base struct metadata
      */
-    void writeBaseBegin(StructMetadata metadata) throws IOException;
+    void writeBaseBegin(Metadata metadata) throws IOException;
 
     /**
      * End writing a base struct.
@@ -54,7 +55,7 @@ public interface ProtocolWriter {
      * @param id       identifier of the field
      * @param metadata metadata of the field
      */
-    void writeFieldBegin(BondDataType type, int id, FieldMetadata metadata) throws IOException;
+    void writeFieldBegin(BondDataType type, int id, Metadata metadata) throws IOException;
 
     /**
      * End writing a field.
@@ -68,7 +69,7 @@ public interface ProtocolWriter {
      * @param id       identifier of the field
      * @param metadata metadata of the field
      */
-    void writeFieldOmitted(BondDataType type, int id, FieldMetadata metadata) throws IOException;
+    void writeFieldOmitted(BondDataType type, int id, Metadata metadata) throws IOException;
 
     /**
      * Start writing a list or set container.

--- a/java/core/src/main/java/org/bondlib/protocol/SchemaHelper.java
+++ b/java/core/src/main/java/org/bondlib/protocol/SchemaHelper.java
@@ -1,0 +1,66 @@
+package org.bondlib.protocol;
+
+import org.bondlib.Metadata;
+import org.bondlib.Modifier;
+
+/**
+ * Contains helper methods for working with schema.
+ */
+public final class SchemaHelper {
+
+    private SchemaHelper() {
+    }
+
+    public static byte getDefaultUInt8FieldValue(Metadata fieldMetadata) {
+        return (byte) fieldMetadata.default_value.uint_value;
+    }
+
+    public static short getDefaultUInt16FieldValue(Metadata fieldMetadata) {
+        return (short) fieldMetadata.default_value.uint_value;
+    }
+
+    public static int getDefaultUInt32FieldValue(Metadata fieldMetadata) {
+        return (int) fieldMetadata.default_value.uint_value;
+    }
+
+    public static long getDefaultUInt64FieldValue(Metadata fieldMetadata) {
+        return fieldMetadata.default_value.uint_value;
+    }
+
+    public static byte getDefaultInt8FieldValue(Metadata fieldMetadata) {
+        return (byte) fieldMetadata.default_value.int_value;
+    }
+
+    public static short getDefaultInt16FieldValue(Metadata fieldMetadata) {
+        return (short) fieldMetadata.default_value.int_value;
+    }
+
+    public static int getDefaultInt32FieldValue(Metadata fieldMetadata) {
+        return (int) fieldMetadata.default_value.int_value;
+    }
+
+    public static long getDefaultInt64FieldValue(Metadata fieldMetadata) {
+        return fieldMetadata.default_value.int_value;
+    }
+
+    public static boolean getDefaultBoolFieldValue(Metadata fieldMetadata) {
+        // false is represented by 0; everything else is considered true
+        return fieldMetadata.default_value.int_value != 0;
+    }
+
+    public static float getDefaultFloatFieldValue(Metadata fieldMetadata) {
+        return (float) fieldMetadata.default_value.double_value;
+    }
+
+    public static double getDefaultDoubleFieldValue(Metadata fieldMetadata) {
+        return fieldMetadata.default_value.double_value;
+    }
+
+    public static String getDefaultStringFieldValue(Metadata fieldMetadata) {
+        return fieldMetadata.default_value.string_value;
+    }
+
+    public static String getDefaultWStringFieldValue(Metadata fieldMetadata) {
+        return fieldMetadata.default_value.wstring_value;
+    }
+}

--- a/java/core/src/main/java/org/bondlib/protocol/SimpleBinaryWriter.java
+++ b/java/core/src/main/java/org/bondlib/protocol/SimpleBinaryWriter.java
@@ -5,6 +5,7 @@ package org.bondlib.protocol;
 
 import org.bondlib.BondDataType;
 import org.bondlib.BondEnum;
+import org.bondlib.Metadata;
 import org.bondlib.ProtocolType;
 
 import java.io.IOException;
@@ -48,7 +49,7 @@ public final class SimpleBinaryWriter implements ProtocolWriter {
 
     @Override
     public void writeFieldOmitted(
-        final BondDataType type, final int id, final FieldMetadata metadata) throws IOException {
+        final BondDataType type, final int id, final Metadata metadata) throws IOException {
         // Simple doesn't support omitting fields, so we need to explicitly write the default values
         // for optional fields.
         //
@@ -56,64 +57,58 @@ public final class SimpleBinaryWriter implements ProtocolWriter {
         // serialize such a field if it is actually set to nothing (e.g., a SomethingObject which is
         // null).
 
-        if (metadata.isDefaultNothing()) {
+        if (metadata.default_value.nothing) {
             throw new IllegalArgumentException("can't omit fields with default = nothing in SimpleBinary");
         }
 
         switch (type.value) {
             case BondDataType.Values.BT_BOOL:
-                writeBool((Boolean) metadata.getDefaultValue());
+                this.writeBool(SchemaHelper.getDefaultBoolFieldValue(metadata));
                 break;
             case BondDataType.Values.BT_INT8:
-                writeInt8((Byte) metadata.getDefaultValue());
+                this.writeInt8(SchemaHelper.getDefaultInt8FieldValue(metadata));
                 break;
             case BondDataType.Values.BT_INT16:
-                writeInt16((Short) metadata.getDefaultValue());
+                this.writeInt16(SchemaHelper.getDefaultInt16FieldValue(metadata));
                 break;
             case BondDataType.Values.BT_INT32:
-                // Could be an int32, could be an enum.
-                final Object def = metadata.getDefaultValue();
-                if (def instanceof BondEnum) {
-                    writeInt32(((BondEnum) def).getValue());
-                } else {
-                    writeInt32((Integer) def);
-                }
+                this.writeInt32(SchemaHelper.getDefaultInt32FieldValue(metadata));
                 break;
             case BondDataType.Values.BT_INT64:
-                writeInt64((Long) metadata.getDefaultValue());
+                this.writeInt64(SchemaHelper.getDefaultInt64FieldValue(metadata));
                 break;
             case BondDataType.Values.BT_UINT8:
-                writeUInt8((Byte) metadata.getDefaultValue());
+                this.writeUInt8(SchemaHelper.getDefaultUInt8FieldValue(metadata));
                 break;
             case BondDataType.Values.BT_UINT16:
-                writeUInt16((Short) metadata.getDefaultValue());
+                this.writeUInt16(SchemaHelper.getDefaultUInt16FieldValue(metadata));
                 break;
             case BondDataType.Values.BT_UINT32:
-                writeUInt32((Integer) metadata.getDefaultValue());
+                this.writeUInt32(SchemaHelper.getDefaultUInt32FieldValue(metadata));
                 break;
             case BondDataType.Values.BT_UINT64:
-                writeUInt64((Long) metadata.getDefaultValue());
+                this.writeUInt64(SchemaHelper.getDefaultUInt64FieldValue(metadata));
                 break;
             case BondDataType.Values.BT_FLOAT:
-                writeFloat((Float) metadata.getDefaultValue());
+                this.writeFloat(SchemaHelper.getDefaultFloatFieldValue(metadata));
                 break;
             case BondDataType.Values.BT_DOUBLE:
-                writeDouble((Double) metadata.getDefaultValue());
+                this.writeDouble(SchemaHelper.getDefaultDoubleFieldValue(metadata));
                 break;
             case BondDataType.Values.BT_STRING:
-                writeString((String) metadata.getDefaultValue());
+                this.writeString(SchemaHelper.getDefaultStringFieldValue(metadata));
                 break;
             case BondDataType.Values.BT_WSTRING:
-                writeWString((String) metadata.getDefaultValue());
+                this.writeWString(SchemaHelper.getDefaultWStringFieldValue(metadata));
                 break;
             case BondDataType.Values.BT_LIST:
             case BondDataType.Values.BT_SET:
             case BondDataType.Values.BT_MAP:
-                writeContainerBegin(0, type);
-                writeContainerEnd();
+                this.writeContainerBegin(0, type);
+                this.writeContainerEnd();
                 break;
             default:
-                throw new IllegalArgumentException("Invalid bondType " + type.toString());
+                throw new IllegalArgumentException("Invalid bondType: " + type.toString());
         }
     }
 
@@ -234,7 +229,7 @@ public final class SimpleBinaryWriter implements ProtocolWriter {
     //
 
     @Override
-    public void writeStructBegin(final StructMetadata metadata) throws IOException {
+    public void writeStructBegin(final Metadata metadata) throws IOException {
     }
 
     @Override
@@ -242,7 +237,7 @@ public final class SimpleBinaryWriter implements ProtocolWriter {
     }
 
     @Override
-    public void writeBaseBegin(final StructMetadata metadata) throws IOException {
+    public void writeBaseBegin(final Metadata metadata) throws IOException {
     }
 
     @Override
@@ -251,7 +246,7 @@ public final class SimpleBinaryWriter implements ProtocolWriter {
 
     @Override
     public void writeFieldBegin(
-        final BondDataType type, final int id, final FieldMetadata metadata) throws IOException {
+        final BondDataType type, final int id, final Metadata metadata) throws IOException {
     }
 
     @Override


### PR DESCRIPTION
Changes:

1. Removed FieldMetadata and StructMetadata interfaces and replaced them with the Metadata Bond struct in protocol writers and BondType hierarchy.
2. Added SchemaHelpers class to abstract SchemaDef's intricacies, specifically default field values within a Variant struct.
3. Simplified SimpleBinaryProtocol's logic for getting field default values from schema.
4. Added SchemaDef property to StructBondType with caching (unable to do it at initialization time since that causes a circularity when initializing SchemaDef's own BondType). 
5. Fixed 2 bugs that are currently in other PR's: FieldDef was not added to field collection and initializing Variant with nothing led to null dereference.