### PR TITLE
[grpc] Remove PingLayerData from gRPC compat test

### DIFF
--- a/test/compat/grpc/pingpong.bond
+++ b/test/compat/grpc/pingpong.bond
@@ -28,11 +28,6 @@ struct PingResponse
     0: string Payload;
 }
 
-struct PingLayerData
-{
-    0: int32 data;
-}
-
 service PingPong
 {
     PingResponse Ping(PingRequest);


### PR DESCRIPTION
PingLayerData was used in the old Bond Comm compat test, but is not
needed for the gRPC compat test.