### PR TITLE
[c#] Use null XmlResolver when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ different versioning scheme, following the Haskell community's
 * Fixed a bug that produced C# code that couldn't be compiled when using
   Bond-over-gRPC with a generic type instantiated with a collection.
   [Issue #623](https://github.com/Microsoft/bond/issues/623)
+* When targeting .NET 4.5, avoid resolving external entities when using
+  `SimpleXmlReader`.
 
 [msdn-gzipstream]: https://msdn.microsoft.com/en-us/library/system.io.compression.gzipstream(v=vs.110).aspx
 [msdn-stream-canseek]: https://msdn.microsoft.com/en-us/library/system.io.stream.canseek(v=vs.110).aspx

--- a/cs/nuget/bond.core.csharp.nuspec
+++ b/cs/nuget/bond.core.csharp.nuspec
@@ -33,9 +33,9 @@
         <file target="lib\net45" src="net45\Bond.Reflection.dll" />
         <file target="lib\net45" src="net45\Bond.Reflection.pdb" />
         <file target="lib\net45" src="net45\Bond.Reflection.xml" />
-        <file target="lib\net45" src="net45\Bond.dll" />
-        <file target="lib\net45" src="net45\Bond.pdb" />
-        <file target="lib\net45" src="net45\Bond.xml" />
+        <file target="lib\net45" src="net45-nonportable\Bond.dll" />
+        <file target="lib\net45" src="net45-nonportable\Bond.pdb" />
+        <file target="lib\net45" src="net45-nonportable\Bond.xml" />
 
         <file target="lib\netstandard1.0" src="netstandard1.0\Bond.Attributes.dll" />
         <file target="lib\netstandard1.0" src="netstandard1.0\Bond.Attributes.pdb" />

--- a/cs/src/core/Bond.csproj
+++ b/cs/src/core/Bond.csproj
@@ -1,7 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath32)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath32)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="$(MSBuildThisFileDirectory)\..\..\build\internal\Portable.Internal.props" />
+  <PropertyGroup Condition="'$(BuildNonportable)' == 'true'">
+    <BuildFramework>net45-nonportable</BuildFramework>
+    <DefineConstants>$(DefineConstants);SUPPORTS_XMLRESOLVER</DefineConstants>
+  </PropertyGroup>
+  <Import Condition="'$(BuildNonportable)' == 'true'" Project="$(MSBuildThisFileDirectory)\..\..\build\internal\Common.Internal.props" />
+  <Import Condition="'$(BuildNonportable)' != 'true'" Project="$(MSBuildThisFileDirectory)\..\..\build\internal\Portable.Internal.props" />
   <PropertyGroup>
     <ProjectGuid>{43CBBA9B-C4BC-4E64-8733-7B72562D2E91}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -9,6 +14,8 @@
     <RootNamespace>Bond</RootNamespace>
     <AssemblyName>Bond</AssemblyName>
     <BondRedistributable>true</BondRedistributable>
+    <DependentOutputPath>bin\$(BuildType)\net45</DependentOutputPath>
+    <HasNonportableVersion>true</HasNonportableVersion>
   </PropertyGroup>
   <ItemGroup>
     <BondCodegen Include="$(BOND_INCLUDE_PATH)\bond\core\bond.bond" />
@@ -84,10 +91,10 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Bond.Attributes">
-      <HintPath>..\attributes\$(OutputPath)\Bond.Attributes.dll</HintPath>
+      <HintPath>..\attributes\$(DependentOutputPath)\Bond.Attributes.dll</HintPath>
     </Reference>
     <Reference Include="Bond.Reflection">
-      <HintPath>..\reflection\$(OutputPath)\Bond.Reflection.dll</HintPath>
+      <HintPath>..\reflection\$(DependentOutputPath)\Bond.Reflection.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildThisFileDirectory)\..\..\build\internal\Common.Internal.targets" />

--- a/cs/src/core/protocols/SimpleXmlReader.cs
+++ b/cs/src/core/protocols/SimpleXmlReader.cs
@@ -26,22 +26,22 @@ namespace Bond.Protocols
                     IgnoreComments = true,
                     IgnoreProcessingInstructions = true,
 #if SUPPORTS_XMLRESOLVER
-                // do not attempt to resolve any external resources
-                XmlResolver = null,
+                    // do not attempt to resolve any external resources
+                    XmlResolver = null,
 #endif
                 }))
         { }
 
         public SimpleXmlReader(TextReader textReader)
-    : this(XmlReader.Create(textReader, new XmlReaderSettings
-    {
-        IgnoreComments = true,
-        IgnoreProcessingInstructions = true,
+            : this(XmlReader.Create(textReader, new XmlReaderSettings
+                {
+                    IgnoreComments = true,
+                    IgnoreProcessingInstructions = true,
 #if SUPPORTS_XMLRESOLVER
-                // do not attempt to resolve any external resources
-                XmlResolver = null,
+                    // do not attempt to resolve any external resources
+                    XmlResolver = null,
 #endif
-            }))
+                }))
         { }
 
         public bool EOF

