### PR TITLE
[c++] Guard against min/max being function macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ different versioning scheme, following the Haskell community's
 * Guard against overflows in OutputMemoryStream, blob, and SimpleArray.
 * Use RapidJSON's iterative parser to handle deeply nested JSON data without
   causing a stack overflow.
+* Guard against min/max being function-style macros in more places.
 
 ### C# ###
 

--- a/cpp/inc/bond/core/detail/cmdargs.h
+++ b/cpp/inc/bond/core/detail/cmdargs.h
@@ -518,7 +518,7 @@ public:
 protected:
     void Print(const std::string& arg, const std::string& abbr, const std::string& help) const
     {
-        int indent = std::max(30, static_cast<int>(arg.size()) + 5);
+        int indent = (std::max)(30, static_cast<int>(arg.size()) + 5);
         std::string formated = FormatHelp(help, indent);
         out << " ";
         out.width(2);

--- a/cpp/inc/bond/ext/grpc/bond_utils.h
+++ b/cpp/inc/bond/ext/grpc/bond_utils.h
@@ -63,7 +63,7 @@ namespace grpc {
 
             const size_t bufferSize = grpc_byte_buffer_length(buffer);
 
-            if (bufferSize > std::numeric_limits<uint32_t>::max())
+            if (bufferSize > (std::numeric_limits<uint32_t>::max)())
             {
                 grpc_byte_buffer_destroy(buffer);
                 return Status(StatusCode::INTERNAL, "Buffer is too large");


### PR DESCRIPTION
Sometimes min/max are function-style macros, which interferes with use
of things like std::numeric_limits::max() and std::min(). An extra set
of parenthesis guards against this.