### PR TITLE
[c++ grpc] Drop client callback after executing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ different versioning scheme, following the Haskell community's
   causing a stack overflow.
 * Guard against min/max being function-style macros in more places.
 * Provide compile-time access to metadata about gRPC services and methods.
-
+* Using `bond::ext::gRPC::wait_callback` no longer causes a shared_ptr cycle
+  and the resulting resource leak.
 
 ### C# ###
 


### PR DESCRIPTION
After executing the client callback upon receiving a response, clear the
stored callback to prevent a shared_ptr cycle.

Previously, when the callback function was not cleared, if the callback
happened to store the unary_call_result that it was invoked with (like
wait_callback does), there would be a shared_ptr cycle: the callback
would have a shared_ptr to the unary_call_result, which was keeping its
parent client_unary_call_data alive. This client_unary_call_data had a
copy of the callback function, which had a shared_ptr to the
unary_call_result.

This change resets the callback to empty after is has been executed,
breaking the cycle.