--- a/cs/src/core/protocols/SimpleXmlReader.cs
+++ b/cs/src/core/protocols/SimpleXmlReader.cs
@@ -21,11 +21,27 @@ namespace Bond.Protocols
         }
 
         public SimpleXmlReader(Stream stream)
-            : this(XmlReader.Create(stream, new XmlReaderSettings 
+            : this(XmlReader.Create(stream, new XmlReaderSettings
                 {
                     IgnoreComments = true,
-                    IgnoreProcessingInstructions = true
+                    IgnoreProcessingInstructions = true,
+#if SUPPORTS_XMLRESOLVER
+                // do not attempt to resolve any external resources
+                XmlResolver = null,
+#endif
                 }))
+        { }
+
+        public SimpleXmlReader(TextReader textReader)
+    : this(XmlReader.Create(textReader, new XmlReaderSettings
+    {
+        IgnoreComments = true,
+        IgnoreProcessingInstructions = true,
+#if SUPPORTS_XMLRESOLVER
+                // do not attempt to resolve any external resources
+                XmlResolver = null,
+#endif
+            }))
         { }
 
         public bool EOF

--- a/cs/test/core/Core.csproj
+++ b/cs/test/core/Core.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath32)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath32)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup Condition="'$(BuildNonportable)' == 'true'">
     <BuildFramework>net45-nonportable</BuildFramework>
-    <DefineConstants>$(DefineConstants);SUPPORTS_BIGINTEGER</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_BIGINTEGER;SUPPORTS_XMLRESOLVER</DefineConstants>
   </PropertyGroup>
   <Import Project="$(MSBuildThisFileDirectory)\..\..\build\internal\Common.Internal.props" />
   <PropertyGroup>
@@ -104,7 +104,8 @@
       <HintPath>..\..\src\attributes\$(DependentOutputPath)\Bond.Attributes.dll</HintPath>
     </Reference>
     <Reference Include="Bond">
-      <HintPath>..\..\src\core\$(DependentOutputPath)\Bond.dll</HintPath>
+      <!-- Intentionally not DependentOutputPath to match BuildFramework-->
+      <HintPath>..\..\src\core\$(OrigOutputPath)\Bond.dll</HintPath>
     </Reference>
     <Reference Include="Bond.Reflection">
       <HintPath>..\..\src\reflection\$(DependentOutputPath)\Bond.Reflection.dll</HintPath>
@@ -113,7 +114,8 @@
       <HintPath>..\..\src\io\$(DependentOutputPath)\Bond.IO.dll</HintPath>
     </Reference>
     <Reference Include="Bond.JSON">
-      <HintPath>..\..\src\json\$(OrigOutputPath)\Bond.JSON.dll</HintPath> <!-- Intentionally not DependentOutputPath to match BuildFramework-->
+      <!-- Intentionally not DependentOutputPath to match BuildFramework-->
+      <HintPath>..\..\src\json\$(OrigOutputPath)\Bond.JSON.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/cs/test/core/DeserializerControlsTests.cs
+++ b/cs/test/core/DeserializerControlsTests.cs
@@ -118,7 +118,7 @@
                 Serialize.To(xmlWriter, obj);
                 xmlWriter.Flush();
 
-                var reader = new SimpleXmlReader(XmlReader.Create(new StringReader(xmlString.ToString())));
+                var reader = new SimpleXmlReader(new StringReader(xmlString.ToString()));
                 T obj2 = new Deserializer<SimpleXmlReader>(typeof(T)).Deserialize<T>(reader);
 
                 Assert.True(Comparer.Equal<T>(obj, obj2));

--- a/cs/test/core/XmlParsingTests.cs
+++ b/cs/test/core/XmlParsingTests.cs
@@ -20,6 +20,9 @@
                 ValidationType = ValidationType.None,
                 ValidationFlags = XmlSchemaValidationFlags.None,
 #endif
+#if SUPPORTS_XMLRESOLVER
+                XmlResolver = null,
+#endif
             };
 
         [Test]

--- a/examples/cs/core/simple_xml/program.cs
+++ b/examples/cs/core/simple_xml/program.cs
@@ -39,7 +39,7 @@
   <Variant>Complex</Variant>
 </Config>";
 
-            var reader = new SimpleXmlReader(XmlReader.Create(new StringReader(configString)));
+            var reader = new SimpleXmlReader(new StringReader(configString));
             config = Deserialize<Config>.From(reader);
             Debug.Assert(config.Enabled == false);
         }


### PR DESCRIPTION
By setting XmlReaderSettings.XmlResolver to null, we can avoid having
XmlReader resolve external XML entities. Attempting to resolve these
external entities can potentially access the network, which is not
something we want to do during deserialization.

This API only exists when targeting the full .NET 4.5 framework, hence
the need for a net45-nonportable version of Bond.dll.