### PR TITLE
Remove extra blob conversions during serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ different versioning scheme, following the Haskell community's
   [Issue #623](https://github.com/Microsoft/bond/issues/623)
 * When targeting .NET 4.5, avoid resolving external entities when using
   `SimpleXmlReader`.
+* Reduce redundant conversions during serialization of aliased blobs.
 
 [msdn-gzipstream]: https://msdn.microsoft.com/en-us/library/system.io.compression.gzipstream(v=vs.110).aspx
 [msdn-stream-canseek]: https://msdn.microsoft.com/en-us/library/system.io.stream.canseek(v=vs.110).aspx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ different versioning scheme, following the Haskell community's
   [Issue #623](https://github.com/Microsoft/bond/issues/623)
 * When targeting .NET 4.5, avoid resolving external entities when using
   `SimpleXmlReader`.
-* Reduce redundant conversions during serialization of aliased blobs.
+* Remove redundant conversions during serialization of aliased blobs.
 
 [msdn-gzipstream]: https://msdn.microsoft.com/en-us/library/system.io.compression.gzipstream(v=vs.110).aspx
 [msdn-stream-canseek]: https://msdn.microsoft.com/en-us/library/system.io.stream.canseek(v=vs.110).aspx

--- a/cs/src/core/expressions/DeserializerTransform.cs
+++ b/cs/src/core/expressions/DeserializerTransform.cs
@@ -241,7 +241,7 @@ namespace Bond.Expressions
         Expression Nullable(IParser parser, Expression var, Type schemaType, bool initialize)
         {
             return parser.Container(schemaType.GetBondDataType(),
-                (valueParser, valueType, next, count) =>
+                (valueParser, valueType, next, count, arraySegment) =>
                 {
                     var body = new List<Expression>();
 
@@ -260,7 +260,7 @@ namespace Bond.Expressions
             var itemSchemaType = schemaType.GetValueType();
 
             return parser.Container(itemSchemaType.GetBondDataType(),
-                (valueParser, elementType, next, count) =>
+                (valueParser, elementType, next, count, arraySegment) =>
                 {
                     Expression addItem;
                     ParameterExpression[] parameters;

--- a/cs/src/core/expressions/IParser.cs
+++ b/cs/src/core/expressions/IParser.cs
@@ -13,9 +13,10 @@ namespace Bond.Expressions
     /// <param name="valueType">Expression of type BondDataType indicating the element type</param>
     /// <param name="next">Expression of type bool indicating if there are more elements</param>
     /// <param name="count">Expression of type int indicating number of elements, may be null</param>
+    /// <param name="arraySegment">Parameter expression of type ArraySegment that holds conveted input bytes, may be null</param>
     /// <returns>Expression to handle the container</returns>
     public delegate Expression ContainerHandler(
-        IParser valueParser, Expression valueType, Expression next, Expression count);
+        IParser valueParser, Expression valueType, Expression next, Expression count, ParameterExpression arraySegment);
     
     /// <summary>
     /// Handler for maps

--- a/cs/src/core/expressions/ObjectParser.cs
+++ b/cs/src/core/expressions/ObjectParser.cs
@@ -100,7 +100,27 @@ namespace Bond.Expressions
             var fieldId = Expression.Constant(id);
             var fieldType = Expression.Constant(fieldSchemaType.GetBondDataType());
             var fieldValue = DataExpression.PropertyOrField(structVar, schemaField.Name);
-            var parser = new ObjectParser(this, fieldValue, fieldSchemaType);
+
+            ObjectParser parser = null;
+
+            Expression blob = null;
+            ParameterExpression convertedBlob = null;
+
+            // To avoid calling Convert multiple times on the same aliased Blob
+            // we must construct a new ObjectParser with the expected return type of
+            // of Convert
+            if (fieldSchemaType.IsBondBlob())
+            {
+                blob = typeAlias.Convert(fieldValue, fieldSchemaType);
+                convertedBlob = Expression.Variable(blob.Type, "convertedBlob");
+
+                if (blob.Type != fieldValue.Type)
+                {
+                    parser = new ObjectParser(this, convertedBlob, convertedBlob.Type);
+                }
+            }
+
+            parser = parser ?? new ObjectParser(this, fieldValue, fieldSchemaType);
 
             var processField = field != null
                 ? field.Value(parser, fieldType)
@@ -121,9 +141,14 @@ namespace Bond.Expressions
 
                 if (fieldSchemaType.IsBondBlob())
                 {
-                    cannotOmit = Expression.NotEqual(
-                        typeAlias.Convert(fieldValue, fieldSchemaType), 
+                    var notEqual = Expression.NotEqual(
+                        convertedBlob,
                         Expression.Default(typeof(ArraySegment<byte>)));
+
+                    return Expression.Block(
+                        new[] { convertedBlob },
+                        Expression.Assign(convertedBlob, blob),
+                        PrunedExpression.IfThenElse(notEqual,processField,omitField));
                 }
                 else if (fieldSchemaType.IsBondContainer())
                 {
@@ -154,7 +179,8 @@ namespace Bond.Expressions
                 new ObjectParser(this, item, itemType),
                 Expression.Constant(itemType.GetBondDataType()),
                 next,
-                count);
+                count,
+                null);
 
             if (value.Type.IsArray)
                 return ArrayContainer(itemHandler);
@@ -332,7 +358,8 @@ namespace Bond.Expressions
                 new ObjectParser(this, value, valueType),
                 Expression.Constant(valueType.GetBondDataType()),
                 Expression.NotEqual(Expression.PostDecrementAssign(count), Expression.Constant(0)),
-                count);
+                count,
+                null);
 
             return Expression.Block(
                 new[] { count },
@@ -355,7 +382,8 @@ namespace Bond.Expressions
                 new ObjectParser(this, item, typeof(sbyte)),
                 Expression.Constant(BondDataType.BT_INT8),
                 Expression.LessThan(index, end),
-                count);
+                count,
+                arraySegment);
 
             return Expression.Block(
                 new[] { arraySegment, count, index, end },

--- a/cs/src/core/expressions/TaggedParser.cs
+++ b/cs/src/core/expressions/TaggedParser.cs
@@ -139,7 +139,7 @@ namespace Bond.Expressions
             var loops = MatchOrCompatible(
                 elementType,
                 expectedType,
-                type => handler(this, type, next, count));
+                type => handler(this, type, next, count, null));
 
             return Expression.Block(
                 new[] { count, elementType },

--- a/cs/src/core/expressions/UntaggedParser.cs
+++ b/cs/src/core/expressions/UntaggedParser.cs
@@ -115,7 +115,8 @@ namespace Bond.Expressions
                 new UntaggedParser<R>(this, schema.GetElementSchema()),
                 Expression.Constant(schema.TypeDef.element.id),
                 Expression.GreaterThan(Expression.PostDecrementAssign(count), Expression.Constant(0)),
-                count);
+                count,
+                null);
 
             return Expression.Block(
                 new[] { count },
@@ -207,13 +208,13 @@ namespace Bond.Expressions
 
         Expression SkipSet()
         {
-            return Container(null, (valueParser, elementType, next, count) =>
+            return Container(null, (valueParser, elementType, next, count, arraySegment) =>
                 ControlExpression.While(next, valueParser.Skip(elementType)));
         }
 
         Expression SkipList()
         {
-            return Container(null, (valueParser, elementType, next, count) =>
+            return Container(null, (valueParser, elementType, next, count, arraySegment) =>
             {
                 Debug.Assert(elementType is ConstantExpression);
                 var elementDataType = (BondDataType)(elementType as ConstantExpression).Value;

--- a/cs/src/core/expressions/xml/SimpleXmlParser.cs
+++ b/cs/src/core/expressions/xml/SimpleXmlParser.cs
@@ -182,7 +182,8 @@ namespace Bond.Expressions.Xml
                 new SimpleXmlParser<R>(this, Schema.GetElementSchema()), 
                 Expression.Constant(Schema.TypeDef.element.id), 
                 nextItem, 
-                Expression.Constant(0)));
+                Expression.Constant(0),
+                null));
         }
 
         public override Expression Map(BondDataType? expectedKeyType, BondDataType? expectedValueType, MapHandler handler)

--- a/cs/src/json/expressions/json/SimpleJsonParser.cs
+++ b/cs/src/json/expressions/json/SimpleJsonParser.cs
@@ -62,12 +62,12 @@ namespace Bond.Expressions.Json
             // into a nullable
             var readJsonNullAsEmptyList = Expression.Block(
                 Reader.Read(),
-                handler(parser, elementType, Expression.Constant(false), Expression.Constant(0)));
+                handler(parser, elementType, Expression.Constant(false), Expression.Constant(0), null));
 
             // if the json contains an array, read the array into the list
             var readJsonArrayAsList = Expression.Block(
                 Reader.Read(),
-                handler(parser, elementType, JsonTokenNotEquals(JsonToken.EndArray), Expression.Constant(0)),
+                handler(parser, elementType, JsonTokenNotEquals(JsonToken.EndArray), Expression.Constant(0), null),
                 Reader.Read());
 
             return Expression.IfThenElse(

--- a/cs/test/core/ConvertTests.cs
+++ b/cs/test/core/ConvertTests.cs
@@ -1,0 +1,150 @@
+﻿namespace UnitTest.Convert
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading;
+    using Bond;
+    using NUnit.Framework;
+    using Bond.IO.Safe;
+    using Bond.Protocols;
+
+    [global::Bond.Schema]
+    public partial class Decimals
+    {
+        [global::Bond.Id(0), global::Bond.Type(typeof(global::Bond.Tag.blob))]
+        public System.Decimal _dec { get; set; }
+
+        [global::Bond.Id(1), global::Bond.Type(typeof(List<global::Bond.Tag.blob>))]
+        public List<decimal> _decVector { get; set; }
+
+        [global::Bond.Id(2), global::Bond.Type(typeof(LinkedList<global::Bond.Tag.blob>))]
+        public LinkedList<decimal> _decList { get; set; }
+
+        [global::Bond.Id(3), global::Bond.Type(typeof(Dictionary<int, global::Bond.Tag.blob>))]
+        public Dictionary<int, decimal> _decMap { get; set; }
+
+        public Decimals()
+            : this("UnitTest.Convert.Decimals", "Decimals")
+        { }
+
+        protected Decimals(string fullName, string name)
+        {
+            _dec = new decimal();
+            _decVector = new List<decimal>();
+            _decList = new LinkedList<decimal>();
+            _decMap = new Dictionary<int, decimal>();
+        }
+
+        internal int CountDecimals()
+        {
+            return 1 + _decVector.Count + _decList.Count + _decMap.Count;
+        }
+    }
+
+    public static class BondTypeAliasConverter
+    {
+        public static int ConvertToDecimalCount = 0;
+        public static int ConvertToArraySegmentCount = 0;
+
+        public static decimal Convert(ArraySegment<byte> value, decimal unused)
+        {
+            var bits = new int[value.Count / sizeof(int)];
+            Buffer.BlockCopy(value.Array, value.Offset, bits, 0, bits.Length * sizeof(int));
+
+            Interlocked.Increment(ref ConvertToDecimalCount);
+
+            return new decimal(bits);
+        }
+
+        public static ArraySegment<byte> Convert(decimal value, ArraySegment<byte> unused)
+        {
+            var bits = decimal.GetBits(value);
+            var data = new byte[bits.Length * sizeof(int)];
+            Buffer.BlockCopy(bits, 0, data, 0, data.Length);
+
+            Interlocked.Increment(ref ConvertToArraySegmentCount);
+
+            return new ArraySegment<byte>(data);
+        }
+
+        public static void Clear()
+        {
+            ConvertToDecimalCount = 0;
+            ConvertToArraySegmentCount = 0;
+        }
+    }
+
+
+    [TestFixture]
+    public class ConvertTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            BondTypeAliasConverter.Clear();
+        }
+
+        [Test]
+        public void CorrectSerializeConvertCount()
+        {
+            var foo = new Decimals();
+            foo._dec = new decimal(19.91);
+            foo._decVector.Add(new decimal(10.10));
+            foo._decVector.Add(new decimal(11.11));
+            foo._decList.AddLast(new decimal(12.12));
+            foo._decList.AddLast(new decimal(13.13));
+            foo._decList.AddLast(new decimal(14.14));
+
+            foo._decMap.Add(1, new decimal(15.15));
+            foo._decMap.Add(2, new decimal(16.16));
+            foo._decMap.Add(3, new decimal(17.17));
+
+            var outputStream = new OutputBuffer();
+            var writer = new CompactBinaryWriter<OutputBuffer>(outputStream);
+            var serializer = new Serializer<CompactBinaryWriter<OutputBuffer>>(typeof(Decimals));
+
+            serializer.Serialize(foo, writer);
+
+            Assert.AreEqual(foo.CountDecimals(), BondTypeAliasConverter.ConvertToArraySegmentCount);
+            Assert.AreEqual(0, BondTypeAliasConverter.ConvertToDecimalCount);
+        }
+
+        [Test]
+        public void CorrectRoundtripConvertCount()
+        {
+            var foo = new Decimals();
+            foo._dec = new decimal(19.91);
+            foo._decVector.Add(new decimal(10.10));
+            foo._decVector.Add(new decimal(11.11));
+            foo._decList.AddLast(new decimal(12.12));
+            foo._decList.AddLast(new decimal(13.13));
+            foo._decList.AddLast(new decimal(14.14));
+
+            foo._decMap.Add(1, new decimal(15.15));
+            foo._decMap.Add(2, new decimal(16.16));
+            foo._decMap.Add(3, new decimal(17.17));
+
+            var output = new OutputBuffer();
+            var writer = new CompactBinaryWriter<OutputBuffer>(output);
+            var serializer = new Serializer<CompactBinaryWriter<OutputBuffer>>(typeof(Decimals));
+
+            serializer.Serialize(foo, writer);
+
+
+            var input = new InputBuffer(output.Data);
+            var reader = new CompactBinaryReader<InputBuffer>(input);
+
+            var deserializer = new Deserializer<CompactBinaryReader<InputBuffer>>(typeof(Decimals));
+            var foo2 = deserializer.Deserialize<Decimals>(reader);
+
+            Assert.AreEqual(foo.CountDecimals(), BondTypeAliasConverter.ConvertToArraySegmentCount);
+            Assert.AreEqual(foo2.CountDecimals(), BondTypeAliasConverter.ConvertToDecimalCount);
+            Assert.AreEqual(foo.CountDecimals(), foo2.CountDecimals());
+            Assert.IsTrue(Bond.Comparer.Equal(foo, foo2));
+        }
+    }
+}

--- a/cs/test/core/ConvertTests.cs
+++ b/cs/test/core/ConvertTests.cs
@@ -305,12 +305,6 @@
             Assert.AreEqual(foo.CountInstances(), BondTypeAliasConverter.ConvertFromRefObjectCount);
             Assert.AreEqual(foo2.CountInstances(), BondTypeAliasConverter.ConvertToRefObjectCount);
             Assert.AreEqual(foo.CountInstances(), foo2.CountInstances());
-
-            Assert.AreEqual(foo._ref, foo2._ref);
-            Assert.AreEqual(foo._refVector, foo2._refVector);
-            Assert.AreEqual(foo._refVector, foo2._refVector);
-            Assert.AreEqual(foo._refList, foo2._refList);
-            Assert.AreEqual(foo._refNullable, foo2._refNullable);
             Assert.IsTrue(Bond.Comparer.Equal(foo, foo2));
         }
 

--- a/cs/test/core/Core.csproj
+++ b/cs/test/core/Core.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath32)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath32)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup Condition="'$(BuildNonportable)' == 'true'">
@@ -54,6 +54,7 @@
     <Compile Include="SerializerGeneratorFactoryTests.cs" />
     <Compile Include="StreamTests.cs" />
     <Compile Include="Structs.cs" />
+    <Compile Include="ConvertTests.cs" />
     <Compile Include="TypeAliasTests.cs" />
     <Compile Include="Util.cs" />
     <Compile Include="XmlParsingTests.cs" />

--- a/cs/test/core/Core.csproj
+++ b/cs/test/core/Core.csproj
@@ -36,6 +36,7 @@
     <Compile Include="BondClass.cs" />
     <Compile Include="BondedTests.cs" />
     <Compile Include="CloningTests.cs" />
+    <Compile Include="ConvertTests.cs" />
     <Compile Include="CustomBondedTests.cs" />
     <Compile Include="DeserializerControlsTests.cs" />
     <Compile Include="EnumString.cs" />
@@ -54,7 +55,6 @@
     <Compile Include="SerializerGeneratorFactoryTests.cs" />
     <Compile Include="StreamTests.cs" />
     <Compile Include="Structs.cs" />
-    <Compile Include="ConvertTests.cs" />
     <Compile Include="TypeAliasTests.cs" />
     <Compile Include="Util.cs" />
     <Compile Include="XmlParsingTests.cs" />

--- a/cs/test/expressions/DeserializeCB.expressions
+++ b/cs/test/expressions/DeserializeCB.expressions
@@ -1543,6 +1543,376 @@
                 }
                 .LabelTarget end:;
                 .Loop  {
+                    .If ((System.Int32)$fieldType > 1) {
+                        .Block() {
+                            .If ($fieldId == .Constant<System.UInt16>(72)) {
+                                .Block() {
+                                    .If ($fieldType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                        .Block(
+                                            System.Int32 $count,
+                                            Bond.BondDataType $elementType) {
+                                            .Call $reader.ReadContainerBegin(
+                                                $count,
+                                                $elementType);
+                                            .If ($elementType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                .Block(System.Decimal $Example._decVector_item) {
+                                                    .Block(System.Int32 $Example._decVector_count) {
+                                                        $Example._decVector_count = $count;
+                                                        .If ($Example._decVector_count > 65536) {
+                                                            $Example._decVector_count = 65536
+                                                        } .Else {
+                                                            .Default(System.Void)
+                                                        };
+                                                        ($Example._decVector).Capacity = $Example._decVector_count
+                                                    };
+                                                    .Loop  {
+                                                        .If ($count-- > 0) {
+                                                            .Block() {
+                                                                .Block(
+                                                                    System.Int32 $count,
+                                                                    Bond.BondDataType $elementType) {
+                                                                    .Call $reader.ReadContainerBegin(
+                                                                        $count,
+                                                                        $elementType);
+                                                                    .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                        $Example._decVector_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                            .Call $reader.ReadBytes($count),
+                                                                            .Default(System.Decimal))
+                                                                    } .Else {
+                                                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                            .Constant<Bond.BondDataType>(BT_INT8),
+                                                                            $elementType)
+                                                                    };
+                                                                    .Call $reader.ReadContainerEnd()
+                                                                };
+                                                                .Call ($Example._decVector).Add($Example._decVector_item)
+                                                            }
+                                                        } .Else {
+                                                            .Break end { }
+                                                        }
+                                                    }
+                                                    .LabelTarget end:;
+                                                    .Default(System.Void)
+                                                }
+                                            } .Else {
+                                                .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                                    $elementType)
+                                            };
+                                            .Call $reader.ReadContainerEnd()
+                                        }
+                                    } .Else {
+                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                            .Constant<Bond.BondDataType>(BT_LIST),
+                                            $fieldType)
+                                    };
+                                    .Call $reader.ReadFieldEnd();
+                                    .Call $reader.ReadFieldBegin(
+                                        $fieldType,
+                                        $fieldId);
+                                    .Break end { }
+                                }
+                            } .Else {
+                                .If ($fieldId > .Constant<System.UInt16>(72)) {
+                                    .Block() {
+                                        .Default(System.Void);
+                                        .Break end { }
+                                    }
+                                } .Else {
+                                    .Call $reader.Skip($fieldType)
+                                }
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .If ($fieldId > .Constant<System.UInt16>(72)) {
+                                .Break end { }
+                            } .Else {
+                                .Default(System.Void)
+                            }
+                        }
+                    } .Else {
+                        .Block() {
+                            .Default(System.Void);
+                            .Break end { }
+                        }
+                    }
+                }
+                .LabelTarget end:;
+                .Loop  {
+                    .If ((System.Int32)$fieldType > 1) {
+                        .Block() {
+                            .If ($fieldId == .Constant<System.UInt16>(73)) {
+                                .Block() {
+                                    .If ($fieldType == .Constant<Bond.BondDataType>(BT_MAP)) {
+                                        .Block(
+                                            System.Int32 $count,
+                                            Bond.BondDataType $keyType,
+                                            Bond.BondDataType $valueType) {
+                                            .Call $reader.ReadContainerBegin(
+                                                $count,
+                                                $keyType,
+                                                $valueType);
+                                            .If ($keyType == .Constant<Bond.BondDataType>(BT_INT32)) {
+                                                .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                    .Block(
+                                                        System.Int32 $Example._decMap_key,
+                                                        System.Decimal $Example._decMap_value) {
+                                                        .Default(System.Void);
+                                                        .Loop  {
+                                                            .If ($count-- > 0) {
+                                                                .Block() {
+                                                                    $Example._decMap_key = .Call $reader.ReadInt32();
+                                                                    .Default(System.Void);
+                                                                    .Block(
+                                                                        System.Int32 $count,
+                                                                        Bond.BondDataType $elementType) {
+                                                                        .Call $reader.ReadContainerBegin(
+                                                                            $count,
+                                                                            $elementType);
+                                                                        .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                            $Example._decMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                .Call $reader.ReadBytes($count),
+                                                                                .Default(System.Decimal))
+                                                                        } .Else {
+                                                                            .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                                .Constant<Bond.BondDataType>(BT_INT8),
+                                                                                $elementType)
+                                                                        };
+                                                                        .Call $reader.ReadContainerEnd()
+                                                                    };
+                                                                    ($Example._decMap).Item[$Example._decMap_key] = $Example._decMap_value
+                                                                }
+                                                            } .Else {
+                                                                .Break end { }
+                                                            }
+                                                        }
+                                                        .LabelTarget end:
+                                                    }
+                                                } .Else {
+                                                    .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                        .Constant<Bond.BondDataType>(BT_LIST),
+                                                        $valueType)
+                                                }
+                                            } .Else {
+                                                .If ($keyType == .Constant<Bond.BondDataType>(BT_INT16)) {
+                                                    .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                        .Block(
+                                                            System.Int32 $Example._decMap_key,
+                                                            System.Decimal $Example._decMap_value) {
+                                                            .Default(System.Void);
+                                                            .Loop  {
+                                                                .If ($count-- > 0) {
+                                                                    .Block() {
+                                                                        $Example._decMap_key = (System.Int32).Call $reader.ReadInt16();
+                                                                        .Default(System.Void);
+                                                                        .Block(
+                                                                            System.Int32 $count,
+                                                                            Bond.BondDataType $elementType) {
+                                                                            .Call $reader.ReadContainerBegin(
+                                                                                $count,
+                                                                                $elementType);
+                                                                            .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                                $Example._decMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                    .Call $reader.ReadBytes($count),
+                                                                                    .Default(System.Decimal))
+                                                                            } .Else {
+                                                                                .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                                    .Constant<Bond.BondDataType>(BT_INT8),
+                                                                                    $elementType)
+                                                                            };
+                                                                            .Call $reader.ReadContainerEnd()
+                                                                        };
+                                                                        ($Example._decMap).Item[$Example._decMap_key] = $Example._decMap_value
+                                                                    }
+                                                                } .Else {
+                                                                    .Break end { }
+                                                                }
+                                                            }
+                                                            .LabelTarget end:
+                                                        }
+                                                    } .Else {
+                                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                            .Constant<Bond.BondDataType>(BT_LIST),
+                                                            $valueType)
+                                                    }
+                                                } .Else {
+                                                    .If ($keyType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                        .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                            .Block(
+                                                                System.Int32 $Example._decMap_key,
+                                                                System.Decimal $Example._decMap_value) {
+                                                                .Default(System.Void);
+                                                                .Loop  {
+                                                                    .If ($count-- > 0) {
+                                                                        .Block() {
+                                                                            $Example._decMap_key = (System.Int32).Call $reader.ReadInt8();
+                                                                            .Default(System.Void);
+                                                                            .Block(
+                                                                                System.Int32 $count,
+                                                                                Bond.BondDataType $elementType) {
+                                                                                .Call $reader.ReadContainerBegin(
+                                                                                    $count,
+                                                                                    $elementType);
+                                                                                .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                                    $Example._decMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                        .Call $reader.ReadBytes($count),
+                                                                                        .Default(System.Decimal))
+                                                                                } .Else {
+                                                                                    .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                                        .Constant<Bond.BondDataType>(BT_INT8),
+                                                                                        $elementType)
+                                                                                };
+                                                                                .Call $reader.ReadContainerEnd()
+                                                                            };
+                                                                            ($Example._decMap).Item[$Example._decMap_key] = $Example._decMap_value
+                                                                        }
+                                                                    } .Else {
+                                                                        .Break end { }
+                                                                    }
+                                                                }
+                                                                .LabelTarget end:
+                                                            }
+                                                        } .Else {
+                                                            .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                .Constant<Bond.BondDataType>(BT_LIST),
+                                                                $valueType)
+                                                        }
+                                                    } .Else {
+                                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                            .Constant<Bond.BondDataType>(BT_INT32),
+                                                            $keyType)
+                                                    }
+                                                }
+                                            };
+                                            .Call $reader.ReadContainerEnd()
+                                        }
+                                    } .Else {
+                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                            .Constant<Bond.BondDataType>(BT_MAP),
+                                            $fieldType)
+                                    };
+                                    .Call $reader.ReadFieldEnd();
+                                    .Call $reader.ReadFieldBegin(
+                                        $fieldType,
+                                        $fieldId);
+                                    .Break end { }
+                                }
+                            } .Else {
+                                .If ($fieldId > .Constant<System.UInt16>(73)) {
+                                    .Block() {
+                                        .Default(System.Void);
+                                        .Break end { }
+                                    }
+                                } .Else {
+                                    .Call $reader.Skip($fieldType)
+                                }
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .If ($fieldId > .Constant<System.UInt16>(73)) {
+                                .Break end { }
+                            } .Else {
+                                .Default(System.Void)
+                            }
+                        }
+                    } .Else {
+                        .Block() {
+                            .Default(System.Void);
+                            .Break end { }
+                        }
+                    }
+                }
+                .LabelTarget end:;
+                .Loop  {
+                    .If ((System.Int32)$fieldType > 1) {
+                        .Block() {
+                            .If ($fieldId == .Constant<System.UInt16>(74)) {
+                                .Block() {
+                                    .If ($fieldType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                        .Block(
+                                            System.Int32 $count,
+                                            Bond.BondDataType $elementType) {
+                                            .Call $reader.ReadContainerBegin(
+                                                $count,
+                                                $elementType);
+                                            .If ($elementType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                .Block() {
+                                                    .Loop  {
+                                                        .If ($count-- > 0) {
+                                                            .Block(
+                                                                System.Int32 $count,
+                                                                Bond.BondDataType $elementType) {
+                                                                .Call $reader.ReadContainerBegin(
+                                                                    $count,
+                                                                    $elementType);
+                                                                .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                    $Example._decNullable = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                        .Call $reader.ReadBytes($count),
+                                                                        .Default(System.Decimal))
+                                                                } .Else {
+                                                                    .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                        .Constant<Bond.BondDataType>(BT_INT8),
+                                                                        $elementType)
+                                                                };
+                                                                .Call $reader.ReadContainerEnd()
+                                                            }
+                                                        } .Else {
+                                                            .Break end { }
+                                                        }
+                                                    }
+                                                    .LabelTarget end:
+                                                }
+                                            } .Else {
+                                                .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                                    $elementType)
+                                            };
+                                            .Call $reader.ReadContainerEnd()
+                                        }
+                                    } .Else {
+                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                            .Constant<Bond.BondDataType>(BT_LIST),
+                                            $fieldType)
+                                    };
+                                    .Call $reader.ReadFieldEnd();
+                                    .Call $reader.ReadFieldBegin(
+                                        $fieldType,
+                                        $fieldId);
+                                    .Break end { }
+                                }
+                            } .Else {
+                                .If ($fieldId > .Constant<System.UInt16>(74)) {
+                                    .Block() {
+                                        .Default(System.Void);
+                                        .Break end { }
+                                    }
+                                } .Else {
+                                    .Call $reader.Skip($fieldType)
+                                }
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .If ($fieldId > .Constant<System.UInt16>(74)) {
+                                .Break end { }
+                            } .Else {
+                                .Default(System.Void)
+                            }
+                        }
+                    } .Else {
+                        .Block() {
+                            .Default(System.Void);
+                            .Break end { }
+                        }
+                    }
+                }
+                .LabelTarget end:;
+                .Loop  {
                     .If ($fieldType != .Constant<Bond.BondDataType>(BT_STOP)) {
                         .Block() {
                             .If ($fieldType == .Constant<Bond.BondDataType>(BT_STOP_BASE)) {

--- a/cs/test/expressions/DeserializeCB.expressions
+++ b/cs/test/expressions/DeserializeCB.expressions
@@ -1391,6 +1391,158 @@
                 }
                 .LabelTarget end:;
                 .Loop  {
+                    .If ((System.Int32)$fieldType > 1) {
+                        .Block() {
+                            .If ($fieldId == .Constant<System.UInt16>(70)) {
+                                .Block() {
+                                    .If ($fieldType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                        .Block(
+                                            System.Int32 $count,
+                                            Bond.BondDataType $elementType) {
+                                            .Call $reader.ReadContainerBegin(
+                                                $count,
+                                                $elementType);
+                                            .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                $Example._decimal = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                    .Call $reader.ReadBytes($count),
+                                                    .Default(System.Decimal))
+                                            } .Else {
+                                                .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                    .Constant<Bond.BondDataType>(BT_INT8),
+                                                    $elementType)
+                                            };
+                                            .Call $reader.ReadContainerEnd()
+                                        }
+                                    } .Else {
+                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                            .Constant<Bond.BondDataType>(BT_LIST),
+                                            $fieldType)
+                                    };
+                                    .Call $reader.ReadFieldEnd();
+                                    .Call $reader.ReadFieldBegin(
+                                        $fieldType,
+                                        $fieldId);
+                                    .Break end { }
+                                }
+                            } .Else {
+                                .If ($fieldId > .Constant<System.UInt16>(70)) {
+                                    .Block() {
+                                        .Default(System.Void);
+                                        .Break end { }
+                                    }
+                                } .Else {
+                                    .Call $reader.Skip($fieldType)
+                                }
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .If ($fieldId > .Constant<System.UInt16>(70)) {
+                                .Break end { }
+                            } .Else {
+                                .Default(System.Void)
+                            }
+                        }
+                    } .Else {
+                        .Block() {
+                            .Default(System.Void);
+                            .Break end { }
+                        }
+                    }
+                }
+                .LabelTarget end:;
+                .Loop  {
+                    .If ((System.Int32)$fieldType > 1) {
+                        .Block() {
+                            .If ($fieldId == .Constant<System.UInt16>(71)) {
+                                .Block() {
+                                    .If ($fieldType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                        .Block(
+                                            System.Int32 $count,
+                                            Bond.BondDataType $elementType) {
+                                            .Call $reader.ReadContainerBegin(
+                                                $count,
+                                                $elementType);
+                                            .If ($elementType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                .Block(System.Decimal $Example._decList_item) {
+                                                    .Default(System.Void);
+                                                    .Loop  {
+                                                        .If ($count-- > 0) {
+                                                            .Block() {
+                                                                .Block(
+                                                                    System.Int32 $count,
+                                                                    Bond.BondDataType $elementType) {
+                                                                    .Call $reader.ReadContainerBegin(
+                                                                        $count,
+                                                                        $elementType);
+                                                                    .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                        $Example._decList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                            .Call $reader.ReadBytes($count),
+                                                                            .Default(System.Decimal))
+                                                                    } .Else {
+                                                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                            .Constant<Bond.BondDataType>(BT_INT8),
+                                                                            $elementType)
+                                                                    };
+                                                                    .Call $reader.ReadContainerEnd()
+                                                                };
+                                                                .Call ($Example._decList).Add($Example._decList_item)
+                                                            }
+                                                        } .Else {
+                                                            .Break end { }
+                                                        }
+                                                    }
+                                                    .LabelTarget end:;
+                                                    .Default(System.Void)
+                                                }
+                                            } .Else {
+                                                .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                                    $elementType)
+                                            };
+                                            .Call $reader.ReadContainerEnd()
+                                        }
+                                    } .Else {
+                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                            .Constant<Bond.BondDataType>(BT_LIST),
+                                            $fieldType)
+                                    };
+                                    .Call $reader.ReadFieldEnd();
+                                    .Call $reader.ReadFieldBegin(
+                                        $fieldType,
+                                        $fieldId);
+                                    .Break end { }
+                                }
+                            } .Else {
+                                .If ($fieldId > .Constant<System.UInt16>(71)) {
+                                    .Block() {
+                                        .Default(System.Void);
+                                        .Break end { }
+                                    }
+                                } .Else {
+                                    .Call $reader.Skip($fieldType)
+                                }
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .If ($fieldId > .Constant<System.UInt16>(71)) {
+                                .Break end { }
+                            } .Else {
+                                .Default(System.Void)
+                            }
+                        }
+                    } .Else {
+                        .Block() {
+                            .Default(System.Void);
+                            .Break end { }
+                        }
+                    }
+                }
+                .LabelTarget end:;
+                .Loop  {
                     .If ($fieldType != .Constant<Bond.BondDataType>(BT_STOP)) {
                         .Block() {
                             .If ($fieldType == .Constant<Bond.BondDataType>(BT_STOP_BASE)) {

--- a/cs/test/expressions/DeserializeCB.expressions
+++ b/cs/test/expressions/DeserializeCB.expressions
@@ -1191,6 +1191,454 @@
                 .Loop  {
                     .If ((System.Int32)$fieldType > 1) {
                         .Block() {
+                            .If ($fieldId == .Constant<System.UInt16>(51)) {
+                                .Block() {
+                                    .If ($fieldType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                        .Block(
+                                            System.Int32 $count,
+                                            Bond.BondDataType $elementType) {
+                                            .Call $reader.ReadContainerBegin(
+                                                $count,
+                                                $elementType);
+                                            .If ($elementType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                .Block(System.ArraySegment`1[System.Byte] $Example._blobList_item) {
+                                                    .Default(System.Void);
+                                                    .Loop  {
+                                                        .If ($count-- > 0) {
+                                                            .Block() {
+                                                                .Block(
+                                                                    System.Int32 $count,
+                                                                    Bond.BondDataType $elementType) {
+                                                                    .Call $reader.ReadContainerBegin(
+                                                                        $count,
+                                                                        $elementType);
+                                                                    .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                        $Example._blobList_item = .Call $reader.ReadBytes($count)
+                                                                    } .Else {
+                                                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                            .Constant<Bond.BondDataType>(BT_INT8),
+                                                                            $elementType)
+                                                                    };
+                                                                    .Call $reader.ReadContainerEnd()
+                                                                };
+                                                                .Call ($Example._blobList).Add($Example._blobList_item)
+                                                            }
+                                                        } .Else {
+                                                            .Break end { }
+                                                        }
+                                                    }
+                                                    .LabelTarget end:;
+                                                    .Default(System.Void)
+                                                }
+                                            } .Else {
+                                                .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                                    $elementType)
+                                            };
+                                            .Call $reader.ReadContainerEnd()
+                                        }
+                                    } .Else {
+                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                            .Constant<Bond.BondDataType>(BT_LIST),
+                                            $fieldType)
+                                    };
+                                    .Call $reader.ReadFieldEnd();
+                                    .Call $reader.ReadFieldBegin(
+                                        $fieldType,
+                                        $fieldId);
+                                    .Break end { }
+                                }
+                            } .Else {
+                                .If ($fieldId > .Constant<System.UInt16>(51)) {
+                                    .Block() {
+                                        .Default(System.Void);
+                                        .Break end { }
+                                    }
+                                } .Else {
+                                    .Call $reader.Skip($fieldType)
+                                }
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .If ($fieldId > .Constant<System.UInt16>(51)) {
+                                .Break end { }
+                            } .Else {
+                                .Default(System.Void)
+                            }
+                        }
+                    } .Else {
+                        .Block() {
+                            .Default(System.Void);
+                            .Break end { }
+                        }
+                    }
+                }
+                .LabelTarget end:;
+                .Loop  {
+                    .If ((System.Int32)$fieldType > 1) {
+                        .Block() {
+                            .If ($fieldId == .Constant<System.UInt16>(52)) {
+                                .Block() {
+                                    .If ($fieldType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                        .Block(
+                                            System.Int32 $count,
+                                            Bond.BondDataType $elementType) {
+                                            .Call $reader.ReadContainerBegin(
+                                                $count,
+                                                $elementType);
+                                            .If ($elementType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                .Block(System.ArraySegment`1[System.Byte] $Example._blobVector_item) {
+                                                    .Block(System.Int32 $Example._blobVector_count) {
+                                                        $Example._blobVector_count = $count;
+                                                        .If ($Example._blobVector_count > 65536) {
+                                                            $Example._blobVector_count = 65536
+                                                        } .Else {
+                                                            .Default(System.Void)
+                                                        };
+                                                        ($Example._blobVector).Capacity = $Example._blobVector_count
+                                                    };
+                                                    .Loop  {
+                                                        .If ($count-- > 0) {
+                                                            .Block() {
+                                                                .Block(
+                                                                    System.Int32 $count,
+                                                                    Bond.BondDataType $elementType) {
+                                                                    .Call $reader.ReadContainerBegin(
+                                                                        $count,
+                                                                        $elementType);
+                                                                    .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                        $Example._blobVector_item = .Call $reader.ReadBytes($count)
+                                                                    } .Else {
+                                                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                            .Constant<Bond.BondDataType>(BT_INT8),
+                                                                            $elementType)
+                                                                    };
+                                                                    .Call $reader.ReadContainerEnd()
+                                                                };
+                                                                .Call ($Example._blobVector).Add($Example._blobVector_item)
+                                                            }
+                                                        } .Else {
+                                                            .Break end { }
+                                                        }
+                                                    }
+                                                    .LabelTarget end:;
+                                                    .Default(System.Void)
+                                                }
+                                            } .Else {
+                                                .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                                    $elementType)
+                                            };
+                                            .Call $reader.ReadContainerEnd()
+                                        }
+                                    } .Else {
+                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                            .Constant<Bond.BondDataType>(BT_LIST),
+                                            $fieldType)
+                                    };
+                                    .Call $reader.ReadFieldEnd();
+                                    .Call $reader.ReadFieldBegin(
+                                        $fieldType,
+                                        $fieldId);
+                                    .Break end { }
+                                }
+                            } .Else {
+                                .If ($fieldId > .Constant<System.UInt16>(52)) {
+                                    .Block() {
+                                        .Default(System.Void);
+                                        .Break end { }
+                                    }
+                                } .Else {
+                                    .Call $reader.Skip($fieldType)
+                                }
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .If ($fieldId > .Constant<System.UInt16>(52)) {
+                                .Break end { }
+                            } .Else {
+                                .Default(System.Void)
+                            }
+                        }
+                    } .Else {
+                        .Block() {
+                            .Default(System.Void);
+                            .Break end { }
+                        }
+                    }
+                }
+                .LabelTarget end:;
+                .Loop  {
+                    .If ((System.Int32)$fieldType > 1) {
+                        .Block() {
+                            .If ($fieldId == .Constant<System.UInt16>(53)) {
+                                .Block() {
+                                    .If ($fieldType == .Constant<Bond.BondDataType>(BT_MAP)) {
+                                        .Block(
+                                            System.Int32 $count,
+                                            Bond.BondDataType $keyType,
+                                            Bond.BondDataType $valueType) {
+                                            .Call $reader.ReadContainerBegin(
+                                                $count,
+                                                $keyType,
+                                                $valueType);
+                                            .If ($keyType == .Constant<Bond.BondDataType>(BT_INT32)) {
+                                                .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                    .Block(
+                                                        System.Int32 $Example._blobMap_key,
+                                                        System.ArraySegment`1[System.Byte] $Example._blobMap_value) {
+                                                        .Default(System.Void);
+                                                        .Loop  {
+                                                            .If ($count-- > 0) {
+                                                                .Block() {
+                                                                    $Example._blobMap_key = .Call $reader.ReadInt32();
+                                                                    .Default(System.Void);
+                                                                    .Block(
+                                                                        System.Int32 $count,
+                                                                        Bond.BondDataType $elementType) {
+                                                                        .Call $reader.ReadContainerBegin(
+                                                                            $count,
+                                                                            $elementType);
+                                                                        .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                            $Example._blobMap_value = .Call $reader.ReadBytes($count)
+                                                                        } .Else {
+                                                                            .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                                .Constant<Bond.BondDataType>(BT_INT8),
+                                                                                $elementType)
+                                                                        };
+                                                                        .Call $reader.ReadContainerEnd()
+                                                                    };
+                                                                    ($Example._blobMap).Item[$Example._blobMap_key] = $Example._blobMap_value
+                                                                }
+                                                            } .Else {
+                                                                .Break end { }
+                                                            }
+                                                        }
+                                                        .LabelTarget end:
+                                                    }
+                                                } .Else {
+                                                    .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                        .Constant<Bond.BondDataType>(BT_LIST),
+                                                        $valueType)
+                                                }
+                                            } .Else {
+                                                .If ($keyType == .Constant<Bond.BondDataType>(BT_INT16)) {
+                                                    .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                        .Block(
+                                                            System.Int32 $Example._blobMap_key,
+                                                            System.ArraySegment`1[System.Byte] $Example._blobMap_value) {
+                                                            .Default(System.Void);
+                                                            .Loop  {
+                                                                .If ($count-- > 0) {
+                                                                    .Block() {
+                                                                        $Example._blobMap_key = (System.Int32).Call $reader.ReadInt16();
+                                                                        .Default(System.Void);
+                                                                        .Block(
+                                                                            System.Int32 $count,
+                                                                            Bond.BondDataType $elementType) {
+                                                                            .Call $reader.ReadContainerBegin(
+                                                                                $count,
+                                                                                $elementType);
+                                                                            .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                                $Example._blobMap_value = .Call $reader.ReadBytes($count)
+                                                                            } .Else {
+                                                                                .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                                    .Constant<Bond.BondDataType>(BT_INT8),
+                                                                                    $elementType)
+                                                                            };
+                                                                            .Call $reader.ReadContainerEnd()
+                                                                        };
+                                                                        ($Example._blobMap).Item[$Example._blobMap_key] = $Example._blobMap_value
+                                                                    }
+                                                                } .Else {
+                                                                    .Break end { }
+                                                                }
+                                                            }
+                                                            .LabelTarget end:
+                                                        }
+                                                    } .Else {
+                                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                            .Constant<Bond.BondDataType>(BT_LIST),
+                                                            $valueType)
+                                                    }
+                                                } .Else {
+                                                    .If ($keyType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                        .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                            .Block(
+                                                                System.Int32 $Example._blobMap_key,
+                                                                System.ArraySegment`1[System.Byte] $Example._blobMap_value) {
+                                                                .Default(System.Void);
+                                                                .Loop  {
+                                                                    .If ($count-- > 0) {
+                                                                        .Block() {
+                                                                            $Example._blobMap_key = (System.Int32).Call $reader.ReadInt8();
+                                                                            .Default(System.Void);
+                                                                            .Block(
+                                                                                System.Int32 $count,
+                                                                                Bond.BondDataType $elementType) {
+                                                                                .Call $reader.ReadContainerBegin(
+                                                                                    $count,
+                                                                                    $elementType);
+                                                                                .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                                    $Example._blobMap_value = .Call $reader.ReadBytes($count)
+                                                                                } .Else {
+                                                                                    .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                                        .Constant<Bond.BondDataType>(BT_INT8),
+                                                                                        $elementType)
+                                                                                };
+                                                                                .Call $reader.ReadContainerEnd()
+                                                                            };
+                                                                            ($Example._blobMap).Item[$Example._blobMap_key] = $Example._blobMap_value
+                                                                        }
+                                                                    } .Else {
+                                                                        .Break end { }
+                                                                    }
+                                                                }
+                                                                .LabelTarget end:
+                                                            }
+                                                        } .Else {
+                                                            .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                .Constant<Bond.BondDataType>(BT_LIST),
+                                                                $valueType)
+                                                        }
+                                                    } .Else {
+                                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                            .Constant<Bond.BondDataType>(BT_INT32),
+                                                            $keyType)
+                                                    }
+                                                }
+                                            };
+                                            .Call $reader.ReadContainerEnd()
+                                        }
+                                    } .Else {
+                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                            .Constant<Bond.BondDataType>(BT_MAP),
+                                            $fieldType)
+                                    };
+                                    .Call $reader.ReadFieldEnd();
+                                    .Call $reader.ReadFieldBegin(
+                                        $fieldType,
+                                        $fieldId);
+                                    .Break end { }
+                                }
+                            } .Else {
+                                .If ($fieldId > .Constant<System.UInt16>(53)) {
+                                    .Block() {
+                                        .Default(System.Void);
+                                        .Break end { }
+                                    }
+                                } .Else {
+                                    .Call $reader.Skip($fieldType)
+                                }
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .If ($fieldId > .Constant<System.UInt16>(53)) {
+                                .Break end { }
+                            } .Else {
+                                .Default(System.Void)
+                            }
+                        }
+                    } .Else {
+                        .Block() {
+                            .Default(System.Void);
+                            .Break end { }
+                        }
+                    }
+                }
+                .LabelTarget end:;
+                .Loop  {
+                    .If ((System.Int32)$fieldType > 1) {
+                        .Block() {
+                            .If ($fieldId == .Constant<System.UInt16>(54)) {
+                                .Block() {
+                                    .If ($fieldType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                        .Block(
+                                            System.Int32 $count,
+                                            Bond.BondDataType $elementType) {
+                                            .Call $reader.ReadContainerBegin(
+                                                $count,
+                                                $elementType);
+                                            .If ($elementType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                .Block() {
+                                                    .Loop  {
+                                                        .If ($count-- > 0) {
+                                                            .Block(
+                                                                System.Int32 $count,
+                                                                Bond.BondDataType $elementType) {
+                                                                .Call $reader.ReadContainerBegin(
+                                                                    $count,
+                                                                    $elementType);
+                                                                .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                    $Example._blobNullable = .Call $reader.ReadBytes($count)
+                                                                } .Else {
+                                                                    .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                        .Constant<Bond.BondDataType>(BT_INT8),
+                                                                        $elementType)
+                                                                };
+                                                                .Call $reader.ReadContainerEnd()
+                                                            }
+                                                        } .Else {
+                                                            .Break end { }
+                                                        }
+                                                    }
+                                                    .LabelTarget end:
+                                                }
+                                            } .Else {
+                                                .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                                    $elementType)
+                                            };
+                                            .Call $reader.ReadContainerEnd()
+                                        }
+                                    } .Else {
+                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                            .Constant<Bond.BondDataType>(BT_LIST),
+                                            $fieldType)
+                                    };
+                                    .Call $reader.ReadFieldEnd();
+                                    .Call $reader.ReadFieldBegin(
+                                        $fieldType,
+                                        $fieldId);
+                                    .Break end { }
+                                }
+                            } .Else {
+                                .If ($fieldId > .Constant<System.UInt16>(54)) {
+                                    .Block() {
+                                        .Default(System.Void);
+                                        .Break end { }
+                                    }
+                                } .Else {
+                                    .Call $reader.Skip($fieldType)
+                                }
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .If ($fieldId > .Constant<System.UInt16>(54)) {
+                                .Break end { }
+                            } .Else {
+                                .Default(System.Void)
+                            }
+                        }
+                    } .Else {
+                        .Block() {
+                            .Default(System.Void);
+                            .Break end { }
+                        }
+                    }
+                }
+                .LabelTarget end:;
+                .Loop  {
+                    .If ((System.Int32)$fieldType > 1) {
+                        .Block() {
                             .If ($fieldId == .Constant<System.UInt16>(60)) {
                                 .Block() {
                                     .If ($fieldType == .Constant<Bond.BondDataType>(BT_MAP)) {
@@ -1899,6 +2347,529 @@
                                 $fieldType,
                                 $fieldId);
                             .If ($fieldId > .Constant<System.UInt16>(74)) {
+                                .Break end { }
+                            } .Else {
+                                .Default(System.Void)
+                            }
+                        }
+                    } .Else {
+                        .Block() {
+                            .Default(System.Void);
+                            .Break end { }
+                        }
+                    }
+                }
+                .LabelTarget end:;
+                .Loop  {
+                    .If ((System.Int32)$fieldType > 1) {
+                        .Block() {
+                            .If ($fieldId == .Constant<System.UInt16>(80)) {
+                                .Block() {
+                                    .If ($fieldType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                        .Block(
+                                            System.Int32 $count,
+                                            Bond.BondDataType $elementType) {
+                                            .Call $reader.ReadContainerBegin(
+                                                $count,
+                                                $elementType);
+                                            .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                $Example._reference = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                    .Call $reader.ReadBytes($count),
+                                                    .Default(ExpressionsTest.RefObject))
+                                            } .Else {
+                                                .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                    .Constant<Bond.BondDataType>(BT_INT8),
+                                                    $elementType)
+                                            };
+                                            .Call $reader.ReadContainerEnd()
+                                        }
+                                    } .Else {
+                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                            .Constant<Bond.BondDataType>(BT_LIST),
+                                            $fieldType)
+                                    };
+                                    .Call $reader.ReadFieldEnd();
+                                    .Call $reader.ReadFieldBegin(
+                                        $fieldType,
+                                        $fieldId);
+                                    .Break end { }
+                                }
+                            } .Else {
+                                .If ($fieldId > .Constant<System.UInt16>(80)) {
+                                    .Block() {
+                                        .Default(System.Void);
+                                        .Break end { }
+                                    }
+                                } .Else {
+                                    .Call $reader.Skip($fieldType)
+                                }
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .If ($fieldId > .Constant<System.UInt16>(80)) {
+                                .Break end { }
+                            } .Else {
+                                .Default(System.Void)
+                            }
+                        }
+                    } .Else {
+                        .Block() {
+                            .Default(System.Void);
+                            .Break end { }
+                        }
+                    }
+                }
+                .LabelTarget end:;
+                .Loop  {
+                    .If ((System.Int32)$fieldType > 1) {
+                        .Block() {
+                            .If ($fieldId == .Constant<System.UInt16>(81)) {
+                                .Block() {
+                                    .If ($fieldType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                        .Block(
+                                            System.Int32 $count,
+                                            Bond.BondDataType $elementType) {
+                                            .Call $reader.ReadContainerBegin(
+                                                $count,
+                                                $elementType);
+                                            .If ($elementType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                .Block(ExpressionsTest.RefObject $Example._refList_item) {
+                                                    .Default(System.Void);
+                                                    .Loop  {
+                                                        .If ($count-- > 0) {
+                                                            .Block() {
+                                                                .Block(
+                                                                    System.Int32 $count,
+                                                                    Bond.BondDataType $elementType) {
+                                                                    .Call $reader.ReadContainerBegin(
+                                                                        $count,
+                                                                        $elementType);
+                                                                    .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                        $Example._refList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                            .Call $reader.ReadBytes($count),
+                                                                            .Default(ExpressionsTest.RefObject))
+                                                                    } .Else {
+                                                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                            .Constant<Bond.BondDataType>(BT_INT8),
+                                                                            $elementType)
+                                                                    };
+                                                                    .Call $reader.ReadContainerEnd()
+                                                                };
+                                                                .Call ($Example._refList).Add($Example._refList_item)
+                                                            }
+                                                        } .Else {
+                                                            .Break end { }
+                                                        }
+                                                    }
+                                                    .LabelTarget end:;
+                                                    .Default(System.Void)
+                                                }
+                                            } .Else {
+                                                .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                                    $elementType)
+                                            };
+                                            .Call $reader.ReadContainerEnd()
+                                        }
+                                    } .Else {
+                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                            .Constant<Bond.BondDataType>(BT_LIST),
+                                            $fieldType)
+                                    };
+                                    .Call $reader.ReadFieldEnd();
+                                    .Call $reader.ReadFieldBegin(
+                                        $fieldType,
+                                        $fieldId);
+                                    .Break end { }
+                                }
+                            } .Else {
+                                .If ($fieldId > .Constant<System.UInt16>(81)) {
+                                    .Block() {
+                                        .Default(System.Void);
+                                        .Break end { }
+                                    }
+                                } .Else {
+                                    .Call $reader.Skip($fieldType)
+                                }
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .If ($fieldId > .Constant<System.UInt16>(81)) {
+                                .Break end { }
+                            } .Else {
+                                .Default(System.Void)
+                            }
+                        }
+                    } .Else {
+                        .Block() {
+                            .Default(System.Void);
+                            .Break end { }
+                        }
+                    }
+                }
+                .LabelTarget end:;
+                .Loop  {
+                    .If ((System.Int32)$fieldType > 1) {
+                        .Block() {
+                            .If ($fieldId == .Constant<System.UInt16>(82)) {
+                                .Block() {
+                                    .If ($fieldType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                        .Block(
+                                            System.Int32 $count,
+                                            Bond.BondDataType $elementType) {
+                                            .Call $reader.ReadContainerBegin(
+                                                $count,
+                                                $elementType);
+                                            .If ($elementType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                .Block(ExpressionsTest.RefObject $Example._refVector_item) {
+                                                    .Block(System.Int32 $Example._refVector_count) {
+                                                        $Example._refVector_count = $count;
+                                                        .If ($Example._refVector_count > 65536) {
+                                                            $Example._refVector_count = 65536
+                                                        } .Else {
+                                                            .Default(System.Void)
+                                                        };
+                                                        ($Example._refVector).Capacity = $Example._refVector_count
+                                                    };
+                                                    .Loop  {
+                                                        .If ($count-- > 0) {
+                                                            .Block() {
+                                                                .Block(
+                                                                    System.Int32 $count,
+                                                                    Bond.BondDataType $elementType) {
+                                                                    .Call $reader.ReadContainerBegin(
+                                                                        $count,
+                                                                        $elementType);
+                                                                    .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                        $Example._refVector_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                            .Call $reader.ReadBytes($count),
+                                                                            .Default(ExpressionsTest.RefObject))
+                                                                    } .Else {
+                                                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                            .Constant<Bond.BondDataType>(BT_INT8),
+                                                                            $elementType)
+                                                                    };
+                                                                    .Call $reader.ReadContainerEnd()
+                                                                };
+                                                                .Call ($Example._refVector).Add($Example._refVector_item)
+                                                            }
+                                                        } .Else {
+                                                            .Break end { }
+                                                        }
+                                                    }
+                                                    .LabelTarget end:;
+                                                    .Default(System.Void)
+                                                }
+                                            } .Else {
+                                                .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                                    $elementType)
+                                            };
+                                            .Call $reader.ReadContainerEnd()
+                                        }
+                                    } .Else {
+                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                            .Constant<Bond.BondDataType>(BT_LIST),
+                                            $fieldType)
+                                    };
+                                    .Call $reader.ReadFieldEnd();
+                                    .Call $reader.ReadFieldBegin(
+                                        $fieldType,
+                                        $fieldId);
+                                    .Break end { }
+                                }
+                            } .Else {
+                                .If ($fieldId > .Constant<System.UInt16>(82)) {
+                                    .Block() {
+                                        .Default(System.Void);
+                                        .Break end { }
+                                    }
+                                } .Else {
+                                    .Call $reader.Skip($fieldType)
+                                }
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .If ($fieldId > .Constant<System.UInt16>(82)) {
+                                .Break end { }
+                            } .Else {
+                                .Default(System.Void)
+                            }
+                        }
+                    } .Else {
+                        .Block() {
+                            .Default(System.Void);
+                            .Break end { }
+                        }
+                    }
+                }
+                .LabelTarget end:;
+                .Loop  {
+                    .If ((System.Int32)$fieldType > 1) {
+                        .Block() {
+                            .If ($fieldId == .Constant<System.UInt16>(83)) {
+                                .Block() {
+                                    .If ($fieldType == .Constant<Bond.BondDataType>(BT_MAP)) {
+                                        .Block(
+                                            System.Int32 $count,
+                                            Bond.BondDataType $keyType,
+                                            Bond.BondDataType $valueType) {
+                                            .Call $reader.ReadContainerBegin(
+                                                $count,
+                                                $keyType,
+                                                $valueType);
+                                            .If ($keyType == .Constant<Bond.BondDataType>(BT_INT32)) {
+                                                .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                    .Block(
+                                                        System.Int32 $Example._refMap_key,
+                                                        ExpressionsTest.RefObject $Example._refMap_value) {
+                                                        .Default(System.Void);
+                                                        .Loop  {
+                                                            .If ($count-- > 0) {
+                                                                .Block() {
+                                                                    $Example._refMap_key = .Call $reader.ReadInt32();
+                                                                    .Default(System.Void);
+                                                                    .Block(
+                                                                        System.Int32 $count,
+                                                                        Bond.BondDataType $elementType) {
+                                                                        .Call $reader.ReadContainerBegin(
+                                                                            $count,
+                                                                            $elementType);
+                                                                        .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                            $Example._refMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                .Call $reader.ReadBytes($count),
+                                                                                .Default(ExpressionsTest.RefObject))
+                                                                        } .Else {
+                                                                            .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                                .Constant<Bond.BondDataType>(BT_INT8),
+                                                                                $elementType)
+                                                                        };
+                                                                        .Call $reader.ReadContainerEnd()
+                                                                    };
+                                                                    ($Example._refMap).Item[$Example._refMap_key] = $Example._refMap_value
+                                                                }
+                                                            } .Else {
+                                                                .Break end { }
+                                                            }
+                                                        }
+                                                        .LabelTarget end:
+                                                    }
+                                                } .Else {
+                                                    .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                        .Constant<Bond.BondDataType>(BT_LIST),
+                                                        $valueType)
+                                                }
+                                            } .Else {
+                                                .If ($keyType == .Constant<Bond.BondDataType>(BT_INT16)) {
+                                                    .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                        .Block(
+                                                            System.Int32 $Example._refMap_key,
+                                                            ExpressionsTest.RefObject $Example._refMap_value) {
+                                                            .Default(System.Void);
+                                                            .Loop  {
+                                                                .If ($count-- > 0) {
+                                                                    .Block() {
+                                                                        $Example._refMap_key = (System.Int32).Call $reader.ReadInt16();
+                                                                        .Default(System.Void);
+                                                                        .Block(
+                                                                            System.Int32 $count,
+                                                                            Bond.BondDataType $elementType) {
+                                                                            .Call $reader.ReadContainerBegin(
+                                                                                $count,
+                                                                                $elementType);
+                                                                            .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                                $Example._refMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                    .Call $reader.ReadBytes($count),
+                                                                                    .Default(ExpressionsTest.RefObject))
+                                                                            } .Else {
+                                                                                .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                                    .Constant<Bond.BondDataType>(BT_INT8),
+                                                                                    $elementType)
+                                                                            };
+                                                                            .Call $reader.ReadContainerEnd()
+                                                                        };
+                                                                        ($Example._refMap).Item[$Example._refMap_key] = $Example._refMap_value
+                                                                    }
+                                                                } .Else {
+                                                                    .Break end { }
+                                                                }
+                                                            }
+                                                            .LabelTarget end:
+                                                        }
+                                                    } .Else {
+                                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                            .Constant<Bond.BondDataType>(BT_LIST),
+                                                            $valueType)
+                                                    }
+                                                } .Else {
+                                                    .If ($keyType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                        .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                            .Block(
+                                                                System.Int32 $Example._refMap_key,
+                                                                ExpressionsTest.RefObject $Example._refMap_value) {
+                                                                .Default(System.Void);
+                                                                .Loop  {
+                                                                    .If ($count-- > 0) {
+                                                                        .Block() {
+                                                                            $Example._refMap_key = (System.Int32).Call $reader.ReadInt8();
+                                                                            .Default(System.Void);
+                                                                            .Block(
+                                                                                System.Int32 $count,
+                                                                                Bond.BondDataType $elementType) {
+                                                                                .Call $reader.ReadContainerBegin(
+                                                                                    $count,
+                                                                                    $elementType);
+                                                                                .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                                    $Example._refMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                        .Call $reader.ReadBytes($count),
+                                                                                        .Default(ExpressionsTest.RefObject))
+                                                                                } .Else {
+                                                                                    .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                                        .Constant<Bond.BondDataType>(BT_INT8),
+                                                                                        $elementType)
+                                                                                };
+                                                                                .Call $reader.ReadContainerEnd()
+                                                                            };
+                                                                            ($Example._refMap).Item[$Example._refMap_key] = $Example._refMap_value
+                                                                        }
+                                                                    } .Else {
+                                                                        .Break end { }
+                                                                    }
+                                                                }
+                                                                .LabelTarget end:
+                                                            }
+                                                        } .Else {
+                                                            .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                .Constant<Bond.BondDataType>(BT_LIST),
+                                                                $valueType)
+                                                        }
+                                                    } .Else {
+                                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                            .Constant<Bond.BondDataType>(BT_INT32),
+                                                            $keyType)
+                                                    }
+                                                }
+                                            };
+                                            .Call $reader.ReadContainerEnd()
+                                        }
+                                    } .Else {
+                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                            .Constant<Bond.BondDataType>(BT_MAP),
+                                            $fieldType)
+                                    };
+                                    .Call $reader.ReadFieldEnd();
+                                    .Call $reader.ReadFieldBegin(
+                                        $fieldType,
+                                        $fieldId);
+                                    .Break end { }
+                                }
+                            } .Else {
+                                .If ($fieldId > .Constant<System.UInt16>(83)) {
+                                    .Block() {
+                                        .Default(System.Void);
+                                        .Break end { }
+                                    }
+                                } .Else {
+                                    .Call $reader.Skip($fieldType)
+                                }
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .If ($fieldId > .Constant<System.UInt16>(83)) {
+                                .Break end { }
+                            } .Else {
+                                .Default(System.Void)
+                            }
+                        }
+                    } .Else {
+                        .Block() {
+                            .Default(System.Void);
+                            .Break end { }
+                        }
+                    }
+                }
+                .LabelTarget end:;
+                .Loop  {
+                    .If ((System.Int32)$fieldType > 1) {
+                        .Block() {
+                            .If ($fieldId == .Constant<System.UInt16>(84)) {
+                                .Block() {
+                                    .If ($fieldType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                        .Block(
+                                            System.Int32 $count,
+                                            Bond.BondDataType $elementType) {
+                                            .Call $reader.ReadContainerBegin(
+                                                $count,
+                                                $elementType);
+                                            .If ($elementType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                                                .Block() {
+                                                    $Example._refNullable = .Default(ExpressionsTest.RefObject);
+                                                    .Loop  {
+                                                        .If ($count-- > 0) {
+                                                            .Block(
+                                                                System.Int32 $count,
+                                                                Bond.BondDataType $elementType) {
+                                                                .Call $reader.ReadContainerBegin(
+                                                                    $count,
+                                                                    $elementType);
+                                                                .If ($elementType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                                                                    $Example._refNullable = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                        .Call $reader.ReadBytes($count),
+                                                                        .Default(ExpressionsTest.RefObject))
+                                                                } .Else {
+                                                                    .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                                        .Constant<Bond.BondDataType>(BT_INT8),
+                                                                        $elementType)
+                                                                };
+                                                                .Call $reader.ReadContainerEnd()
+                                                            }
+                                                        } .Else {
+                                                            .Break end { }
+                                                        }
+                                                    }
+                                                    .LabelTarget end:
+                                                }
+                                            } .Else {
+                                                .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                                    $elementType)
+                                            };
+                                            .Call $reader.ReadContainerEnd()
+                                        }
+                                    } .Else {
+                                        .Invoke (.Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                                            .Constant<Bond.BondDataType>(BT_LIST),
+                                            $fieldType)
+                                    };
+                                    .Call $reader.ReadFieldEnd();
+                                    .Call $reader.ReadFieldBegin(
+                                        $fieldType,
+                                        $fieldId);
+                                    .Break end { }
+                                }
+                            } .Else {
+                                .If ($fieldId > .Constant<System.UInt16>(84)) {
+                                    .Block() {
+                                        .Default(System.Void);
+                                        .Break end { }
+                                    }
+                                } .Else {
+                                    .Call $reader.Skip($fieldType)
+                                }
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .If ($fieldId > .Constant<System.UInt16>(84)) {
                                 .Break end { }
                             } .Else {
                                 .Default(System.Void)

--- a/cs/test/expressions/DeserializeJson.expressions
+++ b/cs/test/expressions/DeserializeJson.expressions
@@ -193,140 +193,133 @@
                                                     }
                                                 }
                                             } .Else {
-                                                .If ((System.String)$reader.Value == "_decList") {
+                                                .If ((System.String)$reader.Value == "_decNullable") {
                                                     .Block() {
                                                         .Call $reader.Read();
                                                         .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
                                                             .Block() {
                                                                 .Call $reader.Read();
-                                                                .Block(System.Decimal $Example._decList_item) {
-                                                                    .Default(System.Void);
+                                                                .Block() {
                                                                     .Loop  {
                                                                         .Break end { }
                                                                     }
-                                                                    .LabelTarget end:;
-                                                                    .Default(System.Void)
+                                                                    .LabelTarget end:
                                                                 }
                                                             }
                                                         } .Else {
                                                             .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
                                                                 .Block() {
                                                                     .Call $reader.Read();
-                                                                    .Block(System.Decimal $Example._decList_item) {
-                                                                        .Default(System.Void);
+                                                                    .Block() {
                                                                         .Loop  {
                                                                             .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
-                                                                                .Block() {
-                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                    .Block() {
+                                                                                        .Call $reader.Read();
+                                                                                        .Block(
+                                                                                            System.Int32 $index,
+                                                                                            System.Byte[] $array) {
+                                                                                            .Block(System.Int32 $Example._decNullable_count) {
+                                                                                                $Example._decNullable_count = 0;
+                                                                                                .Default(System.Void);
+                                                                                                .Block() {
+                                                                                                    $index = 0;
+                                                                                                    $array = .NewArray System.Byte[$Example._decNullable_count]
+                                                                                                }
+                                                                                            };
+                                                                                            .Loop  {
+                                                                                                .Break end { }
+                                                                                            }
+                                                                                            .LabelTarget end:;
+                                                                                            $Example._decNullable = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                .New System.ArraySegment`1[System.Byte](
+                                                                                                    $array,
+                                                                                                    0,
+                                                                                                    $index),
+                                                                                                .Default(System.Decimal))
+                                                                                        }
+                                                                                    }
+                                                                                } .Else {
+                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
                                                                                         .Block() {
                                                                                             .Call $reader.Read();
                                                                                             .Block(
                                                                                                 System.Int32 $index,
                                                                                                 System.Byte[] $array) {
-                                                                                                .Block(System.Int32 $Example._decList_item_count) {
-                                                                                                    $Example._decList_item_count = 0;
+                                                                                                .Block(System.Int32 $Example._decNullable_count) {
+                                                                                                    $Example._decNullable_count = 0;
                                                                                                     .Default(System.Void);
                                                                                                     .Block() {
                                                                                                         $index = 0;
-                                                                                                        $array = .NewArray System.Byte[$Example._decList_item_count]
+                                                                                                        $array = .NewArray System.Byte[$Example._decNullable_count]
                                                                                                     }
                                                                                                 };
                                                                                                 .Loop  {
-                                                                                                    .Break end { }
+                                                                                                    .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                        .Block() {
+                                                                                                            .If ($index >= $array.Length) {
+                                                                                                                .Call System.Array.Resize(
+                                                                                                                    $array,
+                                                                                                                    .If ($index > 512) {
+                                                                                                                        $index * 2
+                                                                                                                    } .Else {
+                                                                                                                        1024
+                                                                                                                    })
+                                                                                                            } .Else {
+                                                                                                                .Default(System.Void)
+                                                                                                            };
+                                                                                                            .Block() {
+                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                    $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
+                                                                                                                } .Else {
+                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                            "{0} (line {1} position {2})",
+                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                .Call System.String.Format(
+                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                        .Constant<System.Object>(Integer),
+                                                                                                                                        (System.Object)$reader.TokenType
+                                                                                                                                    }),
+                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                            }))
+                                                                                                                };
+                                                                                                                .Call $reader.Read()
+                                                                                                            }
+                                                                                                        }
+                                                                                                    } .Else {
+                                                                                                        .Break end { }
+                                                                                                    }
                                                                                                 }
                                                                                                 .LabelTarget end:;
-                                                                                                $Example._decList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                $Example._decNullable = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                                                                                                     .New System.ArraySegment`1[System.Byte](
                                                                                                         $array,
                                                                                                         0,
                                                                                                         $index),
                                                                                                     .Default(System.Decimal))
-                                                                                            }
+                                                                                            };
+                                                                                            .Call $reader.Read()
                                                                                         }
                                                                                     } .Else {
-                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
-                                                                                            .Block() {
-                                                                                                .Call $reader.Read();
-                                                                                                .Block(
-                                                                                                    System.Int32 $index,
-                                                                                                    System.Byte[] $array) {
-                                                                                                    .Block(System.Int32 $Example._decList_item_count) {
-                                                                                                        $Example._decList_item_count = 0;
-                                                                                                        .Default(System.Void);
-                                                                                                        .Block() {
-                                                                                                            $index = 0;
-                                                                                                            $array = .NewArray System.Byte[$Example._decList_item_count]
-                                                                                                        }
-                                                                                                    };
-                                                                                                    .Loop  {
-                                                                                                        .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
-                                                                                                            .Block() {
-                                                                                                                .If ($index >= $array.Length) {
-                                                                                                                    .Call System.Array.Resize(
-                                                                                                                        $array,
-                                                                                                                        .If ($index > 512) {
-                                                                                                                            $index * 2
-                                                                                                                        } .Else {
-                                                                                                                            1024
-                                                                                                                        })
-                                                                                                                } .Else {
-                                                                                                                    .Default(System.Void)
-                                                                                                                };
-                                                                                                                .Block() {
-                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                        $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
-                                                                                                                    } .Else {
-                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                "{0} (line {1} position {2})",
-                                                                                                                                .NewArray System.Object[] {
-                                                                                                                                    .Call System.String.Format(
-                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                        .NewArray System.Object[] {
-                                                                                                                                            .Constant<System.Object>(Integer),
-                                                                                                                                            (System.Object)$reader.TokenType
-                                                                                                                                        }),
-                                                                                                                                    (System.Object)$reader.LineNumber,
-                                                                                                                                    (System.Object)$reader.LinePosition
-                                                                                                                                }))
-                                                                                                                    };
-                                                                                                                    .Call $reader.Read()
-                                                                                                                }
-                                                                                                            }
-                                                                                                        } .Else {
-                                                                                                            .Break end { }
-                                                                                                        }
-                                                                                                    }
-                                                                                                    .LabelTarget end:;
-                                                                                                    $Example._decList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
-                                                                                                        .New System.ArraySegment`1[System.Byte](
-                                                                                                            $array,
-                                                                                                            0,
-                                                                                                            $index),
-                                                                                                        .Default(System.Decimal))
-                                                                                                };
-                                                                                                .Call $reader.Read()
-                                                                                            }
-                                                                                        } .Else {
-                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                    "{0} (line {1} position {2})",
-                                                                                                    .NewArray System.Object[] {
-                                                                                                        "Expected JSON array or null.",
-                                                                                                        (System.Object)$reader.LineNumber,
-                                                                                                        (System.Object)$reader.LinePosition
-                                                                                                    }))
-                                                                                        }
-                                                                                    };
-                                                                                    .Call ($Example._decList).Add($Example._decList_item)
+                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                "{0} (line {1} position {2})",
+                                                                                                .NewArray System.Object[] {
+                                                                                                    "Expected JSON array or null.",
+                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                }))
+                                                                                    }
                                                                                 }
                                                                             } .Else {
                                                                                 .Break end { }
                                                                             }
                                                                         }
-                                                                        .LabelTarget end:;
-                                                                        .Default(System.Void)
+                                                                        .LabelTarget end:
                                                                     };
                                                                     .Call $reader.Read()
                                                                 }
@@ -343,627 +336,394 @@
                                                         }
                                                     }
                                                 } .Else {
-                                                    .If ((System.String)$reader.Value == "_decimal") {
+                                                    .If ((System.String)$reader.Value == "_decMap") {
                                                         .Block() {
                                                             .Call $reader.Read();
-                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
-                                                                .Block() {
-                                                                    .Call $reader.Read();
-                                                                    .Block(
-                                                                        System.Int32 $index,
-                                                                        System.Byte[] $array) {
-                                                                        .Block(System.Int32 $Example._decimal_count) {
-                                                                            $Example._decimal_count = 0;
-                                                                            .Default(System.Void);
+                                                            .Block() {
+                                                                .Call $reader.Read();
+                                                                .Block(
+                                                                    System.Int32 $Example._decMap_key,
+                                                                    System.Decimal $Example._decMap_value) {
+                                                                    .Default(System.Void);
+                                                                    .Loop  {
+                                                                        .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
                                                                             .Block() {
-                                                                                $index = 0;
-                                                                                $array = .NewArray System.Byte[$Example._decimal_count]
-                                                                            }
-                                                                        };
-                                                                        .Loop  {
-                                                                            .Break end { }
-                                                                        }
-                                                                        .LabelTarget end:;
-                                                                        $Example._decimal = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
-                                                                            .New System.ArraySegment`1[System.Byte](
-                                                                                $array,
-                                                                                0,
-                                                                                $index),
-                                                                            .Default(System.Decimal))
-                                                                    }
-                                                                }
-                                                            } .Else {
-                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
-                                                                    .Block() {
-                                                                        .Call $reader.Read();
-                                                                        .Block(
-                                                                            System.Int32 $index,
-                                                                            System.Byte[] $array) {
-                                                                            .Block(System.Int32 $Example._decimal_count) {
-                                                                                $Example._decimal_count = 0;
-                                                                                .Default(System.Void);
                                                                                 .Block() {
-                                                                                    $index = 0;
-                                                                                    $array = .NewArray System.Byte[$Example._decimal_count]
-                                                                                }
-                                                                            };
-                                                                            .Loop  {
-                                                                                .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
-                                                                                    .Block() {
-                                                                                        .If ($index >= $array.Length) {
-                                                                                            .Call System.Array.Resize(
-                                                                                                $array,
-                                                                                                .If ($index > 512) {
-                                                                                                    $index * 2
-                                                                                                } .Else {
-                                                                                                    1024
-                                                                                                })
-                                                                                        } .Else {
-                                                                                            .Default(System.Void)
-                                                                                        };
-                                                                                        .Block() {
-                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
-                                                                                            } .Else {
-                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                        $Example._decMap_key = (System.Int32)((System.Int64)$reader.Value)
+                                                                                    } .Else {
+                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                "{0} (line {1} position {2})",
+                                                                                                .NewArray System.Object[] {
+                                                                                                    .Call System.String.Format(
                                                                                                         System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                        "{0} (line {1} position {2})",
+                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
                                                                                                         .NewArray System.Object[] {
-                                                                                                            .Call System.String.Format(
-                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                .NewArray System.Object[] {
-                                                                                                                    .Constant<System.Object>(Integer),
-                                                                                                                    (System.Object)$reader.TokenType
-                                                                                                                }),
-                                                                                                            (System.Object)$reader.LineNumber,
-                                                                                                            (System.Object)$reader.LinePosition
-                                                                                                        }))
+                                                                                                            .Constant<System.Object>(Integer),
+                                                                                                            (System.Object)$reader.TokenType
+                                                                                                        }),
+                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                }))
+                                                                                    };
+                                                                                    .Call $reader.Read()
+                                                                                };
+                                                                                $reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray);
+                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                    .Block() {
+                                                                                        .Call $reader.Read();
+                                                                                        .Block(
+                                                                                            System.Int32 $index,
+                                                                                            System.Byte[] $array) {
+                                                                                            .Block(System.Int32 $Example._decMap_value_count) {
+                                                                                                $Example._decMap_value_count = 0;
+                                                                                                .Default(System.Void);
+                                                                                                .Block() {
+                                                                                                    $index = 0;
+                                                                                                    $array = .NewArray System.Byte[$Example._decMap_value_count]
+                                                                                                }
                                                                                             };
-                                                                                            .Call $reader.Read()
+                                                                                            .Loop  {
+                                                                                                .Break end { }
+                                                                                            }
+                                                                                            .LabelTarget end:;
+                                                                                            $Example._decMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                .New System.ArraySegment`1[System.Byte](
+                                                                                                    $array,
+                                                                                                    0,
+                                                                                                    $index),
+                                                                                                .Default(System.Decimal))
                                                                                         }
                                                                                     }
                                                                                 } .Else {
-                                                                                    .Break end { }
-                                                                                }
+                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                        .Block() {
+                                                                                            .Call $reader.Read();
+                                                                                            .Block(
+                                                                                                System.Int32 $index,
+                                                                                                System.Byte[] $array) {
+                                                                                                .Block(System.Int32 $Example._decMap_value_count) {
+                                                                                                    $Example._decMap_value_count = 0;
+                                                                                                    .Default(System.Void);
+                                                                                                    .Block() {
+                                                                                                        $index = 0;
+                                                                                                        $array = .NewArray System.Byte[$Example._decMap_value_count]
+                                                                                                    }
+                                                                                                };
+                                                                                                .Loop  {
+                                                                                                    .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                        .Block() {
+                                                                                                            .If ($index >= $array.Length) {
+                                                                                                                .Call System.Array.Resize(
+                                                                                                                    $array,
+                                                                                                                    .If ($index > 512) {
+                                                                                                                        $index * 2
+                                                                                                                    } .Else {
+                                                                                                                        1024
+                                                                                                                    })
+                                                                                                            } .Else {
+                                                                                                                .Default(System.Void)
+                                                                                                            };
+                                                                                                            .Block() {
+                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                    $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
+                                                                                                                } .Else {
+                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                            "{0} (line {1} position {2})",
+                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                .Call System.String.Format(
+                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                        .Constant<System.Object>(Integer),
+                                                                                                                                        (System.Object)$reader.TokenType
+                                                                                                                                    }),
+                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                            }))
+                                                                                                                };
+                                                                                                                .Call $reader.Read()
+                                                                                                            }
+                                                                                                        }
+                                                                                                    } .Else {
+                                                                                                        .Break end { }
+                                                                                                    }
+                                                                                                }
+                                                                                                .LabelTarget end:;
+                                                                                                $Example._decMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                    .New System.ArraySegment`1[System.Byte](
+                                                                                                        $array,
+                                                                                                        0,
+                                                                                                        $index),
+                                                                                                    .Default(System.Decimal))
+                                                                                            };
+                                                                                            .Call $reader.Read()
+                                                                                        }
+                                                                                    } .Else {
+                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                "{0} (line {1} position {2})",
+                                                                                                .NewArray System.Object[] {
+                                                                                                    "Expected JSON array or null.",
+                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                }))
+                                                                                    }
+                                                                                };
+                                                                                ($Example._decMap).Item[$Example._decMap_key] = $Example._decMap_value
                                                                             }
-                                                                            .LabelTarget end:;
-                                                                            $Example._decimal = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
-                                                                                .New System.ArraySegment`1[System.Byte](
-                                                                                    $array,
-                                                                                    0,
-                                                                                    $index),
-                                                                                .Default(System.Decimal))
-                                                                        };
-                                                                        .Call $reader.Read()
+                                                                        } .Else {
+                                                                            .Break end { }
+                                                                        }
                                                                     }
-                                                                } .Else {
-                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                            "{0} (line {1} position {2})",
-                                                                            .NewArray System.Object[] {
-                                                                                "Expected JSON array or null.",
-                                                                                (System.Object)$reader.LineNumber,
-                                                                                (System.Object)$reader.LinePosition
-                                                                            }))
-                                                                }
+                                                                    .LabelTarget end:
+                                                                };
+                                                                .Call $reader.Read()
                                                             }
                                                         }
                                                     } .Else {
-                                                        .If ((System.String)$reader.Value == "_map") {
+                                                        .If ((System.String)$reader.Value == "_decVector") {
                                                             .Block() {
                                                                 .Call $reader.Read();
-                                                                .Block() {
-                                                                    .Call $reader.Read();
-                                                                    .Block(
-                                                                        System.Int32 $Example._map_key,
-                                                                        System.Double $Example._map_value) {
-                                                                        .Default(System.Void);
-                                                                        .Loop  {
-                                                                            .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
-                                                                                .Block() {
-                                                                                    .Block() {
-                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                            $Example._map_key = (System.Int32)((System.Int64)$reader.Value)
-                                                                                        } .Else {
-                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                    "{0} (line {1} position {2})",
-                                                                                                    .NewArray System.Object[] {
-                                                                                                        .Call System.String.Format(
-                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                            .NewArray System.Object[] {
-                                                                                                                .Constant<System.Object>(Integer),
-                                                                                                                (System.Object)$reader.TokenType
-                                                                                                            }),
-                                                                                                        (System.Object)$reader.LineNumber,
-                                                                                                        (System.Object)$reader.LinePosition
-                                                                                                    }))
-                                                                                        };
-                                                                                        .Call $reader.Read()
-                                                                                    };
-                                                                                    $reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray);
-                                                                                    .Block() {
-                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                            $Example._map_value = (System.Double)((System.Int64)$reader.Value)
-                                                                                        } .Else {
-                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
-                                                                                                $Example._map_value = (System.Double)$reader.Value
-                                                                                            } .Else {
-                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                        "{0} (line {1} position {2})",
-                                                                                                        .NewArray System.Object[] {
-                                                                                                            .Call System.String.Format(
-                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                .NewArray System.Object[] {
-                                                                                                                    .Constant<System.Object>(Float),
-                                                                                                                    (System.Object)$reader.TokenType
-                                                                                                                }),
-                                                                                                            (System.Object)$reader.LineNumber,
-                                                                                                            (System.Object)$reader.LinePosition
-                                                                                                        }))
-                                                                                            }
-                                                                                        };
-                                                                                        .Call $reader.Read()
-                                                                                    };
-                                                                                    ($Example._map).Item[$Example._map_key] = $Example._map_value
-                                                                                }
-                                                                            } .Else {
+                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                    .Block() {
+                                                                        .Call $reader.Read();
+                                                                        .Block(System.Decimal $Example._decVector_item) {
+                                                                            .Block(System.Int32 $Example._decVector_count) {
+                                                                                $Example._decVector_count = 0;
+                                                                                .Default(System.Void);
+                                                                                ($Example._decVector).Capacity = $Example._decVector_count
+                                                                            };
+                                                                            .Loop  {
                                                                                 .Break end { }
                                                                             }
+                                                                            .LabelTarget end:;
+                                                                            .Default(System.Void)
                                                                         }
-                                                                        .LabelTarget end:
-                                                                    };
-                                                                    .Call $reader.Read()
+                                                                    }
+                                                                } .Else {
+                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                        .Block() {
+                                                                            .Call $reader.Read();
+                                                                            .Block(System.Decimal $Example._decVector_item) {
+                                                                                .Block(System.Int32 $Example._decVector_count) {
+                                                                                    $Example._decVector_count = 0;
+                                                                                    .Default(System.Void);
+                                                                                    ($Example._decVector).Capacity = $Example._decVector_count
+                                                                                };
+                                                                                .Loop  {
+                                                                                    .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                        .Block() {
+                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                                .Block() {
+                                                                                                    .Call $reader.Read();
+                                                                                                    .Block(
+                                                                                                        System.Int32 $index,
+                                                                                                        System.Byte[] $array) {
+                                                                                                        .Block(System.Int32 $Example._decVector_item_count) {
+                                                                                                            $Example._decVector_item_count = 0;
+                                                                                                            .Default(System.Void);
+                                                                                                            .Block() {
+                                                                                                                $index = 0;
+                                                                                                                $array = .NewArray System.Byte[$Example._decVector_item_count]
+                                                                                                            }
+                                                                                                        };
+                                                                                                        .Loop  {
+                                                                                                            .Break end { }
+                                                                                                        }
+                                                                                                        .LabelTarget end:;
+                                                                                                        $Example._decVector_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                            .New System.ArraySegment`1[System.Byte](
+                                                                                                                $array,
+                                                                                                                0,
+                                                                                                                $index),
+                                                                                                            .Default(System.Decimal))
+                                                                                                    }
+                                                                                                }
+                                                                                            } .Else {
+                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                                    .Block() {
+                                                                                                        .Call $reader.Read();
+                                                                                                        .Block(
+                                                                                                            System.Int32 $index,
+                                                                                                            System.Byte[] $array) {
+                                                                                                            .Block(System.Int32 $Example._decVector_item_count) {
+                                                                                                                $Example._decVector_item_count = 0;
+                                                                                                                .Default(System.Void);
+                                                                                                                .Block() {
+                                                                                                                    $index = 0;
+                                                                                                                    $array = .NewArray System.Byte[$Example._decVector_item_count]
+                                                                                                                }
+                                                                                                            };
+                                                                                                            .Loop  {
+                                                                                                                .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                                    .Block() {
+                                                                                                                        .If ($index >= $array.Length) {
+                                                                                                                            .Call System.Array.Resize(
+                                                                                                                                $array,
+                                                                                                                                .If ($index > 512) {
+                                                                                                                                    $index * 2
+                                                                                                                                } .Else {
+                                                                                                                                    1024
+                                                                                                                                })
+                                                                                                                        } .Else {
+                                                                                                                            .Default(System.Void)
+                                                                                                                        };
+                                                                                                                        .Block() {
+                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
+                                                                                                                            } .Else {
+                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                        "{0} (line {1} position {2})",
+                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                            .Call System.String.Format(
+                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                    .Constant<System.Object>(Integer),
+                                                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                                                }),
+                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                        }))
+                                                                                                                            };
+                                                                                                                            .Call $reader.Read()
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                } .Else {
+                                                                                                                    .Break end { }
+                                                                                                                }
+                                                                                                            }
+                                                                                                            .LabelTarget end:;
+                                                                                                            $Example._decVector_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                                .New System.ArraySegment`1[System.Byte](
+                                                                                                                    $array,
+                                                                                                                    0,
+                                                                                                                    $index),
+                                                                                                                .Default(System.Decimal))
+                                                                                                        };
+                                                                                                        .Call $reader.Read()
+                                                                                                    }
+                                                                                                } .Else {
+                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                            "{0} (line {1} position {2})",
+                                                                                                            .NewArray System.Object[] {
+                                                                                                                "Expected JSON array or null.",
+                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                            }))
+                                                                                                }
+                                                                                            };
+                                                                                            .Call ($Example._decVector).Add($Example._decVector_item)
+                                                                                        }
+                                                                                    } .Else {
+                                                                                        .Break end { }
+                                                                                    }
+                                                                                }
+                                                                                .LabelTarget end:;
+                                                                                .Default(System.Void)
+                                                                            };
+                                                                            .Call $reader.Read()
+                                                                        }
+                                                                    } .Else {
+                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                "{0} (line {1} position {2})",
+                                                                                .NewArray System.Object[] {
+                                                                                    "Expected JSON array or null.",
+                                                                                    (System.Object)$reader.LineNumber,
+                                                                                    (System.Object)$reader.LinePosition
+                                                                                }))
+                                                                    }
                                                                 }
                                                             }
                                                         } .Else {
-                                                            .If ((System.String)$reader.Value == "b") {
+                                                            .If ((System.String)$reader.Value == "_decList") {
                                                                 .Block() {
                                                                     .Call $reader.Read();
                                                                     .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
                                                                         .Block() {
                                                                             .Call $reader.Read();
-                                                                            .Block(
-                                                                                System.Int32 $index,
-                                                                                System.Byte[] $array) {
-                                                                                .Block(System.Int32 $Example.b_count) {
-                                                                                    $Example.b_count = 0;
-                                                                                    .Default(System.Void);
-                                                                                    .Block() {
-                                                                                        $index = 0;
-                                                                                        $array = .NewArray System.Byte[$Example.b_count]
-                                                                                    }
-                                                                                };
+                                                                            .Block(System.Decimal $Example._decList_item) {
+                                                                                .Default(System.Void);
                                                                                 .Loop  {
                                                                                     .Break end { }
                                                                                 }
                                                                                 .LabelTarget end:;
-                                                                                $Example.b = .New System.ArraySegment`1[System.Byte](
-                                                                                    $array,
-                                                                                    0,
-                                                                                    $index)
+                                                                                .Default(System.Void)
                                                                             }
                                                                         }
                                                                     } .Else {
                                                                         .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
                                                                             .Block() {
                                                                                 .Call $reader.Read();
-                                                                                .Block(
-                                                                                    System.Int32 $index,
-                                                                                    System.Byte[] $array) {
-                                                                                    .Block(System.Int32 $Example.b_count) {
-                                                                                        $Example.b_count = 0;
-                                                                                        .Default(System.Void);
-                                                                                        .Block() {
-                                                                                            $index = 0;
-                                                                                            $array = .NewArray System.Byte[$Example.b_count]
-                                                                                        }
-                                                                                    };
+                                                                                .Block(System.Decimal $Example._decList_item) {
+                                                                                    .Default(System.Void);
                                                                                     .Loop  {
                                                                                         .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
                                                                                             .Block() {
-                                                                                                .If ($index >= $array.Length) {
-                                                                                                    .Call System.Array.Resize(
-                                                                                                        $array,
-                                                                                                        .If ($index > 512) {
-                                                                                                            $index * 2
-                                                                                                        } .Else {
-                                                                                                            1024
-                                                                                                        })
-                                                                                                } .Else {
-                                                                                                    .Default(System.Void)
-                                                                                                };
-                                                                                                .Block() {
-                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                        $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
-                                                                                                    } .Else {
-                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                "{0} (line {1} position {2})",
-                                                                                                                .NewArray System.Object[] {
-                                                                                                                    .Call System.String.Format(
-                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                        .NewArray System.Object[] {
-                                                                                                                            .Constant<System.Object>(Integer),
-                                                                                                                            (System.Object)$reader.TokenType
-                                                                                                                        }),
-                                                                                                                    (System.Object)$reader.LineNumber,
-                                                                                                                    (System.Object)$reader.LinePosition
-                                                                                                                }))
-                                                                                                    };
-                                                                                                    .Call $reader.Read()
-                                                                                                }
-                                                                                            }
-                                                                                        } .Else {
-                                                                                            .Break end { }
-                                                                                        }
-                                                                                    }
-                                                                                    .LabelTarget end:;
-                                                                                    $Example.b = .New System.ArraySegment`1[System.Byte](
-                                                                                        $array,
-                                                                                        0,
-                                                                                        $index)
-                                                                                };
-                                                                                .Call $reader.Read()
-                                                                            }
-                                                                        } .Else {
-                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                    "{0} (line {1} position {2})",
-                                                                                    .NewArray System.Object[] {
-                                                                                        "Expected JSON array or null.",
-                                                                                        (System.Object)$reader.LineNumber,
-                                                                                        (System.Object)$reader.LinePosition
-                                                                                    }))
-                                                                        }
-                                                                    }
-                                                                }
-                                                            } .Else {
-                                                                .If ((System.String)$reader.Value == "_nestedVector") {
-                                                                    .Block() {
-                                                                        .Call $reader.Read();
-                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
-                                                                            .Block() {
-                                                                                .Call $reader.Read();
-                                                                                .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
-                                                                                    .Default(System.Void);
-                                                                                    .Loop  {
-                                                                                        .Break end { }
-                                                                                    }
-                                                                                    .LabelTarget end:;
-                                                                                    .Default(System.Void)
-                                                                                }
-                                                                            }
-                                                                        } .Else {
-                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
-                                                                                .Block() {
-                                                                                    .Call $reader.Read();
-                                                                                    .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
-                                                                                        .Default(System.Void);
-                                                                                        .Loop  {
-                                                                                            .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
-                                                                                                .Block() {
+                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
                                                                                                     .Block() {
-                                                                                                        $Example._nestedVector_item = .New ExpressionsTest.Nested();
+                                                                                                        .Call $reader.Read();
                                                                                                         .Block(
-                                                                                                            System.Byte $state,
-                                                                                                            Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
-                                                                                                            .Default(System.Void);
-                                                                                                            .Default(System.Void);
-                                                                                                            $state = .Constant<System.Byte>(1);
-                                                                                                            .Loop  {
-                                                                                                                .If (
-                                                                                                                    !$reader.EOF && $state != .Constant<System.Byte>(5)
-                                                                                                                ) {
-                                                                                                                    .Switch ($reader.TokenType) {
-                                                                                                                    .Case (.Constant<Newtonsoft.Json.JsonToken>(None)):
-                                                                                                                            .Switch ($state) {
-                                                                                                                            .Case (.Constant<System.Byte>(1)):
-                                                                                                                                    .Block() {
-                                                                                                                                        .Call $reader.Read();
-                                                                                                                                        .Default(System.Void)
-                                                                                                                                    }
-                                                                                                                            .Default:
-                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                            "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                                            .NewArray System.Object[] {
-                                                                                                                                                (System.Object)$reader.TokenType,
-                                                                                                                                                (System.Object)$state,
-                                                                                                                                                (System.Object)$reader.LineNumber,
-                                                                                                                                                (System.Object)$reader.LinePosition
-                                                                                                                                            }))
-                                                                                                                            }
-                                                                                                                    .Case (.Constant<Newtonsoft.Json.JsonToken>(StartObject)):
-                                                                                                                            .Switch ($state) {
-                                                                                                                            .Case (.Constant<System.Byte>(1)):
-                                                                                                                                    .Block() {
-                                                                                                                                        .Call $reader.Read();
-                                                                                                                                        $state = .Constant<System.Byte>(2);
-                                                                                                                                        .Default(System.Void)
-                                                                                                                                    }
-                                                                                                                            .Default:
-                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                            "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                                            .NewArray System.Object[] {
-                                                                                                                                                (System.Object)$reader.TokenType,
-                                                                                                                                                (System.Object)$state,
-                                                                                                                                                (System.Object)$reader.LineNumber,
-                                                                                                                                                (System.Object)$reader.LinePosition
-                                                                                                                                            }))
-                                                                                                                            }
-                                                                                                                    .Case (.Constant<Newtonsoft.Json.JsonToken>(EndObject)):
-                                                                                                                            .Switch ($state) {
-                                                                                                                            .Case (.Constant<System.Byte>(2)):
-                                                                                                                                    .Block() {
-                                                                                                                                        .Call $reader.Read();
-                                                                                                                                        $state = .Constant<System.Byte>(5);
-                                                                                                                                        .Default(System.Void)
-                                                                                                                                    }
-                                                                                                                            .Default:
-                                                                                                                                    .Default(System.Void)
-                                                                                                                            }
-                                                                                                                    .Case (.Constant<Newtonsoft.Json.JsonToken>(PropertyName)):
-                                                                                                                            .Switch ($state) {
-                                                                                                                            .Case (.Constant<System.Byte>(2)):
-                                                                                                                                    .Block() {
-                                                                                                                                        .If ((System.String)$reader.Value == "_double") {
-                                                                                                                                            .Block() {
-                                                                                                                                                .Call $reader.Read();
-                                                                                                                                                .Block() {
-                                                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                                                        $Example._nestedVector_item._double = (System.Double)((System.Int64)$reader.Value)
-                                                                                                                                                    } .Else {
-                                                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
-                                                                                                                                                            $Example._nestedVector_item._double = (System.Double)$reader.Value
-                                                                                                                                                        } .Else {
-                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                                                    "{0} (line {1} position {2})",
-                                                                                                                                                                    .NewArray System.Object[] {
-                                                                                                                                                                        .Call System.String.Format(
-                                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                                                            .NewArray System.Object[] {
-                                                                                                                                                                                .Constant<System.Object>(Float),
-                                                                                                                                                                                (System.Object)$reader.TokenType
-                                                                                                                                                                            }),
-                                                                                                                                                                        (System.Object)$reader.LineNumber,
-                                                                                                                                                                        (System.Object)$reader.LinePosition
-                                                                                                                                                                    }))
-                                                                                                                                                        }
-                                                                                                                                                    };
-                                                                                                                                                    .Call $reader.Read()
-                                                                                                                                                }
-                                                                                                                                            }
-                                                                                                                                        } .Else {
-                                                                                                                                            .Block() {
-                                                                                                                                                .Call $reader.Read();
-                                                                                                                                                .Block() {
-                                                                                                                                                    .If (
-                                                                                                                                                        $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
-                                                                                                                                                    ) {
-                                                                                                                                                        .Call $reader.Skip()
-                                                                                                                                                    } .Else {
-                                                                                                                                                        .Default(System.Void)
-                                                                                                                                                    };
-                                                                                                                                                    .Call $reader.Read()
-                                                                                                                                                }
-                                                                                                                                            }
-                                                                                                                                        };
-                                                                                                                                        .Default(System.Void)
-                                                                                                                                    }
-                                                                                                                            .Default:
-                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                            "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                                            .NewArray System.Object[] {
-                                                                                                                                                (System.Object)$reader.TokenType,
-                                                                                                                                                (System.Object)$state,
-                                                                                                                                                (System.Object)$reader.LineNumber,
-                                                                                                                                                (System.Object)$reader.LinePosition
-                                                                                                                                            }))
-                                                                                                                            }
-                                                                                                                    .Default:
-                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                    "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                                    .NewArray System.Object[] {
-                                                                                                                                        (System.Object)$reader.TokenType,
-                                                                                                                                        (System.Object)$state,
-                                                                                                                                        (System.Object)$reader.LineNumber,
-                                                                                                                                        (System.Object)$reader.LinePosition
-                                                                                                                                    }))
-                                                                                                                    }
-                                                                                                                } .Else {
-                                                                                                                    .Break endStateMachineLoop { }
+                                                                                                            System.Int32 $index,
+                                                                                                            System.Byte[] $array) {
+                                                                                                            .Block(System.Int32 $Example._decList_item_count) {
+                                                                                                                $Example._decList_item_count = 0;
+                                                                                                                .Default(System.Void);
+                                                                                                                .Block() {
+                                                                                                                    $index = 0;
+                                                                                                                    $array = .NewArray System.Byte[$Example._decList_item_count]
                                                                                                                 }
-                                                                                                            }
-                                                                                                            .LabelTarget endStateMachineLoop:;
-                                                                                                            .Default(System.Void);
-                                                                                                            .Default(System.Void)
-                                                                                                        }
-                                                                                                    };
-                                                                                                    .Call ($Example._nestedVector).Add($Example._nestedVector_item)
-                                                                                                }
-                                                                                            } .Else {
-                                                                                                .Break end { }
-                                                                                            }
-                                                                                        }
-                                                                                        .LabelTarget end:;
-                                                                                        .Default(System.Void)
-                                                                                    };
-                                                                                    .Call $reader.Read()
-                                                                                }
-                                                                            } .Else {
-                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                        "{0} (line {1} position {2})",
-                                                                                        .NewArray System.Object[] {
-                                                                                            "Expected JSON array or null.",
-                                                                                            (System.Object)$reader.LineNumber,
-                                                                                            (System.Object)$reader.LinePosition
-                                                                                        }))
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                } .Else {
-                                                                    .If ((System.String)$reader.Value == "_int32Vector") {
-                                                                        .Block() {
-                                                                            .Call $reader.Read();
-                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
-                                                                                .Block() {
-                                                                                    .Call $reader.Read();
-                                                                                    .Block(System.Int32 $Example._int32Vector_item) {
-                                                                                        .Block(System.Int32 $Example._int32Vector_count) {
-                                                                                            $Example._int32Vector_count = 0;
-                                                                                            .Default(System.Void);
-                                                                                            ($Example._int32Vector).Capacity = $Example._int32Vector_count
-                                                                                        };
-                                                                                        .Loop  {
-                                                                                            .Break end { }
-                                                                                        }
-                                                                                        .LabelTarget end:;
-                                                                                        .Default(System.Void)
-                                                                                    }
-                                                                                }
-                                                                            } .Else {
-                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
-                                                                                    .Block() {
-                                                                                        .Call $reader.Read();
-                                                                                        .Block(System.Int32 $Example._int32Vector_item) {
-                                                                                            .Block(System.Int32 $Example._int32Vector_count) {
-                                                                                                $Example._int32Vector_count = 0;
-                                                                                                .Default(System.Void);
-                                                                                                ($Example._int32Vector).Capacity = $Example._int32Vector_count
-                                                                                            };
-                                                                                            .Loop  {
-                                                                                                .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
-                                                                                                    .Block() {
-                                                                                                        .Block() {
-                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                $Example._int32Vector_item = (System.Int32)((System.Int64)$reader.Value)
-                                                                                                            } .Else {
-                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                        "{0} (line {1} position {2})",
-                                                                                                                        .NewArray System.Object[] {
-                                                                                                                            .Call System.String.Format(
-                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                .NewArray System.Object[] {
-                                                                                                                                    .Constant<System.Object>(Integer),
-                                                                                                                                    (System.Object)$reader.TokenType
-                                                                                                                                }),
-                                                                                                                            (System.Object)$reader.LineNumber,
-                                                                                                                            (System.Object)$reader.LinePosition
-                                                                                                                        }))
                                                                                                             };
-                                                                                                            .Call $reader.Read()
-                                                                                                        };
-                                                                                                        .Call ($Example._int32Vector).Add($Example._int32Vector_item)
+                                                                                                            .Loop  {
+                                                                                                                .Break end { }
+                                                                                                            }
+                                                                                                            .LabelTarget end:;
+                                                                                                            $Example._decList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                                .New System.ArraySegment`1[System.Byte](
+                                                                                                                    $array,
+                                                                                                                    0,
+                                                                                                                    $index),
+                                                                                                                .Default(System.Decimal))
+                                                                                                        }
                                                                                                     }
                                                                                                 } .Else {
-                                                                                                    .Break end { }
-                                                                                                }
-                                                                                            }
-                                                                                            .LabelTarget end:;
-                                                                                            .Default(System.Void)
-                                                                                        };
-                                                                                        .Call $reader.Read()
-                                                                                    }
-                                                                                } .Else {
-                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                            "{0} (line {1} position {2})",
-                                                                                            .NewArray System.Object[] {
-                                                                                                "Expected JSON array or null.",
-                                                                                                (System.Object)$reader.LineNumber,
-                                                                                                (System.Object)$reader.LinePosition
-                                                                                            }))
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    } .Else {
-                                                                        .If ((System.String)$reader.Value == "guid") {
-                                                                            .Block() {
-                                                                                .Call $reader.Read();
-                                                                                .Block() {
-                                                                                    .Block(
-                                                                                        System.Byte $state,
-                                                                                        Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
-                                                                                        .Default(System.Void);
-                                                                                        .Default(System.Void);
-                                                                                        $state = .Constant<System.Byte>(1);
-                                                                                        .Loop  {
-                                                                                            .If (
-                                                                                                !$reader.EOF && $state != .Constant<System.Byte>(5)
-                                                                                            ) {
-                                                                                                .Switch ($reader.TokenType) {
-                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(None)):
-                                                                                                        .Switch ($state) {
-                                                                                                        .Case (.Constant<System.Byte>(1)):
-                                                                                                                .Block() {
-                                                                                                                    .Call $reader.Read();
-                                                                                                                    .Default(System.Void)
-                                                                                                                }
-                                                                                                        .Default:
-                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                        "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                        .NewArray System.Object[] {
-                                                                                                                            (System.Object)$reader.TokenType,
-                                                                                                                            (System.Object)$state,
-                                                                                                                            (System.Object)$reader.LineNumber,
-                                                                                                                            (System.Object)$reader.LinePosition
-                                                                                                                        }))
-                                                                                                        }
-                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(StartObject)):
-                                                                                                        .Switch ($state) {
-                                                                                                        .Case (.Constant<System.Byte>(1)):
-                                                                                                                .Block() {
-                                                                                                                    .Call $reader.Read();
-                                                                                                                    $state = .Constant<System.Byte>(2);
-                                                                                                                    .Default(System.Void)
-                                                                                                                }
-                                                                                                        .Default:
-                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                        "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                        .NewArray System.Object[] {
-                                                                                                                            (System.Object)$reader.TokenType,
-                                                                                                                            (System.Object)$state,
-                                                                                                                            (System.Object)$reader.LineNumber,
-                                                                                                                            (System.Object)$reader.LinePosition
-                                                                                                                        }))
-                                                                                                        }
-                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(EndObject)):
-                                                                                                        .Switch ($state) {
-                                                                                                        .Case (.Constant<System.Byte>(2)):
-                                                                                                                .Block() {
-                                                                                                                    .Call $reader.Read();
-                                                                                                                    $state = .Constant<System.Byte>(5);
-                                                                                                                    .Default(System.Void)
-                                                                                                                }
-                                                                                                        .Default:
-                                                                                                                .Default(System.Void)
-                                                                                                        }
-                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(PropertyName)):
-                                                                                                        .Switch ($state) {
-                                                                                                        .Case (.Constant<System.Byte>(2)):
-                                                                                                                .Block() {
-                                                                                                                    .If ((System.String)$reader.Value == "Data4") {
+                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                                        .Block() {
+                                                                                                            .Call $reader.Read();
+                                                                                                            .Block(
+                                                                                                                System.Int32 $index,
+                                                                                                                System.Byte[] $array) {
+                                                                                                                .Block(System.Int32 $Example._decList_item_count) {
+                                                                                                                    $Example._decList_item_count = 0;
+                                                                                                                    .Default(System.Void);
+                                                                                                                    .Block() {
+                                                                                                                        $index = 0;
+                                                                                                                        $array = .NewArray System.Byte[$Example._decList_item_count]
+                                                                                                                    }
+                                                                                                                };
+                                                                                                                .Loop  {
+                                                                                                                    .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
                                                                                                                         .Block() {
-                                                                                                                            .Call $reader.Read();
+                                                                                                                            .If ($index >= $array.Length) {
+                                                                                                                                .Call System.Array.Resize(
+                                                                                                                                    $array,
+                                                                                                                                    .If ($index > 512) {
+                                                                                                                                        $index * 2
+                                                                                                                                    } .Else {
+                                                                                                                                        1024
+                                                                                                                                    })
+                                                                                                                            } .Else {
+                                                                                                                                .Default(System.Void)
+                                                                                                                            };
                                                                                                                             .Block() {
                                                                                                                                 .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                                    ($Example.guid).Data4 = (System.UInt64)((System.Int64)$reader.Value)
+                                                                                                                                    $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
                                                                                                                                 } .Else {
                                                                                                                                     .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                                                             System.Globalization.CultureInfo.InvariantCulture,
@@ -984,64 +744,675 @@
                                                                                                                             }
                                                                                                                         }
                                                                                                                     } .Else {
-                                                                                                                        .If ((System.String)$reader.Value == "Data3") {
-                                                                                                                            .Block() {
-                                                                                                                                .Call $reader.Read();
-                                                                                                                                .Block() {
-                                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                                        ($Example.guid).Data3 = (System.UInt16)((System.Int64)$reader.Value)
-                                                                                                                                    } .Else {
+                                                                                                                        .Break end { }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                                .LabelTarget end:;
+                                                                                                                $Example._decList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                                    .New System.ArraySegment`1[System.Byte](
+                                                                                                                        $array,
+                                                                                                                        0,
+                                                                                                                        $index),
+                                                                                                                    .Default(System.Decimal))
+                                                                                                            };
+                                                                                                            .Call $reader.Read()
+                                                                                                        }
+                                                                                                    } .Else {
+                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                "{0} (line {1} position {2})",
+                                                                                                                .NewArray System.Object[] {
+                                                                                                                    "Expected JSON array or null.",
+                                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                                }))
+                                                                                                    }
+                                                                                                };
+                                                                                                .Call ($Example._decList).Add($Example._decList_item)
+                                                                                            }
+                                                                                        } .Else {
+                                                                                            .Break end { }
+                                                                                        }
+                                                                                    }
+                                                                                    .LabelTarget end:;
+                                                                                    .Default(System.Void)
+                                                                                };
+                                                                                .Call $reader.Read()
+                                                                            }
+                                                                        } .Else {
+                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                    "{0} (line {1} position {2})",
+                                                                                    .NewArray System.Object[] {
+                                                                                        "Expected JSON array or null.",
+                                                                                        (System.Object)$reader.LineNumber,
+                                                                                        (System.Object)$reader.LinePosition
+                                                                                    }))
+                                                                        }
+                                                                    }
+                                                                }
+                                                            } .Else {
+                                                                .If ((System.String)$reader.Value == "_decimal") {
+                                                                    .Block() {
+                                                                        .Call $reader.Read();
+                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                            .Block() {
+                                                                                .Call $reader.Read();
+                                                                                .Block(
+                                                                                    System.Int32 $index,
+                                                                                    System.Byte[] $array) {
+                                                                                    .Block(System.Int32 $Example._decimal_count) {
+                                                                                        $Example._decimal_count = 0;
+                                                                                        .Default(System.Void);
+                                                                                        .Block() {
+                                                                                            $index = 0;
+                                                                                            $array = .NewArray System.Byte[$Example._decimal_count]
+                                                                                        }
+                                                                                    };
+                                                                                    .Loop  {
+                                                                                        .Break end { }
+                                                                                    }
+                                                                                    .LabelTarget end:;
+                                                                                    $Example._decimal = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                        .New System.ArraySegment`1[System.Byte](
+                                                                                            $array,
+                                                                                            0,
+                                                                                            $index),
+                                                                                        .Default(System.Decimal))
+                                                                                }
+                                                                            }
+                                                                        } .Else {
+                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                .Block() {
+                                                                                    .Call $reader.Read();
+                                                                                    .Block(
+                                                                                        System.Int32 $index,
+                                                                                        System.Byte[] $array) {
+                                                                                        .Block(System.Int32 $Example._decimal_count) {
+                                                                                            $Example._decimal_count = 0;
+                                                                                            .Default(System.Void);
+                                                                                            .Block() {
+                                                                                                $index = 0;
+                                                                                                $array = .NewArray System.Byte[$Example._decimal_count]
+                                                                                            }
+                                                                                        };
+                                                                                        .Loop  {
+                                                                                            .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                .Block() {
+                                                                                                    .If ($index >= $array.Length) {
+                                                                                                        .Call System.Array.Resize(
+                                                                                                            $array,
+                                                                                                            .If ($index > 512) {
+                                                                                                                $index * 2
+                                                                                                            } .Else {
+                                                                                                                1024
+                                                                                                            })
+                                                                                                    } .Else {
+                                                                                                        .Default(System.Void)
+                                                                                                    };
+                                                                                                    .Block() {
+                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                            $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
+                                                                                                        } .Else {
+                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                    "{0} (line {1} position {2})",
+                                                                                                                    .NewArray System.Object[] {
+                                                                                                                        .Call System.String.Format(
+                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                .Constant<System.Object>(Integer),
+                                                                                                                                (System.Object)$reader.TokenType
+                                                                                                                            }),
+                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                    }))
+                                                                                                        };
+                                                                                                        .Call $reader.Read()
+                                                                                                    }
+                                                                                                }
+                                                                                            } .Else {
+                                                                                                .Break end { }
+                                                                                            }
+                                                                                        }
+                                                                                        .LabelTarget end:;
+                                                                                        $Example._decimal = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                            .New System.ArraySegment`1[System.Byte](
+                                                                                                $array,
+                                                                                                0,
+                                                                                                $index),
+                                                                                            .Default(System.Decimal))
+                                                                                    };
+                                                                                    .Call $reader.Read()
+                                                                                }
+                                                                            } .Else {
+                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                        "{0} (line {1} position {2})",
+                                                                                        .NewArray System.Object[] {
+                                                                                            "Expected JSON array or null.",
+                                                                                            (System.Object)$reader.LineNumber,
+                                                                                            (System.Object)$reader.LinePosition
+                                                                                        }))
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                } .Else {
+                                                                    .If ((System.String)$reader.Value == "_map") {
+                                                                        .Block() {
+                                                                            .Call $reader.Read();
+                                                                            .Block() {
+                                                                                .Call $reader.Read();
+                                                                                .Block(
+                                                                                    System.Int32 $Example._map_key,
+                                                                                    System.Double $Example._map_value) {
+                                                                                    .Default(System.Void);
+                                                                                    .Loop  {
+                                                                                        .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                            .Block() {
+                                                                                                .Block() {
+                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                        $Example._map_key = (System.Int32)((System.Int64)$reader.Value)
+                                                                                                    } .Else {
+                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                "{0} (line {1} position {2})",
+                                                                                                                .NewArray System.Object[] {
+                                                                                                                    .Call System.String.Format(
+                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                        .NewArray System.Object[] {
+                                                                                                                            .Constant<System.Object>(Integer),
+                                                                                                                            (System.Object)$reader.TokenType
+                                                                                                                        }),
+                                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                                }))
+                                                                                                    };
+                                                                                                    .Call $reader.Read()
+                                                                                                };
+                                                                                                $reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray);
+                                                                                                .Block() {
+                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                        $Example._map_value = (System.Double)((System.Int64)$reader.Value)
+                                                                                                    } .Else {
+                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
+                                                                                                            $Example._map_value = (System.Double)$reader.Value
+                                                                                                        } .Else {
+                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                    "{0} (line {1} position {2})",
+                                                                                                                    .NewArray System.Object[] {
+                                                                                                                        .Call System.String.Format(
+                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                .Constant<System.Object>(Float),
+                                                                                                                                (System.Object)$reader.TokenType
+                                                                                                                            }),
+                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                    }))
+                                                                                                        }
+                                                                                                    };
+                                                                                                    .Call $reader.Read()
+                                                                                                };
+                                                                                                ($Example._map).Item[$Example._map_key] = $Example._map_value
+                                                                                            }
+                                                                                        } .Else {
+                                                                                            .Break end { }
+                                                                                        }
+                                                                                    }
+                                                                                    .LabelTarget end:
+                                                                                };
+                                                                                .Call $reader.Read()
+                                                                            }
+                                                                        }
+                                                                    } .Else {
+                                                                        .If ((System.String)$reader.Value == "b") {
+                                                                            .Block() {
+                                                                                .Call $reader.Read();
+                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                    .Block() {
+                                                                                        .Call $reader.Read();
+                                                                                        .Block(
+                                                                                            System.Int32 $index,
+                                                                                            System.Byte[] $array) {
+                                                                                            .Block(System.Int32 $Example.b_count) {
+                                                                                                $Example.b_count = 0;
+                                                                                                .Default(System.Void);
+                                                                                                .Block() {
+                                                                                                    $index = 0;
+                                                                                                    $array = .NewArray System.Byte[$Example.b_count]
+                                                                                                }
+                                                                                            };
+                                                                                            .Loop  {
+                                                                                                .Break end { }
+                                                                                            }
+                                                                                            .LabelTarget end:;
+                                                                                            $Example.b = .New System.ArraySegment`1[System.Byte](
+                                                                                                $array,
+                                                                                                0,
+                                                                                                $index)
+                                                                                        }
+                                                                                    }
+                                                                                } .Else {
+                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                        .Block() {
+                                                                                            .Call $reader.Read();
+                                                                                            .Block(
+                                                                                                System.Int32 $index,
+                                                                                                System.Byte[] $array) {
+                                                                                                .Block(System.Int32 $Example.b_count) {
+                                                                                                    $Example.b_count = 0;
+                                                                                                    .Default(System.Void);
+                                                                                                    .Block() {
+                                                                                                        $index = 0;
+                                                                                                        $array = .NewArray System.Byte[$Example.b_count]
+                                                                                                    }
+                                                                                                };
+                                                                                                .Loop  {
+                                                                                                    .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                        .Block() {
+                                                                                                            .If ($index >= $array.Length) {
+                                                                                                                .Call System.Array.Resize(
+                                                                                                                    $array,
+                                                                                                                    .If ($index > 512) {
+                                                                                                                        $index * 2
+                                                                                                                    } .Else {
+                                                                                                                        1024
+                                                                                                                    })
+                                                                                                            } .Else {
+                                                                                                                .Default(System.Void)
+                                                                                                            };
+                                                                                                            .Block() {
+                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                    $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
+                                                                                                                } .Else {
+                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                            "{0} (line {1} position {2})",
+                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                .Call System.String.Format(
+                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                        .Constant<System.Object>(Integer),
+                                                                                                                                        (System.Object)$reader.TokenType
+                                                                                                                                    }),
+                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                            }))
+                                                                                                                };
+                                                                                                                .Call $reader.Read()
+                                                                                                            }
+                                                                                                        }
+                                                                                                    } .Else {
+                                                                                                        .Break end { }
+                                                                                                    }
+                                                                                                }
+                                                                                                .LabelTarget end:;
+                                                                                                $Example.b = .New System.ArraySegment`1[System.Byte](
+                                                                                                    $array,
+                                                                                                    0,
+                                                                                                    $index)
+                                                                                            };
+                                                                                            .Call $reader.Read()
+                                                                                        }
+                                                                                    } .Else {
+                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                "{0} (line {1} position {2})",
+                                                                                                .NewArray System.Object[] {
+                                                                                                    "Expected JSON array or null.",
+                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                }))
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        } .Else {
+                                                                            .If ((System.String)$reader.Value == "_nestedVector") {
+                                                                                .Block() {
+                                                                                    .Call $reader.Read();
+                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                        .Block() {
+                                                                                            .Call $reader.Read();
+                                                                                            .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
+                                                                                                .Default(System.Void);
+                                                                                                .Loop  {
+                                                                                                    .Break end { }
+                                                                                                }
+                                                                                                .LabelTarget end:;
+                                                                                                .Default(System.Void)
+                                                                                            }
+                                                                                        }
+                                                                                    } .Else {
+                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                            .Block() {
+                                                                                                .Call $reader.Read();
+                                                                                                .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
+                                                                                                    .Default(System.Void);
+                                                                                                    .Loop  {
+                                                                                                        .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                            .Block() {
+                                                                                                                .Block() {
+                                                                                                                    $Example._nestedVector_item = .New ExpressionsTest.Nested();
+                                                                                                                    .Block(
+                                                                                                                        System.Byte $state,
+                                                                                                                        Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
+                                                                                                                        .Default(System.Void);
+                                                                                                                        .Default(System.Void);
+                                                                                                                        $state = .Constant<System.Byte>(1);
+                                                                                                                        .Loop  {
+                                                                                                                            .If (
+                                                                                                                                !$reader.EOF && $state != .Constant<System.Byte>(5)
+                                                                                                                            ) {
+                                                                                                                                .Switch ($reader.TokenType) {
+                                                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(None)):
+                                                                                                                                        .Switch ($state) {
+                                                                                                                                        .Case (.Constant<System.Byte>(1)):
+                                                                                                                                                .Block() {
+                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                }
+                                                                                                                                        .Default:
+                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                        "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                            (System.Object)$reader.TokenType,
+                                                                                                                                                            (System.Object)$state,
+                                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                                        }))
+                                                                                                                                        }
+                                                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(StartObject)):
+                                                                                                                                        .Switch ($state) {
+                                                                                                                                        .Case (.Constant<System.Byte>(1)):
+                                                                                                                                                .Block() {
+                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                    $state = .Constant<System.Byte>(2);
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                }
+                                                                                                                                        .Default:
+                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                        "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                            (System.Object)$reader.TokenType,
+                                                                                                                                                            (System.Object)$state,
+                                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                                        }))
+                                                                                                                                        }
+                                                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(EndObject)):
+                                                                                                                                        .Switch ($state) {
+                                                                                                                                        .Case (.Constant<System.Byte>(2)):
+                                                                                                                                                .Block() {
+                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                    $state = .Constant<System.Byte>(5);
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                }
+                                                                                                                                        .Default:
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                        }
+                                                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(PropertyName)):
+                                                                                                                                        .Switch ($state) {
+                                                                                                                                        .Case (.Constant<System.Byte>(2)):
+                                                                                                                                                .Block() {
+                                                                                                                                                    .If ((System.String)$reader.Value == "_double") {
+                                                                                                                                                        .Block() {
+                                                                                                                                                            .Call $reader.Read();
+                                                                                                                                                            .Block() {
+                                                                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                                    $Example._nestedVector_item._double = (System.Double)((System.Int64)$reader.Value)
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
+                                                                                                                                                                        $Example._nestedVector_item._double = (System.Double)$reader.Value
+                                                                                                                                                                    } .Else {
+                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                "{0} (line {1} position {2})",
+                                                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                                                    .Call System.String.Format(
+                                                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                                                            .Constant<System.Object>(Float),
+                                                                                                                                                                                            (System.Object)$reader.TokenType
+                                                                                                                                                                                        }),
+                                                                                                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                                                                                                }))
+                                                                                                                                                                    }
+                                                                                                                                                                };
+                                                                                                                                                                .Call $reader.Read()
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Block() {
+                                                                                                                                                            .Call $reader.Read();
+                                                                                                                                                            .Block() {
+                                                                                                                                                                .If (
+                                                                                                                                                                    $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
+                                                                                                                                                                ) {
+                                                                                                                                                                    .Call $reader.Skip()
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                };
+                                                                                                                                                                .Call $reader.Read()
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    };
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                }
+                                                                                                                                        .Default:
+                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                        "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                            (System.Object)$reader.TokenType,
+                                                                                                                                                            (System.Object)$state,
+                                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                                        }))
+                                                                                                                                        }
+                                                                                                                                .Default:
                                                                                                                                         .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                                                                 System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                                "{0} (line {1} position {2})",
+                                                                                                                                                "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
                                                                                                                                                 .NewArray System.Object[] {
-                                                                                                                                                    .Call System.String.Format(
-                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                                        .NewArray System.Object[] {
-                                                                                                                                                            .Constant<System.Object>(Integer),
-                                                                                                                                                            (System.Object)$reader.TokenType
-                                                                                                                                                        }),
+                                                                                                                                                    (System.Object)$reader.TokenType,
+                                                                                                                                                    (System.Object)$state,
                                                                                                                                                     (System.Object)$reader.LineNumber,
                                                                                                                                                     (System.Object)$reader.LinePosition
                                                                                                                                                 }))
-                                                                                                                                    };
-                                                                                                                                    .Call $reader.Read()
-                                                                                                                                }
-                                                                                                                            }
-                                                                                                                        } .Else {
-                                                                                                                            .If ((System.String)$reader.Value == "Data2") {
-                                                                                                                                .Block() {
-                                                                                                                                    .Call $reader.Read();
-                                                                                                                                    .Block() {
-                                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                                            ($Example.guid).Data2 = (System.UInt16)((System.Int64)$reader.Value)
-                                                                                                                                        } .Else {
-                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                                    "{0} (line {1} position {2})",
-                                                                                                                                                    .NewArray System.Object[] {
-                                                                                                                                                        .Call System.String.Format(
-                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                                            .NewArray System.Object[] {
-                                                                                                                                                                .Constant<System.Object>(Integer),
-                                                                                                                                                                (System.Object)$reader.TokenType
-                                                                                                                                                            }),
-                                                                                                                                                        (System.Object)$reader.LineNumber,
-                                                                                                                                                        (System.Object)$reader.LinePosition
-                                                                                                                                                    }))
-                                                                                                                                        };
-                                                                                                                                        .Call $reader.Read()
-                                                                                                                                    }
                                                                                                                                 }
                                                                                                                             } .Else {
-                                                                                                                                .If ((System.String)$reader.Value == "Data1") {
+                                                                                                                                .Break endStateMachineLoop { }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                        .LabelTarget endStateMachineLoop:;
+                                                                                                                        .Default(System.Void);
+                                                                                                                        .Default(System.Void)
+                                                                                                                    }
+                                                                                                                };
+                                                                                                                .Call ($Example._nestedVector).Add($Example._nestedVector_item)
+                                                                                                            }
+                                                                                                        } .Else {
+                                                                                                            .Break end { }
+                                                                                                        }
+                                                                                                    }
+                                                                                                    .LabelTarget end:;
+                                                                                                    .Default(System.Void)
+                                                                                                };
+                                                                                                .Call $reader.Read()
+                                                                                            }
+                                                                                        } .Else {
+                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                    "{0} (line {1} position {2})",
+                                                                                                    .NewArray System.Object[] {
+                                                                                                        "Expected JSON array or null.",
+                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                    }))
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            } .Else {
+                                                                                .If ((System.String)$reader.Value == "_int32Vector") {
+                                                                                    .Block() {
+                                                                                        .Call $reader.Read();
+                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                            .Block() {
+                                                                                                .Call $reader.Read();
+                                                                                                .Block(System.Int32 $Example._int32Vector_item) {
+                                                                                                    .Block(System.Int32 $Example._int32Vector_count) {
+                                                                                                        $Example._int32Vector_count = 0;
+                                                                                                        .Default(System.Void);
+                                                                                                        ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                                                                    };
+                                                                                                    .Loop  {
+                                                                                                        .Break end { }
+                                                                                                    }
+                                                                                                    .LabelTarget end:;
+                                                                                                    .Default(System.Void)
+                                                                                                }
+                                                                                            }
+                                                                                        } .Else {
+                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                                .Block() {
+                                                                                                    .Call $reader.Read();
+                                                                                                    .Block(System.Int32 $Example._int32Vector_item) {
+                                                                                                        .Block(System.Int32 $Example._int32Vector_count) {
+                                                                                                            $Example._int32Vector_count = 0;
+                                                                                                            .Default(System.Void);
+                                                                                                            ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                                                                        };
+                                                                                                        .Loop  {
+                                                                                                            .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                                .Block() {
+                                                                                                                    .Block() {
+                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                            $Example._int32Vector_item = (System.Int32)((System.Int64)$reader.Value)
+                                                                                                                        } .Else {
+                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                    "{0} (line {1} position {2})",
+                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                        .Call System.String.Format(
+                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                .Constant<System.Object>(Integer),
+                                                                                                                                                (System.Object)$reader.TokenType
+                                                                                                                                            }),
+                                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                                    }))
+                                                                                                                        };
+                                                                                                                        .Call $reader.Read()
+                                                                                                                    };
+                                                                                                                    .Call ($Example._int32Vector).Add($Example._int32Vector_item)
+                                                                                                                }
+                                                                                                            } .Else {
+                                                                                                                .Break end { }
+                                                                                                            }
+                                                                                                        }
+                                                                                                        .LabelTarget end:;
+                                                                                                        .Default(System.Void)
+                                                                                                    };
+                                                                                                    .Call $reader.Read()
+                                                                                                }
+                                                                                            } .Else {
+                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                        "{0} (line {1} position {2})",
+                                                                                                        .NewArray System.Object[] {
+                                                                                                            "Expected JSON array or null.",
+                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                        }))
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                } .Else {
+                                                                                    .If ((System.String)$reader.Value == "guid") {
+                                                                                        .Block() {
+                                                                                            .Call $reader.Read();
+                                                                                            .Block() {
+                                                                                                .Block(
+                                                                                                    System.Byte $state,
+                                                                                                    Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
+                                                                                                    .Default(System.Void);
+                                                                                                    .Default(System.Void);
+                                                                                                    $state = .Constant<System.Byte>(1);
+                                                                                                    .Loop  {
+                                                                                                        .If (
+                                                                                                            !$reader.EOF && $state != .Constant<System.Byte>(5)
+                                                                                                        ) {
+                                                                                                            .Switch ($reader.TokenType) {
+                                                                                                            .Case (.Constant<Newtonsoft.Json.JsonToken>(None)):
+                                                                                                                    .Switch ($state) {
+                                                                                                                    .Case (.Constant<System.Byte>(1)):
+                                                                                                                            .Block() {
+                                                                                                                                .Call $reader.Read();
+                                                                                                                                .Default(System.Void)
+                                                                                                                            }
+                                                                                                                    .Default:
+                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                    "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                        (System.Object)$reader.TokenType,
+                                                                                                                                        (System.Object)$state,
+                                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                                    }))
+                                                                                                                    }
+                                                                                                            .Case (.Constant<Newtonsoft.Json.JsonToken>(StartObject)):
+                                                                                                                    .Switch ($state) {
+                                                                                                                    .Case (.Constant<System.Byte>(1)):
+                                                                                                                            .Block() {
+                                                                                                                                .Call $reader.Read();
+                                                                                                                                $state = .Constant<System.Byte>(2);
+                                                                                                                                .Default(System.Void)
+                                                                                                                            }
+                                                                                                                    .Default:
+                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                    "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                        (System.Object)$reader.TokenType,
+                                                                                                                                        (System.Object)$state,
+                                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                                    }))
+                                                                                                                    }
+                                                                                                            .Case (.Constant<Newtonsoft.Json.JsonToken>(EndObject)):
+                                                                                                                    .Switch ($state) {
+                                                                                                                    .Case (.Constant<System.Byte>(2)):
+                                                                                                                            .Block() {
+                                                                                                                                .Call $reader.Read();
+                                                                                                                                $state = .Constant<System.Byte>(5);
+                                                                                                                                .Default(System.Void)
+                                                                                                                            }
+                                                                                                                    .Default:
+                                                                                                                            .Default(System.Void)
+                                                                                                                    }
+                                                                                                            .Case (.Constant<Newtonsoft.Json.JsonToken>(PropertyName)):
+                                                                                                                    .Switch ($state) {
+                                                                                                                    .Case (.Constant<System.Byte>(2)):
+                                                                                                                            .Block() {
+                                                                                                                                .If ((System.String)$reader.Value == "Data4") {
                                                                                                                                     .Block() {
                                                                                                                                         .Call $reader.Read();
                                                                                                                                         .Block() {
                                                                                                                                             .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                                                ($Example.guid).Data1 = (System.UInt32)((System.Int64)$reader.Value)
+                                                                                                                                                ($Example.guid).Data4 = (System.UInt64)((System.Int64)$reader.Value)
                                                                                                                                             } .Else {
                                                                                                                                                 .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                                                                         System.Globalization.CultureInfo.InvariantCulture,
@@ -1062,177 +1433,145 @@
                                                                                                                                         }
                                                                                                                                     }
                                                                                                                                 } .Else {
-                                                                                                                                    .Block() {
-                                                                                                                                        .Call $reader.Read();
+                                                                                                                                    .If ((System.String)$reader.Value == "Data3") {
                                                                                                                                         .Block() {
-                                                                                                                                            .If (
-                                                                                                                                                $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
-                                                                                                                                            ) {
-                                                                                                                                                .Call $reader.Skip()
+                                                                                                                                            .Call $reader.Read();
+                                                                                                                                            .Block() {
+                                                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                    ($Example.guid).Data3 = (System.UInt16)((System.Int64)$reader.Value)
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                            "{0} (line {1} position {2})",
+                                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                                .Call System.String.Format(
+                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                                                        .Constant<System.Object>(Integer),
+                                                                                                                                                                        (System.Object)$reader.TokenType
+                                                                                                                                                                    }),
+                                                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                                                            }))
+                                                                                                                                                };
+                                                                                                                                                .Call $reader.Read()
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    } .Else {
+                                                                                                                                        .If ((System.String)$reader.Value == "Data2") {
+                                                                                                                                            .Block() {
+                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                .Block() {
+                                                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                        ($Example.guid).Data2 = (System.UInt16)((System.Int64)$reader.Value)
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                "{0} (line {1} position {2})",
+                                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                                    .Call System.String.Format(
+                                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                                            .Constant<System.Object>(Integer),
+                                                                                                                                                                            (System.Object)$reader.TokenType
+                                                                                                                                                                        }),
+                                                                                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                                                                                }))
+                                                                                                                                                    };
+                                                                                                                                                    .Call $reader.Read()
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        } .Else {
+                                                                                                                                            .If ((System.String)$reader.Value == "Data1") {
+                                                                                                                                                .Block() {
+                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                            ($Example.guid).Data1 = (System.UInt32)((System.Int64)$reader.Value)
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                    "{0} (line {1} position {2})",
+                                                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                                                        .Call System.String.Format(
+                                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                                                .Constant<System.Object>(Integer),
+                                                                                                                                                                                (System.Object)$reader.TokenType
+                                                                                                                                                                            }),
+                                                                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                                                                    }))
+                                                                                                                                                        };
+                                                                                                                                                        .Call $reader.Read()
+                                                                                                                                                    }
+                                                                                                                                                }
                                                                                                                                             } .Else {
-                                                                                                                                                .Default(System.Void)
-                                                                                                                                            };
-                                                                                                                                            .Call $reader.Read()
+                                                                                                                                                .Block() {
+                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .If (
+                                                                                                                                                            $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
+                                                                                                                                                        ) {
+                                                                                                                                                            .Call $reader.Skip()
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                        };
+                                                                                                                                                        .Call $reader.Read()
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            }
                                                                                                                                         }
                                                                                                                                     }
-                                                                                                                                }
+                                                                                                                                };
+                                                                                                                                .Default(System.Void)
                                                                                                                             }
-                                                                                                                        }
-                                                                                                                    };
-                                                                                                                    .Default(System.Void)
-                                                                                                                }
-                                                                                                        .Default:
-                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                        "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                        .NewArray System.Object[] {
-                                                                                                                            (System.Object)$reader.TokenType,
-                                                                                                                            (System.Object)$state,
-                                                                                                                            (System.Object)$reader.LineNumber,
-                                                                                                                            (System.Object)$reader.LinePosition
-                                                                                                                        }))
+                                                                                                                    .Default:
+                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                    "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                        (System.Object)$reader.TokenType,
+                                                                                                                                        (System.Object)$state,
+                                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                                    }))
+                                                                                                                    }
+                                                                                                            .Default:
+                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                            "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                (System.Object)$reader.TokenType,
+                                                                                                                                (System.Object)$state,
+                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                            }))
+                                                                                                            }
+                                                                                                        } .Else {
+                                                                                                            .Break endStateMachineLoop { }
                                                                                                         }
-                                                                                                .Default:
-                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                .NewArray System.Object[] {
-                                                                                                                    (System.Object)$reader.TokenType,
-                                                                                                                    (System.Object)$state,
-                                                                                                                    (System.Object)$reader.LineNumber,
-                                                                                                                    (System.Object)$reader.LinePosition
-                                                                                                                }))
+                                                                                                    }
+                                                                                                    .LabelTarget endStateMachineLoop:;
+                                                                                                    .Default(System.Void);
+                                                                                                    .Default(System.Void)
                                                                                                 }
-                                                                                            } .Else {
-                                                                                                .Break endStateMachineLoop { }
-                                                                                            }
-                                                                                        }
-                                                                                        .LabelTarget endStateMachineLoop:;
-                                                                                        .Default(System.Void);
-                                                                                        .Default(System.Void)
-                                                                                    }
-                                                                                }
-                                                                            }
-                                                                        } .Else {
-                                                                            .If ((System.String)$reader.Value == "_double") {
-                                                                                .Block() {
-                                                                                    .Call $reader.Read();
-                                                                                    .Block() {
-                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                            $Example._double = (System.Double)((System.Int64)$reader.Value)
-                                                                                        } .Else {
-                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
-                                                                                                $Example._double = (System.Double)$reader.Value
-                                                                                            } .Else {
-                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                        "{0} (line {1} position {2})",
-                                                                                                        .NewArray System.Object[] {
-                                                                                                            .Call System.String.Format(
-                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                .NewArray System.Object[] {
-                                                                                                                    .Constant<System.Object>(Float),
-                                                                                                                    (System.Object)$reader.TokenType
-                                                                                                                }),
-                                                                                                            (System.Object)$reader.LineNumber,
-                                                                                                            (System.Object)$reader.LinePosition
-                                                                                                        }))
-                                                                                            }
-                                                                                        };
-                                                                                        .Call $reader.Read()
-                                                                                    }
-                                                                                }
-                                                                            } .Else {
-                                                                                .If ((System.String)$reader.Value == "_int64") {
-                                                                                    .Block() {
-                                                                                        .Call $reader.Read();
-                                                                                        .Block() {
-                                                                                            .Call $requiredFields.Reset(
-                                                                                                0,
-                                                                                                1L);
-                                                                                            .Block() {
-                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                    $Example._int64 = (System.Int64)$reader.Value
-                                                                                                } .Else {
-                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                            "{0} (line {1} position {2})",
-                                                                                                            .NewArray System.Object[] {
-                                                                                                                .Call System.String.Format(
-                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                    .NewArray System.Object[] {
-                                                                                                                        .Constant<System.Object>(Integer),
-                                                                                                                        (System.Object)$reader.TokenType
-                                                                                                                    }),
-                                                                                                                (System.Object)$reader.LineNumber,
-                                                                                                                (System.Object)$reader.LinePosition
-                                                                                                            }))
-                                                                                                };
-                                                                                                .Call $reader.Read()
-                                                                                            }
-                                                                                        }
-                                                                                    }
-                                                                                } .Else {
-                                                                                    .If ((System.String)$reader.Value == "_int8") {
-                                                                                        .Block() {
-                                                                                            .Call $reader.Read();
-                                                                                            .Block() {
-                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                    $Example._int8 = (System.SByte)((System.Int64)$reader.Value)
-                                                                                                } .Else {
-                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                            "{0} (line {1} position {2})",
-                                                                                                            .NewArray System.Object[] {
-                                                                                                                .Call System.String.Format(
-                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                    .NewArray System.Object[] {
-                                                                                                                        .Constant<System.Object>(Integer),
-                                                                                                                        (System.Object)$reader.TokenType
-                                                                                                                    }),
-                                                                                                                (System.Object)$reader.LineNumber,
-                                                                                                                (System.Object)$reader.LinePosition
-                                                                                                            }))
-                                                                                                };
-                                                                                                .Call $reader.Read()
                                                                                             }
                                                                                         }
                                                                                     } .Else {
-                                                                                        .If ((System.String)$reader.Value == "JsonUint32") {
+                                                                                        .If ((System.String)$reader.Value == "_double") {
                                                                                             .Block() {
                                                                                                 .Call $reader.Read();
                                                                                                 .Block() {
                                                                                                     .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                        $Example._uint32 = (System.UInt32)((System.Int64)$reader.Value)
+                                                                                                        $Example._double = (System.Double)((System.Int64)$reader.Value)
                                                                                                     } .Else {
-                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                "{0} (line {1} position {2})",
-                                                                                                                .NewArray System.Object[] {
-                                                                                                                    .Call System.String.Format(
-                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                        .NewArray System.Object[] {
-                                                                                                                            .Constant<System.Object>(Integer),
-                                                                                                                            (System.Object)$reader.TokenType
-                                                                                                                        }),
-                                                                                                                    (System.Object)$reader.LineNumber,
-                                                                                                                    (System.Object)$reader.LinePosition
-                                                                                                                }))
-                                                                                                    };
-                                                                                                    .Call $reader.Read()
-                                                                                                }
-                                                                                            }
-                                                                                        } .Else {
-                                                                                            .If ((System.String)$reader.Value == "_str") {
-                                                                                                .Block() {
-                                                                                                    .Call $reader.Read();
-                                                                                                    .Block() {
-                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(String)) {
-                                                                                                            $Example._str = (System.String)$reader.Value
+                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
+                                                                                                            $Example._double = (System.Double)$reader.Value
                                                                                                         } .Else {
                                                                                                             .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                                     System.Globalization.CultureInfo.InvariantCulture,
@@ -1242,23 +1581,28 @@
                                                                                                                             System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                             "Invalid input, expected JSON token of type {0}, encountered {1}",
                                                                                                                             .NewArray System.Object[] {
-                                                                                                                                .Constant<System.Object>(String),
+                                                                                                                                .Constant<System.Object>(Float),
                                                                                                                                 (System.Object)$reader.TokenType
                                                                                                                             }),
                                                                                                                         (System.Object)$reader.LineNumber,
                                                                                                                         (System.Object)$reader.LinePosition
                                                                                                                     }))
-                                                                                                        };
-                                                                                                        .Call $reader.Read()
-                                                                                                    }
+                                                                                                        }
+                                                                                                    };
+                                                                                                    .Call $reader.Read()
                                                                                                 }
-                                                                                            } .Else {
-                                                                                                .If ((System.String)$reader.Value == "_bool") {
+                                                                                            }
+                                                                                        } .Else {
+                                                                                            .If ((System.String)$reader.Value == "_int64") {
+                                                                                                .Block() {
+                                                                                                    .Call $reader.Read();
                                                                                                     .Block() {
-                                                                                                        .Call $reader.Read();
+                                                                                                        .Call $requiredFields.Reset(
+                                                                                                            0,
+                                                                                                            1L);
                                                                                                         .Block() {
-                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Boolean)) {
-                                                                                                                $Example._bool = (System.Boolean)$reader.Value
+                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                $Example._int64 = (System.Int64)$reader.Value
                                                                                                             } .Else {
                                                                                                                 .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                                         System.Globalization.CultureInfo.InvariantCulture,
@@ -1268,7 +1612,34 @@
                                                                                                                                 System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                                 "Invalid input, expected JSON token of type {0}, encountered {1}",
                                                                                                                                 .NewArray System.Object[] {
-                                                                                                                                    .Constant<System.Object>(Boolean),
+                                                                                                                                    .Constant<System.Object>(Integer),
+                                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                                }),
+                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                        }))
+                                                                                                            };
+                                                                                                            .Call $reader.Read()
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            } .Else {
+                                                                                                .If ((System.String)$reader.Value == "_int8") {
+                                                                                                    .Block() {
+                                                                                                        .Call $reader.Read();
+                                                                                                        .Block() {
+                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                $Example._int8 = (System.SByte)((System.Int64)$reader.Value)
+                                                                                                            } .Else {
+                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                        "{0} (line {1} position {2})",
+                                                                                                                        .NewArray System.Object[] {
+                                                                                                                            .Call System.String.Format(
+                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                    .Constant<System.Object>(Integer),
                                                                                                                                     (System.Object)$reader.TokenType
                                                                                                                                 }),
                                                                                                                             (System.Object)$reader.LineNumber,
@@ -1279,17 +1650,98 @@
                                                                                                         }
                                                                                                     }
                                                                                                 } .Else {
-                                                                                                    .Block() {
-                                                                                                        .Call $reader.Read();
+                                                                                                    .If ((System.String)$reader.Value == "JsonUint32") {
                                                                                                         .Block() {
-                                                                                                            .If (
-                                                                                                                $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
-                                                                                                            ) {
-                                                                                                                .Call $reader.Skip()
+                                                                                                            .Call $reader.Read();
+                                                                                                            .Block() {
+                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                    $Example._uint32 = (System.UInt32)((System.Int64)$reader.Value)
+                                                                                                                } .Else {
+                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                            "{0} (line {1} position {2})",
+                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                .Call System.String.Format(
+                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                        .Constant<System.Object>(Integer),
+                                                                                                                                        (System.Object)$reader.TokenType
+                                                                                                                                    }),
+                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                            }))
+                                                                                                                };
+                                                                                                                .Call $reader.Read()
+                                                                                                            }
+                                                                                                        }
+                                                                                                    } .Else {
+                                                                                                        .If ((System.String)$reader.Value == "_str") {
+                                                                                                            .Block() {
+                                                                                                                .Call $reader.Read();
+                                                                                                                .Block() {
+                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(String)) {
+                                                                                                                        $Example._str = (System.String)$reader.Value
+                                                                                                                    } .Else {
+                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                "{0} (line {1} position {2})",
+                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                    .Call System.String.Format(
+                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                            .Constant<System.Object>(String),
+                                                                                                                                            (System.Object)$reader.TokenType
+                                                                                                                                        }),
+                                                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                                                }))
+                                                                                                                    };
+                                                                                                                    .Call $reader.Read()
+                                                                                                                }
+                                                                                                            }
+                                                                                                        } .Else {
+                                                                                                            .If ((System.String)$reader.Value == "_bool") {
+                                                                                                                .Block() {
+                                                                                                                    .Call $reader.Read();
+                                                                                                                    .Block() {
+                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Boolean)) {
+                                                                                                                            $Example._bool = (System.Boolean)$reader.Value
+                                                                                                                        } .Else {
+                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                    "{0} (line {1} position {2})",
+                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                        .Call System.String.Format(
+                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                .Constant<System.Object>(Boolean),
+                                                                                                                                                (System.Object)$reader.TokenType
+                                                                                                                                            }),
+                                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                                    }))
+                                                                                                                        };
+                                                                                                                        .Call $reader.Read()
+                                                                                                                    }
+                                                                                                                }
                                                                                                             } .Else {
-                                                                                                                .Default(System.Void)
-                                                                                                            };
-                                                                                                            .Call $reader.Read()
+                                                                                                                .Block() {
+                                                                                                                    .Call $reader.Read();
+                                                                                                                    .Block() {
+                                                                                                                        .If (
+                                                                                                                            $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
+                                                                                                                        ) {
+                                                                                                                            .Call $reader.Skip()
+                                                                                                                        } .Else {
+                                                                                                                            .Default(System.Void)
+                                                                                                                        };
+                                                                                                                        .Call $reader.Read()
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
                                                                                                         }
                                                                                                     }
                                                                                                 }

--- a/cs/test/expressions/DeserializeJson.expressions
+++ b/cs/test/expressions/DeserializeJson.expressions
@@ -193,13 +193,14 @@
                                                     }
                                                 }
                                             } .Else {
-                                                .If ((System.String)$reader.Value == "_decNullable") {
+                                                .If ((System.String)$reader.Value == "_refNullable") {
                                                     .Block() {
                                                         .Call $reader.Read();
                                                         .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
                                                             .Block() {
                                                                 .Call $reader.Read();
                                                                 .Block() {
+                                                                    $Example._refNullable = .Default(ExpressionsTest.RefObject);
                                                                     .Loop  {
                                                                         .Break end { }
                                                                     }
@@ -211,6 +212,7 @@
                                                                 .Block() {
                                                                     .Call $reader.Read();
                                                                     .Block() {
+                                                                        $Example._refNullable = .Default(ExpressionsTest.RefObject);
                                                                         .Loop  {
                                                                             .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
                                                                                 .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
@@ -219,24 +221,24 @@
                                                                                         .Block(
                                                                                             System.Int32 $index,
                                                                                             System.Byte[] $array) {
-                                                                                            .Block(System.Int32 $Example._decNullable_count) {
-                                                                                                $Example._decNullable_count = 0;
+                                                                                            .Block(System.Int32 $Example._refNullable_count) {
+                                                                                                $Example._refNullable_count = 0;
                                                                                                 .Default(System.Void);
                                                                                                 .Block() {
                                                                                                     $index = 0;
-                                                                                                    $array = .NewArray System.Byte[$Example._decNullable_count]
+                                                                                                    $array = .NewArray System.Byte[$Example._refNullable_count]
                                                                                                 }
                                                                                             };
                                                                                             .Loop  {
                                                                                                 .Break end { }
                                                                                             }
                                                                                             .LabelTarget end:;
-                                                                                            $Example._decNullable = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                            $Example._refNullable = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                                                                                                 .New System.ArraySegment`1[System.Byte](
                                                                                                     $array,
                                                                                                     0,
                                                                                                     $index),
-                                                                                                .Default(System.Decimal))
+                                                                                                .Default(ExpressionsTest.RefObject))
                                                                                         }
                                                                                     }
                                                                                 } .Else {
@@ -246,12 +248,12 @@
                                                                                             .Block(
                                                                                                 System.Int32 $index,
                                                                                                 System.Byte[] $array) {
-                                                                                                .Block(System.Int32 $Example._decNullable_count) {
-                                                                                                    $Example._decNullable_count = 0;
+                                                                                                .Block(System.Int32 $Example._refNullable_count) {
+                                                                                                    $Example._refNullable_count = 0;
                                                                                                     .Default(System.Void);
                                                                                                     .Block() {
                                                                                                         $index = 0;
-                                                                                                        $array = .NewArray System.Byte[$Example._decNullable_count]
+                                                                                                        $array = .NewArray System.Byte[$Example._refNullable_count]
                                                                                                     }
                                                                                                 };
                                                                                                 .Loop  {
@@ -295,12 +297,12 @@
                                                                                                     }
                                                                                                 }
                                                                                                 .LabelTarget end:;
-                                                                                                $Example._decNullable = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                $Example._refNullable = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                                                                                                     .New System.ArraySegment`1[System.Byte](
                                                                                                         $array,
                                                                                                         0,
                                                                                                         $index),
-                                                                                                    .Default(System.Decimal))
+                                                                                                    .Default(ExpressionsTest.RefObject))
                                                                                             };
                                                                                             .Call $reader.Read()
                                                                                         }
@@ -336,21 +338,21 @@
                                                         }
                                                     }
                                                 } .Else {
-                                                    .If ((System.String)$reader.Value == "_decMap") {
+                                                    .If ((System.String)$reader.Value == "_refMap") {
                                                         .Block() {
                                                             .Call $reader.Read();
                                                             .Block() {
                                                                 .Call $reader.Read();
                                                                 .Block(
-                                                                    System.Int32 $Example._decMap_key,
-                                                                    System.Decimal $Example._decMap_value) {
+                                                                    System.Int32 $Example._refMap_key,
+                                                                    ExpressionsTest.RefObject $Example._refMap_value) {
                                                                     .Default(System.Void);
                                                                     .Loop  {
                                                                         .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
                                                                             .Block() {
                                                                                 .Block() {
                                                                                     .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                        $Example._decMap_key = (System.Int32)((System.Int64)$reader.Value)
+                                                                                        $Example._refMap_key = (System.Int32)((System.Int64)$reader.Value)
                                                                                     } .Else {
                                                                                         .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                 System.Globalization.CultureInfo.InvariantCulture,
@@ -376,24 +378,24 @@
                                                                                         .Block(
                                                                                             System.Int32 $index,
                                                                                             System.Byte[] $array) {
-                                                                                            .Block(System.Int32 $Example._decMap_value_count) {
-                                                                                                $Example._decMap_value_count = 0;
+                                                                                            .Block(System.Int32 $Example._refMap_value_count) {
+                                                                                                $Example._refMap_value_count = 0;
                                                                                                 .Default(System.Void);
                                                                                                 .Block() {
                                                                                                     $index = 0;
-                                                                                                    $array = .NewArray System.Byte[$Example._decMap_value_count]
+                                                                                                    $array = .NewArray System.Byte[$Example._refMap_value_count]
                                                                                                 }
                                                                                             };
                                                                                             .Loop  {
                                                                                                 .Break end { }
                                                                                             }
                                                                                             .LabelTarget end:;
-                                                                                            $Example._decMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                            $Example._refMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                                                                                                 .New System.ArraySegment`1[System.Byte](
                                                                                                     $array,
                                                                                                     0,
                                                                                                     $index),
-                                                                                                .Default(System.Decimal))
+                                                                                                .Default(ExpressionsTest.RefObject))
                                                                                         }
                                                                                     }
                                                                                 } .Else {
@@ -403,12 +405,12 @@
                                                                                             .Block(
                                                                                                 System.Int32 $index,
                                                                                                 System.Byte[] $array) {
-                                                                                                .Block(System.Int32 $Example._decMap_value_count) {
-                                                                                                    $Example._decMap_value_count = 0;
+                                                                                                .Block(System.Int32 $Example._refMap_value_count) {
+                                                                                                    $Example._refMap_value_count = 0;
                                                                                                     .Default(System.Void);
                                                                                                     .Block() {
                                                                                                         $index = 0;
-                                                                                                        $array = .NewArray System.Byte[$Example._decMap_value_count]
+                                                                                                        $array = .NewArray System.Byte[$Example._refMap_value_count]
                                                                                                     }
                                                                                                 };
                                                                                                 .Loop  {
@@ -452,12 +454,12 @@
                                                                                                     }
                                                                                                 }
                                                                                                 .LabelTarget end:;
-                                                                                                $Example._decMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                $Example._refMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                                                                                                     .New System.ArraySegment`1[System.Byte](
                                                                                                         $array,
                                                                                                         0,
                                                                                                         $index),
-                                                                                                    .Default(System.Decimal))
+                                                                                                    .Default(ExpressionsTest.RefObject))
                                                                                             };
                                                                                             .Call $reader.Read()
                                                                                         }
@@ -472,7 +474,7 @@
                                                                                                 }))
                                                                                     }
                                                                                 };
-                                                                                ($Example._decMap).Item[$Example._decMap_key] = $Example._decMap_value
+                                                                                ($Example._refMap).Item[$Example._refMap_key] = $Example._refMap_value
                                                                             }
                                                                         } .Else {
                                                                             .Break end { }
@@ -484,17 +486,17 @@
                                                             }
                                                         }
                                                     } .Else {
-                                                        .If ((System.String)$reader.Value == "_decVector") {
+                                                        .If ((System.String)$reader.Value == "_refVector") {
                                                             .Block() {
                                                                 .Call $reader.Read();
                                                                 .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
                                                                     .Block() {
                                                                         .Call $reader.Read();
-                                                                        .Block(System.Decimal $Example._decVector_item) {
-                                                                            .Block(System.Int32 $Example._decVector_count) {
-                                                                                $Example._decVector_count = 0;
+                                                                        .Block(ExpressionsTest.RefObject $Example._refVector_item) {
+                                                                            .Block(System.Int32 $Example._refVector_count) {
+                                                                                $Example._refVector_count = 0;
                                                                                 .Default(System.Void);
-                                                                                ($Example._decVector).Capacity = $Example._decVector_count
+                                                                                ($Example._refVector).Capacity = $Example._refVector_count
                                                                             };
                                                                             .Loop  {
                                                                                 .Break end { }
@@ -507,11 +509,11 @@
                                                                     .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
                                                                         .Block() {
                                                                             .Call $reader.Read();
-                                                                            .Block(System.Decimal $Example._decVector_item) {
-                                                                                .Block(System.Int32 $Example._decVector_count) {
-                                                                                    $Example._decVector_count = 0;
+                                                                            .Block(ExpressionsTest.RefObject $Example._refVector_item) {
+                                                                                .Block(System.Int32 $Example._refVector_count) {
+                                                                                    $Example._refVector_count = 0;
                                                                                     .Default(System.Void);
-                                                                                    ($Example._decVector).Capacity = $Example._decVector_count
+                                                                                    ($Example._refVector).Capacity = $Example._refVector_count
                                                                                 };
                                                                                 .Loop  {
                                                                                     .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
@@ -522,24 +524,24 @@
                                                                                                     .Block(
                                                                                                         System.Int32 $index,
                                                                                                         System.Byte[] $array) {
-                                                                                                        .Block(System.Int32 $Example._decVector_item_count) {
-                                                                                                            $Example._decVector_item_count = 0;
+                                                                                                        .Block(System.Int32 $Example._refVector_item_count) {
+                                                                                                            $Example._refVector_item_count = 0;
                                                                                                             .Default(System.Void);
                                                                                                             .Block() {
                                                                                                                 $index = 0;
-                                                                                                                $array = .NewArray System.Byte[$Example._decVector_item_count]
+                                                                                                                $array = .NewArray System.Byte[$Example._refVector_item_count]
                                                                                                             }
                                                                                                         };
                                                                                                         .Loop  {
                                                                                                             .Break end { }
                                                                                                         }
                                                                                                         .LabelTarget end:;
-                                                                                                        $Example._decVector_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                        $Example._refVector_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                                                                                                             .New System.ArraySegment`1[System.Byte](
                                                                                                                 $array,
                                                                                                                 0,
                                                                                                                 $index),
-                                                                                                            .Default(System.Decimal))
+                                                                                                            .Default(ExpressionsTest.RefObject))
                                                                                                     }
                                                                                                 }
                                                                                             } .Else {
@@ -549,12 +551,12 @@
                                                                                                         .Block(
                                                                                                             System.Int32 $index,
                                                                                                             System.Byte[] $array) {
-                                                                                                            .Block(System.Int32 $Example._decVector_item_count) {
-                                                                                                                $Example._decVector_item_count = 0;
+                                                                                                            .Block(System.Int32 $Example._refVector_item_count) {
+                                                                                                                $Example._refVector_item_count = 0;
                                                                                                                 .Default(System.Void);
                                                                                                                 .Block() {
                                                                                                                     $index = 0;
-                                                                                                                    $array = .NewArray System.Byte[$Example._decVector_item_count]
+                                                                                                                    $array = .NewArray System.Byte[$Example._refVector_item_count]
                                                                                                                 }
                                                                                                             };
                                                                                                             .Loop  {
@@ -598,12 +600,12 @@
                                                                                                                 }
                                                                                                             }
                                                                                                             .LabelTarget end:;
-                                                                                                            $Example._decVector_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                            $Example._refVector_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                                                                                                                 .New System.ArraySegment`1[System.Byte](
                                                                                                                     $array,
                                                                                                                     0,
                                                                                                                     $index),
-                                                                                                                .Default(System.Decimal))
+                                                                                                                .Default(ExpressionsTest.RefObject))
                                                                                                         };
                                                                                                         .Call $reader.Read()
                                                                                                     }
@@ -618,7 +620,7 @@
                                                                                                             }))
                                                                                                 }
                                                                                             };
-                                                                                            .Call ($Example._decVector).Add($Example._decVector_item)
+                                                                                            .Call ($Example._refVector).Add($Example._refVector_item)
                                                                                         }
                                                                                     } .Else {
                                                                                         .Break end { }
@@ -642,13 +644,13 @@
                                                                 }
                                                             }
                                                         } .Else {
-                                                            .If ((System.String)$reader.Value == "_decList") {
+                                                            .If ((System.String)$reader.Value == "_refList") {
                                                                 .Block() {
                                                                     .Call $reader.Read();
                                                                     .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
                                                                         .Block() {
                                                                             .Call $reader.Read();
-                                                                            .Block(System.Decimal $Example._decList_item) {
+                                                                            .Block(ExpressionsTest.RefObject $Example._refList_item) {
                                                                                 .Default(System.Void);
                                                                                 .Loop  {
                                                                                     .Break end { }
@@ -661,7 +663,7 @@
                                                                         .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
                                                                             .Block() {
                                                                                 .Call $reader.Read();
-                                                                                .Block(System.Decimal $Example._decList_item) {
+                                                                                .Block(ExpressionsTest.RefObject $Example._refList_item) {
                                                                                     .Default(System.Void);
                                                                                     .Loop  {
                                                                                         .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
@@ -672,24 +674,24 @@
                                                                                                         .Block(
                                                                                                             System.Int32 $index,
                                                                                                             System.Byte[] $array) {
-                                                                                                            .Block(System.Int32 $Example._decList_item_count) {
-                                                                                                                $Example._decList_item_count = 0;
+                                                                                                            .Block(System.Int32 $Example._refList_item_count) {
+                                                                                                                $Example._refList_item_count = 0;
                                                                                                                 .Default(System.Void);
                                                                                                                 .Block() {
                                                                                                                     $index = 0;
-                                                                                                                    $array = .NewArray System.Byte[$Example._decList_item_count]
+                                                                                                                    $array = .NewArray System.Byte[$Example._refList_item_count]
                                                                                                                 }
                                                                                                             };
                                                                                                             .Loop  {
                                                                                                                 .Break end { }
                                                                                                             }
                                                                                                             .LabelTarget end:;
-                                                                                                            $Example._decList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                            $Example._refList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                                                                                                                 .New System.ArraySegment`1[System.Byte](
                                                                                                                     $array,
                                                                                                                     0,
                                                                                                                     $index),
-                                                                                                                .Default(System.Decimal))
+                                                                                                                .Default(ExpressionsTest.RefObject))
                                                                                                         }
                                                                                                     }
                                                                                                 } .Else {
@@ -699,12 +701,12 @@
                                                                                                             .Block(
                                                                                                                 System.Int32 $index,
                                                                                                                 System.Byte[] $array) {
-                                                                                                                .Block(System.Int32 $Example._decList_item_count) {
-                                                                                                                    $Example._decList_item_count = 0;
+                                                                                                                .Block(System.Int32 $Example._refList_item_count) {
+                                                                                                                    $Example._refList_item_count = 0;
                                                                                                                     .Default(System.Void);
                                                                                                                     .Block() {
                                                                                                                         $index = 0;
-                                                                                                                        $array = .NewArray System.Byte[$Example._decList_item_count]
+                                                                                                                        $array = .NewArray System.Byte[$Example._refList_item_count]
                                                                                                                     }
                                                                                                                 };
                                                                                                                 .Loop  {
@@ -748,12 +750,12 @@
                                                                                                                     }
                                                                                                                 }
                                                                                                                 .LabelTarget end:;
-                                                                                                                $Example._decList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                                $Example._refList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                                                                                                                     .New System.ArraySegment`1[System.Byte](
                                                                                                                         $array,
                                                                                                                         0,
                                                                                                                         $index),
-                                                                                                                    .Default(System.Decimal))
+                                                                                                                    .Default(ExpressionsTest.RefObject))
                                                                                                             };
                                                                                                             .Call $reader.Read()
                                                                                                         }
@@ -768,7 +770,7 @@
                                                                                                                 }))
                                                                                                     }
                                                                                                 };
-                                                                                                .Call ($Example._decList).Add($Example._decList_item)
+                                                                                                .Call ($Example._refList).Add($Example._refList_item)
                                                                                             }
                                                                                         } .Else {
                                                                                             .Break end { }
@@ -792,7 +794,7 @@
                                                                     }
                                                                 }
                                                             } .Else {
-                                                                .If ((System.String)$reader.Value == "_decimal") {
+                                                                .If ((System.String)$reader.Value == "_reference") {
                                                                     .Block() {
                                                                         .Call $reader.Read();
                                                                         .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
@@ -801,24 +803,24 @@
                                                                                 .Block(
                                                                                     System.Int32 $index,
                                                                                     System.Byte[] $array) {
-                                                                                    .Block(System.Int32 $Example._decimal_count) {
-                                                                                        $Example._decimal_count = 0;
+                                                                                    .Block(System.Int32 $Example._reference_count) {
+                                                                                        $Example._reference_count = 0;
                                                                                         .Default(System.Void);
                                                                                         .Block() {
                                                                                             $index = 0;
-                                                                                            $array = .NewArray System.Byte[$Example._decimal_count]
+                                                                                            $array = .NewArray System.Byte[$Example._reference_count]
                                                                                         }
                                                                                     };
                                                                                     .Loop  {
                                                                                         .Break end { }
                                                                                     }
                                                                                     .LabelTarget end:;
-                                                                                    $Example._decimal = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                    $Example._reference = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                                                                                         .New System.ArraySegment`1[System.Byte](
                                                                                             $array,
                                                                                             0,
                                                                                             $index),
-                                                                                        .Default(System.Decimal))
+                                                                                        .Default(ExpressionsTest.RefObject))
                                                                                 }
                                                                             }
                                                                         } .Else {
@@ -828,12 +830,12 @@
                                                                                     .Block(
                                                                                         System.Int32 $index,
                                                                                         System.Byte[] $array) {
-                                                                                        .Block(System.Int32 $Example._decimal_count) {
-                                                                                            $Example._decimal_count = 0;
+                                                                                        .Block(System.Int32 $Example._reference_count) {
+                                                                                            $Example._reference_count = 0;
                                                                                             .Default(System.Void);
                                                                                             .Block() {
                                                                                                 $index = 0;
-                                                                                                $array = .NewArray System.Byte[$Example._decimal_count]
+                                                                                                $array = .NewArray System.Byte[$Example._reference_count]
                                                                                             }
                                                                                         };
                                                                                         .Loop  {
@@ -877,12 +879,12 @@
                                                                                             }
                                                                                         }
                                                                                         .LabelTarget end:;
-                                                                                        $Example._decimal = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                        $Example._reference = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                                                                                             .New System.ArraySegment`1[System.Byte](
                                                                                                 $array,
                                                                                                 0,
                                                                                                 $index),
-                                                                                            .Default(System.Decimal))
+                                                                                            .Default(ExpressionsTest.RefObject))
                                                                                     };
                                                                                     .Call $reader.Read()
                                                                                 }
@@ -899,46 +901,164 @@
                                                                         }
                                                                     }
                                                                 } .Else {
-                                                                    .If ((System.String)$reader.Value == "_map") {
+                                                                    .If ((System.String)$reader.Value == "_decNullable") {
                                                                         .Block() {
                                                                             .Call $reader.Read();
+                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                .Block() {
+                                                                                    .Call $reader.Read();
+                                                                                    .Block() {
+                                                                                        .Loop  {
+                                                                                            .Break end { }
+                                                                                        }
+                                                                                        .LabelTarget end:
+                                                                                    }
+                                                                                }
+                                                                            } .Else {
+                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                    .Block() {
+                                                                                        .Call $reader.Read();
+                                                                                        .Block() {
+                                                                                            .Loop  {
+                                                                                                .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                                        .Block() {
+                                                                                                            .Call $reader.Read();
+                                                                                                            .Block(
+                                                                                                                System.Int32 $index,
+                                                                                                                System.Byte[] $array) {
+                                                                                                                .Block(System.Int32 $Example._decNullable_count) {
+                                                                                                                    $Example._decNullable_count = 0;
+                                                                                                                    .Default(System.Void);
+                                                                                                                    .Block() {
+                                                                                                                        $index = 0;
+                                                                                                                        $array = .NewArray System.Byte[$Example._decNullable_count]
+                                                                                                                    }
+                                                                                                                };
+                                                                                                                .Loop  {
+                                                                                                                    .Break end { }
+                                                                                                                }
+                                                                                                                .LabelTarget end:;
+                                                                                                                $Example._decNullable = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                                    .New System.ArraySegment`1[System.Byte](
+                                                                                                                        $array,
+                                                                                                                        0,
+                                                                                                                        $index),
+                                                                                                                    .Default(System.Decimal))
+                                                                                                            }
+                                                                                                        }
+                                                                                                    } .Else {
+                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                                            .Block() {
+                                                                                                                .Call $reader.Read();
+                                                                                                                .Block(
+                                                                                                                    System.Int32 $index,
+                                                                                                                    System.Byte[] $array) {
+                                                                                                                    .Block(System.Int32 $Example._decNullable_count) {
+                                                                                                                        $Example._decNullable_count = 0;
+                                                                                                                        .Default(System.Void);
+                                                                                                                        .Block() {
+                                                                                                                            $index = 0;
+                                                                                                                            $array = .NewArray System.Byte[$Example._decNullable_count]
+                                                                                                                        }
+                                                                                                                    };
+                                                                                                                    .Loop  {
+                                                                                                                        .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                                            .Block() {
+                                                                                                                                .If ($index >= $array.Length) {
+                                                                                                                                    .Call System.Array.Resize(
+                                                                                                                                        $array,
+                                                                                                                                        .If ($index > 512) {
+                                                                                                                                            $index * 2
+                                                                                                                                        } .Else {
+                                                                                                                                            1024
+                                                                                                                                        })
+                                                                                                                                } .Else {
+                                                                                                                                    .Default(System.Void)
+                                                                                                                                };
+                                                                                                                                .Block() {
+                                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                        $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
+                                                                                                                                    } .Else {
+                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                "{0} (line {1} position {2})",
+                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                    .Call System.String.Format(
+                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                            .Constant<System.Object>(Integer),
+                                                                                                                                                            (System.Object)$reader.TokenType
+                                                                                                                                                        }),
+                                                                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                                                                }))
+                                                                                                                                    };
+                                                                                                                                    .Call $reader.Read()
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        } .Else {
+                                                                                                                            .Break end { }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                    .LabelTarget end:;
+                                                                                                                    $Example._decNullable = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                                        .New System.ArraySegment`1[System.Byte](
+                                                                                                                            $array,
+                                                                                                                            0,
+                                                                                                                            $index),
+                                                                                                                        .Default(System.Decimal))
+                                                                                                                };
+                                                                                                                .Call $reader.Read()
+                                                                                                            }
+                                                                                                        } .Else {
+                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                    "{0} (line {1} position {2})",
+                                                                                                                    .NewArray System.Object[] {
+                                                                                                                        "Expected JSON array or null.",
+                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                    }))
+                                                                                                        }
+                                                                                                    }
+                                                                                                } .Else {
+                                                                                                    .Break end { }
+                                                                                                }
+                                                                                            }
+                                                                                            .LabelTarget end:
+                                                                                        };
+                                                                                        .Call $reader.Read()
+                                                                                    }
+                                                                                } .Else {
+                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                            "{0} (line {1} position {2})",
+                                                                                            .NewArray System.Object[] {
+                                                                                                "Expected JSON array or null.",
+                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                (System.Object)$reader.LinePosition
+                                                                                            }))
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    } .Else {
+                                                                        .If ((System.String)$reader.Value == "_decMap") {
                                                                             .Block() {
                                                                                 .Call $reader.Read();
-                                                                                .Block(
-                                                                                    System.Int32 $Example._map_key,
-                                                                                    System.Double $Example._map_value) {
-                                                                                    .Default(System.Void);
-                                                                                    .Loop  {
-                                                                                        .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
-                                                                                            .Block() {
+                                                                                .Block() {
+                                                                                    .Call $reader.Read();
+                                                                                    .Block(
+                                                                                        System.Int32 $Example._decMap_key,
+                                                                                        System.Decimal $Example._decMap_value) {
+                                                                                        .Default(System.Void);
+                                                                                        .Loop  {
+                                                                                            .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
                                                                                                 .Block() {
-                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                        $Example._map_key = (System.Int32)((System.Int64)$reader.Value)
-                                                                                                    } .Else {
-                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                "{0} (line {1} position {2})",
-                                                                                                                .NewArray System.Object[] {
-                                                                                                                    .Call System.String.Format(
-                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                        .NewArray System.Object[] {
-                                                                                                                            .Constant<System.Object>(Integer),
-                                                                                                                            (System.Object)$reader.TokenType
-                                                                                                                        }),
-                                                                                                                    (System.Object)$reader.LineNumber,
-                                                                                                                    (System.Object)$reader.LinePosition
-                                                                                                                }))
-                                                                                                    };
-                                                                                                    .Call $reader.Read()
-                                                                                                };
-                                                                                                $reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray);
-                                                                                                .Block() {
-                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                        $Example._map_value = (System.Double)((System.Int64)$reader.Value)
-                                                                                                    } .Else {
-                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
-                                                                                                            $Example._map_value = (System.Double)$reader.Value
+                                                                                                    .Block() {
+                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                            $Example._decMap_key = (System.Int32)((System.Int64)$reader.Value)
                                                                                                         } .Else {
                                                                                                             .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                                     System.Globalization.CultureInfo.InvariantCulture,
@@ -948,139 +1068,142 @@
                                                                                                                             System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                             "Invalid input, expected JSON token of type {0}, encountered {1}",
                                                                                                                             .NewArray System.Object[] {
-                                                                                                                                .Constant<System.Object>(Float),
+                                                                                                                                .Constant<System.Object>(Integer),
                                                                                                                                 (System.Object)$reader.TokenType
                                                                                                                             }),
                                                                                                                         (System.Object)$reader.LineNumber,
                                                                                                                         (System.Object)$reader.LinePosition
                                                                                                                     }))
-                                                                                                        }
+                                                                                                        };
+                                                                                                        .Call $reader.Read()
                                                                                                     };
-                                                                                                    .Call $reader.Read()
-                                                                                                };
-                                                                                                ($Example._map).Item[$Example._map_key] = $Example._map_value
-                                                                                            }
-                                                                                        } .Else {
-                                                                                            .Break end { }
-                                                                                        }
-                                                                                    }
-                                                                                    .LabelTarget end:
-                                                                                };
-                                                                                .Call $reader.Read()
-                                                                            }
-                                                                        }
-                                                                    } .Else {
-                                                                        .If ((System.String)$reader.Value == "b") {
-                                                                            .Block() {
-                                                                                .Call $reader.Read();
-                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
-                                                                                    .Block() {
-                                                                                        .Call $reader.Read();
-                                                                                        .Block(
-                                                                                            System.Int32 $index,
-                                                                                            System.Byte[] $array) {
-                                                                                            .Block(System.Int32 $Example.b_count) {
-                                                                                                $Example.b_count = 0;
-                                                                                                .Default(System.Void);
-                                                                                                .Block() {
-                                                                                                    $index = 0;
-                                                                                                    $array = .NewArray System.Byte[$Example.b_count]
-                                                                                                }
-                                                                                            };
-                                                                                            .Loop  {
-                                                                                                .Break end { }
-                                                                                            }
-                                                                                            .LabelTarget end:;
-                                                                                            $Example.b = .New System.ArraySegment`1[System.Byte](
-                                                                                                $array,
-                                                                                                0,
-                                                                                                $index)
-                                                                                        }
-                                                                                    }
-                                                                                } .Else {
-                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
-                                                                                        .Block() {
-                                                                                            .Call $reader.Read();
-                                                                                            .Block(
-                                                                                                System.Int32 $index,
-                                                                                                System.Byte[] $array) {
-                                                                                                .Block(System.Int32 $Example.b_count) {
-                                                                                                    $Example.b_count = 0;
-                                                                                                    .Default(System.Void);
-                                                                                                    .Block() {
-                                                                                                        $index = 0;
-                                                                                                        $array = .NewArray System.Byte[$Example.b_count]
-                                                                                                    }
-                                                                                                };
-                                                                                                .Loop  {
-                                                                                                    .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                    $reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray);
+                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
                                                                                                         .Block() {
-                                                                                                            .If ($index >= $array.Length) {
-                                                                                                                .Call System.Array.Resize(
-                                                                                                                    $array,
-                                                                                                                    .If ($index > 512) {
-                                                                                                                        $index * 2
-                                                                                                                    } .Else {
-                                                                                                                        1024
-                                                                                                                    })
-                                                                                                            } .Else {
-                                                                                                                .Default(System.Void)
-                                                                                                            };
-                                                                                                            .Block() {
-                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                    $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
-                                                                                                                } .Else {
-                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                            "{0} (line {1} position {2})",
-                                                                                                                            .NewArray System.Object[] {
-                                                                                                                                .Call System.String.Format(
-                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                    .NewArray System.Object[] {
-                                                                                                                                        .Constant<System.Object>(Integer),
-                                                                                                                                        (System.Object)$reader.TokenType
-                                                                                                                                    }),
-                                                                                                                                (System.Object)$reader.LineNumber,
-                                                                                                                                (System.Object)$reader.LinePosition
-                                                                                                                            }))
+                                                                                                            .Call $reader.Read();
+                                                                                                            .Block(
+                                                                                                                System.Int32 $index,
+                                                                                                                System.Byte[] $array) {
+                                                                                                                .Block(System.Int32 $Example._decMap_value_count) {
+                                                                                                                    $Example._decMap_value_count = 0;
+                                                                                                                    .Default(System.Void);
+                                                                                                                    .Block() {
+                                                                                                                        $index = 0;
+                                                                                                                        $array = .NewArray System.Byte[$Example._decMap_value_count]
+                                                                                                                    }
                                                                                                                 };
-                                                                                                                .Call $reader.Read()
+                                                                                                                .Loop  {
+                                                                                                                    .Break end { }
+                                                                                                                }
+                                                                                                                .LabelTarget end:;
+                                                                                                                $Example._decMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                                    .New System.ArraySegment`1[System.Byte](
+                                                                                                                        $array,
+                                                                                                                        0,
+                                                                                                                        $index),
+                                                                                                                    .Default(System.Decimal))
                                                                                                             }
                                                                                                         }
                                                                                                     } .Else {
-                                                                                                        .Break end { }
-                                                                                                    }
+                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                                            .Block() {
+                                                                                                                .Call $reader.Read();
+                                                                                                                .Block(
+                                                                                                                    System.Int32 $index,
+                                                                                                                    System.Byte[] $array) {
+                                                                                                                    .Block(System.Int32 $Example._decMap_value_count) {
+                                                                                                                        $Example._decMap_value_count = 0;
+                                                                                                                        .Default(System.Void);
+                                                                                                                        .Block() {
+                                                                                                                            $index = 0;
+                                                                                                                            $array = .NewArray System.Byte[$Example._decMap_value_count]
+                                                                                                                        }
+                                                                                                                    };
+                                                                                                                    .Loop  {
+                                                                                                                        .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                                            .Block() {
+                                                                                                                                .If ($index >= $array.Length) {
+                                                                                                                                    .Call System.Array.Resize(
+                                                                                                                                        $array,
+                                                                                                                                        .If ($index > 512) {
+                                                                                                                                            $index * 2
+                                                                                                                                        } .Else {
+                                                                                                                                            1024
+                                                                                                                                        })
+                                                                                                                                } .Else {
+                                                                                                                                    .Default(System.Void)
+                                                                                                                                };
+                                                                                                                                .Block() {
+                                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                        $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
+                                                                                                                                    } .Else {
+                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                "{0} (line {1} position {2})",
+                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                    .Call System.String.Format(
+                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                            .Constant<System.Object>(Integer),
+                                                                                                                                                            (System.Object)$reader.TokenType
+                                                                                                                                                        }),
+                                                                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                                                                }))
+                                                                                                                                    };
+                                                                                                                                    .Call $reader.Read()
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        } .Else {
+                                                                                                                            .Break end { }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                    .LabelTarget end:;
+                                                                                                                    $Example._decMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                                        .New System.ArraySegment`1[System.Byte](
+                                                                                                                            $array,
+                                                                                                                            0,
+                                                                                                                            $index),
+                                                                                                                        .Default(System.Decimal))
+                                                                                                                };
+                                                                                                                .Call $reader.Read()
+                                                                                                            }
+                                                                                                        } .Else {
+                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                    "{0} (line {1} position {2})",
+                                                                                                                    .NewArray System.Object[] {
+                                                                                                                        "Expected JSON array or null.",
+                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                    }))
+                                                                                                        }
+                                                                                                    };
+                                                                                                    ($Example._decMap).Item[$Example._decMap_key] = $Example._decMap_value
                                                                                                 }
-                                                                                                .LabelTarget end:;
-                                                                                                $Example.b = .New System.ArraySegment`1[System.Byte](
-                                                                                                    $array,
-                                                                                                    0,
-                                                                                                    $index)
-                                                                                            };
-                                                                                            .Call $reader.Read()
+                                                                                            } .Else {
+                                                                                                .Break end { }
+                                                                                            }
                                                                                         }
-                                                                                    } .Else {
-                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                "{0} (line {1} position {2})",
-                                                                                                .NewArray System.Object[] {
-                                                                                                    "Expected JSON array or null.",
-                                                                                                    (System.Object)$reader.LineNumber,
-                                                                                                    (System.Object)$reader.LinePosition
-                                                                                                }))
-                                                                                    }
+                                                                                        .LabelTarget end:
+                                                                                    };
+                                                                                    .Call $reader.Read()
                                                                                 }
                                                                             }
                                                                         } .Else {
-                                                                            .If ((System.String)$reader.Value == "_nestedVector") {
+                                                                            .If ((System.String)$reader.Value == "_decVector") {
                                                                                 .Block() {
                                                                                     .Call $reader.Read();
                                                                                     .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
                                                                                         .Block() {
                                                                                             .Call $reader.Read();
-                                                                                            .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
-                                                                                                .Default(System.Void);
+                                                                                            .Block(System.Decimal $Example._decVector_item) {
+                                                                                                .Block(System.Int32 $Example._decVector_count) {
+                                                                                                    $Example._decVector_count = 0;
+                                                                                                    .Default(System.Void);
+                                                                                                    ($Example._decVector).Capacity = $Example._decVector_count
+                                                                                                };
                                                                                                 .Loop  {
                                                                                                     .Break end { }
                                                                                                 }
@@ -1092,154 +1215,118 @@
                                                                                         .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
                                                                                             .Block() {
                                                                                                 .Call $reader.Read();
-                                                                                                .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
-                                                                                                    .Default(System.Void);
+                                                                                                .Block(System.Decimal $Example._decVector_item) {
+                                                                                                    .Block(System.Int32 $Example._decVector_count) {
+                                                                                                        $Example._decVector_count = 0;
+                                                                                                        .Default(System.Void);
+                                                                                                        ($Example._decVector).Capacity = $Example._decVector_count
+                                                                                                    };
                                                                                                     .Loop  {
                                                                                                         .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
                                                                                                             .Block() {
-                                                                                                                .Block() {
-                                                                                                                    $Example._nestedVector_item = .New ExpressionsTest.Nested();
-                                                                                                                    .Block(
-                                                                                                                        System.Byte $state,
-                                                                                                                        Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
-                                                                                                                        .Default(System.Void);
-                                                                                                                        .Default(System.Void);
-                                                                                                                        $state = .Constant<System.Byte>(1);
-                                                                                                                        .Loop  {
-                                                                                                                            .If (
-                                                                                                                                !$reader.EOF && $state != .Constant<System.Byte>(5)
-                                                                                                                            ) {
-                                                                                                                                .Switch ($reader.TokenType) {
-                                                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(None)):
-                                                                                                                                        .Switch ($state) {
-                                                                                                                                        .Case (.Constant<System.Byte>(1)):
-                                                                                                                                                .Block() {
-                                                                                                                                                    .Call $reader.Read();
-                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                }
-                                                                                                                                        .Default:
-                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                                        "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                                                        .NewArray System.Object[] {
-                                                                                                                                                            (System.Object)$reader.TokenType,
-                                                                                                                                                            (System.Object)$state,
-                                                                                                                                                            (System.Object)$reader.LineNumber,
-                                                                                                                                                            (System.Object)$reader.LinePosition
-                                                                                                                                                        }))
-                                                                                                                                        }
-                                                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(StartObject)):
-                                                                                                                                        .Switch ($state) {
-                                                                                                                                        .Case (.Constant<System.Byte>(1)):
-                                                                                                                                                .Block() {
-                                                                                                                                                    .Call $reader.Read();
-                                                                                                                                                    $state = .Constant<System.Byte>(2);
-                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                }
-                                                                                                                                        .Default:
-                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                                        "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                                                        .NewArray System.Object[] {
-                                                                                                                                                            (System.Object)$reader.TokenType,
-                                                                                                                                                            (System.Object)$state,
-                                                                                                                                                            (System.Object)$reader.LineNumber,
-                                                                                                                                                            (System.Object)$reader.LinePosition
-                                                                                                                                                        }))
-                                                                                                                                        }
-                                                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(EndObject)):
-                                                                                                                                        .Switch ($state) {
-                                                                                                                                        .Case (.Constant<System.Byte>(2)):
-                                                                                                                                                .Block() {
-                                                                                                                                                    .Call $reader.Read();
-                                                                                                                                                    $state = .Constant<System.Byte>(5);
-                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                }
-                                                                                                                                        .Default:
-                                                                                                                                                .Default(System.Void)
-                                                                                                                                        }
-                                                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(PropertyName)):
-                                                                                                                                        .Switch ($state) {
-                                                                                                                                        .Case (.Constant<System.Byte>(2)):
-                                                                                                                                                .Block() {
-                                                                                                                                                    .If ((System.String)$reader.Value == "_double") {
-                                                                                                                                                        .Block() {
-                                                                                                                                                            .Call $reader.Read();
-                                                                                                                                                            .Block() {
-                                                                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                                                                    $Example._nestedVector_item._double = (System.Double)((System.Int64)$reader.Value)
-                                                                                                                                                                } .Else {
-                                                                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
-                                                                                                                                                                        $Example._nestedVector_item._double = (System.Double)$reader.Value
-                                                                                                                                                                    } .Else {
-                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                                                                "{0} (line {1} position {2})",
-                                                                                                                                                                                .NewArray System.Object[] {
-                                                                                                                                                                                    .Call System.String.Format(
-                                                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                                                                        .NewArray System.Object[] {
-                                                                                                                                                                                            .Constant<System.Object>(Float),
-                                                                                                                                                                                            (System.Object)$reader.TokenType
-                                                                                                                                                                                        }),
-                                                                                                                                                                                    (System.Object)$reader.LineNumber,
-                                                                                                                                                                                    (System.Object)$reader.LinePosition
-                                                                                                                                                                                }))
-                                                                                                                                                                    }
-                                                                                                                                                                };
-                                                                                                                                                                .Call $reader.Read()
-                                                                                                                                                            }
-                                                                                                                                                        }
-                                                                                                                                                    } .Else {
-                                                                                                                                                        .Block() {
-                                                                                                                                                            .Call $reader.Read();
-                                                                                                                                                            .Block() {
-                                                                                                                                                                .If (
-                                                                                                                                                                    $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
-                                                                                                                                                                ) {
-                                                                                                                                                                    .Call $reader.Skip()
-                                                                                                                                                                } .Else {
-                                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                                };
-                                                                                                                                                                .Call $reader.Read()
-                                                                                                                                                            }
-                                                                                                                                                        }
-                                                                                                                                                    };
-                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                }
-                                                                                                                                        .Default:
-                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                                        "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                                                        .NewArray System.Object[] {
-                                                                                                                                                            (System.Object)$reader.TokenType,
-                                                                                                                                                            (System.Object)$state,
-                                                                                                                                                            (System.Object)$reader.LineNumber,
-                                                                                                                                                            (System.Object)$reader.LinePosition
-                                                                                                                                                        }))
-                                                                                                                                        }
-                                                                                                                                .Default:
-                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                                "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                                                .NewArray System.Object[] {
-                                                                                                                                                    (System.Object)$reader.TokenType,
-                                                                                                                                                    (System.Object)$state,
-                                                                                                                                                    (System.Object)$reader.LineNumber,
-                                                                                                                                                    (System.Object)$reader.LinePosition
-                                                                                                                                                }))
+                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                                                    .Block() {
+                                                                                                                        .Call $reader.Read();
+                                                                                                                        .Block(
+                                                                                                                            System.Int32 $index,
+                                                                                                                            System.Byte[] $array) {
+                                                                                                                            .Block(System.Int32 $Example._decVector_item_count) {
+                                                                                                                                $Example._decVector_item_count = 0;
+                                                                                                                                .Default(System.Void);
+                                                                                                                                .Block() {
+                                                                                                                                    $index = 0;
+                                                                                                                                    $array = .NewArray System.Byte[$Example._decVector_item_count]
                                                                                                                                 }
-                                                                                                                            } .Else {
-                                                                                                                                .Break endStateMachineLoop { }
+                                                                                                                            };
+                                                                                                                            .Loop  {
+                                                                                                                                .Break end { }
                                                                                                                             }
+                                                                                                                            .LabelTarget end:;
+                                                                                                                            $Example._decVector_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                                                .New System.ArraySegment`1[System.Byte](
+                                                                                                                                    $array,
+                                                                                                                                    0,
+                                                                                                                                    $index),
+                                                                                                                                .Default(System.Decimal))
                                                                                                                         }
-                                                                                                                        .LabelTarget endStateMachineLoop:;
-                                                                                                                        .Default(System.Void);
-                                                                                                                        .Default(System.Void)
+                                                                                                                    }
+                                                                                                                } .Else {
+                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                                                        .Block() {
+                                                                                                                            .Call $reader.Read();
+                                                                                                                            .Block(
+                                                                                                                                System.Int32 $index,
+                                                                                                                                System.Byte[] $array) {
+                                                                                                                                .Block(System.Int32 $Example._decVector_item_count) {
+                                                                                                                                    $Example._decVector_item_count = 0;
+                                                                                                                                    .Default(System.Void);
+                                                                                                                                    .Block() {
+                                                                                                                                        $index = 0;
+                                                                                                                                        $array = .NewArray System.Byte[$Example._decVector_item_count]
+                                                                                                                                    }
+                                                                                                                                };
+                                                                                                                                .Loop  {
+                                                                                                                                    .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                                                        .Block() {
+                                                                                                                                            .If ($index >= $array.Length) {
+                                                                                                                                                .Call System.Array.Resize(
+                                                                                                                                                    $array,
+                                                                                                                                                    .If ($index > 512) {
+                                                                                                                                                        $index * 2
+                                                                                                                                                    } .Else {
+                                                                                                                                                        1024
+                                                                                                                                                    })
+                                                                                                                                            } .Else {
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                            };
+                                                                                                                                            .Block() {
+                                                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                    $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                            "{0} (line {1} position {2})",
+                                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                                .Call System.String.Format(
+                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                                                        .Constant<System.Object>(Integer),
+                                                                                                                                                                        (System.Object)$reader.TokenType
+                                                                                                                                                                    }),
+                                                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                                                            }))
+                                                                                                                                                };
+                                                                                                                                                .Call $reader.Read()
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    } .Else {
+                                                                                                                                        .Break end { }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                                .LabelTarget end:;
+                                                                                                                                $Example._decVector_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                                                    .New System.ArraySegment`1[System.Byte](
+                                                                                                                                        $array,
+                                                                                                                                        0,
+                                                                                                                                        $index),
+                                                                                                                                    .Default(System.Decimal))
+                                                                                                                            };
+                                                                                                                            .Call $reader.Read()
+                                                                                                                        }
+                                                                                                                    } .Else {
+                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                "{0} (line {1} position {2})",
+                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                    "Expected JSON array or null.",
+                                                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                                                }))
                                                                                                                     }
                                                                                                                 };
-                                                                                                                .Call ($Example._nestedVector).Add($Example._nestedVector_item)
+                                                                                                                .Call ($Example._decVector).Add($Example._decVector_item)
                                                                                                             }
                                                                                                         } .Else {
                                                                                                             .Break end { }
@@ -1263,18 +1350,14 @@
                                                                                     }
                                                                                 }
                                                                             } .Else {
-                                                                                .If ((System.String)$reader.Value == "_int32Vector") {
+                                                                                .If ((System.String)$reader.Value == "_decList") {
                                                                                     .Block() {
                                                                                         .Call $reader.Read();
                                                                                         .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
                                                                                             .Block() {
                                                                                                 .Call $reader.Read();
-                                                                                                .Block(System.Int32 $Example._int32Vector_item) {
-                                                                                                    .Block(System.Int32 $Example._int32Vector_count) {
-                                                                                                        $Example._int32Vector_count = 0;
-                                                                                                        .Default(System.Void);
-                                                                                                        ($Example._int32Vector).Capacity = $Example._int32Vector_count
-                                                                                                    };
+                                                                                                .Block(System.Decimal $Example._decList_item) {
+                                                                                                    .Default(System.Void);
                                                                                                     .Loop  {
                                                                                                         .Break end { }
                                                                                                     }
@@ -1286,37 +1369,114 @@
                                                                                             .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
                                                                                                 .Block() {
                                                                                                     .Call $reader.Read();
-                                                                                                    .Block(System.Int32 $Example._int32Vector_item) {
-                                                                                                        .Block(System.Int32 $Example._int32Vector_count) {
-                                                                                                            $Example._int32Vector_count = 0;
-                                                                                                            .Default(System.Void);
-                                                                                                            ($Example._int32Vector).Capacity = $Example._int32Vector_count
-                                                                                                        };
+                                                                                                    .Block(System.Decimal $Example._decList_item) {
+                                                                                                        .Default(System.Void);
                                                                                                         .Loop  {
                                                                                                             .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
                                                                                                                 .Block() {
-                                                                                                                    .Block() {
-                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                            $Example._int32Vector_item = (System.Int32)((System.Int64)$reader.Value)
+                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                                                        .Block() {
+                                                                                                                            .Call $reader.Read();
+                                                                                                                            .Block(
+                                                                                                                                System.Int32 $index,
+                                                                                                                                System.Byte[] $array) {
+                                                                                                                                .Block(System.Int32 $Example._decList_item_count) {
+                                                                                                                                    $Example._decList_item_count = 0;
+                                                                                                                                    .Default(System.Void);
+                                                                                                                                    .Block() {
+                                                                                                                                        $index = 0;
+                                                                                                                                        $array = .NewArray System.Byte[$Example._decList_item_count]
+                                                                                                                                    }
+                                                                                                                                };
+                                                                                                                                .Loop  {
+                                                                                                                                    .Break end { }
+                                                                                                                                }
+                                                                                                                                .LabelTarget end:;
+                                                                                                                                $Example._decList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                                                    .New System.ArraySegment`1[System.Byte](
+                                                                                                                                        $array,
+                                                                                                                                        0,
+                                                                                                                                        $index),
+                                                                                                                                    .Default(System.Decimal))
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    } .Else {
+                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                                                            .Block() {
+                                                                                                                                .Call $reader.Read();
+                                                                                                                                .Block(
+                                                                                                                                    System.Int32 $index,
+                                                                                                                                    System.Byte[] $array) {
+                                                                                                                                    .Block(System.Int32 $Example._decList_item_count) {
+                                                                                                                                        $Example._decList_item_count = 0;
+                                                                                                                                        .Default(System.Void);
+                                                                                                                                        .Block() {
+                                                                                                                                            $index = 0;
+                                                                                                                                            $array = .NewArray System.Byte[$Example._decList_item_count]
+                                                                                                                                        }
+                                                                                                                                    };
+                                                                                                                                    .Loop  {
+                                                                                                                                        .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                                                            .Block() {
+                                                                                                                                                .If ($index >= $array.Length) {
+                                                                                                                                                    .Call System.Array.Resize(
+                                                                                                                                                        $array,
+                                                                                                                                                        .If ($index > 512) {
+                                                                                                                                                            $index * 2
+                                                                                                                                                        } .Else {
+                                                                                                                                                            1024
+                                                                                                                                                        })
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                };
+                                                                                                                                                .Block() {
+                                                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                        $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                "{0} (line {1} position {2})",
+                                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                                    .Call System.String.Format(
+                                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                                            .Constant<System.Object>(Integer),
+                                                                                                                                                                            (System.Object)$reader.TokenType
+                                                                                                                                                                        }),
+                                                                                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                                                                                }))
+                                                                                                                                                    };
+                                                                                                                                                    .Call $reader.Read()
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        } .Else {
+                                                                                                                                            .Break end { }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                    .LabelTarget end:;
+                                                                                                                                    $Example._decList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                                                        .New System.ArraySegment`1[System.Byte](
+                                                                                                                                            $array,
+                                                                                                                                            0,
+                                                                                                                                            $index),
+                                                                                                                                        .Default(System.Decimal))
+                                                                                                                                };
+                                                                                                                                .Call $reader.Read()
+                                                                                                                            }
                                                                                                                         } .Else {
                                                                                                                             .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                                                     System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                                     "{0} (line {1} position {2})",
                                                                                                                                     .NewArray System.Object[] {
-                                                                                                                                        .Call System.String.Format(
-                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                            .NewArray System.Object[] {
-                                                                                                                                                .Constant<System.Object>(Integer),
-                                                                                                                                                (System.Object)$reader.TokenType
-                                                                                                                                            }),
+                                                                                                                                        "Expected JSON array or null.",
                                                                                                                                         (System.Object)$reader.LineNumber,
                                                                                                                                         (System.Object)$reader.LinePosition
                                                                                                                                     }))
-                                                                                                                        };
-                                                                                                                        .Call $reader.Read()
+                                                                                                                        }
                                                                                                                     };
-                                                                                                                    .Call ($Example._int32Vector).Add($Example._int32Vector_item)
+                                                                                                                    .Call ($Example._decList).Add($Example._decList_item)
                                                                                                                 }
                                                                                                             } .Else {
                                                                                                                 .Break end { }
@@ -1340,131 +1500,826 @@
                                                                                         }
                                                                                     }
                                                                                 } .Else {
-                                                                                    .If ((System.String)$reader.Value == "guid") {
+                                                                                    .If ((System.String)$reader.Value == "_decimal") {
                                                                                         .Block() {
                                                                                             .Call $reader.Read();
-                                                                                            .Block() {
-                                                                                                .Block(
-                                                                                                    System.Byte $state,
-                                                                                                    Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
-                                                                                                    .Default(System.Void);
-                                                                                                    .Default(System.Void);
-                                                                                                    $state = .Constant<System.Byte>(1);
-                                                                                                    .Loop  {
-                                                                                                        .If (
-                                                                                                            !$reader.EOF && $state != .Constant<System.Byte>(5)
-                                                                                                        ) {
-                                                                                                            .Switch ($reader.TokenType) {
-                                                                                                            .Case (.Constant<Newtonsoft.Json.JsonToken>(None)):
-                                                                                                                    .Switch ($state) {
-                                                                                                                    .Case (.Constant<System.Byte>(1)):
-                                                                                                                            .Block() {
-                                                                                                                                .Call $reader.Read();
-                                                                                                                                .Default(System.Void)
-                                                                                                                            }
-                                                                                                                    .Default:
-                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                    "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                                    .NewArray System.Object[] {
-                                                                                                                                        (System.Object)$reader.TokenType,
-                                                                                                                                        (System.Object)$state,
-                                                                                                                                        (System.Object)$reader.LineNumber,
-                                                                                                                                        (System.Object)$reader.LinePosition
-                                                                                                                                    }))
-                                                                                                                    }
-                                                                                                            .Case (.Constant<Newtonsoft.Json.JsonToken>(StartObject)):
-                                                                                                                    .Switch ($state) {
-                                                                                                                    .Case (.Constant<System.Byte>(1)):
-                                                                                                                            .Block() {
-                                                                                                                                .Call $reader.Read();
-                                                                                                                                $state = .Constant<System.Byte>(2);
-                                                                                                                                .Default(System.Void)
-                                                                                                                            }
-                                                                                                                    .Default:
-                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                    "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                                    .NewArray System.Object[] {
-                                                                                                                                        (System.Object)$reader.TokenType,
-                                                                                                                                        (System.Object)$state,
-                                                                                                                                        (System.Object)$reader.LineNumber,
-                                                                                                                                        (System.Object)$reader.LinePosition
-                                                                                                                                    }))
-                                                                                                                    }
-                                                                                                            .Case (.Constant<Newtonsoft.Json.JsonToken>(EndObject)):
-                                                                                                                    .Switch ($state) {
-                                                                                                                    .Case (.Constant<System.Byte>(2)):
-                                                                                                                            .Block() {
-                                                                                                                                .Call $reader.Read();
-                                                                                                                                $state = .Constant<System.Byte>(5);
-                                                                                                                                .Default(System.Void)
-                                                                                                                            }
-                                                                                                                    .Default:
+                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                                .Block() {
+                                                                                                    .Call $reader.Read();
+                                                                                                    .Block(
+                                                                                                        System.Int32 $index,
+                                                                                                        System.Byte[] $array) {
+                                                                                                        .Block(System.Int32 $Example._decimal_count) {
+                                                                                                            $Example._decimal_count = 0;
+                                                                                                            .Default(System.Void);
+                                                                                                            .Block() {
+                                                                                                                $index = 0;
+                                                                                                                $array = .NewArray System.Byte[$Example._decimal_count]
+                                                                                                            }
+                                                                                                        };
+                                                                                                        .Loop  {
+                                                                                                            .Break end { }
+                                                                                                        }
+                                                                                                        .LabelTarget end:;
+                                                                                                        $Example._decimal = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                            .New System.ArraySegment`1[System.Byte](
+                                                                                                                $array,
+                                                                                                                0,
+                                                                                                                $index),
+                                                                                                            .Default(System.Decimal))
+                                                                                                    }
+                                                                                                }
+                                                                                            } .Else {
+                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                                    .Block() {
+                                                                                                        .Call $reader.Read();
+                                                                                                        .Block(
+                                                                                                            System.Int32 $index,
+                                                                                                            System.Byte[] $array) {
+                                                                                                            .Block(System.Int32 $Example._decimal_count) {
+                                                                                                                $Example._decimal_count = 0;
+                                                                                                                .Default(System.Void);
+                                                                                                                .Block() {
+                                                                                                                    $index = 0;
+                                                                                                                    $array = .NewArray System.Byte[$Example._decimal_count]
+                                                                                                                }
+                                                                                                            };
+                                                                                                            .Loop  {
+                                                                                                                .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                                    .Block() {
+                                                                                                                        .If ($index >= $array.Length) {
+                                                                                                                            .Call System.Array.Resize(
+                                                                                                                                $array,
+                                                                                                                                .If ($index > 512) {
+                                                                                                                                    $index * 2
+                                                                                                                                } .Else {
+                                                                                                                                    1024
+                                                                                                                                })
+                                                                                                                        } .Else {
                                                                                                                             .Default(System.Void)
+                                                                                                                        };
+                                                                                                                        .Block() {
+                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
+                                                                                                                            } .Else {
+                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                        "{0} (line {1} position {2})",
+                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                            .Call System.String.Format(
+                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                    .Constant<System.Object>(Integer),
+                                                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                                                }),
+                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                        }))
+                                                                                                                            };
+                                                                                                                            .Call $reader.Read()
+                                                                                                                        }
                                                                                                                     }
-                                                                                                            .Case (.Constant<Newtonsoft.Json.JsonToken>(PropertyName)):
-                                                                                                                    .Switch ($state) {
-                                                                                                                    .Case (.Constant<System.Byte>(2)):
-                                                                                                                            .Block() {
-                                                                                                                                .If ((System.String)$reader.Value == "Data4") {
+                                                                                                                } .Else {
+                                                                                                                    .Break end { }
+                                                                                                                }
+                                                                                                            }
+                                                                                                            .LabelTarget end:;
+                                                                                                            $Example._decimal = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                                .New System.ArraySegment`1[System.Byte](
+                                                                                                                    $array,
+                                                                                                                    0,
+                                                                                                                    $index),
+                                                                                                                .Default(System.Decimal))
+                                                                                                        };
+                                                                                                        .Call $reader.Read()
+                                                                                                    }
+                                                                                                } .Else {
+                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                            "{0} (line {1} position {2})",
+                                                                                                            .NewArray System.Object[] {
+                                                                                                                "Expected JSON array or null.",
+                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                            }))
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    } .Else {
+                                                                                        .If ((System.String)$reader.Value == "_map") {
+                                                                                            .Block() {
+                                                                                                .Call $reader.Read();
+                                                                                                .Block() {
+                                                                                                    .Call $reader.Read();
+                                                                                                    .Block(
+                                                                                                        System.Int32 $Example._map_key,
+                                                                                                        System.Double $Example._map_value) {
+                                                                                                        .Default(System.Void);
+                                                                                                        .Loop  {
+                                                                                                            .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                                .Block() {
+                                                                                                                    .Block() {
+                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                            $Example._map_key = (System.Int32)((System.Int64)$reader.Value)
+                                                                                                                        } .Else {
+                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                    "{0} (line {1} position {2})",
+                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                        .Call System.String.Format(
+                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                .Constant<System.Object>(Integer),
+                                                                                                                                                (System.Object)$reader.TokenType
+                                                                                                                                            }),
+                                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                                    }))
+                                                                                                                        };
+                                                                                                                        .Call $reader.Read()
+                                                                                                                    };
+                                                                                                                    $reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray);
+                                                                                                                    .Block() {
+                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                            $Example._map_value = (System.Double)((System.Int64)$reader.Value)
+                                                                                                                        } .Else {
+                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
+                                                                                                                                $Example._map_value = (System.Double)$reader.Value
+                                                                                                                            } .Else {
+                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                        "{0} (line {1} position {2})",
+                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                            .Call System.String.Format(
+                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                    .Constant<System.Object>(Float),
+                                                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                                                }),
+                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                        }))
+                                                                                                                            }
+                                                                                                                        };
+                                                                                                                        .Call $reader.Read()
+                                                                                                                    };
+                                                                                                                    ($Example._map).Item[$Example._map_key] = $Example._map_value
+                                                                                                                }
+                                                                                                            } .Else {
+                                                                                                                .Break end { }
+                                                                                                            }
+                                                                                                        }
+                                                                                                        .LabelTarget end:
+                                                                                                    };
+                                                                                                    .Call $reader.Read()
+                                                                                                }
+                                                                                            }
+                                                                                        } .Else {
+                                                                                            .If ((System.String)$reader.Value == "_blobNullable") {
+                                                                                                .Block() {
+                                                                                                    .Call $reader.Read();
+                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                                        .Block() {
+                                                                                                            .Call $reader.Read();
+                                                                                                            .Block() {
+                                                                                                                .Loop  {
+                                                                                                                    .Break end { }
+                                                                                                                }
+                                                                                                                .LabelTarget end:
+                                                                                                            }
+                                                                                                        }
+                                                                                                    } .Else {
+                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                                            .Block() {
+                                                                                                                .Call $reader.Read();
+                                                                                                                .Block() {
+                                                                                                                    .Loop  {
+                                                                                                                        .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                                                                .Block() {
+                                                                                                                                    .Call $reader.Read();
+                                                                                                                                    .Block(
+                                                                                                                                        System.Int32 $index,
+                                                                                                                                        System.Byte[] $array) {
+                                                                                                                                        .Block(System.Int32 $Example._blobNullable_count) {
+                                                                                                                                            $Example._blobNullable_count = 0;
+                                                                                                                                            .Default(System.Void);
+                                                                                                                                            .Block() {
+                                                                                                                                                $index = 0;
+                                                                                                                                                $array = .NewArray System.Byte[$Example._blobNullable_count]
+                                                                                                                                            }
+                                                                                                                                        };
+                                                                                                                                        .Loop  {
+                                                                                                                                            .Break end { }
+                                                                                                                                        }
+                                                                                                                                        .LabelTarget end:;
+                                                                                                                                        $Example._blobNullable = .New System.ArraySegment`1[System.Byte](
+                                                                                                                                            $array,
+                                                                                                                                            0,
+                                                                                                                                            $index)
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            } .Else {
+                                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
                                                                                                                                     .Block() {
                                                                                                                                         .Call $reader.Read();
-                                                                                                                                        .Block() {
-                                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                                                ($Example.guid).Data4 = (System.UInt64)((System.Int64)$reader.Value)
+                                                                                                                                        .Block(
+                                                                                                                                            System.Int32 $index,
+                                                                                                                                            System.Byte[] $array) {
+                                                                                                                                            .Block(System.Int32 $Example._blobNullable_count) {
+                                                                                                                                                $Example._blobNullable_count = 0;
+                                                                                                                                                .Default(System.Void);
+                                                                                                                                                .Block() {
+                                                                                                                                                    $index = 0;
+                                                                                                                                                    $array = .NewArray System.Byte[$Example._blobNullable_count]
+                                                                                                                                                }
+                                                                                                                                            };
+                                                                                                                                            .Loop  {
+                                                                                                                                                .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .If ($index >= $array.Length) {
+                                                                                                                                                            .Call System.Array.Resize(
+                                                                                                                                                                $array,
+                                                                                                                                                                .If ($index > 512) {
+                                                                                                                                                                    $index * 2
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    1024
+                                                                                                                                                                })
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                        };
+                                                                                                                                                        .Block() {
+                                                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                                $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                        "{0} (line {1} position {2})",
+                                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                                            .Call System.String.Format(
+                                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                                                    .Constant<System.Object>(Integer),
+                                                                                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                                                                                }),
+                                                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                                                        }))
+                                                                                                                                                            };
+                                                                                                                                                            .Call $reader.Read()
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Break end { }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                            .LabelTarget end:;
+                                                                                                                                            $Example._blobNullable = .New System.ArraySegment`1[System.Byte](
+                                                                                                                                                $array,
+                                                                                                                                                0,
+                                                                                                                                                $index)
+                                                                                                                                        };
+                                                                                                                                        .Call $reader.Read()
+                                                                                                                                    }
+                                                                                                                                } .Else {
+                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                            "{0} (line {1} position {2})",
+                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                "Expected JSON array or null.",
+                                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                                            }))
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        } .Else {
+                                                                                                                            .Break end { }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                    .LabelTarget end:
+                                                                                                                };
+                                                                                                                .Call $reader.Read()
+                                                                                                            }
+                                                                                                        } .Else {
+                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                    "{0} (line {1} position {2})",
+                                                                                                                    .NewArray System.Object[] {
+                                                                                                                        "Expected JSON array or null.",
+                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                    }))
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            } .Else {
+                                                                                                .If ((System.String)$reader.Value == "_blobMap") {
+                                                                                                    .Block() {
+                                                                                                        .Call $reader.Read();
+                                                                                                        .Block() {
+                                                                                                            .Call $reader.Read();
+                                                                                                            .Block(
+                                                                                                                System.Int32 $Example._blobMap_key,
+                                                                                                                System.ArraySegment`1[System.Byte] $Example._blobMap_value) {
+                                                                                                                .Default(System.Void);
+                                                                                                                .Loop  {
+                                                                                                                    .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                                        .Block() {
+                                                                                                                            .Block() {
+                                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                    $Example._blobMap_key = (System.Int32)((System.Int64)$reader.Value)
+                                                                                                                                } .Else {
+                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                            "{0} (line {1} position {2})",
+                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                .Call System.String.Format(
+                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                                        .Constant<System.Object>(Integer),
+                                                                                                                                                        (System.Object)$reader.TokenType
+                                                                                                                                                    }),
+                                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                                            }))
+                                                                                                                                };
+                                                                                                                                .Call $reader.Read()
+                                                                                                                            };
+                                                                                                                            $reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray);
+                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                                                                .Block() {
+                                                                                                                                    .Call $reader.Read();
+                                                                                                                                    .Block(
+                                                                                                                                        System.Int32 $index,
+                                                                                                                                        System.Byte[] $array) {
+                                                                                                                                        .Block(System.Int32 $Example._blobMap_value_count) {
+                                                                                                                                            $Example._blobMap_value_count = 0;
+                                                                                                                                            .Default(System.Void);
+                                                                                                                                            .Block() {
+                                                                                                                                                $index = 0;
+                                                                                                                                                $array = .NewArray System.Byte[$Example._blobMap_value_count]
+                                                                                                                                            }
+                                                                                                                                        };
+                                                                                                                                        .Loop  {
+                                                                                                                                            .Break end { }
+                                                                                                                                        }
+                                                                                                                                        .LabelTarget end:;
+                                                                                                                                        $Example._blobMap_value = .New System.ArraySegment`1[System.Byte](
+                                                                                                                                            $array,
+                                                                                                                                            0,
+                                                                                                                                            $index)
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            } .Else {
+                                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                                                                    .Block() {
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        .Block(
+                                                                                                                                            System.Int32 $index,
+                                                                                                                                            System.Byte[] $array) {
+                                                                                                                                            .Block(System.Int32 $Example._blobMap_value_count) {
+                                                                                                                                                $Example._blobMap_value_count = 0;
+                                                                                                                                                .Default(System.Void);
+                                                                                                                                                .Block() {
+                                                                                                                                                    $index = 0;
+                                                                                                                                                    $array = .NewArray System.Byte[$Example._blobMap_value_count]
+                                                                                                                                                }
+                                                                                                                                            };
+                                                                                                                                            .Loop  {
+                                                                                                                                                .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .If ($index >= $array.Length) {
+                                                                                                                                                            .Call System.Array.Resize(
+                                                                                                                                                                $array,
+                                                                                                                                                                .If ($index > 512) {
+                                                                                                                                                                    $index * 2
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    1024
+                                                                                                                                                                })
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                        };
+                                                                                                                                                        .Block() {
+                                                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                                $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                        "{0} (line {1} position {2})",
+                                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                                            .Call System.String.Format(
+                                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                                                    .Constant<System.Object>(Integer),
+                                                                                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                                                                                }),
+                                                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                                                        }))
+                                                                                                                                                            };
+                                                                                                                                                            .Call $reader.Read()
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Break end { }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                            .LabelTarget end:;
+                                                                                                                                            $Example._blobMap_value = .New System.ArraySegment`1[System.Byte](
+                                                                                                                                                $array,
+                                                                                                                                                0,
+                                                                                                                                                $index)
+                                                                                                                                        };
+                                                                                                                                        .Call $reader.Read()
+                                                                                                                                    }
+                                                                                                                                } .Else {
+                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                            "{0} (line {1} position {2})",
+                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                "Expected JSON array or null.",
+                                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                                            }))
+                                                                                                                                }
+                                                                                                                            };
+                                                                                                                            ($Example._blobMap).Item[$Example._blobMap_key] = $Example._blobMap_value
+                                                                                                                        }
+                                                                                                                    } .Else {
+                                                                                                                        .Break end { }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                                .LabelTarget end:
+                                                                                                            };
+                                                                                                            .Call $reader.Read()
+                                                                                                        }
+                                                                                                    }
+                                                                                                } .Else {
+                                                                                                    .If ((System.String)$reader.Value == "_blobVector") {
+                                                                                                        .Block() {
+                                                                                                            .Call $reader.Read();
+                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                                                .Block() {
+                                                                                                                    .Call $reader.Read();
+                                                                                                                    .Block(System.ArraySegment`1[System.Byte] $Example._blobVector_item) {
+                                                                                                                        .Block(System.Int32 $Example._blobVector_count) {
+                                                                                                                            $Example._blobVector_count = 0;
+                                                                                                                            .Default(System.Void);
+                                                                                                                            ($Example._blobVector).Capacity = $Example._blobVector_count
+                                                                                                                        };
+                                                                                                                        .Loop  {
+                                                                                                                            .Break end { }
+                                                                                                                        }
+                                                                                                                        .LabelTarget end:;
+                                                                                                                        .Default(System.Void)
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            } .Else {
+                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                                                    .Block() {
+                                                                                                                        .Call $reader.Read();
+                                                                                                                        .Block(System.ArraySegment`1[System.Byte] $Example._blobVector_item) {
+                                                                                                                            .Block(System.Int32 $Example._blobVector_count) {
+                                                                                                                                $Example._blobVector_count = 0;
+                                                                                                                                .Default(System.Void);
+                                                                                                                                ($Example._blobVector).Capacity = $Example._blobVector_count
+                                                                                                                            };
+                                                                                                                            .Loop  {
+                                                                                                                                .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                                                    .Block() {
+                                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                                                                            .Block() {
+                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                .Block(
+                                                                                                                                                    System.Int32 $index,
+                                                                                                                                                    System.Byte[] $array) {
+                                                                                                                                                    .Block(System.Int32 $Example._blobVector_item_count) {
+                                                                                                                                                        $Example._blobVector_item_count = 0;
+                                                                                                                                                        .Default(System.Void);
+                                                                                                                                                        .Block() {
+                                                                                                                                                            $index = 0;
+                                                                                                                                                            $array = .NewArray System.Byte[$Example._blobVector_item_count]
+                                                                                                                                                        }
+                                                                                                                                                    };
+                                                                                                                                                    .Loop  {
+                                                                                                                                                        .Break end { }
+                                                                                                                                                    }
+                                                                                                                                                    .LabelTarget end:;
+                                                                                                                                                    $Example._blobVector_item = .New System.ArraySegment`1[System.Byte](
+                                                                                                                                                        $array,
+                                                                                                                                                        0,
+                                                                                                                                                        $index)
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        } .Else {
+                                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                                                                                .Block() {
+                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                    .Block(
+                                                                                                                                                        System.Int32 $index,
+                                                                                                                                                        System.Byte[] $array) {
+                                                                                                                                                        .Block(System.Int32 $Example._blobVector_item_count) {
+                                                                                                                                                            $Example._blobVector_item_count = 0;
+                                                                                                                                                            .Default(System.Void);
+                                                                                                                                                            .Block() {
+                                                                                                                                                                $index = 0;
+                                                                                                                                                                $array = .NewArray System.Byte[$Example._blobVector_item_count]
+                                                                                                                                                            }
+                                                                                                                                                        };
+                                                                                                                                                        .Loop  {
+                                                                                                                                                            .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                                                                                .Block() {
+                                                                                                                                                                    .If ($index >= $array.Length) {
+                                                                                                                                                                        .Call System.Array.Resize(
+                                                                                                                                                                            $array,
+                                                                                                                                                                            .If ($index > 512) {
+                                                                                                                                                                                $index * 2
+                                                                                                                                                                            } .Else {
+                                                                                                                                                                                1024
+                                                                                                                                                                            })
+                                                                                                                                                                    } .Else {
+                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                    };
+                                                                                                                                                                    .Block() {
+                                                                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                                            $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
+                                                                                                                                                                        } .Else {
+                                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                    "{0} (line {1} position {2})",
+                                                                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                                                                        .Call System.String.Format(
+                                                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                                                                .Constant<System.Object>(Integer),
+                                                                                                                                                                                                (System.Object)$reader.TokenType
+                                                                                                                                                                                            }),
+                                                                                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                                                                                    }))
+                                                                                                                                                                        };
+                                                                                                                                                                        .Call $reader.Read()
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Break end { }
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                        .LabelTarget end:;
+                                                                                                                                                        $Example._blobVector_item = .New System.ArraySegment`1[System.Byte](
+                                                                                                                                                            $array,
+                                                                                                                                                            0,
+                                                                                                                                                            $index)
+                                                                                                                                                    };
+                                                                                                                                                    .Call $reader.Read()
+                                                                                                                                                }
                                                                                                                                             } .Else {
                                                                                                                                                 .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                                                                         System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                                                         "{0} (line {1} position {2})",
                                                                                                                                                         .NewArray System.Object[] {
-                                                                                                                                                            .Call System.String.Format(
-                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                                                .NewArray System.Object[] {
-                                                                                                                                                                    .Constant<System.Object>(Integer),
-                                                                                                                                                                    (System.Object)$reader.TokenType
-                                                                                                                                                                }),
+                                                                                                                                                            "Expected JSON array or null.",
                                                                                                                                                             (System.Object)$reader.LineNumber,
                                                                                                                                                             (System.Object)$reader.LinePosition
                                                                                                                                                         }))
-                                                                                                                                            };
-                                                                                                                                            .Call $reader.Read()
-                                                                                                                                        }
+                                                                                                                                            }
+                                                                                                                                        };
+                                                                                                                                        .Call ($Example._blobVector).Add($Example._blobVector_item)
                                                                                                                                     }
                                                                                                                                 } .Else {
-                                                                                                                                    .If ((System.String)$reader.Value == "Data3") {
+                                                                                                                                    .Break end { }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                            .LabelTarget end:;
+                                                                                                                            .Default(System.Void)
+                                                                                                                        };
+                                                                                                                        .Call $reader.Read()
+                                                                                                                    }
+                                                                                                                } .Else {
+                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                            "{0} (line {1} position {2})",
+                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                "Expected JSON array or null.",
+                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                            }))
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    } .Else {
+                                                                                                        .If ((System.String)$reader.Value == "_blobList") {
+                                                                                                            .Block() {
+                                                                                                                .Call $reader.Read();
+                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                                                    .Block() {
+                                                                                                                        .Call $reader.Read();
+                                                                                                                        .Block(System.ArraySegment`1[System.Byte] $Example._blobList_item) {
+                                                                                                                            .Default(System.Void);
+                                                                                                                            .Loop  {
+                                                                                                                                .Break end { }
+                                                                                                                            }
+                                                                                                                            .LabelTarget end:;
+                                                                                                                            .Default(System.Void)
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                } .Else {
+                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                                                        .Block() {
+                                                                                                                            .Call $reader.Read();
+                                                                                                                            .Block(System.ArraySegment`1[System.Byte] $Example._blobList_item) {
+                                                                                                                                .Default(System.Void);
+                                                                                                                                .Loop  {
+                                                                                                                                    .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
                                                                                                                                         .Block() {
-                                                                                                                                            .Call $reader.Read();
-                                                                                                                                            .Block() {
-                                                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                                                    ($Example.guid).Data3 = (System.UInt16)((System.Int64)$reader.Value)
+                                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                                                                                .Block() {
+                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                    .Block(
+                                                                                                                                                        System.Int32 $index,
+                                                                                                                                                        System.Byte[] $array) {
+                                                                                                                                                        .Block(System.Int32 $Example._blobList_item_count) {
+                                                                                                                                                            $Example._blobList_item_count = 0;
+                                                                                                                                                            .Default(System.Void);
+                                                                                                                                                            .Block() {
+                                                                                                                                                                $index = 0;
+                                                                                                                                                                $array = .NewArray System.Byte[$Example._blobList_item_count]
+                                                                                                                                                            }
+                                                                                                                                                        };
+                                                                                                                                                        .Loop  {
+                                                                                                                                                            .Break end { }
+                                                                                                                                                        }
+                                                                                                                                                        .LabelTarget end:;
+                                                                                                                                                        $Example._blobList_item = .New System.ArraySegment`1[System.Byte](
+                                                                                                                                                            $array,
+                                                                                                                                                            0,
+                                                                                                                                                            $index)
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            } .Else {
+                                                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                        .Block(
+                                                                                                                                                            System.Int32 $index,
+                                                                                                                                                            System.Byte[] $array) {
+                                                                                                                                                            .Block(System.Int32 $Example._blobList_item_count) {
+                                                                                                                                                                $Example._blobList_item_count = 0;
+                                                                                                                                                                .Default(System.Void);
+                                                                                                                                                                .Block() {
+                                                                                                                                                                    $index = 0;
+                                                                                                                                                                    $array = .NewArray System.Byte[$Example._blobList_item_count]
+                                                                                                                                                                }
+                                                                                                                                                            };
+                                                                                                                                                            .Loop  {
+                                                                                                                                                                .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                                                                                    .Block() {
+                                                                                                                                                                        .If ($index >= $array.Length) {
+                                                                                                                                                                            .Call System.Array.Resize(
+                                                                                                                                                                                $array,
+                                                                                                                                                                                .If ($index > 512) {
+                                                                                                                                                                                    $index * 2
+                                                                                                                                                                                } .Else {
+                                                                                                                                                                                    1024
+                                                                                                                                                                                })
+                                                                                                                                                                        } .Else {
+                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                        };
+                                                                                                                                                                        .Block() {
+                                                                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                                                $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
+                                                                                                                                                                            } .Else {
+                                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                        "{0} (line {1} position {2})",
+                                                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                                                            .Call System.String.Format(
+                                                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                                                                    .Constant<System.Object>(Integer),
+                                                                                                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                                                                                                }),
+                                                                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                                                                        }))
+                                                                                                                                                                            };
+                                                                                                                                                                            .Call $reader.Read()
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Break end { }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                            .LabelTarget end:;
+                                                                                                                                                            $Example._blobList_item = .New System.ArraySegment`1[System.Byte](
+                                                                                                                                                                $array,
+                                                                                                                                                                0,
+                                                                                                                                                                $index)
+                                                                                                                                                        };
+                                                                                                                                                        .Call $reader.Read()
+                                                                                                                                                    }
                                                                                                                                                 } .Else {
                                                                                                                                                     .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                                                                             System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                                                             "{0} (line {1} position {2})",
                                                                                                                                                             .NewArray System.Object[] {
-                                                                                                                                                                .Call System.String.Format(
-                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                                                    .NewArray System.Object[] {
-                                                                                                                                                                        .Constant<System.Object>(Integer),
-                                                                                                                                                                        (System.Object)$reader.TokenType
-                                                                                                                                                                    }),
+                                                                                                                                                                "Expected JSON array or null.",
                                                                                                                                                                 (System.Object)$reader.LineNumber,
                                                                                                                                                                 (System.Object)$reader.LinePosition
                                                                                                                                                             }))
-                                                                                                                                                };
-                                                                                                                                                .Call $reader.Read()
-                                                                                                                                            }
+                                                                                                                                                }
+                                                                                                                                            };
+                                                                                                                                            .Call ($Example._blobList).Add($Example._blobList_item)
                                                                                                                                         }
                                                                                                                                     } .Else {
-                                                                                                                                        .If ((System.String)$reader.Value == "Data2") {
+                                                                                                                                        .Break end { }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                                .LabelTarget end:;
+                                                                                                                                .Default(System.Void)
+                                                                                                                            };
+                                                                                                                            .Call $reader.Read()
+                                                                                                                        }
+                                                                                                                    } .Else {
+                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                "{0} (line {1} position {2})",
+                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                    "Expected JSON array or null.",
+                                                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                                                }))
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        } .Else {
+                                                                                                            .If ((System.String)$reader.Value == "b") {
+                                                                                                                .Block() {
+                                                                                                                    .Call $reader.Read();
+                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                                                        .Block() {
+                                                                                                                            .Call $reader.Read();
+                                                                                                                            .Block(
+                                                                                                                                System.Int32 $index,
+                                                                                                                                System.Byte[] $array) {
+                                                                                                                                .Block(System.Int32 $Example.b_count) {
+                                                                                                                                    $Example.b_count = 0;
+                                                                                                                                    .Default(System.Void);
+                                                                                                                                    .Block() {
+                                                                                                                                        $index = 0;
+                                                                                                                                        $array = .NewArray System.Byte[$Example.b_count]
+                                                                                                                                    }
+                                                                                                                                };
+                                                                                                                                .Loop  {
+                                                                                                                                    .Break end { }
+                                                                                                                                }
+                                                                                                                                .LabelTarget end:;
+                                                                                                                                $Example.b = .New System.ArraySegment`1[System.Byte](
+                                                                                                                                    $array,
+                                                                                                                                    0,
+                                                                                                                                    $index)
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    } .Else {
+                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                                                            .Block() {
+                                                                                                                                .Call $reader.Read();
+                                                                                                                                .Block(
+                                                                                                                                    System.Int32 $index,
+                                                                                                                                    System.Byte[] $array) {
+                                                                                                                                    .Block(System.Int32 $Example.b_count) {
+                                                                                                                                        $Example.b_count = 0;
+                                                                                                                                        .Default(System.Void);
+                                                                                                                                        .Block() {
+                                                                                                                                            $index = 0;
+                                                                                                                                            $array = .NewArray System.Byte[$Example.b_count]
+                                                                                                                                        }
+                                                                                                                                    };
+                                                                                                                                    .Loop  {
+                                                                                                                                        .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
                                                                                                                                             .Block() {
-                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                .If ($index >= $array.Length) {
+                                                                                                                                                    .Call System.Array.Resize(
+                                                                                                                                                        $array,
+                                                                                                                                                        .If ($index > 512) {
+                                                                                                                                                            $index * 2
+                                                                                                                                                        } .Else {
+                                                                                                                                                            1024
+                                                                                                                                                        })
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                };
                                                                                                                                                 .Block() {
                                                                                                                                                     .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                                                        ($Example.guid).Data2 = (System.UInt16)((System.Int64)$reader.Value)
+                                                                                                                                                        $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
                                                                                                                                                     } .Else {
                                                                                                                                                         .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                                                                                 System.Globalization.CultureInfo.InvariantCulture,
@@ -1485,12 +2340,639 @@
                                                                                                                                                 }
                                                                                                                                             }
                                                                                                                                         } .Else {
-                                                                                                                                            .If ((System.String)$reader.Value == "Data1") {
+                                                                                                                                            .Break end { }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                    .LabelTarget end:;
+                                                                                                                                    $Example.b = .New System.ArraySegment`1[System.Byte](
+                                                                                                                                        $array,
+                                                                                                                                        0,
+                                                                                                                                        $index)
+                                                                                                                                };
+                                                                                                                                .Call $reader.Read()
+                                                                                                                            }
+                                                                                                                        } .Else {
+                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                    "{0} (line {1} position {2})",
+                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                        "Expected JSON array or null.",
+                                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                                    }))
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            } .Else {
+                                                                                                                .If ((System.String)$reader.Value == "_nestedVector") {
+                                                                                                                    .Block() {
+                                                                                                                        .Call $reader.Read();
+                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                                                            .Block() {
+                                                                                                                                .Call $reader.Read();
+                                                                                                                                .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
+                                                                                                                                    .Default(System.Void);
+                                                                                                                                    .Loop  {
+                                                                                                                                        .Break end { }
+                                                                                                                                    }
+                                                                                                                                    .LabelTarget end:;
+                                                                                                                                    .Default(System.Void)
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        } .Else {
+                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                                                                .Block() {
+                                                                                                                                    .Call $reader.Read();
+                                                                                                                                    .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
+                                                                                                                                        .Default(System.Void);
+                                                                                                                                        .Loop  {
+                                                                                                                                            .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                                                                .Block() {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        $Example._nestedVector_item = .New ExpressionsTest.Nested();
+                                                                                                                                                        .Block(
+                                                                                                                                                            System.Byte $state,
+                                                                                                                                                            Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
+                                                                                                                                                            .Default(System.Void);
+                                                                                                                                                            .Default(System.Void);
+                                                                                                                                                            $state = .Constant<System.Byte>(1);
+                                                                                                                                                            .Loop  {
+                                                                                                                                                                .If (
+                                                                                                                                                                    !$reader.EOF && $state != .Constant<System.Byte>(5)
+                                                                                                                                                                ) {
+                                                                                                                                                                    .Switch ($reader.TokenType) {
+                                                                                                                                                                    .Case (.Constant<Newtonsoft.Json.JsonToken>(None)):
+                                                                                                                                                                            .Switch ($state) {
+                                                                                                                                                                            .Case (.Constant<System.Byte>(1)):
+                                                                                                                                                                                    .Block() {
+                                                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                    }
+                                                                                                                                                                            .Default:
+                                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                            "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                                                                (System.Object)$reader.TokenType,
+                                                                                                                                                                                                (System.Object)$state,
+                                                                                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                                                                                            }))
+                                                                                                                                                                            }
+                                                                                                                                                                    .Case (.Constant<Newtonsoft.Json.JsonToken>(StartObject)):
+                                                                                                                                                                            .Switch ($state) {
+                                                                                                                                                                            .Case (.Constant<System.Byte>(1)):
+                                                                                                                                                                                    .Block() {
+                                                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                                                        $state = .Constant<System.Byte>(2);
+                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                    }
+                                                                                                                                                                            .Default:
+                                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                            "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                                                                (System.Object)$reader.TokenType,
+                                                                                                                                                                                                (System.Object)$state,
+                                                                                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                                                                                            }))
+                                                                                                                                                                            }
+                                                                                                                                                                    .Case (.Constant<Newtonsoft.Json.JsonToken>(EndObject)):
+                                                                                                                                                                            .Switch ($state) {
+                                                                                                                                                                            .Case (.Constant<System.Byte>(2)):
+                                                                                                                                                                                    .Block() {
+                                                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                                                        $state = .Constant<System.Byte>(5);
+                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                    }
+                                                                                                                                                                            .Default:
+                                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                            }
+                                                                                                                                                                    .Case (.Constant<Newtonsoft.Json.JsonToken>(PropertyName)):
+                                                                                                                                                                            .Switch ($state) {
+                                                                                                                                                                            .Case (.Constant<System.Byte>(2)):
+                                                                                                                                                                                    .Block() {
+                                                                                                                                                                                        .If ((System.String)$reader.Value == "_double") {
+                                                                                                                                                                                            .Block() {
+                                                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                                                .Block() {
+                                                                                                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                                                                        $Example._nestedVector_item._double = (System.Double)((System.Int64)$reader.Value)
+                                                                                                                                                                                                    } .Else {
+                                                                                                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
+                                                                                                                                                                                                            $Example._nestedVector_item._double = (System.Double)$reader.Value
+                                                                                                                                                                                                        } .Else {
+                                                                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                                                    "{0} (line {1} position {2})",
+                                                                                                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                                                                                                        .Call System.String.Format(
+                                                                                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                                                                                                .Constant<System.Object>(Float),
+                                                                                                                                                                                                                                (System.Object)$reader.TokenType
+                                                                                                                                                                                                                            }),
+                                                                                                                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                                                                                                                    }))
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    };
+                                                                                                                                                                                                    .Call $reader.Read()
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        } .Else {
+                                                                                                                                                                                            .Block() {
+                                                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                                                .Block() {
+                                                                                                                                                                                                    .If (
+                                                                                                                                                                                                        $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
+                                                                                                                                                                                                    ) {
+                                                                                                                                                                                                        .Call $reader.Skip()
+                                                                                                                                                                                                    } .Else {
+                                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                                    };
+                                                                                                                                                                                                    .Call $reader.Read()
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        };
+                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                    }
+                                                                                                                                                                            .Default:
+                                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                            "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                                                                (System.Object)$reader.TokenType,
+                                                                                                                                                                                                (System.Object)$state,
+                                                                                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                                                                                            }))
+                                                                                                                                                                            }
+                                                                                                                                                                    .Default:
+                                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                    "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                                                                        (System.Object)$reader.TokenType,
+                                                                                                                                                                                        (System.Object)$state,
+                                                                                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                                                                                    }))
+                                                                                                                                                                    }
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Break endStateMachineLoop { }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                            .LabelTarget endStateMachineLoop:;
+                                                                                                                                                            .Default(System.Void);
+                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                        }
+                                                                                                                                                    };
+                                                                                                                                                    .Call ($Example._nestedVector).Add($Example._nestedVector_item)
+                                                                                                                                                }
+                                                                                                                                            } .Else {
+                                                                                                                                                .Break end { }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                        .LabelTarget end:;
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    };
+                                                                                                                                    .Call $reader.Read()
+                                                                                                                                }
+                                                                                                                            } .Else {
+                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                        "{0} (line {1} position {2})",
+                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                            "Expected JSON array or null.",
+                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                        }))
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                } .Else {
+                                                                                                                    .If ((System.String)$reader.Value == "_int32Vector") {
+                                                                                                                        .Block() {
+                                                                                                                            .Call $reader.Read();
+                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                                                                .Block() {
+                                                                                                                                    .Call $reader.Read();
+                                                                                                                                    .Block(System.Int32 $Example._int32Vector_item) {
+                                                                                                                                        .Block(System.Int32 $Example._int32Vector_count) {
+                                                                                                                                            $Example._int32Vector_count = 0;
+                                                                                                                                            .Default(System.Void);
+                                                                                                                                            ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                                                                                                        };
+                                                                                                                                        .Loop  {
+                                                                                                                                            .Break end { }
+                                                                                                                                        }
+                                                                                                                                        .LabelTarget end:;
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            } .Else {
+                                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                                                                    .Block() {
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        .Block(System.Int32 $Example._int32Vector_item) {
+                                                                                                                                            .Block(System.Int32 $Example._int32Vector_count) {
+                                                                                                                                                $Example._int32Vector_count = 0;
+                                                                                                                                                .Default(System.Void);
+                                                                                                                                                ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                                                                                                            };
+                                                                                                                                            .Loop  {
+                                                                                                                                                .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .Block() {
+                                                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                                $Example._int32Vector_item = (System.Int32)((System.Int64)$reader.Value)
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                        "{0} (line {1} position {2})",
+                                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                                            .Call System.String.Format(
+                                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                                                    .Constant<System.Object>(Integer),
+                                                                                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                                                                                }),
+                                                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                                                        }))
+                                                                                                                                                            };
+                                                                                                                                                            .Call $reader.Read()
+                                                                                                                                                        };
+                                                                                                                                                        .Call ($Example._int32Vector).Add($Example._int32Vector_item)
+                                                                                                                                                    }
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Break end { }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                            .LabelTarget end:;
+                                                                                                                                            .Default(System.Void)
+                                                                                                                                        };
+                                                                                                                                        .Call $reader.Read()
+                                                                                                                                    }
+                                                                                                                                } .Else {
+                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                            "{0} (line {1} position {2})",
+                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                "Expected JSON array or null.",
+                                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                                            }))
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    } .Else {
+                                                                                                                        .If ((System.String)$reader.Value == "guid") {
+                                                                                                                            .Block() {
+                                                                                                                                .Call $reader.Read();
+                                                                                                                                .Block() {
+                                                                                                                                    .Block(
+                                                                                                                                        System.Byte $state,
+                                                                                                                                        Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
+                                                                                                                                        .Default(System.Void);
+                                                                                                                                        .Default(System.Void);
+                                                                                                                                        $state = .Constant<System.Byte>(1);
+                                                                                                                                        .Loop  {
+                                                                                                                                            .If (
+                                                                                                                                                !$reader.EOF && $state != .Constant<System.Byte>(5)
+                                                                                                                                            ) {
+                                                                                                                                                .Switch ($reader.TokenType) {
+                                                                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(None)):
+                                                                                                                                                        .Switch ($state) {
+                                                                                                                                                        .Case (.Constant<System.Byte>(1)):
+                                                                                                                                                                .Block() {
+                                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                }
+                                                                                                                                                        .Default:
+                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                        "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                                            (System.Object)$reader.TokenType,
+                                                                                                                                                                            (System.Object)$state,
+                                                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                                                        }))
+                                                                                                                                                        }
+                                                                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(StartObject)):
+                                                                                                                                                        .Switch ($state) {
+                                                                                                                                                        .Case (.Constant<System.Byte>(1)):
+                                                                                                                                                                .Block() {
+                                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                                    $state = .Constant<System.Byte>(2);
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                }
+                                                                                                                                                        .Default:
+                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                        "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                                            (System.Object)$reader.TokenType,
+                                                                                                                                                                            (System.Object)$state,
+                                                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                                                        }))
+                                                                                                                                                        }
+                                                                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(EndObject)):
+                                                                                                                                                        .Switch ($state) {
+                                                                                                                                                        .Case (.Constant<System.Byte>(2)):
+                                                                                                                                                                .Block() {
+                                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                                    $state = .Constant<System.Byte>(5);
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                }
+                                                                                                                                                        .Default:
+                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                        }
+                                                                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(PropertyName)):
+                                                                                                                                                        .Switch ($state) {
+                                                                                                                                                        .Case (.Constant<System.Byte>(2)):
+                                                                                                                                                                .Block() {
+                                                                                                                                                                    .If ((System.String)$reader.Value == "Data4") {
+                                                                                                                                                                        .Block() {
+                                                                                                                                                                            .Call $reader.Read();
+                                                                                                                                                                            .Block() {
+                                                                                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                                                    ($Example.guid).Data4 = (System.UInt64)((System.Int64)$reader.Value)
+                                                                                                                                                                                } .Else {
+                                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                            "{0} (line {1} position {2})",
+                                                                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                                                                .Call System.String.Format(
+                                                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                                                                                        .Constant<System.Object>(Integer),
+                                                                                                                                                                                                        (System.Object)$reader.TokenType
+                                                                                                                                                                                                    }),
+                                                                                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                                                                                            }))
+                                                                                                                                                                                };
+                                                                                                                                                                                .Call $reader.Read()
+                                                                                                                                                                            }
+                                                                                                                                                                        }
+                                                                                                                                                                    } .Else {
+                                                                                                                                                                        .If ((System.String)$reader.Value == "Data3") {
+                                                                                                                                                                            .Block() {
+                                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                                .Block() {
+                                                                                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                                                        ($Example.guid).Data3 = (System.UInt16)((System.Int64)$reader.Value)
+                                                                                                                                                                                    } .Else {
+                                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                                "{0} (line {1} position {2})",
+                                                                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                                                                    .Call System.String.Format(
+                                                                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                                                                            .Constant<System.Object>(Integer),
+                                                                                                                                                                                                            (System.Object)$reader.TokenType
+                                                                                                                                                                                                        }),
+                                                                                                                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                                                                                                                }))
+                                                                                                                                                                                    };
+                                                                                                                                                                                    .Call $reader.Read()
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        } .Else {
+                                                                                                                                                                            .If ((System.String)$reader.Value == "Data2") {
+                                                                                                                                                                                .Block() {
+                                                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                                                    .Block() {
+                                                                                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                                                            ($Example.guid).Data2 = (System.UInt16)((System.Int64)$reader.Value)
+                                                                                                                                                                                        } .Else {
+                                                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                                    "{0} (line {1} position {2})",
+                                                                                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                                                                                        .Call System.String.Format(
+                                                                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                                                                                .Constant<System.Object>(Integer),
+                                                                                                                                                                                                                (System.Object)$reader.TokenType
+                                                                                                                                                                                                            }),
+                                                                                                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                                                                                                    }))
+                                                                                                                                                                                        };
+                                                                                                                                                                                        .Call $reader.Read()
+                                                                                                                                                                                    }
+                                                                                                                                                                                }
+                                                                                                                                                                            } .Else {
+                                                                                                                                                                                .If ((System.String)$reader.Value == "Data1") {
+                                                                                                                                                                                    .Block() {
+                                                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                                                        .Block() {
+                                                                                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                                                                ($Example.guid).Data1 = (System.UInt32)((System.Int64)$reader.Value)
+                                                                                                                                                                                            } .Else {
+                                                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                                        "{0} (line {1} position {2})",
+                                                                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                                                                            .Call System.String.Format(
+                                                                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                                                                                    .Constant<System.Object>(Integer),
+                                                                                                                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                                                                                                                }),
+                                                                                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                                                                                        }))
+                                                                                                                                                                                            };
+                                                                                                                                                                                            .Call $reader.Read()
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                } .Else {
+                                                                                                                                                                                    .Block() {
+                                                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                                                        .Block() {
+                                                                                                                                                                                            .If (
+                                                                                                                                                                                                $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
+                                                                                                                                                                                            ) {
+                                                                                                                                                                                                .Call $reader.Skip()
+                                                                                                                                                                                            } .Else {
+                                                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                                                            };
+                                                                                                                                                                                            .Call $reader.Read()
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        }
+                                                                                                                                                                    };
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                }
+                                                                                                                                                        .Default:
+                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                        "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                                            (System.Object)$reader.TokenType,
+                                                                                                                                                                            (System.Object)$state,
+                                                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                                                        }))
+                                                                                                                                                        }
+                                                                                                                                                .Default:
+                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                                    (System.Object)$reader.TokenType,
+                                                                                                                                                                    (System.Object)$state,
+                                                                                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                                                                                }))
+                                                                                                                                                }
+                                                                                                                                            } .Else {
+                                                                                                                                                .Break endStateMachineLoop { }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                        .LabelTarget endStateMachineLoop:;
+                                                                                                                                        .Default(System.Void);
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        } .Else {
+                                                                                                                            .If ((System.String)$reader.Value == "_double") {
+                                                                                                                                .Block() {
+                                                                                                                                    .Call $reader.Read();
+                                                                                                                                    .Block() {
+                                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                            $Example._double = (System.Double)((System.Int64)$reader.Value)
+                                                                                                                                        } .Else {
+                                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
+                                                                                                                                                $Example._double = (System.Double)$reader.Value
+                                                                                                                                            } .Else {
+                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                        "{0} (line {1} position {2})",
+                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                            .Call System.String.Format(
+                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                                    .Constant<System.Object>(Float),
+                                                                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                                                                }),
+                                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                                        }))
+                                                                                                                                            }
+                                                                                                                                        };
+                                                                                                                                        .Call $reader.Read()
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            } .Else {
+                                                                                                                                .If ((System.String)$reader.Value == "_int64") {
+                                                                                                                                    .Block() {
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        .Block() {
+                                                                                                                                            .Call $requiredFields.Reset(
+                                                                                                                                                0,
+                                                                                                                                                1L);
+                                                                                                                                            .Block() {
+                                                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                    $Example._int64 = (System.Int64)$reader.Value
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                            "{0} (line {1} position {2})",
+                                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                                .Call System.String.Format(
+                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                                                        .Constant<System.Object>(Integer),
+                                                                                                                                                                        (System.Object)$reader.TokenType
+                                                                                                                                                                    }),
+                                                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                                                            }))
+                                                                                                                                                };
+                                                                                                                                                .Call $reader.Read()
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                } .Else {
+                                                                                                                                    .If ((System.String)$reader.Value == "_int8") {
+                                                                                                                                        .Block() {
+                                                                                                                                            .Call $reader.Read();
+                                                                                                                                            .Block() {
+                                                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                    $Example._int8 = (System.SByte)((System.Int64)$reader.Value)
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                            "{0} (line {1} position {2})",
+                                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                                .Call System.String.Format(
+                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                                                        .Constant<System.Object>(Integer),
+                                                                                                                                                                        (System.Object)$reader.TokenType
+                                                                                                                                                                    }),
+                                                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                                                            }))
+                                                                                                                                                };
+                                                                                                                                                .Call $reader.Read()
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    } .Else {
+                                                                                                                                        .If ((System.String)$reader.Value == "JsonUint32") {
+                                                                                                                                            .Block() {
+                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                .Block() {
+                                                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                        $Example._uint32 = (System.UInt32)((System.Int64)$reader.Value)
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                "{0} (line {1} position {2})",
+                                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                                    .Call System.String.Format(
+                                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                                            .Constant<System.Object>(Integer),
+                                                                                                                                                                            (System.Object)$reader.TokenType
+                                                                                                                                                                        }),
+                                                                                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                                                                                }))
+                                                                                                                                                    };
+                                                                                                                                                    .Call $reader.Read()
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        } .Else {
+                                                                                                                                            .If ((System.String)$reader.Value == "_str") {
                                                                                                                                                 .Block() {
                                                                                                                                                     .Call $reader.Read();
                                                                                                                                                     .Block() {
-                                                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                                                            ($Example.guid).Data1 = (System.UInt32)((System.Int64)$reader.Value)
+                                                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(String)) {
+                                                                                                                                                            $Example._str = (System.String)$reader.Value
                                                                                                                                                         } .Else {
                                                                                                                                                             .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                                                                                     System.Globalization.CultureInfo.InvariantCulture,
@@ -1500,7 +2982,7 @@
                                                                                                                                                                             System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                                                                             "Invalid input, expected JSON token of type {0}, encountered {1}",
                                                                                                                                                                             .NewArray System.Object[] {
-                                                                                                                                                                                .Constant<System.Object>(Integer),
+                                                                                                                                                                                .Constant<System.Object>(String),
                                                                                                                                                                                 (System.Object)$reader.TokenType
                                                                                                                                                                             }),
                                                                                                                                                                         (System.Object)$reader.LineNumber,
@@ -1511,234 +2993,52 @@
                                                                                                                                                     }
                                                                                                                                                 }
                                                                                                                                             } .Else {
-                                                                                                                                                .Block() {
-                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                .If ((System.String)$reader.Value == "_bool") {
                                                                                                                                                     .Block() {
-                                                                                                                                                        .If (
-                                                                                                                                                            $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
-                                                                                                                                                        ) {
-                                                                                                                                                            .Call $reader.Skip()
-                                                                                                                                                        } .Else {
-                                                                                                                                                            .Default(System.Void)
-                                                                                                                                                        };
-                                                                                                                                                        .Call $reader.Read()
+                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                        .Block() {
+                                                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Boolean)) {
+                                                                                                                                                                $Example._bool = (System.Boolean)$reader.Value
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                        "{0} (line {1} position {2})",
+                                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                                            .Call System.String.Format(
+                                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                                                    .Constant<System.Object>(Boolean),
+                                                                                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                                                                                }),
+                                                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                                                        }))
+                                                                                                                                                            };
+                                                                                                                                                            .Call $reader.Read()
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                        .Block() {
+                                                                                                                                                            .If (
+                                                                                                                                                                $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
+                                                                                                                                                            ) {
+                                                                                                                                                                .Call $reader.Skip()
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                            };
+                                                                                                                                                            .Call $reader.Read()
+                                                                                                                                                        }
                                                                                                                                                     }
                                                                                                                                                 }
                                                                                                                                             }
                                                                                                                                         }
                                                                                                                                     }
-                                                                                                                                };
-                                                                                                                                .Default(System.Void)
+                                                                                                                                }
                                                                                                                             }
-                                                                                                                    .Default:
-                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                    "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                                    .NewArray System.Object[] {
-                                                                                                                                        (System.Object)$reader.TokenType,
-                                                                                                                                        (System.Object)$state,
-                                                                                                                                        (System.Object)$reader.LineNumber,
-                                                                                                                                        (System.Object)$reader.LinePosition
-                                                                                                                                    }))
-                                                                                                                    }
-                                                                                                            .Default:
-                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                            "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                            .NewArray System.Object[] {
-                                                                                                                                (System.Object)$reader.TokenType,
-                                                                                                                                (System.Object)$state,
-                                                                                                                                (System.Object)$reader.LineNumber,
-                                                                                                                                (System.Object)$reader.LinePosition
-                                                                                                                            }))
-                                                                                                            }
-                                                                                                        } .Else {
-                                                                                                            .Break endStateMachineLoop { }
-                                                                                                        }
-                                                                                                    }
-                                                                                                    .LabelTarget endStateMachineLoop:;
-                                                                                                    .Default(System.Void);
-                                                                                                    .Default(System.Void)
-                                                                                                }
-                                                                                            }
-                                                                                        }
-                                                                                    } .Else {
-                                                                                        .If ((System.String)$reader.Value == "_double") {
-                                                                                            .Block() {
-                                                                                                .Call $reader.Read();
-                                                                                                .Block() {
-                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                        $Example._double = (System.Double)((System.Int64)$reader.Value)
-                                                                                                    } .Else {
-                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
-                                                                                                            $Example._double = (System.Double)$reader.Value
-                                                                                                        } .Else {
-                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                    "{0} (line {1} position {2})",
-                                                                                                                    .NewArray System.Object[] {
-                                                                                                                        .Call System.String.Format(
-                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                            .NewArray System.Object[] {
-                                                                                                                                .Constant<System.Object>(Float),
-                                                                                                                                (System.Object)$reader.TokenType
-                                                                                                                            }),
-                                                                                                                        (System.Object)$reader.LineNumber,
-                                                                                                                        (System.Object)$reader.LinePosition
-                                                                                                                    }))
-                                                                                                        }
-                                                                                                    };
-                                                                                                    .Call $reader.Read()
-                                                                                                }
-                                                                                            }
-                                                                                        } .Else {
-                                                                                            .If ((System.String)$reader.Value == "_int64") {
-                                                                                                .Block() {
-                                                                                                    .Call $reader.Read();
-                                                                                                    .Block() {
-                                                                                                        .Call $requiredFields.Reset(
-                                                                                                            0,
-                                                                                                            1L);
-                                                                                                        .Block() {
-                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                $Example._int64 = (System.Int64)$reader.Value
-                                                                                                            } .Else {
-                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                        "{0} (line {1} position {2})",
-                                                                                                                        .NewArray System.Object[] {
-                                                                                                                            .Call System.String.Format(
-                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                .NewArray System.Object[] {
-                                                                                                                                    .Constant<System.Object>(Integer),
-                                                                                                                                    (System.Object)$reader.TokenType
-                                                                                                                                }),
-                                                                                                                            (System.Object)$reader.LineNumber,
-                                                                                                                            (System.Object)$reader.LinePosition
-                                                                                                                        }))
-                                                                                                            };
-                                                                                                            .Call $reader.Read()
-                                                                                                        }
-                                                                                                    }
-                                                                                                }
-                                                                                            } .Else {
-                                                                                                .If ((System.String)$reader.Value == "_int8") {
-                                                                                                    .Block() {
-                                                                                                        .Call $reader.Read();
-                                                                                                        .Block() {
-                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                $Example._int8 = (System.SByte)((System.Int64)$reader.Value)
-                                                                                                            } .Else {
-                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                        "{0} (line {1} position {2})",
-                                                                                                                        .NewArray System.Object[] {
-                                                                                                                            .Call System.String.Format(
-                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                .NewArray System.Object[] {
-                                                                                                                                    .Constant<System.Object>(Integer),
-                                                                                                                                    (System.Object)$reader.TokenType
-                                                                                                                                }),
-                                                                                                                            (System.Object)$reader.LineNumber,
-                                                                                                                            (System.Object)$reader.LinePosition
-                                                                                                                        }))
-                                                                                                            };
-                                                                                                            .Call $reader.Read()
-                                                                                                        }
-                                                                                                    }
-                                                                                                } .Else {
-                                                                                                    .If ((System.String)$reader.Value == "JsonUint32") {
-                                                                                                        .Block() {
-                                                                                                            .Call $reader.Read();
-                                                                                                            .Block() {
-                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                    $Example._uint32 = (System.UInt32)((System.Int64)$reader.Value)
-                                                                                                                } .Else {
-                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                            "{0} (line {1} position {2})",
-                                                                                                                            .NewArray System.Object[] {
-                                                                                                                                .Call System.String.Format(
-                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                    .NewArray System.Object[] {
-                                                                                                                                        .Constant<System.Object>(Integer),
-                                                                                                                                        (System.Object)$reader.TokenType
-                                                                                                                                    }),
-                                                                                                                                (System.Object)$reader.LineNumber,
-                                                                                                                                (System.Object)$reader.LinePosition
-                                                                                                                            }))
-                                                                                                                };
-                                                                                                                .Call $reader.Read()
-                                                                                                            }
-                                                                                                        }
-                                                                                                    } .Else {
-                                                                                                        .If ((System.String)$reader.Value == "_str") {
-                                                                                                            .Block() {
-                                                                                                                .Call $reader.Read();
-                                                                                                                .Block() {
-                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(String)) {
-                                                                                                                        $Example._str = (System.String)$reader.Value
-                                                                                                                    } .Else {
-                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                "{0} (line {1} position {2})",
-                                                                                                                                .NewArray System.Object[] {
-                                                                                                                                    .Call System.String.Format(
-                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                        .NewArray System.Object[] {
-                                                                                                                                            .Constant<System.Object>(String),
-                                                                                                                                            (System.Object)$reader.TokenType
-                                                                                                                                        }),
-                                                                                                                                    (System.Object)$reader.LineNumber,
-                                                                                                                                    (System.Object)$reader.LinePosition
-                                                                                                                                }))
-                                                                                                                    };
-                                                                                                                    .Call $reader.Read()
-                                                                                                                }
-                                                                                                            }
-                                                                                                        } .Else {
-                                                                                                            .If ((System.String)$reader.Value == "_bool") {
-                                                                                                                .Block() {
-                                                                                                                    .Call $reader.Read();
-                                                                                                                    .Block() {
-                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Boolean)) {
-                                                                                                                            $Example._bool = (System.Boolean)$reader.Value
-                                                                                                                        } .Else {
-                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                    "{0} (line {1} position {2})",
-                                                                                                                                    .NewArray System.Object[] {
-                                                                                                                                        .Call System.String.Format(
-                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                            .NewArray System.Object[] {
-                                                                                                                                                .Constant<System.Object>(Boolean),
-                                                                                                                                                (System.Object)$reader.TokenType
-                                                                                                                                            }),
-                                                                                                                                        (System.Object)$reader.LineNumber,
-                                                                                                                                        (System.Object)$reader.LinePosition
-                                                                                                                                    }))
-                                                                                                                        };
-                                                                                                                        .Call $reader.Read()
-                                                                                                                    }
-                                                                                                                }
-                                                                                                            } .Else {
-                                                                                                                .Block() {
-                                                                                                                    .Call $reader.Read();
-                                                                                                                    .Block() {
-                                                                                                                        .If (
-                                                                                                                            $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
-                                                                                                                        ) {
-                                                                                                                            .Call $reader.Skip()
-                                                                                                                        } .Else {
-                                                                                                                            .Default(System.Void)
-                                                                                                                        };
-                                                                                                                        .Call $reader.Read()
+                                                                                                                        }
                                                                                                                     }
                                                                                                                 }
                                                                                                             }

--- a/cs/test/expressions/DeserializeJson.expressions
+++ b/cs/test/expressions/DeserializeJson.expressions
@@ -193,78 +193,157 @@
                                                     }
                                                 }
                                             } .Else {
-                                                .If ((System.String)$reader.Value == "_map") {
+                                                .If ((System.String)$reader.Value == "_decList") {
                                                     .Block() {
                                                         .Call $reader.Read();
-                                                        .Block() {
-                                                            .Call $reader.Read();
-                                                            .Block(
-                                                                System.Int32 $Example._map_key,
-                                                                System.Double $Example._map_value) {
-                                                                .Default(System.Void);
-                                                                .Loop  {
-                                                                    .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
-                                                                        .Block() {
-                                                                            .Block() {
-                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                    $Example._map_key = (System.Int32)((System.Int64)$reader.Value)
-                                                                                } .Else {
-                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                            "{0} (line {1} position {2})",
-                                                                                            .NewArray System.Object[] {
-                                                                                                .Call System.String.Format(
-                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                    .NewArray System.Object[] {
-                                                                                                        .Constant<System.Object>(Integer),
-                                                                                                        (System.Object)$reader.TokenType
-                                                                                                    }),
-                                                                                                (System.Object)$reader.LineNumber,
-                                                                                                (System.Object)$reader.LinePosition
-                                                                                            }))
-                                                                                };
-                                                                                .Call $reader.Read()
-                                                                            };
-                                                                            $reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray);
-                                                                            .Block() {
-                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                    $Example._map_value = (System.Double)((System.Int64)$reader.Value)
-                                                                                } .Else {
-                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
-                                                                                        $Example._map_value = (System.Double)$reader.Value
-                                                                                    } .Else {
-                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                "{0} (line {1} position {2})",
-                                                                                                .NewArray System.Object[] {
-                                                                                                    .Call System.String.Format(
-                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                        .NewArray System.Object[] {
-                                                                                                            .Constant<System.Object>(Float),
-                                                                                                            (System.Object)$reader.TokenType
-                                                                                                        }),
-                                                                                                    (System.Object)$reader.LineNumber,
-                                                                                                    (System.Object)$reader.LinePosition
-                                                                                                }))
-                                                                                    }
-                                                                                };
-                                                                                .Call $reader.Read()
-                                                                            };
-                                                                            ($Example._map).Item[$Example._map_key] = $Example._map_value
-                                                                        }
-                                                                    } .Else {
+                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                            .Block() {
+                                                                .Call $reader.Read();
+                                                                .Block(System.Decimal $Example._decList_item) {
+                                                                    .Default(System.Void);
+                                                                    .Loop  {
                                                                         .Break end { }
                                                                     }
+                                                                    .LabelTarget end:;
+                                                                    .Default(System.Void)
                                                                 }
-                                                                .LabelTarget end:
-                                                            };
-                                                            .Call $reader.Read()
+                                                            }
+                                                        } .Else {
+                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                .Block() {
+                                                                    .Call $reader.Read();
+                                                                    .Block(System.Decimal $Example._decList_item) {
+                                                                        .Default(System.Void);
+                                                                        .Loop  {
+                                                                            .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                .Block() {
+                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                        .Block() {
+                                                                                            .Call $reader.Read();
+                                                                                            .Block(
+                                                                                                System.Int32 $index,
+                                                                                                System.Byte[] $array) {
+                                                                                                .Block(System.Int32 $Example._decList_item_count) {
+                                                                                                    $Example._decList_item_count = 0;
+                                                                                                    .Default(System.Void);
+                                                                                                    .Block() {
+                                                                                                        $index = 0;
+                                                                                                        $array = .NewArray System.Byte[$Example._decList_item_count]
+                                                                                                    }
+                                                                                                };
+                                                                                                .Loop  {
+                                                                                                    .Break end { }
+                                                                                                }
+                                                                                                .LabelTarget end:;
+                                                                                                $Example._decList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                    .New System.ArraySegment`1[System.Byte](
+                                                                                                        $array,
+                                                                                                        0,
+                                                                                                        $index),
+                                                                                                    .Default(System.Decimal))
+                                                                                            }
+                                                                                        }
+                                                                                    } .Else {
+                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                            .Block() {
+                                                                                                .Call $reader.Read();
+                                                                                                .Block(
+                                                                                                    System.Int32 $index,
+                                                                                                    System.Byte[] $array) {
+                                                                                                    .Block(System.Int32 $Example._decList_item_count) {
+                                                                                                        $Example._decList_item_count = 0;
+                                                                                                        .Default(System.Void);
+                                                                                                        .Block() {
+                                                                                                            $index = 0;
+                                                                                                            $array = .NewArray System.Byte[$Example._decList_item_count]
+                                                                                                        }
+                                                                                                    };
+                                                                                                    .Loop  {
+                                                                                                        .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                            .Block() {
+                                                                                                                .If ($index >= $array.Length) {
+                                                                                                                    .Call System.Array.Resize(
+                                                                                                                        $array,
+                                                                                                                        .If ($index > 512) {
+                                                                                                                            $index * 2
+                                                                                                                        } .Else {
+                                                                                                                            1024
+                                                                                                                        })
+                                                                                                                } .Else {
+                                                                                                                    .Default(System.Void)
+                                                                                                                };
+                                                                                                                .Block() {
+                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                        $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
+                                                                                                                    } .Else {
+                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                "{0} (line {1} position {2})",
+                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                    .Call System.String.Format(
+                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                            .Constant<System.Object>(Integer),
+                                                                                                                                            (System.Object)$reader.TokenType
+                                                                                                                                        }),
+                                                                                                                                    (System.Object)$reader.LineNumber,
+                                                                                                                                    (System.Object)$reader.LinePosition
+                                                                                                                                }))
+                                                                                                                    };
+                                                                                                                    .Call $reader.Read()
+                                                                                                                }
+                                                                                                            }
+                                                                                                        } .Else {
+                                                                                                            .Break end { }
+                                                                                                        }
+                                                                                                    }
+                                                                                                    .LabelTarget end:;
+                                                                                                    $Example._decList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                        .New System.ArraySegment`1[System.Byte](
+                                                                                                            $array,
+                                                                                                            0,
+                                                                                                            $index),
+                                                                                                        .Default(System.Decimal))
+                                                                                                };
+                                                                                                .Call $reader.Read()
+                                                                                            }
+                                                                                        } .Else {
+                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                    "{0} (line {1} position {2})",
+                                                                                                    .NewArray System.Object[] {
+                                                                                                        "Expected JSON array or null.",
+                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                    }))
+                                                                                        }
+                                                                                    };
+                                                                                    .Call ($Example._decList).Add($Example._decList_item)
+                                                                                }
+                                                                            } .Else {
+                                                                                .Break end { }
+                                                                            }
+                                                                        }
+                                                                        .LabelTarget end:;
+                                                                        .Default(System.Void)
+                                                                    };
+                                                                    .Call $reader.Read()
+                                                                }
+                                                            } .Else {
+                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                        "{0} (line {1} position {2})",
+                                                                        .NewArray System.Object[] {
+                                                                            "Expected JSON array or null.",
+                                                                            (System.Object)$reader.LineNumber,
+                                                                            (System.Object)$reader.LinePosition
+                                                                        }))
+                                                            }
                                                         }
                                                     }
                                                 } .Else {
-                                                    .If ((System.String)$reader.Value == "b") {
+                                                    .If ((System.String)$reader.Value == "_decimal") {
                                                         .Block() {
                                                             .Call $reader.Read();
                                                             .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
@@ -273,22 +352,24 @@
                                                                     .Block(
                                                                         System.Int32 $index,
                                                                         System.Byte[] $array) {
-                                                                        .Block(System.Int32 $Example.b_count) {
-                                                                            $Example.b_count = 0;
+                                                                        .Block(System.Int32 $Example._decimal_count) {
+                                                                            $Example._decimal_count = 0;
                                                                             .Default(System.Void);
                                                                             .Block() {
                                                                                 $index = 0;
-                                                                                $array = .NewArray System.Byte[$Example.b_count]
+                                                                                $array = .NewArray System.Byte[$Example._decimal_count]
                                                                             }
                                                                         };
                                                                         .Loop  {
                                                                             .Break end { }
                                                                         }
                                                                         .LabelTarget end:;
-                                                                        $Example.b = .New System.ArraySegment`1[System.Byte](
-                                                                            $array,
-                                                                            0,
-                                                                            $index)
+                                                                        $Example._decimal = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                            .New System.ArraySegment`1[System.Byte](
+                                                                                $array,
+                                                                                0,
+                                                                                $index),
+                                                                            .Default(System.Decimal))
                                                                     }
                                                                 }
                                                             } .Else {
@@ -298,12 +379,12 @@
                                                                         .Block(
                                                                             System.Int32 $index,
                                                                             System.Byte[] $array) {
-                                                                            .Block(System.Int32 $Example.b_count) {
-                                                                                $Example.b_count = 0;
+                                                                            .Block(System.Int32 $Example._decimal_count) {
+                                                                                $Example._decimal_count = 0;
                                                                                 .Default(System.Void);
                                                                                 .Block() {
                                                                                     $index = 0;
-                                                                                    $array = .NewArray System.Byte[$Example.b_count]
+                                                                                    $array = .NewArray System.Byte[$Example._decimal_count]
                                                                                 }
                                                                             };
                                                                             .Loop  {
@@ -347,10 +428,12 @@
                                                                                 }
                                                                             }
                                                                             .LabelTarget end:;
-                                                                            $Example.b = .New System.ArraySegment`1[System.Byte](
-                                                                                $array,
-                                                                                0,
-                                                                                $index)
+                                                                            $Example._decimal = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                .New System.ArraySegment`1[System.Byte](
+                                                                                    $array,
+                                                                                    0,
+                                                                                    $index),
+                                                                                .Default(System.Decimal))
                                                                         };
                                                                         .Call $reader.Read()
                                                                     }
@@ -367,231 +450,136 @@
                                                             }
                                                         }
                                                     } .Else {
-                                                        .If ((System.String)$reader.Value == "_nestedVector") {
+                                                        .If ((System.String)$reader.Value == "_map") {
                                                             .Block() {
                                                                 .Call $reader.Read();
-                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
-                                                                    .Block() {
-                                                                        .Call $reader.Read();
-                                                                        .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
-                                                                            .Default(System.Void);
-                                                                            .Loop  {
+                                                                .Block() {
+                                                                    .Call $reader.Read();
+                                                                    .Block(
+                                                                        System.Int32 $Example._map_key,
+                                                                        System.Double $Example._map_value) {
+                                                                        .Default(System.Void);
+                                                                        .Loop  {
+                                                                            .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                .Block() {
+                                                                                    .Block() {
+                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                            $Example._map_key = (System.Int32)((System.Int64)$reader.Value)
+                                                                                        } .Else {
+                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                    "{0} (line {1} position {2})",
+                                                                                                    .NewArray System.Object[] {
+                                                                                                        .Call System.String.Format(
+                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                            .NewArray System.Object[] {
+                                                                                                                .Constant<System.Object>(Integer),
+                                                                                                                (System.Object)$reader.TokenType
+                                                                                                            }),
+                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                    }))
+                                                                                        };
+                                                                                        .Call $reader.Read()
+                                                                                    };
+                                                                                    $reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray);
+                                                                                    .Block() {
+                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                            $Example._map_value = (System.Double)((System.Int64)$reader.Value)
+                                                                                        } .Else {
+                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
+                                                                                                $Example._map_value = (System.Double)$reader.Value
+                                                                                            } .Else {
+                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                        "{0} (line {1} position {2})",
+                                                                                                        .NewArray System.Object[] {
+                                                                                                            .Call System.String.Format(
+                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                .NewArray System.Object[] {
+                                                                                                                    .Constant<System.Object>(Float),
+                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                }),
+                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                        }))
+                                                                                            }
+                                                                                        };
+                                                                                        .Call $reader.Read()
+                                                                                    };
+                                                                                    ($Example._map).Item[$Example._map_key] = $Example._map_value
+                                                                                }
+                                                                            } .Else {
                                                                                 .Break end { }
                                                                             }
-                                                                            .LabelTarget end:;
-                                                                            .Default(System.Void)
                                                                         }
-                                                                    }
-                                                                } .Else {
-                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
-                                                                        .Block() {
-                                                                            .Call $reader.Read();
-                                                                            .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
-                                                                                .Default(System.Void);
-                                                                                .Loop  {
-                                                                                    .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
-                                                                                        .Block() {
-                                                                                            .Block() {
-                                                                                                $Example._nestedVector_item = .New ExpressionsTest.Nested();
-                                                                                                .Block(
-                                                                                                    System.Byte $state,
-                                                                                                    Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
-                                                                                                    .Default(System.Void);
-                                                                                                    .Default(System.Void);
-                                                                                                    $state = .Constant<System.Byte>(1);
-                                                                                                    .Loop  {
-                                                                                                        .If (
-                                                                                                            !$reader.EOF && $state != .Constant<System.Byte>(5)
-                                                                                                        ) {
-                                                                                                            .Switch ($reader.TokenType) {
-                                                                                                            .Case (.Constant<Newtonsoft.Json.JsonToken>(None)):
-                                                                                                                    .Switch ($state) {
-                                                                                                                    .Case (.Constant<System.Byte>(1)):
-                                                                                                                            .Block() {
-                                                                                                                                .Call $reader.Read();
-                                                                                                                                .Default(System.Void)
-                                                                                                                            }
-                                                                                                                    .Default:
-                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                    "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                                    .NewArray System.Object[] {
-                                                                                                                                        (System.Object)$reader.TokenType,
-                                                                                                                                        (System.Object)$state,
-                                                                                                                                        (System.Object)$reader.LineNumber,
-                                                                                                                                        (System.Object)$reader.LinePosition
-                                                                                                                                    }))
-                                                                                                                    }
-                                                                                                            .Case (.Constant<Newtonsoft.Json.JsonToken>(StartObject)):
-                                                                                                                    .Switch ($state) {
-                                                                                                                    .Case (.Constant<System.Byte>(1)):
-                                                                                                                            .Block() {
-                                                                                                                                .Call $reader.Read();
-                                                                                                                                $state = .Constant<System.Byte>(2);
-                                                                                                                                .Default(System.Void)
-                                                                                                                            }
-                                                                                                                    .Default:
-                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                    "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                                    .NewArray System.Object[] {
-                                                                                                                                        (System.Object)$reader.TokenType,
-                                                                                                                                        (System.Object)$state,
-                                                                                                                                        (System.Object)$reader.LineNumber,
-                                                                                                                                        (System.Object)$reader.LinePosition
-                                                                                                                                    }))
-                                                                                                                    }
-                                                                                                            .Case (.Constant<Newtonsoft.Json.JsonToken>(EndObject)):
-                                                                                                                    .Switch ($state) {
-                                                                                                                    .Case (.Constant<System.Byte>(2)):
-                                                                                                                            .Block() {
-                                                                                                                                .Call $reader.Read();
-                                                                                                                                $state = .Constant<System.Byte>(5);
-                                                                                                                                .Default(System.Void)
-                                                                                                                            }
-                                                                                                                    .Default:
-                                                                                                                            .Default(System.Void)
-                                                                                                                    }
-                                                                                                            .Case (.Constant<Newtonsoft.Json.JsonToken>(PropertyName)):
-                                                                                                                    .Switch ($state) {
-                                                                                                                    .Case (.Constant<System.Byte>(2)):
-                                                                                                                            .Block() {
-                                                                                                                                .If ((System.String)$reader.Value == "_double") {
-                                                                                                                                    .Block() {
-                                                                                                                                        .Call $reader.Read();
-                                                                                                                                        .Block() {
-                                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                                                $Example._nestedVector_item._double = (System.Double)((System.Int64)$reader.Value)
-                                                                                                                                            } .Else {
-                                                                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
-                                                                                                                                                    $Example._nestedVector_item._double = (System.Double)$reader.Value
-                                                                                                                                                } .Else {
-                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                                            "{0} (line {1} position {2})",
-                                                                                                                                                            .NewArray System.Object[] {
-                                                                                                                                                                .Call System.String.Format(
-                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                                                    .NewArray System.Object[] {
-                                                                                                                                                                        .Constant<System.Object>(Float),
-                                                                                                                                                                        (System.Object)$reader.TokenType
-                                                                                                                                                                    }),
-                                                                                                                                                                (System.Object)$reader.LineNumber,
-                                                                                                                                                                (System.Object)$reader.LinePosition
-                                                                                                                                                            }))
-                                                                                                                                                }
-                                                                                                                                            };
-                                                                                                                                            .Call $reader.Read()
-                                                                                                                                        }
-                                                                                                                                    }
-                                                                                                                                } .Else {
-                                                                                                                                    .Block() {
-                                                                                                                                        .Call $reader.Read();
-                                                                                                                                        .Block() {
-                                                                                                                                            .If (
-                                                                                                                                                $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
-                                                                                                                                            ) {
-                                                                                                                                                .Call $reader.Skip()
-                                                                                                                                            } .Else {
-                                                                                                                                                .Default(System.Void)
-                                                                                                                                            };
-                                                                                                                                            .Call $reader.Read()
-                                                                                                                                        }
-                                                                                                                                    }
-                                                                                                                                };
-                                                                                                                                .Default(System.Void)
-                                                                                                                            }
-                                                                                                                    .Default:
-                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                    "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                                    .NewArray System.Object[] {
-                                                                                                                                        (System.Object)$reader.TokenType,
-                                                                                                                                        (System.Object)$state,
-                                                                                                                                        (System.Object)$reader.LineNumber,
-                                                                                                                                        (System.Object)$reader.LinePosition
-                                                                                                                                    }))
-                                                                                                                    }
-                                                                                                            .Default:
-                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                            "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                            .NewArray System.Object[] {
-                                                                                                                                (System.Object)$reader.TokenType,
-                                                                                                                                (System.Object)$state,
-                                                                                                                                (System.Object)$reader.LineNumber,
-                                                                                                                                (System.Object)$reader.LinePosition
-                                                                                                                            }))
-                                                                                                            }
-                                                                                                        } .Else {
-                                                                                                            .Break endStateMachineLoop { }
-                                                                                                        }
-                                                                                                    }
-                                                                                                    .LabelTarget endStateMachineLoop:;
-                                                                                                    .Default(System.Void);
-                                                                                                    .Default(System.Void)
-                                                                                                }
-                                                                                            };
-                                                                                            .Call ($Example._nestedVector).Add($Example._nestedVector_item)
-                                                                                        }
-                                                                                    } .Else {
-                                                                                        .Break end { }
-                                                                                    }
-                                                                                }
-                                                                                .LabelTarget end:;
-                                                                                .Default(System.Void)
-                                                                            };
-                                                                            .Call $reader.Read()
-                                                                        }
-                                                                    } .Else {
-                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                "{0} (line {1} position {2})",
-                                                                                .NewArray System.Object[] {
-                                                                                    "Expected JSON array or null.",
-                                                                                    (System.Object)$reader.LineNumber,
-                                                                                    (System.Object)$reader.LinePosition
-                                                                                }))
-                                                                    }
+                                                                        .LabelTarget end:
+                                                                    };
+                                                                    .Call $reader.Read()
                                                                 }
                                                             }
                                                         } .Else {
-                                                            .If ((System.String)$reader.Value == "_int32Vector") {
+                                                            .If ((System.String)$reader.Value == "b") {
                                                                 .Block() {
                                                                     .Call $reader.Read();
                                                                     .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
                                                                         .Block() {
                                                                             .Call $reader.Read();
-                                                                            .Block(System.Int32 $Example._int32Vector_item) {
-                                                                                .Block(System.Int32 $Example._int32Vector_count) {
-                                                                                    $Example._int32Vector_count = 0;
+                                                                            .Block(
+                                                                                System.Int32 $index,
+                                                                                System.Byte[] $array) {
+                                                                                .Block(System.Int32 $Example.b_count) {
+                                                                                    $Example.b_count = 0;
                                                                                     .Default(System.Void);
-                                                                                    ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                                                    .Block() {
+                                                                                        $index = 0;
+                                                                                        $array = .NewArray System.Byte[$Example.b_count]
+                                                                                    }
                                                                                 };
                                                                                 .Loop  {
                                                                                     .Break end { }
                                                                                 }
                                                                                 .LabelTarget end:;
-                                                                                .Default(System.Void)
+                                                                                $Example.b = .New System.ArraySegment`1[System.Byte](
+                                                                                    $array,
+                                                                                    0,
+                                                                                    $index)
                                                                             }
                                                                         }
                                                                     } .Else {
                                                                         .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
                                                                             .Block() {
                                                                                 .Call $reader.Read();
-                                                                                .Block(System.Int32 $Example._int32Vector_item) {
-                                                                                    .Block(System.Int32 $Example._int32Vector_count) {
-                                                                                        $Example._int32Vector_count = 0;
+                                                                                .Block(
+                                                                                    System.Int32 $index,
+                                                                                    System.Byte[] $array) {
+                                                                                    .Block(System.Int32 $Example.b_count) {
+                                                                                        $Example.b_count = 0;
                                                                                         .Default(System.Void);
-                                                                                        ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                                                        .Block() {
+                                                                                            $index = 0;
+                                                                                            $array = .NewArray System.Byte[$Example.b_count]
+                                                                                        }
                                                                                     };
                                                                                     .Loop  {
                                                                                         .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
                                                                                             .Block() {
+                                                                                                .If ($index >= $array.Length) {
+                                                                                                    .Call System.Array.Resize(
+                                                                                                        $array,
+                                                                                                        .If ($index > 512) {
+                                                                                                            $index * 2
+                                                                                                        } .Else {
+                                                                                                            1024
+                                                                                                        })
+                                                                                                } .Else {
+                                                                                                    .Default(System.Void)
+                                                                                                };
                                                                                                 .Block() {
                                                                                                     .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                        $Example._int32Vector_item = (System.Int32)((System.Int64)$reader.Value)
+                                                                                                        $array[$index++] = (System.Byte)((System.Int64)$reader.Value)
                                                                                                     } .Else {
                                                                                                         .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                                 System.Globalization.CultureInfo.InvariantCulture,
@@ -609,15 +597,17 @@
                                                                                                                 }))
                                                                                                     };
                                                                                                     .Call $reader.Read()
-                                                                                                };
-                                                                                                .Call ($Example._int32Vector).Add($Example._int32Vector_item)
+                                                                                                }
                                                                                             }
                                                                                         } .Else {
                                                                                             .Break end { }
                                                                                         }
                                                                                     }
                                                                                     .LabelTarget end:;
-                                                                                    .Default(System.Void)
+                                                                                    $Example.b = .New System.ArraySegment`1[System.Byte](
+                                                                                        $array,
+                                                                                        0,
+                                                                                        $index)
                                                                                 };
                                                                                 .Call $reader.Read()
                                                                             }
@@ -634,131 +624,346 @@
                                                                     }
                                                                 }
                                                             } .Else {
-                                                                .If ((System.String)$reader.Value == "guid") {
+                                                                .If ((System.String)$reader.Value == "_nestedVector") {
                                                                     .Block() {
                                                                         .Call $reader.Read();
-                                                                        .Block() {
-                                                                            .Block(
-                                                                                System.Byte $state,
-                                                                                Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
-                                                                                .Default(System.Void);
-                                                                                .Default(System.Void);
-                                                                                $state = .Constant<System.Byte>(1);
-                                                                                .Loop  {
-                                                                                    .If (
-                                                                                        !$reader.EOF && $state != .Constant<System.Byte>(5)
-                                                                                    ) {
-                                                                                        .Switch ($reader.TokenType) {
-                                                                                        .Case (.Constant<Newtonsoft.Json.JsonToken>(None)):
-                                                                                                .Switch ($state) {
-                                                                                                .Case (.Constant<System.Byte>(1)):
-                                                                                                        .Block() {
-                                                                                                            .Call $reader.Read();
-                                                                                                            .Default(System.Void)
-                                                                                                        }
-                                                                                                .Default:
-                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                .NewArray System.Object[] {
-                                                                                                                    (System.Object)$reader.TokenType,
-                                                                                                                    (System.Object)$state,
-                                                                                                                    (System.Object)$reader.LineNumber,
-                                                                                                                    (System.Object)$reader.LinePosition
-                                                                                                                }))
-                                                                                                }
-                                                                                        .Case (.Constant<Newtonsoft.Json.JsonToken>(StartObject)):
-                                                                                                .Switch ($state) {
-                                                                                                .Case (.Constant<System.Byte>(1)):
-                                                                                                        .Block() {
-                                                                                                            .Call $reader.Read();
-                                                                                                            $state = .Constant<System.Byte>(2);
-                                                                                                            .Default(System.Void)
-                                                                                                        }
-                                                                                                .Default:
-                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                                .NewArray System.Object[] {
-                                                                                                                    (System.Object)$reader.TokenType,
-                                                                                                                    (System.Object)$state,
-                                                                                                                    (System.Object)$reader.LineNumber,
-                                                                                                                    (System.Object)$reader.LinePosition
-                                                                                                                }))
-                                                                                                }
-                                                                                        .Case (.Constant<Newtonsoft.Json.JsonToken>(EndObject)):
-                                                                                                .Switch ($state) {
-                                                                                                .Case (.Constant<System.Byte>(2)):
-                                                                                                        .Block() {
-                                                                                                            .Call $reader.Read();
-                                                                                                            $state = .Constant<System.Byte>(5);
-                                                                                                            .Default(System.Void)
-                                                                                                        }
-                                                                                                .Default:
-                                                                                                        .Default(System.Void)
-                                                                                                }
-                                                                                        .Case (.Constant<Newtonsoft.Json.JsonToken>(PropertyName)):
-                                                                                                .Switch ($state) {
-                                                                                                .Case (.Constant<System.Byte>(2)):
-                                                                                                        .Block() {
-                                                                                                            .If ((System.String)$reader.Value == "Data4") {
-                                                                                                                .Block() {
-                                                                                                                    .Call $reader.Read();
-                                                                                                                    .Block() {
-                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                            ($Example.guid).Data4 = (System.UInt64)((System.Int64)$reader.Value)
-                                                                                                                        } .Else {
+                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                            .Block() {
+                                                                                .Call $reader.Read();
+                                                                                .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
+                                                                                    .Default(System.Void);
+                                                                                    .Loop  {
+                                                                                        .Break end { }
+                                                                                    }
+                                                                                    .LabelTarget end:;
+                                                                                    .Default(System.Void)
+                                                                                }
+                                                                            }
+                                                                        } .Else {
+                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                .Block() {
+                                                                                    .Call $reader.Read();
+                                                                                    .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
+                                                                                        .Default(System.Void);
+                                                                                        .Loop  {
+                                                                                            .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                .Block() {
+                                                                                                    .Block() {
+                                                                                                        $Example._nestedVector_item = .New ExpressionsTest.Nested();
+                                                                                                        .Block(
+                                                                                                            System.Byte $state,
+                                                                                                            Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
+                                                                                                            .Default(System.Void);
+                                                                                                            .Default(System.Void);
+                                                                                                            $state = .Constant<System.Byte>(1);
+                                                                                                            .Loop  {
+                                                                                                                .If (
+                                                                                                                    !$reader.EOF && $state != .Constant<System.Byte>(5)
+                                                                                                                ) {
+                                                                                                                    .Switch ($reader.TokenType) {
+                                                                                                                    .Case (.Constant<Newtonsoft.Json.JsonToken>(None)):
+                                                                                                                            .Switch ($state) {
+                                                                                                                            .Case (.Constant<System.Byte>(1)):
+                                                                                                                                    .Block() {
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                            .Default:
+                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                            "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                (System.Object)$reader.TokenType,
+                                                                                                                                                (System.Object)$state,
+                                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                                            }))
+                                                                                                                            }
+                                                                                                                    .Case (.Constant<Newtonsoft.Json.JsonToken>(StartObject)):
+                                                                                                                            .Switch ($state) {
+                                                                                                                            .Case (.Constant<System.Byte>(1)):
+                                                                                                                                    .Block() {
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        $state = .Constant<System.Byte>(2);
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                            .Default:
+                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                            "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                (System.Object)$reader.TokenType,
+                                                                                                                                                (System.Object)$state,
+                                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                                            }))
+                                                                                                                            }
+                                                                                                                    .Case (.Constant<Newtonsoft.Json.JsonToken>(EndObject)):
+                                                                                                                            .Switch ($state) {
+                                                                                                                            .Case (.Constant<System.Byte>(2)):
+                                                                                                                                    .Block() {
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        $state = .Constant<System.Byte>(5);
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                            .Default:
+                                                                                                                                    .Default(System.Void)
+                                                                                                                            }
+                                                                                                                    .Case (.Constant<Newtonsoft.Json.JsonToken>(PropertyName)):
+                                                                                                                            .Switch ($state) {
+                                                                                                                            .Case (.Constant<System.Byte>(2)):
+                                                                                                                                    .Block() {
+                                                                                                                                        .If ((System.String)$reader.Value == "_double") {
+                                                                                                                                            .Block() {
+                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                .Block() {
+                                                                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                        $Example._nestedVector_item._double = (System.Double)((System.Int64)$reader.Value)
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
+                                                                                                                                                            $Example._nestedVector_item._double = (System.Double)$reader.Value
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                    "{0} (line {1} position {2})",
+                                                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                                                        .Call System.String.Format(
+                                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                                                .Constant<System.Object>(Float),
+                                                                                                                                                                                (System.Object)$reader.TokenType
+                                                                                                                                                                            }),
+                                                                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                                                                    }))
+                                                                                                                                                        }
+                                                                                                                                                    };
+                                                                                                                                                    .Call $reader.Read()
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        } .Else {
+                                                                                                                                            .Block() {
+                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                .Block() {
+                                                                                                                                                    .If (
+                                                                                                                                                        $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
+                                                                                                                                                    ) {
+                                                                                                                                                        .Call $reader.Skip()
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                    };
+                                                                                                                                                    .Call $reader.Read()
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        };
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                            .Default:
+                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                            "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                (System.Object)$reader.TokenType,
+                                                                                                                                                (System.Object)$state,
+                                                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                                                            }))
+                                                                                                                            }
+                                                                                                                    .Default:
                                                                                                                             .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                                                     System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                    "{0} (line {1} position {2})",
+                                                                                                                                    "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
                                                                                                                                     .NewArray System.Object[] {
-                                                                                                                                        .Call System.String.Format(
-                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                            .NewArray System.Object[] {
-                                                                                                                                                .Constant<System.Object>(Integer),
-                                                                                                                                                (System.Object)$reader.TokenType
-                                                                                                                                            }),
+                                                                                                                                        (System.Object)$reader.TokenType,
+                                                                                                                                        (System.Object)$state,
                                                                                                                                         (System.Object)$reader.LineNumber,
                                                                                                                                         (System.Object)$reader.LinePosition
                                                                                                                                     }))
-                                                                                                                        };
-                                                                                                                        .Call $reader.Read()
-                                                                                                                    }
-                                                                                                                }
-                                                                                                            } .Else {
-                                                                                                                .If ((System.String)$reader.Value == "Data3") {
-                                                                                                                    .Block() {
-                                                                                                                        .Call $reader.Read();
-                                                                                                                        .Block() {
-                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                                ($Example.guid).Data3 = (System.UInt16)((System.Int64)$reader.Value)
-                                                                                                                            } .Else {
-                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                        "{0} (line {1} position {2})",
-                                                                                                                                        .NewArray System.Object[] {
-                                                                                                                                            .Call System.String.Format(
-                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                                                                .NewArray System.Object[] {
-                                                                                                                                                    .Constant<System.Object>(Integer),
-                                                                                                                                                    (System.Object)$reader.TokenType
-                                                                                                                                                }),
-                                                                                                                                            (System.Object)$reader.LineNumber,
-                                                                                                                                            (System.Object)$reader.LinePosition
-                                                                                                                                        }))
-                                                                                                                            };
-                                                                                                                            .Call $reader.Read()
-                                                                                                                        }
                                                                                                                     }
                                                                                                                 } .Else {
-                                                                                                                    .If ((System.String)$reader.Value == "Data2") {
+                                                                                                                    .Break endStateMachineLoop { }
+                                                                                                                }
+                                                                                                            }
+                                                                                                            .LabelTarget endStateMachineLoop:;
+                                                                                                            .Default(System.Void);
+                                                                                                            .Default(System.Void)
+                                                                                                        }
+                                                                                                    };
+                                                                                                    .Call ($Example._nestedVector).Add($Example._nestedVector_item)
+                                                                                                }
+                                                                                            } .Else {
+                                                                                                .Break end { }
+                                                                                            }
+                                                                                        }
+                                                                                        .LabelTarget end:;
+                                                                                        .Default(System.Void)
+                                                                                    };
+                                                                                    .Call $reader.Read()
+                                                                                }
+                                                                            } .Else {
+                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                        "{0} (line {1} position {2})",
+                                                                                        .NewArray System.Object[] {
+                                                                                            "Expected JSON array or null.",
+                                                                                            (System.Object)$reader.LineNumber,
+                                                                                            (System.Object)$reader.LinePosition
+                                                                                        }))
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                } .Else {
+                                                                    .If ((System.String)$reader.Value == "_int32Vector") {
+                                                                        .Block() {
+                                                                            .Call $reader.Read();
+                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Null)) {
+                                                                                .Block() {
+                                                                                    .Call $reader.Read();
+                                                                                    .Block(System.Int32 $Example._int32Vector_item) {
+                                                                                        .Block(System.Int32 $Example._int32Vector_count) {
+                                                                                            $Example._int32Vector_count = 0;
+                                                                                            .Default(System.Void);
+                                                                                            ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                                                        };
+                                                                                        .Loop  {
+                                                                                            .Break end { }
+                                                                                        }
+                                                                                        .LabelTarget end:;
+                                                                                        .Default(System.Void)
+                                                                                    }
+                                                                                }
+                                                                            } .Else {
+                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)) {
+                                                                                    .Block() {
+                                                                                        .Call $reader.Read();
+                                                                                        .Block(System.Int32 $Example._int32Vector_item) {
+                                                                                            .Block(System.Int32 $Example._int32Vector_count) {
+                                                                                                $Example._int32Vector_count = 0;
+                                                                                                .Default(System.Void);
+                                                                                                ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                                                            };
+                                                                                            .Loop  {
+                                                                                                .If ($reader.TokenType != .Constant<Newtonsoft.Json.JsonToken>(EndArray)) {
+                                                                                                    .Block() {
+                                                                                                        .Block() {
+                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                $Example._int32Vector_item = (System.Int32)((System.Int64)$reader.Value)
+                                                                                                            } .Else {
+                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                        "{0} (line {1} position {2})",
+                                                                                                                        .NewArray System.Object[] {
+                                                                                                                            .Call System.String.Format(
+                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                    .Constant<System.Object>(Integer),
+                                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                                }),
+                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                        }))
+                                                                                                            };
+                                                                                                            .Call $reader.Read()
+                                                                                                        };
+                                                                                                        .Call ($Example._int32Vector).Add($Example._int32Vector_item)
+                                                                                                    }
+                                                                                                } .Else {
+                                                                                                    .Break end { }
+                                                                                                }
+                                                                                            }
+                                                                                            .LabelTarget end:;
+                                                                                            .Default(System.Void)
+                                                                                        };
+                                                                                        .Call $reader.Read()
+                                                                                    }
+                                                                                } .Else {
+                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                            "{0} (line {1} position {2})",
+                                                                                            .NewArray System.Object[] {
+                                                                                                "Expected JSON array or null.",
+                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                (System.Object)$reader.LinePosition
+                                                                                            }))
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    } .Else {
+                                                                        .If ((System.String)$reader.Value == "guid") {
+                                                                            .Block() {
+                                                                                .Call $reader.Read();
+                                                                                .Block() {
+                                                                                    .Block(
+                                                                                        System.Byte $state,
+                                                                                        Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
+                                                                                        .Default(System.Void);
+                                                                                        .Default(System.Void);
+                                                                                        $state = .Constant<System.Byte>(1);
+                                                                                        .Loop  {
+                                                                                            .If (
+                                                                                                !$reader.EOF && $state != .Constant<System.Byte>(5)
+                                                                                            ) {
+                                                                                                .Switch ($reader.TokenType) {
+                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(None)):
+                                                                                                        .Switch ($state) {
+                                                                                                        .Case (.Constant<System.Byte>(1)):
+                                                                                                                .Block() {
+                                                                                                                    .Call $reader.Read();
+                                                                                                                    .Default(System.Void)
+                                                                                                                }
+                                                                                                        .Default:
+                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                        "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                        .NewArray System.Object[] {
+                                                                                                                            (System.Object)$reader.TokenType,
+                                                                                                                            (System.Object)$state,
+                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                        }))
+                                                                                                        }
+                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(StartObject)):
+                                                                                                        .Switch ($state) {
+                                                                                                        .Case (.Constant<System.Byte>(1)):
+                                                                                                                .Block() {
+                                                                                                                    .Call $reader.Read();
+                                                                                                                    $state = .Constant<System.Byte>(2);
+                                                                                                                    .Default(System.Void)
+                                                                                                                }
+                                                                                                        .Default:
+                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                        "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                        .NewArray System.Object[] {
+                                                                                                                            (System.Object)$reader.TokenType,
+                                                                                                                            (System.Object)$state,
+                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                        }))
+                                                                                                        }
+                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(EndObject)):
+                                                                                                        .Switch ($state) {
+                                                                                                        .Case (.Constant<System.Byte>(2)):
+                                                                                                                .Block() {
+                                                                                                                    .Call $reader.Read();
+                                                                                                                    $state = .Constant<System.Byte>(5);
+                                                                                                                    .Default(System.Void)
+                                                                                                                }
+                                                                                                        .Default:
+                                                                                                                .Default(System.Void)
+                                                                                                        }
+                                                                                                .Case (.Constant<Newtonsoft.Json.JsonToken>(PropertyName)):
+                                                                                                        .Switch ($state) {
+                                                                                                        .Case (.Constant<System.Byte>(2)):
+                                                                                                                .Block() {
+                                                                                                                    .If ((System.String)$reader.Value == "Data4") {
                                                                                                                         .Block() {
                                                                                                                             .Call $reader.Read();
                                                                                                                             .Block() {
                                                                                                                                 .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                                    ($Example.guid).Data2 = (System.UInt16)((System.Int64)$reader.Value)
+                                                                                                                                    ($Example.guid).Data4 = (System.UInt64)((System.Int64)$reader.Value)
                                                                                                                                 } .Else {
                                                                                                                                     .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                                                             System.Globalization.CultureInfo.InvariantCulture,
@@ -779,12 +984,12 @@
                                                                                                                             }
                                                                                                                         }
                                                                                                                     } .Else {
-                                                                                                                        .If ((System.String)$reader.Value == "Data1") {
+                                                                                                                        .If ((System.String)$reader.Value == "Data3") {
                                                                                                                             .Block() {
                                                                                                                                 .Call $reader.Read();
                                                                                                                                 .Block() {
                                                                                                                                     .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                                                        ($Example.guid).Data1 = (System.UInt32)((System.Int64)$reader.Value)
+                                                                                                                                        ($Example.guid).Data3 = (System.UInt16)((System.Int64)$reader.Value)
                                                                                                                                     } .Else {
                                                                                                                                         .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                                                                 System.Globalization.CultureInfo.InvariantCulture,
@@ -805,24 +1010,87 @@
                                                                                                                                 }
                                                                                                                             }
                                                                                                                         } .Else {
-                                                                                                                            .Block() {
-                                                                                                                                .Call $reader.Read();
+                                                                                                                            .If ((System.String)$reader.Value == "Data2") {
                                                                                                                                 .Block() {
-                                                                                                                                    .If (
-                                                                                                                                        $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
-                                                                                                                                    ) {
-                                                                                                                                        .Call $reader.Skip()
-                                                                                                                                    } .Else {
-                                                                                                                                        .Default(System.Void)
-                                                                                                                                    };
-                                                                                                                                    .Call $reader.Read()
+                                                                                                                                    .Call $reader.Read();
+                                                                                                                                    .Block() {
+                                                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                            ($Example.guid).Data2 = (System.UInt16)((System.Int64)$reader.Value)
+                                                                                                                                        } .Else {
+                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                    "{0} (line {1} position {2})",
+                                                                                                                                                    .NewArray System.Object[] {
+                                                                                                                                                        .Call System.String.Format(
+                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                                                .Constant<System.Object>(Integer),
+                                                                                                                                                                (System.Object)$reader.TokenType
+                                                                                                                                                            }),
+                                                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                                                    }))
+                                                                                                                                        };
+                                                                                                                                        .Call $reader.Read()
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            } .Else {
+                                                                                                                                .If ((System.String)$reader.Value == "Data1") {
+                                                                                                                                    .Block() {
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        .Block() {
+                                                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                                                                ($Example.guid).Data1 = (System.UInt32)((System.Int64)$reader.Value)
+                                                                                                                                            } .Else {
+                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                        "{0} (line {1} position {2})",
+                                                                                                                                                        .NewArray System.Object[] {
+                                                                                                                                                            .Call System.String.Format(
+                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                                                    .Constant<System.Object>(Integer),
+                                                                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                                                                }),
+                                                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                                                        }))
+                                                                                                                                            };
+                                                                                                                                            .Call $reader.Read()
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                } .Else {
+                                                                                                                                    .Block() {
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        .Block() {
+                                                                                                                                            .If (
+                                                                                                                                                $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
+                                                                                                                                            ) {
+                                                                                                                                                .Call $reader.Skip()
+                                                                                                                                            } .Else {
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                            };
+                                                                                                                                            .Call $reader.Read()
+                                                                                                                                        }
+                                                                                                                                    }
                                                                                                                                 }
                                                                                                                             }
                                                                                                                         }
-                                                                                                                    }
+                                                                                                                    };
+                                                                                                                    .Default(System.Void)
                                                                                                                 }
-                                                                                                            };
-                                                                                                            .Default(System.Void)
+                                                                                                        .Default:
+                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                        "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
+                                                                                                                        .NewArray System.Object[] {
+                                                                                                                            (System.Object)$reader.TokenType,
+                                                                                                                            (System.Object)$state,
+                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                        }))
                                                                                                         }
                                                                                                 .Default:
                                                                                                         .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
@@ -835,121 +1103,26 @@
                                                                                                                     (System.Object)$reader.LinePosition
                                                                                                                 }))
                                                                                                 }
-                                                                                        .Default:
-                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                        "Unexpected JsonToken '{0}' at state {1} (line {2} position {3})",
-                                                                                                        .NewArray System.Object[] {
-                                                                                                            (System.Object)$reader.TokenType,
-                                                                                                            (System.Object)$state,
-                                                                                                            (System.Object)$reader.LineNumber,
-                                                                                                            (System.Object)$reader.LinePosition
-                                                                                                        }))
+                                                                                            } .Else {
+                                                                                                .Break endStateMachineLoop { }
+                                                                                            }
                                                                                         }
-                                                                                    } .Else {
-                                                                                        .Break endStateMachineLoop { }
-                                                                                    }
-                                                                                }
-                                                                                .LabelTarget endStateMachineLoop:;
-                                                                                .Default(System.Void);
-                                                                                .Default(System.Void)
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                } .Else {
-                                                                    .If ((System.String)$reader.Value == "_double") {
-                                                                        .Block() {
-                                                                            .Call $reader.Read();
-                                                                            .Block() {
-                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                    $Example._double = (System.Double)((System.Int64)$reader.Value)
-                                                                                } .Else {
-                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
-                                                                                        $Example._double = (System.Double)$reader.Value
-                                                                                    } .Else {
-                                                                                        .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                "{0} (line {1} position {2})",
-                                                                                                .NewArray System.Object[] {
-                                                                                                    .Call System.String.Format(
-                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                        "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                        .NewArray System.Object[] {
-                                                                                                            .Constant<System.Object>(Float),
-                                                                                                            (System.Object)$reader.TokenType
-                                                                                                        }),
-                                                                                                    (System.Object)$reader.LineNumber,
-                                                                                                    (System.Object)$reader.LinePosition
-                                                                                                }))
-                                                                                    }
-                                                                                };
-                                                                                .Call $reader.Read()
-                                                                            }
-                                                                        }
-                                                                    } .Else {
-                                                                        .If ((System.String)$reader.Value == "_int64") {
-                                                                            .Block() {
-                                                                                .Call $reader.Read();
-                                                                                .Block() {
-                                                                                    .Call $requiredFields.Reset(
-                                                                                        0,
-                                                                                        1L);
-                                                                                    .Block() {
-                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                            $Example._int64 = (System.Int64)$reader.Value
-                                                                                        } .Else {
-                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                    "{0} (line {1} position {2})",
-                                                                                                    .NewArray System.Object[] {
-                                                                                                        .Call System.String.Format(
-                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                            .NewArray System.Object[] {
-                                                                                                                .Constant<System.Object>(Integer),
-                                                                                                                (System.Object)$reader.TokenType
-                                                                                                            }),
-                                                                                                        (System.Object)$reader.LineNumber,
-                                                                                                        (System.Object)$reader.LinePosition
-                                                                                                    }))
-                                                                                        };
-                                                                                        .Call $reader.Read()
+                                                                                        .LabelTarget endStateMachineLoop:;
+                                                                                        .Default(System.Void);
+                                                                                        .Default(System.Void)
                                                                                     }
                                                                                 }
                                                                             }
                                                                         } .Else {
-                                                                            .If ((System.String)$reader.Value == "_int8") {
+                                                                            .If ((System.String)$reader.Value == "_double") {
                                                                                 .Block() {
                                                                                     .Call $reader.Read();
                                                                                     .Block() {
                                                                                         .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                            $Example._int8 = (System.SByte)((System.Int64)$reader.Value)
+                                                                                            $Example._double = (System.Double)((System.Int64)$reader.Value)
                                                                                         } .Else {
-                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
-                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                    "{0} (line {1} position {2})",
-                                                                                                    .NewArray System.Object[] {
-                                                                                                        .Call System.String.Format(
-                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
-                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
-                                                                                                            .NewArray System.Object[] {
-                                                                                                                .Constant<System.Object>(Integer),
-                                                                                                                (System.Object)$reader.TokenType
-                                                                                                            }),
-                                                                                                        (System.Object)$reader.LineNumber,
-                                                                                                        (System.Object)$reader.LinePosition
-                                                                                                    }))
-                                                                                        };
-                                                                                        .Call $reader.Read()
-                                                                                    }
-                                                                                }
-                                                                            } .Else {
-                                                                                .If ((System.String)$reader.Value == "JsonUint32") {
-                                                                                    .Block() {
-                                                                                        .Call $reader.Read();
-                                                                                        .Block() {
-                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
-                                                                                                $Example._uint32 = (System.UInt32)((System.Int64)$reader.Value)
+                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Float)) {
+                                                                                                $Example._double = (System.Double)$reader.Value
                                                                                             } .Else {
                                                                                                 .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                         System.Globalization.CultureInfo.InvariantCulture,
@@ -959,23 +1132,28 @@
                                                                                                                 System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                 "Invalid input, expected JSON token of type {0}, encountered {1}",
                                                                                                                 .NewArray System.Object[] {
-                                                                                                                    .Constant<System.Object>(Integer),
+                                                                                                                    .Constant<System.Object>(Float),
                                                                                                                     (System.Object)$reader.TokenType
                                                                                                                 }),
                                                                                                             (System.Object)$reader.LineNumber,
                                                                                                             (System.Object)$reader.LinePosition
                                                                                                         }))
-                                                                                            };
-                                                                                            .Call $reader.Read()
-                                                                                        }
+                                                                                            }
+                                                                                        };
+                                                                                        .Call $reader.Read()
                                                                                     }
-                                                                                } .Else {
-                                                                                    .If ((System.String)$reader.Value == "_str") {
+                                                                                }
+                                                                            } .Else {
+                                                                                .If ((System.String)$reader.Value == "_int64") {
+                                                                                    .Block() {
+                                                                                        .Call $reader.Read();
                                                                                         .Block() {
-                                                                                            .Call $reader.Read();
+                                                                                            .Call $requiredFields.Reset(
+                                                                                                0,
+                                                                                                1L);
                                                                                             .Block() {
-                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(String)) {
-                                                                                                    $Example._str = (System.String)$reader.Value
+                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                    $Example._int64 = (System.Int64)$reader.Value
                                                                                                 } .Else {
                                                                                                     .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                             System.Globalization.CultureInfo.InvariantCulture,
@@ -985,7 +1163,34 @@
                                                                                                                     System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                     "Invalid input, expected JSON token of type {0}, encountered {1}",
                                                                                                                     .NewArray System.Object[] {
-                                                                                                                        .Constant<System.Object>(String),
+                                                                                                                        .Constant<System.Object>(Integer),
+                                                                                                                        (System.Object)$reader.TokenType
+                                                                                                                    }),
+                                                                                                                (System.Object)$reader.LineNumber,
+                                                                                                                (System.Object)$reader.LinePosition
+                                                                                                            }))
+                                                                                                };
+                                                                                                .Call $reader.Read()
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                } .Else {
+                                                                                    .If ((System.String)$reader.Value == "_int8") {
+                                                                                        .Block() {
+                                                                                            .Call $reader.Read();
+                                                                                            .Block() {
+                                                                                                .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                    $Example._int8 = (System.SByte)((System.Int64)$reader.Value)
+                                                                                                } .Else {
+                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                            "{0} (line {1} position {2})",
+                                                                                                            .NewArray System.Object[] {
+                                                                                                                .Call System.String.Format(
+                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                    "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                    .NewArray System.Object[] {
+                                                                                                                        .Constant<System.Object>(Integer),
                                                                                                                         (System.Object)$reader.TokenType
                                                                                                                     }),
                                                                                                                 (System.Object)$reader.LineNumber,
@@ -996,12 +1201,12 @@
                                                                                             }
                                                                                         }
                                                                                     } .Else {
-                                                                                        .If ((System.String)$reader.Value == "_bool") {
+                                                                                        .If ((System.String)$reader.Value == "JsonUint32") {
                                                                                             .Block() {
                                                                                                 .Call $reader.Read();
                                                                                                 .Block() {
-                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Boolean)) {
-                                                                                                        $Example._bool = (System.Boolean)$reader.Value
+                                                                                                    .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Integer)) {
+                                                                                                        $Example._uint32 = (System.UInt32)((System.Int64)$reader.Value)
                                                                                                     } .Else {
                                                                                                         .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
                                                                                                                 System.Globalization.CultureInfo.InvariantCulture,
@@ -1011,7 +1216,7 @@
                                                                                                                         System.Globalization.CultureInfo.InvariantCulture,
                                                                                                                         "Invalid input, expected JSON token of type {0}, encountered {1}",
                                                                                                                         .NewArray System.Object[] {
-                                                                                                                            .Constant<System.Object>(Boolean),
+                                                                                                                            .Constant<System.Object>(Integer),
                                                                                                                             (System.Object)$reader.TokenType
                                                                                                                         }),
                                                                                                                     (System.Object)$reader.LineNumber,
@@ -1022,17 +1227,71 @@
                                                                                                 }
                                                                                             }
                                                                                         } .Else {
-                                                                                            .Block() {
-                                                                                                .Call $reader.Read();
+                                                                                            .If ((System.String)$reader.Value == "_str") {
                                                                                                 .Block() {
-                                                                                                    .If (
-                                                                                                        $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
-                                                                                                    ) {
-                                                                                                        .Call $reader.Skip()
-                                                                                                    } .Else {
-                                                                                                        .Default(System.Void)
-                                                                                                    };
-                                                                                                    .Call $reader.Read()
+                                                                                                    .Call $reader.Read();
+                                                                                                    .Block() {
+                                                                                                        .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(String)) {
+                                                                                                            $Example._str = (System.String)$reader.Value
+                                                                                                        } .Else {
+                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                    System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                    "{0} (line {1} position {2})",
+                                                                                                                    .NewArray System.Object[] {
+                                                                                                                        .Call System.String.Format(
+                                                                                                                            System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                            "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                            .NewArray System.Object[] {
+                                                                                                                                .Constant<System.Object>(String),
+                                                                                                                                (System.Object)$reader.TokenType
+                                                                                                                            }),
+                                                                                                                        (System.Object)$reader.LineNumber,
+                                                                                                                        (System.Object)$reader.LinePosition
+                                                                                                                    }))
+                                                                                                        };
+                                                                                                        .Call $reader.Read()
+                                                                                                    }
+                                                                                                }
+                                                                                            } .Else {
+                                                                                                .If ((System.String)$reader.Value == "_bool") {
+                                                                                                    .Block() {
+                                                                                                        .Call $reader.Read();
+                                                                                                        .Block() {
+                                                                                                            .If ($reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(Boolean)) {
+                                                                                                                $Example._bool = (System.Boolean)$reader.Value
+                                                                                                            } .Else {
+                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`1[System.String]>)(.Call System.String.Format(
+                                                                                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                        "{0} (line {1} position {2})",
+                                                                                                                        .NewArray System.Object[] {
+                                                                                                                            .Call System.String.Format(
+                                                                                                                                System.Globalization.CultureInfo.InvariantCulture,
+                                                                                                                                "Invalid input, expected JSON token of type {0}, encountered {1}",
+                                                                                                                                .NewArray System.Object[] {
+                                                                                                                                    .Constant<System.Object>(Boolean),
+                                                                                                                                    (System.Object)$reader.TokenType
+                                                                                                                                }),
+                                                                                                                            (System.Object)$reader.LineNumber,
+                                                                                                                            (System.Object)$reader.LinePosition
+                                                                                                                        }))
+                                                                                                            };
+                                                                                                            .Call $reader.Read()
+                                                                                                        }
+                                                                                                    }
+                                                                                                } .Else {
+                                                                                                    .Block() {
+                                                                                                        .Call $reader.Read();
+                                                                                                        .Block() {
+                                                                                                            .If (
+                                                                                                                $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartObject) || $reader.TokenType == .Constant<Newtonsoft.Json.JsonToken>(StartArray)
+                                                                                                            ) {
+                                                                                                                .Call $reader.Skip()
+                                                                                                            } .Else {
+                                                                                                                .Default(System.Void)
+                                                                                                            };
+                                                                                                            .Call $reader.Read()
+                                                                                                        }
+                                                                                                    }
                                                                                                 }
                                                                                             }
                                                                                         }

--- a/cs/test/expressions/DeserializeSP.expressions
+++ b/cs/test/expressions/DeserializeSP.expressions
@@ -264,6 +264,50 @@
                         .Call $reader.ReadContainerEnd()
                     }
                 };
+                .If (
+                    .Call $reader.ReadFieldOmitted()
+                ) {
+                    .Default(System.Void)
+                } .Else {
+                    .Block(System.Int32 $count) {
+                        $count = .Call $reader.ReadContainerBegin();
+                        $Example._decimal = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                            .Call $reader.ReadBytes($count),
+                            .Default(System.Decimal));
+                        .Call $reader.ReadContainerEnd()
+                    }
+                };
+                .If (
+                    .Call $reader.ReadFieldOmitted()
+                ) {
+                    .Default(System.Void)
+                } .Else {
+                    .Block(System.Int32 $count) {
+                        $count = .Call $reader.ReadContainerBegin();
+                        .Block(System.Decimal $Example._decList_item) {
+                            .Default(System.Void);
+                            .Loop  {
+                                .If ($count-- > 0) {
+                                    .Block() {
+                                        .Block(System.Int32 $count) {
+                                            $count = .Call $reader.ReadContainerBegin();
+                                            $Example._decList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                .Call $reader.ReadBytes($count),
+                                                .Default(System.Decimal));
+                                            .Call $reader.ReadContainerEnd()
+                                        };
+                                        .Call ($Example._decList).Add($Example._decList_item)
+                                    }
+                                } .Else {
+                                    .Break end { }
+                                }
+                            }
+                            .LabelTarget end:;
+                            .Default(System.Void)
+                        };
+                        .Call $reader.ReadContainerEnd()
+                    }
+                };
                 .Default(System.Void)
             }
         };

--- a/cs/test/expressions/DeserializeSP.expressions
+++ b/cs/test/expressions/DeserializeSP.expressions
@@ -308,6 +308,105 @@
                         .Call $reader.ReadContainerEnd()
                     }
                 };
+                .If (
+                    .Call $reader.ReadFieldOmitted()
+                ) {
+                    .Default(System.Void)
+                } .Else {
+                    .Block(System.Int32 $count) {
+                        $count = .Call $reader.ReadContainerBegin();
+                        .Block(System.Decimal $Example._decVector_item) {
+                            .Block(System.Int32 $Example._decVector_count) {
+                                $Example._decVector_count = $count;
+                                .If ($Example._decVector_count > 65536) {
+                                    $Example._decVector_count = 65536
+                                } .Else {
+                                    .Default(System.Void)
+                                };
+                                ($Example._decVector).Capacity = $Example._decVector_count
+                            };
+                            .Loop  {
+                                .If ($count-- > 0) {
+                                    .Block() {
+                                        .Block(System.Int32 $count) {
+                                            $count = .Call $reader.ReadContainerBegin();
+                                            $Example._decVector_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                .Call $reader.ReadBytes($count),
+                                                .Default(System.Decimal));
+                                            .Call $reader.ReadContainerEnd()
+                                        };
+                                        .Call ($Example._decVector).Add($Example._decVector_item)
+                                    }
+                                } .Else {
+                                    .Break end { }
+                                }
+                            }
+                            .LabelTarget end:;
+                            .Default(System.Void)
+                        };
+                        .Call $reader.ReadContainerEnd()
+                    }
+                };
+                .If (
+                    .Call $reader.ReadFieldOmitted()
+                ) {
+                    .Default(System.Void)
+                } .Else {
+                    .Block(System.Int32 $count) {
+                        $count = .Call $reader.ReadContainerBegin();
+                        .Block(
+                            System.Int32 $Example._decMap_key,
+                            System.Decimal $Example._decMap_value) {
+                            .Default(System.Void);
+                            .Loop  {
+                                .If ($count-- > 0) {
+                                    .Block() {
+                                        $Example._decMap_key = .Call $reader.ReadInt32();
+                                        .Default(System.Void);
+                                        .Block(System.Int32 $count) {
+                                            $count = .Call $reader.ReadContainerBegin();
+                                            $Example._decMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                .Call $reader.ReadBytes($count),
+                                                .Default(System.Decimal));
+                                            .Call $reader.ReadContainerEnd()
+                                        };
+                                        ($Example._decMap).Item[$Example._decMap_key] = $Example._decMap_value
+                                    }
+                                } .Else {
+                                    .Break end { }
+                                }
+                            }
+                            .LabelTarget end:
+                        };
+                        .Call $reader.ReadContainerEnd()
+                    }
+                };
+                .If (
+                    .Call $reader.ReadFieldOmitted()
+                ) {
+                    .Default(System.Void)
+                } .Else {
+                    .Block(System.Int32 $count) {
+                        $count = .Call $reader.ReadContainerBegin();
+                        .Block() {
+                            .Loop  {
+                                .If ($count-- > 0) {
+                                    .Block(System.Int32 $count) {
+                                        $count = .Call $reader.ReadContainerBegin();
+                                        $Example._decNullable = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            .Call $reader.ReadBytes($count),
+                                            .Default(System.Decimal));
+                                        .Call $reader.ReadContainerEnd()
+                                    }
+                                } .Else {
+                                    .Break end { }
+                                }
+                            }
+                            .LabelTarget end:
+                        };
+                        .Call $reader.ReadContainerEnd()
+                    }
+                };
                 .Default(System.Void)
             }
         };

--- a/cs/test/expressions/DeserializeSP.expressions
+++ b/cs/test/expressions/DeserializeSP.expressions
@@ -243,6 +243,128 @@
                 } .Else {
                     .Block(System.Int32 $count) {
                         $count = .Call $reader.ReadContainerBegin();
+                        .Block(System.ArraySegment`1[System.Byte] $Example._blobList_item) {
+                            .Default(System.Void);
+                            .Loop  {
+                                .If ($count-- > 0) {
+                                    .Block() {
+                                        .Block(System.Int32 $count) {
+                                            $count = .Call $reader.ReadContainerBegin();
+                                            $Example._blobList_item = .Call $reader.ReadBytes($count);
+                                            .Call $reader.ReadContainerEnd()
+                                        };
+                                        .Call ($Example._blobList).Add($Example._blobList_item)
+                                    }
+                                } .Else {
+                                    .Break end { }
+                                }
+                            }
+                            .LabelTarget end:;
+                            .Default(System.Void)
+                        };
+                        .Call $reader.ReadContainerEnd()
+                    }
+                };
+                .If (
+                    .Call $reader.ReadFieldOmitted()
+                ) {
+                    .Default(System.Void)
+                } .Else {
+                    .Block(System.Int32 $count) {
+                        $count = .Call $reader.ReadContainerBegin();
+                        .Block(System.ArraySegment`1[System.Byte] $Example._blobVector_item) {
+                            .Block(System.Int32 $Example._blobVector_count) {
+                                $Example._blobVector_count = $count;
+                                .If ($Example._blobVector_count > 65536) {
+                                    $Example._blobVector_count = 65536
+                                } .Else {
+                                    .Default(System.Void)
+                                };
+                                ($Example._blobVector).Capacity = $Example._blobVector_count
+                            };
+                            .Loop  {
+                                .If ($count-- > 0) {
+                                    .Block() {
+                                        .Block(System.Int32 $count) {
+                                            $count = .Call $reader.ReadContainerBegin();
+                                            $Example._blobVector_item = .Call $reader.ReadBytes($count);
+                                            .Call $reader.ReadContainerEnd()
+                                        };
+                                        .Call ($Example._blobVector).Add($Example._blobVector_item)
+                                    }
+                                } .Else {
+                                    .Break end { }
+                                }
+                            }
+                            .LabelTarget end:;
+                            .Default(System.Void)
+                        };
+                        .Call $reader.ReadContainerEnd()
+                    }
+                };
+                .If (
+                    .Call $reader.ReadFieldOmitted()
+                ) {
+                    .Default(System.Void)
+                } .Else {
+                    .Block(System.Int32 $count) {
+                        $count = .Call $reader.ReadContainerBegin();
+                        .Block(
+                            System.Int32 $Example._blobMap_key,
+                            System.ArraySegment`1[System.Byte] $Example._blobMap_value) {
+                            .Default(System.Void);
+                            .Loop  {
+                                .If ($count-- > 0) {
+                                    .Block() {
+                                        $Example._blobMap_key = .Call $reader.ReadInt32();
+                                        .Default(System.Void);
+                                        .Block(System.Int32 $count) {
+                                            $count = .Call $reader.ReadContainerBegin();
+                                            $Example._blobMap_value = .Call $reader.ReadBytes($count);
+                                            .Call $reader.ReadContainerEnd()
+                                        };
+                                        ($Example._blobMap).Item[$Example._blobMap_key] = $Example._blobMap_value
+                                    }
+                                } .Else {
+                                    .Break end { }
+                                }
+                            }
+                            .LabelTarget end:
+                        };
+                        .Call $reader.ReadContainerEnd()
+                    }
+                };
+                .If (
+                    .Call $reader.ReadFieldOmitted()
+                ) {
+                    .Default(System.Void)
+                } .Else {
+                    .Block(System.Int32 $count) {
+                        $count = .Call $reader.ReadContainerBegin();
+                        .Block() {
+                            .Loop  {
+                                .If ($count-- > 0) {
+                                    .Block(System.Int32 $count) {
+                                        $count = .Call $reader.ReadContainerBegin();
+                                        $Example._blobNullable = .Call $reader.ReadBytes($count);
+                                        .Call $reader.ReadContainerEnd()
+                                    }
+                                } .Else {
+                                    .Break end { }
+                                }
+                            }
+                            .LabelTarget end:
+                        };
+                        .Call $reader.ReadContainerEnd()
+                    }
+                };
+                .If (
+                    .Call $reader.ReadFieldOmitted()
+                ) {
+                    .Default(System.Void)
+                } .Else {
+                    .Block(System.Int32 $count) {
+                        $count = .Call $reader.ReadContainerBegin();
                         .Block(
                             System.Int32 $Example._map_key,
                             System.Double $Example._map_value) {
@@ -396,6 +518,150 @@
                                         $Example._decNullable = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                                             .Call $reader.ReadBytes($count),
                                             .Default(System.Decimal));
+                                        .Call $reader.ReadContainerEnd()
+                                    }
+                                } .Else {
+                                    .Break end { }
+                                }
+                            }
+                            .LabelTarget end:
+                        };
+                        .Call $reader.ReadContainerEnd()
+                    }
+                };
+                .If (
+                    .Call $reader.ReadFieldOmitted()
+                ) {
+                    .Default(System.Void)
+                } .Else {
+                    .Block(System.Int32 $count) {
+                        $count = .Call $reader.ReadContainerBegin();
+                        $Example._reference = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                            .Call $reader.ReadBytes($count),
+                            .Default(ExpressionsTest.RefObject));
+                        .Call $reader.ReadContainerEnd()
+                    }
+                };
+                .If (
+                    .Call $reader.ReadFieldOmitted()
+                ) {
+                    .Default(System.Void)
+                } .Else {
+                    .Block(System.Int32 $count) {
+                        $count = .Call $reader.ReadContainerBegin();
+                        .Block(ExpressionsTest.RefObject $Example._refList_item) {
+                            .Default(System.Void);
+                            .Loop  {
+                                .If ($count-- > 0) {
+                                    .Block() {
+                                        .Block(System.Int32 $count) {
+                                            $count = .Call $reader.ReadContainerBegin();
+                                            $Example._refList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                .Call $reader.ReadBytes($count),
+                                                .Default(ExpressionsTest.RefObject));
+                                            .Call $reader.ReadContainerEnd()
+                                        };
+                                        .Call ($Example._refList).Add($Example._refList_item)
+                                    }
+                                } .Else {
+                                    .Break end { }
+                                }
+                            }
+                            .LabelTarget end:;
+                            .Default(System.Void)
+                        };
+                        .Call $reader.ReadContainerEnd()
+                    }
+                };
+                .If (
+                    .Call $reader.ReadFieldOmitted()
+                ) {
+                    .Default(System.Void)
+                } .Else {
+                    .Block(System.Int32 $count) {
+                        $count = .Call $reader.ReadContainerBegin();
+                        .Block(ExpressionsTest.RefObject $Example._refVector_item) {
+                            .Block(System.Int32 $Example._refVector_count) {
+                                $Example._refVector_count = $count;
+                                .If ($Example._refVector_count > 65536) {
+                                    $Example._refVector_count = 65536
+                                } .Else {
+                                    .Default(System.Void)
+                                };
+                                ($Example._refVector).Capacity = $Example._refVector_count
+                            };
+                            .Loop  {
+                                .If ($count-- > 0) {
+                                    .Block() {
+                                        .Block(System.Int32 $count) {
+                                            $count = .Call $reader.ReadContainerBegin();
+                                            $Example._refVector_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                .Call $reader.ReadBytes($count),
+                                                .Default(ExpressionsTest.RefObject));
+                                            .Call $reader.ReadContainerEnd()
+                                        };
+                                        .Call ($Example._refVector).Add($Example._refVector_item)
+                                    }
+                                } .Else {
+                                    .Break end { }
+                                }
+                            }
+                            .LabelTarget end:;
+                            .Default(System.Void)
+                        };
+                        .Call $reader.ReadContainerEnd()
+                    }
+                };
+                .If (
+                    .Call $reader.ReadFieldOmitted()
+                ) {
+                    .Default(System.Void)
+                } .Else {
+                    .Block(System.Int32 $count) {
+                        $count = .Call $reader.ReadContainerBegin();
+                        .Block(
+                            System.Int32 $Example._refMap_key,
+                            ExpressionsTest.RefObject $Example._refMap_value) {
+                            .Default(System.Void);
+                            .Loop  {
+                                .If ($count-- > 0) {
+                                    .Block() {
+                                        $Example._refMap_key = .Call $reader.ReadInt32();
+                                        .Default(System.Void);
+                                        .Block(System.Int32 $count) {
+                                            $count = .Call $reader.ReadContainerBegin();
+                                            $Example._refMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                .Call $reader.ReadBytes($count),
+                                                .Default(ExpressionsTest.RefObject));
+                                            .Call $reader.ReadContainerEnd()
+                                        };
+                                        ($Example._refMap).Item[$Example._refMap_key] = $Example._refMap_value
+                                    }
+                                } .Else {
+                                    .Break end { }
+                                }
+                            }
+                            .LabelTarget end:
+                        };
+                        .Call $reader.ReadContainerEnd()
+                    }
+                };
+                .If (
+                    .Call $reader.ReadFieldOmitted()
+                ) {
+                    .Default(System.Void)
+                } .Else {
+                    .Block(System.Int32 $count) {
+                        $count = .Call $reader.ReadContainerBegin();
+                        .Block() {
+                            $Example._refNullable = .Default(ExpressionsTest.RefObject);
+                            .Loop  {
+                                .If ($count-- > 0) {
+                                    .Block(System.Int32 $count) {
+                                        $count = .Call $reader.ReadContainerBegin();
+                                        $Example._refNullable = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            .Call $reader.ReadBytes($count),
+                                            .Default(ExpressionsTest.RefObject));
                                         .Call $reader.ReadContainerEnd()
                                     }
                                 } .Else {

--- a/cs/test/expressions/DeserializeXml.expressions
+++ b/cs/test/expressions/DeserializeXml.expressions
@@ -222,7 +222,7 @@
                                                     .If (
                                                         .Call System.String.Equals(
                                                             $reader.LocalName,
-                                                            "_map",
+                                                            "_decList",
                                                             .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                             $reader.NamespaceURI,
                                                             System.String.Empty,
@@ -234,9 +234,7 @@
                                                         .Block() {
                                                             .Block(System.Boolean $isEmpty) {
                                                                 $isEmpty = $reader.IsEmptyElement;
-                                                                .Block(
-                                                                    System.Int32 $Example._map_key,
-                                                                    System.Double $Example._map_value) {
+                                                                .Block(System.Decimal $Example._decList_item) {
                                                                     .Default(System.Void);
                                                                     .Loop  {
                                                                         .If (
@@ -283,20 +281,51 @@
                                                                             }
                                                                         ) {
                                                                             .Block() {
-                                                                                .Block(System.String $valueAsString) {
-                                                                                    .If (
-                                                                                        $reader.IsEmptyElement
-                                                                                    ) {
-                                                                                        $valueAsString = System.String.Empty
-                                                                                    } .Else {
-                                                                                        .Block() {
-                                                                                            .Call $reader.Read();
-                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                $valueAsString = ""
-                                                                                            } .Else {
-                                                                                                .Block() {
-                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                .Block(System.Boolean $isEmpty) {
+                                                                                    $isEmpty = $reader.IsEmptyElement;
+                                                                                    .Block(
+                                                                                        System.Int32 $index,
+                                                                                        System.Byte[] $array) {
+                                                                                        .Block(System.Int32 $Example._decList_item_count) {
+                                                                                            $Example._decList_item_count = 0;
+                                                                                            .Default(System.Void);
+                                                                                            .Block() {
+                                                                                                $index = 0;
+                                                                                                $array = .NewArray System.Byte[$Example._decList_item_count]
+                                                                                            }
+                                                                                        };
+                                                                                        .Loop  {
+                                                                                            .If (
+                                                                                                .If (
+                                                                                                    $isEmpty
+                                                                                                ) {
+                                                                                                    False
+                                                                                                } .Else {
+                                                                                                    .Block() {
+                                                                                                        .Loop  {
+                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                .Call $reader.Read()
+                                                                                                            } .Else {
+                                                                                                                .Break end { }
+                                                                                                            }
+                                                                                                        }
+                                                                                                        .LabelTarget end:;
+                                                                                                        .Loop  {
+                                                                                                            .Block() {
+                                                                                                                .Call $reader.Read();
+                                                                                                                .If (
+                                                                                                                    !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                ) {
+                                                                                                                    .Break end { }
+                                                                                                                } .Else {
+                                                                                                                    .Default(System.Void)
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                        .LabelTarget end:;
+                                                                                                        .If (
+                                                                                                            $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                        ) {
                                                                                                             .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
                                                                                                                 .Constant<System.Byte>(0),
                                                                                                                 $reader.NodeType,
@@ -304,121 +333,89 @@
                                                                                                                 $reader.Value)
                                                                                                         } .Else {
                                                                                                             .Default(System.Void)
-                                                                                                        }
+                                                                                                        };
+                                                                                                        $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                    }
+                                                                                                }
+                                                                                            ) {
+                                                                                                .Block() {
+                                                                                                    .If ($index >= $array.Length) {
+                                                                                                        .Call System.Array.Resize(
+                                                                                                            $array,
+                                                                                                            .If ($index > 512) {
+                                                                                                                $index * 2
+                                                                                                            } .Else {
+                                                                                                                1024
+                                                                                                            })
                                                                                                     } .Else {
                                                                                                         .Default(System.Void)
                                                                                                     };
-                                                                                                    $valueAsString = $reader.Value;
-                                                                                                    .Call $reader.Read();
-                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                            .Constant<System.Byte>(0),
-                                                                                                            $reader.NodeType,
-                                                                                                            $reader.LocalName,
-                                                                                                            $reader.Value)
-                                                                                                    } .Else {
-                                                                                                        .Default(System.Void)
+                                                                                                    .Block(System.String $valueAsString) {
+                                                                                                        .If (
+                                                                                                            $reader.IsEmptyElement
+                                                                                                        ) {
+                                                                                                            $valueAsString = System.String.Empty
+                                                                                                        } .Else {
+                                                                                                            .Block() {
+                                                                                                                .Call $reader.Read();
+                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                    $valueAsString = ""
+                                                                                                                } .Else {
+                                                                                                                    .Block() {
+                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                    $reader.NodeType,
+                                                                                                                                    $reader.LocalName,
+                                                                                                                                    $reader.Value)
+                                                                                                                            } .Else {
+                                                                                                                                .Default(System.Void)
+                                                                                                                            }
+                                                                                                                        } .Else {
+                                                                                                                            .Default(System.Void)
+                                                                                                                        };
+                                                                                                                        $valueAsString = $reader.Value;
+                                                                                                                        .Call $reader.Read();
+                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                $reader.NodeType,
+                                                                                                                                $reader.LocalName,
+                                                                                                                                $reader.Value)
+                                                                                                                        } .Else {
+                                                                                                                            .Default(System.Void)
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        };
+                                                                                                        $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                            $valueAsString,
+                                                                                                            System.Globalization.CultureInfo.InvariantCulture)
                                                                                                     }
                                                                                                 }
-                                                                                            }
-                                                                                        }
-                                                                                    };
-                                                                                    $Example._map_key = .Call System.Convert.ToInt32(
-                                                                                        $valueAsString,
-                                                                                        System.Globalization.CultureInfo.InvariantCulture)
-                                                                                };
-                                                                                .If (
-                                                                                    $isEmpty
-                                                                                ) {
-                                                                                    False
-                                                                                } .Else {
-                                                                                    .Block() {
-                                                                                        .Loop  {
-                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                .Call $reader.Read()
                                                                                             } .Else {
                                                                                                 .Break end { }
                                                                                             }
                                                                                         }
                                                                                         .LabelTarget end:;
-                                                                                        .Loop  {
-                                                                                            .Block() {
-                                                                                                .Call $reader.Read();
-                                                                                                .If (
-                                                                                                    !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
-                                                                                                ) {
-                                                                                                    .Break end { }
-                                                                                                } .Else {
-                                                                                                    .Default(System.Void)
-                                                                                                }
-                                                                                            }
-                                                                                        }
-                                                                                        .LabelTarget end:;
-                                                                                        .If (
-                                                                                            $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
-                                                                                        ) {
-                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                .Constant<System.Byte>(0),
-                                                                                                $reader.NodeType,
-                                                                                                $reader.LocalName,
-                                                                                                $reader.Value)
-                                                                                        } .Else {
-                                                                                            .Default(System.Void)
-                                                                                        };
-                                                                                        $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                        $Example._decList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                            .New System.ArraySegment`1[System.Byte](
+                                                                                                $array,
+                                                                                                0,
+                                                                                                $index),
+                                                                                            .Default(System.Decimal))
                                                                                     }
                                                                                 };
-                                                                                .Block(System.String $valueAsString) {
-                                                                                    .If (
-                                                                                        $reader.IsEmptyElement
-                                                                                    ) {
-                                                                                        $valueAsString = System.String.Empty
-                                                                                    } .Else {
-                                                                                        .Block() {
-                                                                                            .Call $reader.Read();
-                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                $valueAsString = ""
-                                                                                            } .Else {
-                                                                                                .Block() {
-                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                .Constant<System.Byte>(0),
-                                                                                                                $reader.NodeType,
-                                                                                                                $reader.LocalName,
-                                                                                                                $reader.Value)
-                                                                                                        } .Else {
-                                                                                                            .Default(System.Void)
-                                                                                                        }
-                                                                                                    } .Else {
-                                                                                                        .Default(System.Void)
-                                                                                                    };
-                                                                                                    $valueAsString = $reader.Value;
-                                                                                                    .Call $reader.Read();
-                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                            .Constant<System.Byte>(0),
-                                                                                                            $reader.NodeType,
-                                                                                                            $reader.LocalName,
-                                                                                                            $reader.Value)
-                                                                                                    } .Else {
-                                                                                                        .Default(System.Void)
-                                                                                                    }
-                                                                                                }
-                                                                                            }
-                                                                                        }
-                                                                                    };
-                                                                                    $Example._map_value = .Call System.Convert.ToDouble(
-                                                                                        $valueAsString,
-                                                                                        System.Globalization.CultureInfo.InvariantCulture)
-                                                                                };
-                                                                                ($Example._map).Item[$Example._map_key] = $Example._map_value
+                                                                                .Call ($Example._decList).Add($Example._decList_item)
                                                                             }
                                                                         } .Else {
                                                                             .Break end { }
                                                                         }
                                                                     }
-                                                                    .LabelTarget end:
+                                                                    .LabelTarget end:;
+                                                                    .Default(System.Void)
                                                                 }
                                                             };
                                                             $state = .Constant<System.Byte>(3)
@@ -427,7 +424,7 @@
                                                         .If (
                                                             .Call System.String.Equals(
                                                                 $reader.LocalName,
-                                                                "b",
+                                                                "_decimal",
                                                                 .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                 $reader.NamespaceURI,
                                                                 System.String.Empty,
@@ -442,12 +439,12 @@
                                                                     .Block(
                                                                         System.Int32 $index,
                                                                         System.Byte[] $array) {
-                                                                        .Block(System.Int32 $Example.b_count) {
-                                                                            $Example.b_count = 0;
+                                                                        .Block(System.Int32 $Example._decimal_count) {
+                                                                            $Example._decimal_count = 0;
                                                                             .Default(System.Void);
                                                                             .Block() {
                                                                                 $index = 0;
-                                                                                $array = .NewArray System.Byte[$Example.b_count]
+                                                                                $array = .NewArray System.Byte[$Example._decimal_count]
                                                                             }
                                                                         };
                                                                         .Loop  {
@@ -556,10 +553,12 @@
                                                                             }
                                                                         }
                                                                         .LabelTarget end:;
-                                                                        $Example.b = .New System.ArraySegment`1[System.Byte](
-                                                                            $array,
-                                                                            0,
-                                                                            $index)
+                                                                        $Example._decimal = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                            .New System.ArraySegment`1[System.Byte](
+                                                                                $array,
+                                                                                0,
+                                                                                $index),
+                                                                            .Default(System.Decimal))
                                                                     }
                                                                 };
                                                                 $state = .Constant<System.Byte>(3)
@@ -568,7 +567,7 @@
                                                             .If (
                                                                 .Call System.String.Equals(
                                                                     $reader.LocalName,
-                                                                    "_nestedVector",
+                                                                    "_map",
                                                                     .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                     $reader.NamespaceURI,
                                                                     System.String.Empty,
@@ -580,7 +579,9 @@
                                                                 .Block() {
                                                                     .Block(System.Boolean $isEmpty) {
                                                                         $isEmpty = $reader.IsEmptyElement;
-                                                                        .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
+                                                                        .Block(
+                                                                            System.Int32 $Example._map_key,
+                                                                            System.Double $Example._map_value) {
                                                                             .Default(System.Void);
                                                                             .Loop  {
                                                                                 .If (
@@ -627,169 +628,142 @@
                                                                                     }
                                                                                 ) {
                                                                                     .Block() {
-                                                                                        .Block() {
-                                                                                            $Example._nestedVector_item = .New ExpressionsTest.Nested();
-                                                                                            .Block() {
-                                                                                                .Call $reader.Read();
-                                                                                                .Block(
-                                                                                                    System.Byte $state,
-                                                                                                    Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
-                                                                                                    .Default(System.Void);
-                                                                                                    .Default(System.Void);
-                                                                                                    $state = .Constant<System.Byte>(1);
-                                                                                                    .Loop  {
-                                                                                                        .If (
-                                                                                                            !$reader.EOF && $state != .Constant<System.Byte>(4)
-                                                                                                        ) {
-                                                                                                            .Switch ($reader.NodeType) {
-                                                                                                            .Case (.Constant<System.Xml.XmlNodeType>(Element)):
-                                                                                                                    .Switch ($state) {
-                                                                                                                    .Case (.Constant<System.Byte>(1)):
-                                                                                                                            .Block() {
-                                                                                                                                .Block() {
-                                                                                                                                    .If (
-                                                                                                                                        $reader.IsEmptyElement
-                                                                                                                                    ) {
-                                                                                                                                        $state = .Constant<System.Byte>(4)
-                                                                                                                                    } .Else {
-                                                                                                                                        $state = .Constant<System.Byte>(2)
-                                                                                                                                    };
-                                                                                                                                    .Call $reader.Read()
-                                                                                                                                };
-                                                                                                                                .Default(System.Void)
-                                                                                                                            }
-                                                                                                                    .Case (.Constant<System.Byte>(2)):
-                                                                                                                            .Block() {
-                                                                                                                                .If (
-                                                                                                                                    .Call System.String.Equals(
-                                                                                                                                        $reader.LocalName,
-                                                                                                                                        "_double",
-                                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                                                                        $reader.NamespaceURI,
-                                                                                                                                        System.String.Empty,
-                                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                                                                        $reader.NamespaceURI,
-                                                                                                                                        "urn:ExpressionsTest.Nested",
-                                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                                                                                ) {
-                                                                                                                                    .Block() {
-                                                                                                                                        .Block(System.String $valueAsString) {
-                                                                                                                                            .If (
-                                                                                                                                                $reader.IsEmptyElement
-                                                                                                                                            ) {
-                                                                                                                                                $valueAsString = System.String.Empty
-                                                                                                                                            } .Else {
-                                                                                                                                                .Block() {
-                                                                                                                                                    .Call $reader.Read();
-                                                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                                        $valueAsString = ""
-                                                                                                                                                    } .Else {
-                                                                                                                                                        .Block() {
-                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                                        .Constant<System.Byte>(0),
-                                                                                                                                                                        $reader.NodeType,
-                                                                                                                                                                        $reader.LocalName,
-                                                                                                                                                                        $reader.Value)
-                                                                                                                                                                } .Else {
-                                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                                }
-                                                                                                                                                            } .Else {
-                                                                                                                                                                .Default(System.Void)
-                                                                                                                                                            };
-                                                                                                                                                            $valueAsString = $reader.Value;
-                                                                                                                                                            .Call $reader.Read();
-                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                                    .Constant<System.Byte>(0),
-                                                                                                                                                                    $reader.NodeType,
-                                                                                                                                                                    $reader.LocalName,
-                                                                                                                                                                    $reader.Value)
-                                                                                                                                                            } .Else {
-                                                                                                                                                                .Default(System.Void)
-                                                                                                                                                            }
-                                                                                                                                                        }
-                                                                                                                                                    }
-                                                                                                                                                }
-                                                                                                                                            };
-                                                                                                                                            $Example._nestedVector_item._double = .Call System.Convert.ToDouble(
-                                                                                                                                                $valueAsString,
-                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                                                        };
-                                                                                                                                        $state = .Constant<System.Byte>(3)
-                                                                                                                                    }
-                                                                                                                                } .Else {
-                                                                                                                                    .Block() {
-                                                                                                                                        .Call $reader.Skip();
-                                                                                                                                        $state = .Constant<System.Byte>(2)
-                                                                                                                                    }
-                                                                                                                                };
-                                                                                                                                .Default(System.Void)
-                                                                                                                            }
-                                                                                                                    .Case (.Constant<System.Byte>(3)):
-                                                                                                                            .Block() {
-                                                                                                                                .Call $reader.Read();
-                                                                                                                                $state = .Constant<System.Byte>(2);
-                                                                                                                                .Default(System.Void)
-                                                                                                                            }
-                                                                                                                    .Default:
-                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                $state,
-                                                                                                                                $reader.NodeType,
-                                                                                                                                $reader.LocalName,
-                                                                                                                                $reader.Value)
-                                                                                                                    }
-                                                                                                            .Case (.Constant<System.Xml.XmlNodeType>(EndElement)):
-                                                                                                                    .Switch ($state) {
-                                                                                                                    .Case (.Constant<System.Byte>(3)):
-                                                                                                                            .Block() {
-                                                                                                                                .Call $reader.Read();
-                                                                                                                                $state = .Constant<System.Byte>(2);
-                                                                                                                                .Default(System.Void)
-                                                                                                                            }
-                                                                                                                    .Case (.Constant<System.Byte>(2)):
-                                                                                                                            .Block() {
-                                                                                                                                .Call $reader.Read();
-                                                                                                                                $state = .Constant<System.Byte>(4);
-                                                                                                                                .Default(System.Void)
-                                                                                                                            }
-                                                                                                                    .Default:
-                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                $state,
-                                                                                                                                $reader.NodeType,
-                                                                                                                                $reader.LocalName,
-                                                                                                                                $reader.Value)
-                                                                                                                    }
-                                                                                                            .Case (.Constant<System.Xml.XmlNodeType>(Comment)):
-                                                                                                            .Case (.Constant<System.Xml.XmlNodeType>(Text)):
-                                                                                                            .Case (.Constant<System.Xml.XmlNodeType>(Whitespace)):
-                                                                                                            .Case (.Constant<System.Xml.XmlNodeType>(XmlDeclaration)):
-                                                                                                                    .Block() {
-                                                                                                                        .Call $reader.Read();
-                                                                                                                        .Default(System.Void)
-                                                                                                                    }
-                                                                                                            .Default:
-                                                                                                                    .Invoke (.Lambda #Lambda3<System.Action`1[System.Xml.XmlNodeType]>)($reader.NodeType)
+                                                                                        .Block(System.String $valueAsString) {
+                                                                                            .If (
+                                                                                                $reader.IsEmptyElement
+                                                                                            ) {
+                                                                                                $valueAsString = System.String.Empty
+                                                                                            } .Else {
+                                                                                                .Block() {
+                                                                                                    .Call $reader.Read();
+                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                        $valueAsString = ""
+                                                                                                    } .Else {
+                                                                                                        .Block() {
+                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                        $reader.NodeType,
+                                                                                                                        $reader.LocalName,
+                                                                                                                        $reader.Value)
+                                                                                                                } .Else {
+                                                                                                                    .Default(System.Void)
+                                                                                                                }
+                                                                                                            } .Else {
+                                                                                                                .Default(System.Void)
+                                                                                                            };
+                                                                                                            $valueAsString = $reader.Value;
+                                                                                                            .Call $reader.Read();
+                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                    $reader.NodeType,
+                                                                                                                    $reader.LocalName,
+                                                                                                                    $reader.Value)
+                                                                                                            } .Else {
+                                                                                                                .Default(System.Void)
                                                                                                             }
-                                                                                                        } .Else {
-                                                                                                            .Break endStateMachineLoop { }
                                                                                                         }
                                                                                                     }
-                                                                                                    .LabelTarget endStateMachineLoop:;
-                                                                                                    .Default(System.Void);
-                                                                                                    .Default(System.Void)
                                                                                                 }
+                                                                                            };
+                                                                                            $Example._map_key = .Call System.Convert.ToInt32(
+                                                                                                $valueAsString,
+                                                                                                System.Globalization.CultureInfo.InvariantCulture)
+                                                                                        };
+                                                                                        .If (
+                                                                                            $isEmpty
+                                                                                        ) {
+                                                                                            False
+                                                                                        } .Else {
+                                                                                            .Block() {
+                                                                                                .Loop  {
+                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                        .Call $reader.Read()
+                                                                                                    } .Else {
+                                                                                                        .Break end { }
+                                                                                                    }
+                                                                                                }
+                                                                                                .LabelTarget end:;
+                                                                                                .Loop  {
+                                                                                                    .Block() {
+                                                                                                        .Call $reader.Read();
+                                                                                                        .If (
+                                                                                                            !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                        ) {
+                                                                                                            .Break end { }
+                                                                                                        } .Else {
+                                                                                                            .Default(System.Void)
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                                .LabelTarget end:;
+                                                                                                .If (
+                                                                                                    $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                ) {
+                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                        .Constant<System.Byte>(0),
+                                                                                                        $reader.NodeType,
+                                                                                                        $reader.LocalName,
+                                                                                                        $reader.Value)
+                                                                                                } .Else {
+                                                                                                    .Default(System.Void)
+                                                                                                };
+                                                                                                $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
                                                                                             }
                                                                                         };
-                                                                                        .Call ($Example._nestedVector).Add($Example._nestedVector_item)
+                                                                                        .Block(System.String $valueAsString) {
+                                                                                            .If (
+                                                                                                $reader.IsEmptyElement
+                                                                                            ) {
+                                                                                                $valueAsString = System.String.Empty
+                                                                                            } .Else {
+                                                                                                .Block() {
+                                                                                                    .Call $reader.Read();
+                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                        $valueAsString = ""
+                                                                                                    } .Else {
+                                                                                                        .Block() {
+                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                        $reader.NodeType,
+                                                                                                                        $reader.LocalName,
+                                                                                                                        $reader.Value)
+                                                                                                                } .Else {
+                                                                                                                    .Default(System.Void)
+                                                                                                                }
+                                                                                                            } .Else {
+                                                                                                                .Default(System.Void)
+                                                                                                            };
+                                                                                                            $valueAsString = $reader.Value;
+                                                                                                            .Call $reader.Read();
+                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                    $reader.NodeType,
+                                                                                                                    $reader.LocalName,
+                                                                                                                    $reader.Value)
+                                                                                                            } .Else {
+                                                                                                                .Default(System.Void)
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            };
+                                                                                            $Example._map_value = .Call System.Convert.ToDouble(
+                                                                                                $valueAsString,
+                                                                                                System.Globalization.CultureInfo.InvariantCulture)
+                                                                                        };
+                                                                                        ($Example._map).Item[$Example._map_key] = $Example._map_value
                                                                                     }
                                                                                 } .Else {
                                                                                     .Break end { }
                                                                                 }
                                                                             }
-                                                                            .LabelTarget end:;
-                                                                            .Default(System.Void)
+                                                                            .LabelTarget end:
                                                                         }
                                                                     };
                                                                     $state = .Constant<System.Byte>(3)
@@ -798,7 +772,7 @@
                                                                 .If (
                                                                     .Call System.String.Equals(
                                                                         $reader.LocalName,
-                                                                        "_int32Vector",
+                                                                        "b",
                                                                         .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                         $reader.NamespaceURI,
                                                                         System.String.Empty,
@@ -810,11 +784,16 @@
                                                                     .Block() {
                                                                         .Block(System.Boolean $isEmpty) {
                                                                             $isEmpty = $reader.IsEmptyElement;
-                                                                            .Block(System.Int32 $Example._int32Vector_item) {
-                                                                                .Block(System.Int32 $Example._int32Vector_count) {
-                                                                                    $Example._int32Vector_count = 0;
+                                                                            .Block(
+                                                                                System.Int32 $index,
+                                                                                System.Byte[] $array) {
+                                                                                .Block(System.Int32 $Example.b_count) {
+                                                                                    $Example.b_count = 0;
                                                                                     .Default(System.Void);
-                                                                                    ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                                                    .Block() {
+                                                                                        $index = 0;
+                                                                                        $array = .NewArray System.Byte[$Example.b_count]
+                                                                                    }
                                                                                 };
                                                                                 .Loop  {
                                                                                     .If (
@@ -861,6 +840,17 @@
                                                                                         }
                                                                                     ) {
                                                                                         .Block() {
+                                                                                            .If ($index >= $array.Length) {
+                                                                                                .Call System.Array.Resize(
+                                                                                                    $array,
+                                                                                                    .If ($index > 512) {
+                                                                                                        $index * 2
+                                                                                                    } .Else {
+                                                                                                        1024
+                                                                                                    })
+                                                                                            } .Else {
+                                                                                                .Default(System.Void)
+                                                                                            };
                                                                                             .Block(System.String $valueAsString) {
                                                                                                 .If (
                                                                                                     $reader.IsEmptyElement
@@ -901,18 +891,20 @@
                                                                                                         }
                                                                                                     }
                                                                                                 };
-                                                                                                $Example._int32Vector_item = .Call System.Convert.ToInt32(
+                                                                                                $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
                                                                                                     $valueAsString,
                                                                                                     System.Globalization.CultureInfo.InvariantCulture)
-                                                                                            };
-                                                                                            .Call ($Example._int32Vector).Add($Example._int32Vector_item)
+                                                                                            }
                                                                                         }
                                                                                     } .Else {
                                                                                         .Break end { }
                                                                                     }
                                                                                 }
                                                                                 .LabelTarget end:;
-                                                                                .Default(System.Void)
+                                                                                $Example.b = .New System.ArraySegment`1[System.Byte](
+                                                                                    $array,
+                                                                                    0,
+                                                                                    $index)
                                                                             }
                                                                         };
                                                                         $state = .Constant<System.Byte>(3)
@@ -921,7 +913,7 @@
                                                                     .If (
                                                                         .Call System.String.Equals(
                                                                             $reader.LocalName,
-                                                                            "guid",
+                                                                            "_nestedVector",
                                                                             .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                             $reader.NamespaceURI,
                                                                             System.String.Empty,
@@ -931,162 +923,395 @@
                                                                             .Constant<System.StringComparison>(OrdinalIgnoreCase)))
                                                                     ) {
                                                                         .Block() {
+                                                                            .Block(System.Boolean $isEmpty) {
+                                                                                $isEmpty = $reader.IsEmptyElement;
+                                                                                .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
+                                                                                    .Default(System.Void);
+                                                                                    .Loop  {
+                                                                                        .If (
+                                                                                            .If (
+                                                                                                $isEmpty
+                                                                                            ) {
+                                                                                                False
+                                                                                            } .Else {
+                                                                                                .Block() {
+                                                                                                    .Loop  {
+                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                            .Call $reader.Read()
+                                                                                                        } .Else {
+                                                                                                            .Break end { }
+                                                                                                        }
+                                                                                                    }
+                                                                                                    .LabelTarget end:;
+                                                                                                    .Loop  {
+                                                                                                        .Block() {
+                                                                                                            .Call $reader.Read();
+                                                                                                            .If (
+                                                                                                                !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                            ) {
+                                                                                                                .Break end { }
+                                                                                                            } .Else {
+                                                                                                                .Default(System.Void)
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                    .LabelTarget end:;
+                                                                                                    .If (
+                                                                                                        $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                    ) {
+                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                            .Constant<System.Byte>(0),
+                                                                                                            $reader.NodeType,
+                                                                                                            $reader.LocalName,
+                                                                                                            $reader.Value)
+                                                                                                    } .Else {
+                                                                                                        .Default(System.Void)
+                                                                                                    };
+                                                                                                    $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                }
+                                                                                            }
+                                                                                        ) {
+                                                                                            .Block() {
+                                                                                                .Block() {
+                                                                                                    $Example._nestedVector_item = .New ExpressionsTest.Nested();
+                                                                                                    .Block() {
+                                                                                                        .Call $reader.Read();
+                                                                                                        .Block(
+                                                                                                            System.Byte $state,
+                                                                                                            Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
+                                                                                                            .Default(System.Void);
+                                                                                                            .Default(System.Void);
+                                                                                                            $state = .Constant<System.Byte>(1);
+                                                                                                            .Loop  {
+                                                                                                                .If (
+                                                                                                                    !$reader.EOF && $state != .Constant<System.Byte>(4)
+                                                                                                                ) {
+                                                                                                                    .Switch ($reader.NodeType) {
+                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(Element)):
+                                                                                                                            .Switch ($state) {
+                                                                                                                            .Case (.Constant<System.Byte>(1)):
+                                                                                                                                    .Block() {
+                                                                                                                                        .Block() {
+                                                                                                                                            .If (
+                                                                                                                                                $reader.IsEmptyElement
+                                                                                                                                            ) {
+                                                                                                                                                $state = .Constant<System.Byte>(4)
+                                                                                                                                            } .Else {
+                                                                                                                                                $state = .Constant<System.Byte>(2)
+                                                                                                                                            };
+                                                                                                                                            .Call $reader.Read()
+                                                                                                                                        };
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                            .Case (.Constant<System.Byte>(2)):
+                                                                                                                                    .Block() {
+                                                                                                                                        .If (
+                                                                                                                                            .Call System.String.Equals(
+                                                                                                                                                $reader.LocalName,
+                                                                                                                                                "_double",
+                                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                                                $reader.NamespaceURI,
+                                                                                                                                                System.String.Empty,
+                                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                                                $reader.NamespaceURI,
+                                                                                                                                                "urn:ExpressionsTest.Nested",
+                                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                                        ) {
+                                                                                                                                            .Block() {
+                                                                                                                                                .Block(System.String $valueAsString) {
+                                                                                                                                                    .If (
+                                                                                                                                                        $reader.IsEmptyElement
+                                                                                                                                                    ) {
+                                                                                                                                                        $valueAsString = System.String.Empty
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Block() {
+                                                                                                                                                            .Call $reader.Read();
+                                                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                $valueAsString = ""
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Block() {
+                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                                                $reader.NodeType,
+                                                                                                                                                                                $reader.LocalName,
+                                                                                                                                                                                $reader.Value)
+                                                                                                                                                                        } .Else {
+                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                        }
+                                                                                                                                                                    } .Else {
+                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                    };
+                                                                                                                                                                    $valueAsString = $reader.Value;
+                                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                                            $reader.Value)
+                                                                                                                                                                    } .Else {
+                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    };
+                                                                                                                                                    $Example._nestedVector_item._double = .Call System.Convert.ToDouble(
+                                                                                                                                                        $valueAsString,
+                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                                };
+                                                                                                                                                $state = .Constant<System.Byte>(3)
+                                                                                                                                            }
+                                                                                                                                        } .Else {
+                                                                                                                                            .Block() {
+                                                                                                                                                .Call $reader.Skip();
+                                                                                                                                                $state = .Constant<System.Byte>(2)
+                                                                                                                                            }
+                                                                                                                                        };
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                            .Case (.Constant<System.Byte>(3)):
+                                                                                                                                    .Block() {
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        $state = .Constant<System.Byte>(2);
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                            .Default:
+                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                        $state,
+                                                                                                                                        $reader.NodeType,
+                                                                                                                                        $reader.LocalName,
+                                                                                                                                        $reader.Value)
+                                                                                                                            }
+                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(EndElement)):
+                                                                                                                            .Switch ($state) {
+                                                                                                                            .Case (.Constant<System.Byte>(3)):
+                                                                                                                                    .Block() {
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        $state = .Constant<System.Byte>(2);
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                            .Case (.Constant<System.Byte>(2)):
+                                                                                                                                    .Block() {
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        $state = .Constant<System.Byte>(4);
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                            .Default:
+                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                        $state,
+                                                                                                                                        $reader.NodeType,
+                                                                                                                                        $reader.LocalName,
+                                                                                                                                        $reader.Value)
+                                                                                                                            }
+                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(Comment)):
+                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(Text)):
+                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(Whitespace)):
+                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(XmlDeclaration)):
+                                                                                                                            .Block() {
+                                                                                                                                .Call $reader.Read();
+                                                                                                                                .Default(System.Void)
+                                                                                                                            }
+                                                                                                                    .Default:
+                                                                                                                            .Invoke (.Lambda #Lambda3<System.Action`1[System.Xml.XmlNodeType]>)($reader.NodeType)
+                                                                                                                    }
+                                                                                                                } .Else {
+                                                                                                                    .Break endStateMachineLoop { }
+                                                                                                                }
+                                                                                                            }
+                                                                                                            .LabelTarget endStateMachineLoop:;
+                                                                                                            .Default(System.Void);
+                                                                                                            .Default(System.Void)
+                                                                                                        }
+                                                                                                    }
+                                                                                                };
+                                                                                                .Call ($Example._nestedVector).Add($Example._nestedVector_item)
+                                                                                            }
+                                                                                        } .Else {
+                                                                                            .Break end { }
+                                                                                        }
+                                                                                    }
+                                                                                    .LabelTarget end:;
+                                                                                    .Default(System.Void)
+                                                                                }
+                                                                            };
+                                                                            $state = .Constant<System.Byte>(3)
+                                                                        }
+                                                                    } .Else {
+                                                                        .If (
+                                                                            .Call System.String.Equals(
+                                                                                $reader.LocalName,
+                                                                                "_int32Vector",
+                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                $reader.NamespaceURI,
+                                                                                System.String.Empty,
+                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                $reader.NamespaceURI,
+                                                                                "urn:ExpressionsTest.Example",
+                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                        ) {
                                                                             .Block() {
-                                                                                .Block() {
-                                                                                    .Call $reader.Read();
-                                                                                    .Block(
-                                                                                        System.Byte $state,
-                                                                                        Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
-                                                                                        .Default(System.Void);
-                                                                                        .Default(System.Void);
-                                                                                        $state = .Constant<System.Byte>(1);
+                                                                                .Block(System.Boolean $isEmpty) {
+                                                                                    $isEmpty = $reader.IsEmptyElement;
+                                                                                    .Block(System.Int32 $Example._int32Vector_item) {
+                                                                                        .Block(System.Int32 $Example._int32Vector_count) {
+                                                                                            $Example._int32Vector_count = 0;
+                                                                                            .Default(System.Void);
+                                                                                            ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                                                        };
                                                                                         .Loop  {
                                                                                             .If (
-                                                                                                !$reader.EOF && $state != .Constant<System.Byte>(4)
-                                                                                            ) {
-                                                                                                .Switch ($reader.NodeType) {
-                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(Element)):
-                                                                                                        .Switch ($state) {
-                                                                                                        .Case (.Constant<System.Byte>(1)):
-                                                                                                                .Block() {
-                                                                                                                    .Block() {
-                                                                                                                        .If (
-                                                                                                                            $reader.IsEmptyElement
-                                                                                                                        ) {
-                                                                                                                            $state = .Constant<System.Byte>(4)
-                                                                                                                        } .Else {
-                                                                                                                            $state = .Constant<System.Byte>(2)
-                                                                                                                        };
-                                                                                                                        .Call $reader.Read()
-                                                                                                                    };
+                                                                                                .If (
+                                                                                                    $isEmpty
+                                                                                                ) {
+                                                                                                    False
+                                                                                                } .Else {
+                                                                                                    .Block() {
+                                                                                                        .Loop  {
+                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                .Call $reader.Read()
+                                                                                                            } .Else {
+                                                                                                                .Break end { }
+                                                                                                            }
+                                                                                                        }
+                                                                                                        .LabelTarget end:;
+                                                                                                        .Loop  {
+                                                                                                            .Block() {
+                                                                                                                .Call $reader.Read();
+                                                                                                                .If (
+                                                                                                                    !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                ) {
+                                                                                                                    .Break end { }
+                                                                                                                } .Else {
                                                                                                                     .Default(System.Void)
                                                                                                                 }
-                                                                                                        .Case (.Constant<System.Byte>(2)):
-                                                                                                                .Block() {
-                                                                                                                    .If (
-                                                                                                                        .Call System.String.Equals(
-                                                                                                                            $reader.LocalName,
-                                                                                                                            "Data4",
-                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                                                            $reader.NamespaceURI,
-                                                                                                                            System.String.Empty,
-                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                                                            $reader.NamespaceURI,
-                                                                                                                            "urn:bond.GUID",
-                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                                                                    ) {
+                                                                                                            }
+                                                                                                        }
+                                                                                                        .LabelTarget end:;
+                                                                                                        .If (
+                                                                                                            $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                        ) {
+                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                $reader.NodeType,
+                                                                                                                $reader.LocalName,
+                                                                                                                $reader.Value)
+                                                                                                        } .Else {
+                                                                                                            .Default(System.Void)
+                                                                                                        };
+                                                                                                        $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                    }
+                                                                                                }
+                                                                                            ) {
+                                                                                                .Block() {
+                                                                                                    .Block(System.String $valueAsString) {
+                                                                                                        .If (
+                                                                                                            $reader.IsEmptyElement
+                                                                                                        ) {
+                                                                                                            $valueAsString = System.String.Empty
+                                                                                                        } .Else {
+                                                                                                            .Block() {
+                                                                                                                .Call $reader.Read();
+                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                    $valueAsString = ""
+                                                                                                                } .Else {
+                                                                                                                    .Block() {
+                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                    $reader.NodeType,
+                                                                                                                                    $reader.LocalName,
+                                                                                                                                    $reader.Value)
+                                                                                                                            } .Else {
+                                                                                                                                .Default(System.Void)
+                                                                                                                            }
+                                                                                                                        } .Else {
+                                                                                                                            .Default(System.Void)
+                                                                                                                        };
+                                                                                                                        $valueAsString = $reader.Value;
+                                                                                                                        .Call $reader.Read();
+                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                $reader.NodeType,
+                                                                                                                                $reader.LocalName,
+                                                                                                                                $reader.Value)
+                                                                                                                        } .Else {
+                                                                                                                            .Default(System.Void)
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        };
+                                                                                                        $Example._int32Vector_item = .Call System.Convert.ToInt32(
+                                                                                                            $valueAsString,
+                                                                                                            System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                    };
+                                                                                                    .Call ($Example._int32Vector).Add($Example._int32Vector_item)
+                                                                                                }
+                                                                                            } .Else {
+                                                                                                .Break end { }
+                                                                                            }
+                                                                                        }
+                                                                                        .LabelTarget end:;
+                                                                                        .Default(System.Void)
+                                                                                    }
+                                                                                };
+                                                                                $state = .Constant<System.Byte>(3)
+                                                                            }
+                                                                        } .Else {
+                                                                            .If (
+                                                                                .Call System.String.Equals(
+                                                                                    $reader.LocalName,
+                                                                                    "guid",
+                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                    $reader.NamespaceURI,
+                                                                                    System.String.Empty,
+                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                    $reader.NamespaceURI,
+                                                                                    "urn:ExpressionsTest.Example",
+                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                            ) {
+                                                                                .Block() {
+                                                                                    .Block() {
+                                                                                        .Block() {
+                                                                                            .Call $reader.Read();
+                                                                                            .Block(
+                                                                                                System.Byte $state,
+                                                                                                Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
+                                                                                                .Default(System.Void);
+                                                                                                .Default(System.Void);
+                                                                                                $state = .Constant<System.Byte>(1);
+                                                                                                .Loop  {
+                                                                                                    .If (
+                                                                                                        !$reader.EOF && $state != .Constant<System.Byte>(4)
+                                                                                                    ) {
+                                                                                                        .Switch ($reader.NodeType) {
+                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(Element)):
+                                                                                                                .Switch ($state) {
+                                                                                                                .Case (.Constant<System.Byte>(1)):
                                                                                                                         .Block() {
-                                                                                                                            .Block(System.String $valueAsString) {
+                                                                                                                            .Block() {
                                                                                                                                 .If (
                                                                                                                                     $reader.IsEmptyElement
                                                                                                                                 ) {
-                                                                                                                                    $valueAsString = System.String.Empty
+                                                                                                                                    $state = .Constant<System.Byte>(4)
                                                                                                                                 } .Else {
-                                                                                                                                    .Block() {
-                                                                                                                                        .Call $reader.Read();
-                                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                            $valueAsString = ""
-                                                                                                                                        } .Else {
-                                                                                                                                            .Block() {
-                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                            .Constant<System.Byte>(0),
-                                                                                                                                                            $reader.NodeType,
-                                                                                                                                                            $reader.LocalName,
-                                                                                                                                                            $reader.Value)
-                                                                                                                                                    } .Else {
-                                                                                                                                                        .Default(System.Void)
-                                                                                                                                                    }
-                                                                                                                                                } .Else {
-                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                };
-                                                                                                                                                $valueAsString = $reader.Value;
-                                                                                                                                                .Call $reader.Read();
-                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                        .Constant<System.Byte>(0),
-                                                                                                                                                        $reader.NodeType,
-                                                                                                                                                        $reader.LocalName,
-                                                                                                                                                        $reader.Value)
-                                                                                                                                                } .Else {
-                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                }
-                                                                                                                                            }
-                                                                                                                                        }
-                                                                                                                                    }
+                                                                                                                                    $state = .Constant<System.Byte>(2)
                                                                                                                                 };
-                                                                                                                                ($Example.guid).Data4 = .Call System.Convert.ToUInt64(
-                                                                                                                                    $valueAsString,
-                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                .Call $reader.Read()
                                                                                                                             };
-                                                                                                                            $state = .Constant<System.Byte>(3)
+                                                                                                                            .Default(System.Void)
                                                                                                                         }
-                                                                                                                    } .Else {
-                                                                                                                        .If (
-                                                                                                                            .Call System.String.Equals(
-                                                                                                                                $reader.LocalName,
-                                                                                                                                "Data3",
-                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                                                                $reader.NamespaceURI,
-                                                                                                                                System.String.Empty,
-                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                                                                $reader.NamespaceURI,
-                                                                                                                                "urn:bond.GUID",
-                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                                                                        ) {
-                                                                                                                            .Block() {
-                                                                                                                                .Block(System.String $valueAsString) {
-                                                                                                                                    .If (
-                                                                                                                                        $reader.IsEmptyElement
-                                                                                                                                    ) {
-                                                                                                                                        $valueAsString = System.String.Empty
-                                                                                                                                    } .Else {
-                                                                                                                                        .Block() {
-                                                                                                                                            .Call $reader.Read();
-                                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                                $valueAsString = ""
-                                                                                                                                            } .Else {
-                                                                                                                                                .Block() {
-                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                                .Constant<System.Byte>(0),
-                                                                                                                                                                $reader.NodeType,
-                                                                                                                                                                $reader.LocalName,
-                                                                                                                                                                $reader.Value)
-                                                                                                                                                        } .Else {
-                                                                                                                                                            .Default(System.Void)
-                                                                                                                                                        }
-                                                                                                                                                    } .Else {
-                                                                                                                                                        .Default(System.Void)
-                                                                                                                                                    };
-                                                                                                                                                    $valueAsString = $reader.Value;
-                                                                                                                                                    .Call $reader.Read();
-                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                            .Constant<System.Byte>(0),
-                                                                                                                                                            $reader.NodeType,
-                                                                                                                                                            $reader.LocalName,
-                                                                                                                                                            $reader.Value)
-                                                                                                                                                    } .Else {
-                                                                                                                                                        .Default(System.Void)
-                                                                                                                                                    }
-                                                                                                                                                }
-                                                                                                                                            }
-                                                                                                                                        }
-                                                                                                                                    };
-                                                                                                                                    ($Example.guid).Data3 = .Call System.Convert.ToUInt16(
-                                                                                                                                        $valueAsString,
-                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                                                };
-                                                                                                                                $state = .Constant<System.Byte>(3)
-                                                                                                                            }
-                                                                                                                        } .Else {
+                                                                                                                .Case (.Constant<System.Byte>(2)):
+                                                                                                                        .Block() {
                                                                                                                             .If (
                                                                                                                                 .Call System.String.Equals(
                                                                                                                                     $reader.LocalName,
-                                                                                                                                    "Data2",
+                                                                                                                                    "Data4",
                                                                                                                                     .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                                                                     $reader.NamespaceURI,
                                                                                                                                     System.String.Empty,
@@ -1136,7 +1361,7 @@
                                                                                                                                                 }
                                                                                                                                             }
                                                                                                                                         };
-                                                                                                                                        ($Example.guid).Data2 = .Call System.Convert.ToUInt16(
+                                                                                                                                        ($Example.guid).Data4 = .Call System.Convert.ToUInt64(
                                                                                                                                             $valueAsString,
                                                                                                                                             System.Globalization.CultureInfo.InvariantCulture)
                                                                                                                                     };
@@ -1146,7 +1371,7 @@
                                                                                                                                 .If (
                                                                                                                                     .Call System.String.Equals(
                                                                                                                                         $reader.LocalName,
-                                                                                                                                        "Data1",
+                                                                                                                                        "Data3",
                                                                                                                                         .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                                                                         $reader.NamespaceURI,
                                                                                                                                         System.String.Empty,
@@ -1196,208 +1421,205 @@
                                                                                                                                                     }
                                                                                                                                                 }
                                                                                                                                             };
-                                                                                                                                            ($Example.guid).Data1 = .Call System.Convert.ToUInt32(
+                                                                                                                                            ($Example.guid).Data3 = .Call System.Convert.ToUInt16(
                                                                                                                                                 $valueAsString,
                                                                                                                                                 System.Globalization.CultureInfo.InvariantCulture)
                                                                                                                                         };
                                                                                                                                         $state = .Constant<System.Byte>(3)
                                                                                                                                     }
                                                                                                                                 } .Else {
-                                                                                                                                    .Block() {
-                                                                                                                                        .Call $reader.Skip();
-                                                                                                                                        $state = .Constant<System.Byte>(2)
+                                                                                                                                    .If (
+                                                                                                                                        .Call System.String.Equals(
+                                                                                                                                            $reader.LocalName,
+                                                                                                                                            "Data2",
+                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                                            $reader.NamespaceURI,
+                                                                                                                                            System.String.Empty,
+                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                                            $reader.NamespaceURI,
+                                                                                                                                            "urn:bond.GUID",
+                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                                    ) {
+                                                                                                                                        .Block() {
+                                                                                                                                            .Block(System.String $valueAsString) {
+                                                                                                                                                .If (
+                                                                                                                                                    $reader.IsEmptyElement
+                                                                                                                                                ) {
+                                                                                                                                                    $valueAsString = System.String.Empty
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                            $valueAsString = ""
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Block() {
+                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                                            $reader.Value)
+                                                                                                                                                                    } .Else {
+                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                    }
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                };
+                                                                                                                                                                $valueAsString = $reader.Value;
+                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                                        $reader.Value)
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                };
+                                                                                                                                                ($Example.guid).Data2 = .Call System.Convert.ToUInt16(
+                                                                                                                                                    $valueAsString,
+                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                            };
+                                                                                                                                            $state = .Constant<System.Byte>(3)
+                                                                                                                                        }
+                                                                                                                                    } .Else {
+                                                                                                                                        .If (
+                                                                                                                                            .Call System.String.Equals(
+                                                                                                                                                $reader.LocalName,
+                                                                                                                                                "Data1",
+                                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                                                $reader.NamespaceURI,
+                                                                                                                                                System.String.Empty,
+                                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                                                $reader.NamespaceURI,
+                                                                                                                                                "urn:bond.GUID",
+                                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                                        ) {
+                                                                                                                                            .Block() {
+                                                                                                                                                .Block(System.String $valueAsString) {
+                                                                                                                                                    .If (
+                                                                                                                                                        $reader.IsEmptyElement
+                                                                                                                                                    ) {
+                                                                                                                                                        $valueAsString = System.String.Empty
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Block() {
+                                                                                                                                                            .Call $reader.Read();
+                                                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                $valueAsString = ""
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Block() {
+                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                                                $reader.NodeType,
+                                                                                                                                                                                $reader.LocalName,
+                                                                                                                                                                                $reader.Value)
+                                                                                                                                                                        } .Else {
+                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                        }
+                                                                                                                                                                    } .Else {
+                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                    };
+                                                                                                                                                                    $valueAsString = $reader.Value;
+                                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                                            $reader.Value)
+                                                                                                                                                                    } .Else {
+                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    };
+                                                                                                                                                    ($Example.guid).Data1 = .Call System.Convert.ToUInt32(
+                                                                                                                                                        $valueAsString,
+                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                                };
+                                                                                                                                                $state = .Constant<System.Byte>(3)
+                                                                                                                                            }
+                                                                                                                                        } .Else {
+                                                                                                                                            .Block() {
+                                                                                                                                                .Call $reader.Skip();
+                                                                                                                                                $state = .Constant<System.Byte>(2)
+                                                                                                                                            }
+                                                                                                                                        }
                                                                                                                                     }
                                                                                                                                 }
-                                                                                                                            }
+                                                                                                                            };
+                                                                                                                            .Default(System.Void)
                                                                                                                         }
-                                                                                                                    };
-                                                                                                                    .Default(System.Void)
+                                                                                                                .Case (.Constant<System.Byte>(3)):
+                                                                                                                        .Block() {
+                                                                                                                            .Call $reader.Read();
+                                                                                                                            $state = .Constant<System.Byte>(2);
+                                                                                                                            .Default(System.Void)
+                                                                                                                        }
+                                                                                                                .Default:
+                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                            $state,
+                                                                                                                            $reader.NodeType,
+                                                                                                                            $reader.LocalName,
+                                                                                                                            $reader.Value)
                                                                                                                 }
-                                                                                                        .Case (.Constant<System.Byte>(3)):
+                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(EndElement)):
+                                                                                                                .Switch ($state) {
+                                                                                                                .Case (.Constant<System.Byte>(3)):
+                                                                                                                        .Block() {
+                                                                                                                            .Call $reader.Read();
+                                                                                                                            $state = .Constant<System.Byte>(2);
+                                                                                                                            .Default(System.Void)
+                                                                                                                        }
+                                                                                                                .Case (.Constant<System.Byte>(2)):
+                                                                                                                        .Block() {
+                                                                                                                            .Call $reader.Read();
+                                                                                                                            $state = .Constant<System.Byte>(4);
+                                                                                                                            .Default(System.Void)
+                                                                                                                        }
+                                                                                                                .Default:
+                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                            $state,
+                                                                                                                            $reader.NodeType,
+                                                                                                                            $reader.LocalName,
+                                                                                                                            $reader.Value)
+                                                                                                                }
+                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(Comment)):
+                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(Text)):
+                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(Whitespace)):
+                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(XmlDeclaration)):
                                                                                                                 .Block() {
                                                                                                                     .Call $reader.Read();
-                                                                                                                    $state = .Constant<System.Byte>(2);
                                                                                                                     .Default(System.Void)
                                                                                                                 }
                                                                                                         .Default:
-                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                    $state,
-                                                                                                                    $reader.NodeType,
-                                                                                                                    $reader.LocalName,
-                                                                                                                    $reader.Value)
-                                                                                                        }
-                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(EndElement)):
-                                                                                                        .Switch ($state) {
-                                                                                                        .Case (.Constant<System.Byte>(3)):
-                                                                                                                .Block() {
-                                                                                                                    .Call $reader.Read();
-                                                                                                                    $state = .Constant<System.Byte>(2);
-                                                                                                                    .Default(System.Void)
-                                                                                                                }
-                                                                                                        .Case (.Constant<System.Byte>(2)):
-                                                                                                                .Block() {
-                                                                                                                    .Call $reader.Read();
-                                                                                                                    $state = .Constant<System.Byte>(4);
-                                                                                                                    .Default(System.Void)
-                                                                                                                }
-                                                                                                        .Default:
-                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                    $state,
-                                                                                                                    $reader.NodeType,
-                                                                                                                    $reader.LocalName,
-                                                                                                                    $reader.Value)
-                                                                                                        }
-                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(Comment)):
-                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(Text)):
-                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(Whitespace)):
-                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(XmlDeclaration)):
-                                                                                                        .Block() {
-                                                                                                            .Call $reader.Read();
-                                                                                                            .Default(System.Void)
-                                                                                                        }
-                                                                                                .Default:
-                                                                                                        .Invoke (.Lambda #Lambda3<System.Action`1[System.Xml.XmlNodeType]>)($reader.NodeType)
-                                                                                                }
-                                                                                            } .Else {
-                                                                                                .Break endStateMachineLoop { }
-                                                                                            }
-                                                                                        }
-                                                                                        .LabelTarget endStateMachineLoop:;
-                                                                                        .Default(System.Void);
-                                                                                        .Default(System.Void)
-                                                                                    }
-                                                                                }
-                                                                            };
-                                                                            $state = .Constant<System.Byte>(3)
-                                                                        }
-                                                                    } .Else {
-                                                                        .If (
-                                                                            .Call System.String.Equals(
-                                                                                $reader.LocalName,
-                                                                                "_double",
-                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                $reader.NamespaceURI,
-                                                                                System.String.Empty,
-                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                $reader.NamespaceURI,
-                                                                                "urn:ExpressionsTest.Example",
-                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                        ) {
-                                                                            .Block() {
-                                                                                .Block(System.String $valueAsString) {
-                                                                                    .If (
-                                                                                        $reader.IsEmptyElement
-                                                                                    ) {
-                                                                                        $valueAsString = System.String.Empty
-                                                                                    } .Else {
-                                                                                        .Block() {
-                                                                                            .Call $reader.Read();
-                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                $valueAsString = ""
-                                                                                            } .Else {
-                                                                                                .Block() {
-                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                .Constant<System.Byte>(0),
-                                                                                                                $reader.NodeType,
-                                                                                                                $reader.LocalName,
-                                                                                                                $reader.Value)
-                                                                                                        } .Else {
-                                                                                                            .Default(System.Void)
+                                                                                                                .Invoke (.Lambda #Lambda3<System.Action`1[System.Xml.XmlNodeType]>)($reader.NodeType)
                                                                                                         }
                                                                                                     } .Else {
-                                                                                                        .Default(System.Void)
-                                                                                                    };
-                                                                                                    $valueAsString = $reader.Value;
-                                                                                                    .Call $reader.Read();
-                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                            .Constant<System.Byte>(0),
-                                                                                                            $reader.NodeType,
-                                                                                                            $reader.LocalName,
-                                                                                                            $reader.Value)
-                                                                                                    } .Else {
-                                                                                                        .Default(System.Void)
+                                                                                                        .Break endStateMachineLoop { }
                                                                                                     }
                                                                                                 }
+                                                                                                .LabelTarget endStateMachineLoop:;
+                                                                                                .Default(System.Void);
+                                                                                                .Default(System.Void)
                                                                                             }
                                                                                         }
                                                                                     };
-                                                                                    $Example._double = .Call System.Convert.ToDouble(
-                                                                                        $valueAsString,
-                                                                                        System.Globalization.CultureInfo.InvariantCulture)
-                                                                                };
-                                                                                $state = .Constant<System.Byte>(3)
-                                                                            }
-                                                                        } .Else {
-                                                                            .If (
-                                                                                .Call System.String.Equals(
-                                                                                    $reader.LocalName,
-                                                                                    "_int64",
-                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                    $reader.NamespaceURI,
-                                                                                    System.String.Empty,
-                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                    $reader.NamespaceURI,
-                                                                                    "urn:ExpressionsTest.Example",
-                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                            ) {
-                                                                                .Block() {
-                                                                                    .Block(System.String $valueAsString) {
-                                                                                        .If (
-                                                                                            $reader.IsEmptyElement
-                                                                                        ) {
-                                                                                            $valueAsString = System.String.Empty
-                                                                                        } .Else {
-                                                                                            .Block() {
-                                                                                                .Call $reader.Read();
-                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                    $valueAsString = ""
-                                                                                                } .Else {
-                                                                                                    .Block() {
-                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                    .Constant<System.Byte>(0),
-                                                                                                                    $reader.NodeType,
-                                                                                                                    $reader.LocalName,
-                                                                                                                    $reader.Value)
-                                                                                                            } .Else {
-                                                                                                                .Default(System.Void)
-                                                                                                            }
-                                                                                                        } .Else {
-                                                                                                            .Default(System.Void)
-                                                                                                        };
-                                                                                                        $valueAsString = $reader.Value;
-                                                                                                        .Call $reader.Read();
-                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                .Constant<System.Byte>(0),
-                                                                                                                $reader.NodeType,
-                                                                                                                $reader.LocalName,
-                                                                                                                $reader.Value)
-                                                                                                        } .Else {
-                                                                                                            .Default(System.Void)
-                                                                                                        }
-                                                                                                    }
-                                                                                                }
-                                                                                            }
-                                                                                        };
-                                                                                        $Example._int64 = .Call System.Convert.ToInt64(
-                                                                                            $valueAsString,
-                                                                                            System.Globalization.CultureInfo.InvariantCulture)
-                                                                                    };
-                                                                                    $state = .Constant<System.Byte>(3);
-                                                                                    .Call $requiredFields.Reset(
-                                                                                        0,
-                                                                                        1L)
+                                                                                    $state = .Constant<System.Byte>(3)
                                                                                 }
                                                                             } .Else {
                                                                                 .If (
                                                                                     .Call System.String.Equals(
                                                                                         $reader.LocalName,
-                                                                                        "_int8",
+                                                                                        "_double",
                                                                                         .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                         $reader.NamespaceURI,
                                                                                         System.String.Empty,
@@ -1447,7 +1669,7 @@
                                                                                                     }
                                                                                                 }
                                                                                             };
-                                                                                            $Example._int8 = .Call System.Convert.ToSByte(
+                                                                                            $Example._double = .Call System.Convert.ToDouble(
                                                                                                 $valueAsString,
                                                                                                 System.Globalization.CultureInfo.InvariantCulture)
                                                                                         };
@@ -1457,7 +1679,7 @@
                                                                                     .If (
                                                                                         .Call System.String.Equals(
                                                                                             $reader.LocalName,
-                                                                                            "_uint32",
+                                                                                            "_int64",
                                                                                             .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                             $reader.NamespaceURI,
                                                                                             System.String.Empty,
@@ -1507,17 +1729,20 @@
                                                                                                         }
                                                                                                     }
                                                                                                 };
-                                                                                                $Example._uint32 = .Call System.Convert.ToUInt32(
+                                                                                                $Example._int64 = .Call System.Convert.ToInt64(
                                                                                                     $valueAsString,
                                                                                                     System.Globalization.CultureInfo.InvariantCulture)
                                                                                             };
-                                                                                            $state = .Constant<System.Byte>(3)
+                                                                                            $state = .Constant<System.Byte>(3);
+                                                                                            .Call $requiredFields.Reset(
+                                                                                                0,
+                                                                                                1L)
                                                                                         }
                                                                                     } .Else {
                                                                                         .If (
                                                                                             .Call System.String.Equals(
                                                                                                 $reader.LocalName,
-                                                                                                "_str",
+                                                                                                "_int8",
                                                                                                 .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                                 $reader.NamespaceURI,
                                                                                                 System.String.Empty,
@@ -1567,7 +1792,9 @@
                                                                                                             }
                                                                                                         }
                                                                                                     };
-                                                                                                    $Example._str = $valueAsString
+                                                                                                    $Example._int8 = .Call System.Convert.ToSByte(
+                                                                                                        $valueAsString,
+                                                                                                        System.Globalization.CultureInfo.InvariantCulture)
                                                                                                 };
                                                                                                 $state = .Constant<System.Byte>(3)
                                                                                             }
@@ -1575,7 +1802,7 @@
                                                                                             .If (
                                                                                                 .Call System.String.Equals(
                                                                                                     $reader.LocalName,
-                                                                                                    "_bool",
+                                                                                                    "_uint32",
                                                                                                     .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                                     $reader.NamespaceURI,
                                                                                                     System.String.Empty,
@@ -1625,16 +1852,136 @@
                                                                                                                 }
                                                                                                             }
                                                                                                         };
-                                                                                                        $Example._bool = .Call System.Convert.ToBoolean(
+                                                                                                        $Example._uint32 = .Call System.Convert.ToUInt32(
                                                                                                             $valueAsString,
                                                                                                             System.Globalization.CultureInfo.InvariantCulture)
                                                                                                     };
                                                                                                     $state = .Constant<System.Byte>(3)
                                                                                                 }
                                                                                             } .Else {
-                                                                                                .Block() {
-                                                                                                    .Call $reader.Skip();
-                                                                                                    $state = .Constant<System.Byte>(2)
+                                                                                                .If (
+                                                                                                    .Call System.String.Equals(
+                                                                                                        $reader.LocalName,
+                                                                                                        "_str",
+                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                        $reader.NamespaceURI,
+                                                                                                        System.String.Empty,
+                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                        $reader.NamespaceURI,
+                                                                                                        "urn:ExpressionsTest.Example",
+                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                ) {
+                                                                                                    .Block() {
+                                                                                                        .Block(System.String $valueAsString) {
+                                                                                                            .If (
+                                                                                                                $reader.IsEmptyElement
+                                                                                                            ) {
+                                                                                                                $valueAsString = System.String.Empty
+                                                                                                            } .Else {
+                                                                                                                .Block() {
+                                                                                                                    .Call $reader.Read();
+                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                        $valueAsString = ""
+                                                                                                                    } .Else {
+                                                                                                                        .Block() {
+                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                        $reader.NodeType,
+                                                                                                                                        $reader.LocalName,
+                                                                                                                                        $reader.Value)
+                                                                                                                                } .Else {
+                                                                                                                                    .Default(System.Void)
+                                                                                                                                }
+                                                                                                                            } .Else {
+                                                                                                                                .Default(System.Void)
+                                                                                                                            };
+                                                                                                                            $valueAsString = $reader.Value;
+                                                                                                                            .Call $reader.Read();
+                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                    $reader.NodeType,
+                                                                                                                                    $reader.LocalName,
+                                                                                                                                    $reader.Value)
+                                                                                                                            } .Else {
+                                                                                                                                .Default(System.Void)
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            };
+                                                                                                            $Example._str = $valueAsString
+                                                                                                        };
+                                                                                                        $state = .Constant<System.Byte>(3)
+                                                                                                    }
+                                                                                                } .Else {
+                                                                                                    .If (
+                                                                                                        .Call System.String.Equals(
+                                                                                                            $reader.LocalName,
+                                                                                                            "_bool",
+                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                            $reader.NamespaceURI,
+                                                                                                            System.String.Empty,
+                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                            $reader.NamespaceURI,
+                                                                                                            "urn:ExpressionsTest.Example",
+                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                    ) {
+                                                                                                        .Block() {
+                                                                                                            .Block(System.String $valueAsString) {
+                                                                                                                .If (
+                                                                                                                    $reader.IsEmptyElement
+                                                                                                                ) {
+                                                                                                                    $valueAsString = System.String.Empty
+                                                                                                                } .Else {
+                                                                                                                    .Block() {
+                                                                                                                        .Call $reader.Read();
+                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                            $valueAsString = ""
+                                                                                                                        } .Else {
+                                                                                                                            .Block() {
+                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                            $reader.NodeType,
+                                                                                                                                            $reader.LocalName,
+                                                                                                                                            $reader.Value)
+                                                                                                                                    } .Else {
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                                } .Else {
+                                                                                                                                    .Default(System.Void)
+                                                                                                                                };
+                                                                                                                                $valueAsString = $reader.Value;
+                                                                                                                                .Call $reader.Read();
+                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                        $reader.NodeType,
+                                                                                                                                        $reader.LocalName,
+                                                                                                                                        $reader.Value)
+                                                                                                                                } .Else {
+                                                                                                                                    .Default(System.Void)
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                };
+                                                                                                                $Example._bool = .Call System.Convert.ToBoolean(
+                                                                                                                    $valueAsString,
+                                                                                                                    System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                            };
+                                                                                                            $state = .Constant<System.Byte>(3)
+                                                                                                        }
+                                                                                                    } .Else {
+                                                                                                        .Block() {
+                                                                                                            .Call $reader.Skip();
+                                                                                                            $state = .Constant<System.Byte>(2)
+                                                                                                        }
+                                                                                                    }
                                                                                                 }
                                                                                             }
                                                                                         }

--- a/cs/test/expressions/DeserializeXml.expressions
+++ b/cs/test/expressions/DeserializeXml.expressions
@@ -222,7 +222,7 @@
                                                     .If (
                                                         .Call System.String.Equals(
                                                             $reader.LocalName,
-                                                            "_decList",
+                                                            "_decNullable",
                                                             .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                             $reader.NamespaceURI,
                                                             System.String.Empty,
@@ -234,8 +234,7 @@
                                                         .Block() {
                                                             .Block(System.Boolean $isEmpty) {
                                                                 $isEmpty = $reader.IsEmptyElement;
-                                                                .Block(System.Decimal $Example._decList_item) {
-                                                                    .Default(System.Void);
+                                                                .Block() {
                                                                     .Loop  {
                                                                         .If (
                                                                             .If (
@@ -280,653 +279,19 @@
                                                                                 }
                                                                             }
                                                                         ) {
-                                                                            .Block() {
-                                                                                .Block(System.Boolean $isEmpty) {
-                                                                                    $isEmpty = $reader.IsEmptyElement;
-                                                                                    .Block(
-                                                                                        System.Int32 $index,
-                                                                                        System.Byte[] $array) {
-                                                                                        .Block(System.Int32 $Example._decList_item_count) {
-                                                                                            $Example._decList_item_count = 0;
-                                                                                            .Default(System.Void);
-                                                                                            .Block() {
-                                                                                                $index = 0;
-                                                                                                $array = .NewArray System.Byte[$Example._decList_item_count]
-                                                                                            }
-                                                                                        };
-                                                                                        .Loop  {
-                                                                                            .If (
-                                                                                                .If (
-                                                                                                    $isEmpty
-                                                                                                ) {
-                                                                                                    False
-                                                                                                } .Else {
-                                                                                                    .Block() {
-                                                                                                        .Loop  {
-                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                .Call $reader.Read()
-                                                                                                            } .Else {
-                                                                                                                .Break end { }
-                                                                                                            }
-                                                                                                        }
-                                                                                                        .LabelTarget end:;
-                                                                                                        .Loop  {
-                                                                                                            .Block() {
-                                                                                                                .Call $reader.Read();
-                                                                                                                .If (
-                                                                                                                    !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
-                                                                                                                ) {
-                                                                                                                    .Break end { }
-                                                                                                                } .Else {
-                                                                                                                    .Default(System.Void)
-                                                                                                                }
-                                                                                                            }
-                                                                                                        }
-                                                                                                        .LabelTarget end:;
-                                                                                                        .If (
-                                                                                                            $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
-                                                                                                        ) {
-                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                .Constant<System.Byte>(0),
-                                                                                                                $reader.NodeType,
-                                                                                                                $reader.LocalName,
-                                                                                                                $reader.Value)
-                                                                                                        } .Else {
-                                                                                                            .Default(System.Void)
-                                                                                                        };
-                                                                                                        $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
-                                                                                                    }
-                                                                                                }
-                                                                                            ) {
-                                                                                                .Block() {
-                                                                                                    .If ($index >= $array.Length) {
-                                                                                                        .Call System.Array.Resize(
-                                                                                                            $array,
-                                                                                                            .If ($index > 512) {
-                                                                                                                $index * 2
-                                                                                                            } .Else {
-                                                                                                                1024
-                                                                                                            })
-                                                                                                    } .Else {
-                                                                                                        .Default(System.Void)
-                                                                                                    };
-                                                                                                    .Block(System.String $valueAsString) {
-                                                                                                        .If (
-                                                                                                            $reader.IsEmptyElement
-                                                                                                        ) {
-                                                                                                            $valueAsString = System.String.Empty
-                                                                                                        } .Else {
-                                                                                                            .Block() {
-                                                                                                                .Call $reader.Read();
-                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                    $valueAsString = ""
-                                                                                                                } .Else {
-                                                                                                                    .Block() {
-                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                    .Constant<System.Byte>(0),
-                                                                                                                                    $reader.NodeType,
-                                                                                                                                    $reader.LocalName,
-                                                                                                                                    $reader.Value)
-                                                                                                                            } .Else {
-                                                                                                                                .Default(System.Void)
-                                                                                                                            }
-                                                                                                                        } .Else {
-                                                                                                                            .Default(System.Void)
-                                                                                                                        };
-                                                                                                                        $valueAsString = $reader.Value;
-                                                                                                                        .Call $reader.Read();
-                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                .Constant<System.Byte>(0),
-                                                                                                                                $reader.NodeType,
-                                                                                                                                $reader.LocalName,
-                                                                                                                                $reader.Value)
-                                                                                                                        } .Else {
-                                                                                                                            .Default(System.Void)
-                                                                                                                        }
-                                                                                                                    }
-                                                                                                                }
-                                                                                                            }
-                                                                                                        };
-                                                                                                        $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
-                                                                                                            $valueAsString,
-                                                                                                            System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                    }
-                                                                                                }
-                                                                                            } .Else {
-                                                                                                .Break end { }
-                                                                                            }
-                                                                                        }
-                                                                                        .LabelTarget end:;
-                                                                                        $Example._decList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
-                                                                                            .New System.ArraySegment`1[System.Byte](
-                                                                                                $array,
-                                                                                                0,
-                                                                                                $index),
-                                                                                            .Default(System.Decimal))
-                                                                                    }
-                                                                                };
-                                                                                .Call ($Example._decList).Add($Example._decList_item)
-                                                                            }
-                                                                        } .Else {
-                                                                            .Break end { }
-                                                                        }
-                                                                    }
-                                                                    .LabelTarget end:;
-                                                                    .Default(System.Void)
-                                                                }
-                                                            };
-                                                            $state = .Constant<System.Byte>(3)
-                                                        }
-                                                    } .Else {
-                                                        .If (
-                                                            .Call System.String.Equals(
-                                                                $reader.LocalName,
-                                                                "_decimal",
-                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                $reader.NamespaceURI,
-                                                                System.String.Empty,
-                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                $reader.NamespaceURI,
-                                                                "urn:ExpressionsTest.Example",
-                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                        ) {
-                                                            .Block() {
-                                                                .Block(System.Boolean $isEmpty) {
-                                                                    $isEmpty = $reader.IsEmptyElement;
-                                                                    .Block(
-                                                                        System.Int32 $index,
-                                                                        System.Byte[] $array) {
-                                                                        .Block(System.Int32 $Example._decimal_count) {
-                                                                            $Example._decimal_count = 0;
-                                                                            .Default(System.Void);
-                                                                            .Block() {
-                                                                                $index = 0;
-                                                                                $array = .NewArray System.Byte[$Example._decimal_count]
-                                                                            }
-                                                                        };
-                                                                        .Loop  {
-                                                                            .If (
-                                                                                .If (
-                                                                                    $isEmpty
-                                                                                ) {
-                                                                                    False
-                                                                                } .Else {
-                                                                                    .Block() {
-                                                                                        .Loop  {
-                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                .Call $reader.Read()
-                                                                                            } .Else {
-                                                                                                .Break end { }
-                                                                                            }
-                                                                                        }
-                                                                                        .LabelTarget end:;
-                                                                                        .Loop  {
-                                                                                            .Block() {
-                                                                                                .Call $reader.Read();
-                                                                                                .If (
-                                                                                                    !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
-                                                                                                ) {
-                                                                                                    .Break end { }
-                                                                                                } .Else {
-                                                                                                    .Default(System.Void)
-                                                                                                }
-                                                                                            }
-                                                                                        }
-                                                                                        .LabelTarget end:;
-                                                                                        .If (
-                                                                                            $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
-                                                                                        ) {
-                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                .Constant<System.Byte>(0),
-                                                                                                $reader.NodeType,
-                                                                                                $reader.LocalName,
-                                                                                                $reader.Value)
-                                                                                        } .Else {
-                                                                                            .Default(System.Void)
-                                                                                        };
-                                                                                        $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
-                                                                                    }
-                                                                                }
-                                                                            ) {
-                                                                                .Block() {
-                                                                                    .If ($index >= $array.Length) {
-                                                                                        .Call System.Array.Resize(
-                                                                                            $array,
-                                                                                            .If ($index > 512) {
-                                                                                                $index * 2
-                                                                                            } .Else {
-                                                                                                1024
-                                                                                            })
-                                                                                    } .Else {
-                                                                                        .Default(System.Void)
-                                                                                    };
-                                                                                    .Block(System.String $valueAsString) {
-                                                                                        .If (
-                                                                                            $reader.IsEmptyElement
-                                                                                        ) {
-                                                                                            $valueAsString = System.String.Empty
-                                                                                        } .Else {
-                                                                                            .Block() {
-                                                                                                .Call $reader.Read();
-                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                    $valueAsString = ""
-                                                                                                } .Else {
-                                                                                                    .Block() {
-                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                    .Constant<System.Byte>(0),
-                                                                                                                    $reader.NodeType,
-                                                                                                                    $reader.LocalName,
-                                                                                                                    $reader.Value)
-                                                                                                            } .Else {
-                                                                                                                .Default(System.Void)
-                                                                                                            }
-                                                                                                        } .Else {
-                                                                                                            .Default(System.Void)
-                                                                                                        };
-                                                                                                        $valueAsString = $reader.Value;
-                                                                                                        .Call $reader.Read();
-                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                .Constant<System.Byte>(0),
-                                                                                                                $reader.NodeType,
-                                                                                                                $reader.LocalName,
-                                                                                                                $reader.Value)
-                                                                                                        } .Else {
-                                                                                                            .Default(System.Void)
-                                                                                                        }
-                                                                                                    }
-                                                                                                }
-                                                                                            }
-                                                                                        };
-                                                                                        $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
-                                                                                            $valueAsString,
-                                                                                            System.Globalization.CultureInfo.InvariantCulture)
-                                                                                    }
-                                                                                }
-                                                                            } .Else {
-                                                                                .Break end { }
-                                                                            }
-                                                                        }
-                                                                        .LabelTarget end:;
-                                                                        $Example._decimal = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
-                                                                            .New System.ArraySegment`1[System.Byte](
-                                                                                $array,
-                                                                                0,
-                                                                                $index),
-                                                                            .Default(System.Decimal))
-                                                                    }
-                                                                };
-                                                                $state = .Constant<System.Byte>(3)
-                                                            }
-                                                        } .Else {
-                                                            .If (
-                                                                .Call System.String.Equals(
-                                                                    $reader.LocalName,
-                                                                    "_map",
-                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                    $reader.NamespaceURI,
-                                                                    System.String.Empty,
-                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                    $reader.NamespaceURI,
-                                                                    "urn:ExpressionsTest.Example",
-                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                            ) {
-                                                                .Block() {
-                                                                    .Block(System.Boolean $isEmpty) {
-                                                                        $isEmpty = $reader.IsEmptyElement;
-                                                                        .Block(
-                                                                            System.Int32 $Example._map_key,
-                                                                            System.Double $Example._map_value) {
-                                                                            .Default(System.Void);
-                                                                            .Loop  {
-                                                                                .If (
-                                                                                    .If (
-                                                                                        $isEmpty
-                                                                                    ) {
-                                                                                        False
-                                                                                    } .Else {
-                                                                                        .Block() {
-                                                                                            .Loop  {
-                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                    .Call $reader.Read()
-                                                                                                } .Else {
-                                                                                                    .Break end { }
-                                                                                                }
-                                                                                            }
-                                                                                            .LabelTarget end:;
-                                                                                            .Loop  {
-                                                                                                .Block() {
-                                                                                                    .Call $reader.Read();
-                                                                                                    .If (
-                                                                                                        !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
-                                                                                                    ) {
-                                                                                                        .Break end { }
-                                                                                                    } .Else {
-                                                                                                        .Default(System.Void)
-                                                                                                    }
-                                                                                                }
-                                                                                            }
-                                                                                            .LabelTarget end:;
-                                                                                            .If (
-                                                                                                $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
-                                                                                            ) {
-                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                    .Constant<System.Byte>(0),
-                                                                                                    $reader.NodeType,
-                                                                                                    $reader.LocalName,
-                                                                                                    $reader.Value)
-                                                                                            } .Else {
-                                                                                                .Default(System.Void)
-                                                                                            };
-                                                                                            $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
-                                                                                        }
-                                                                                    }
-                                                                                ) {
-                                                                                    .Block() {
-                                                                                        .Block(System.String $valueAsString) {
-                                                                                            .If (
-                                                                                                $reader.IsEmptyElement
-                                                                                            ) {
-                                                                                                $valueAsString = System.String.Empty
-                                                                                            } .Else {
-                                                                                                .Block() {
-                                                                                                    .Call $reader.Read();
-                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                        $valueAsString = ""
-                                                                                                    } .Else {
-                                                                                                        .Block() {
-                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                        .Constant<System.Byte>(0),
-                                                                                                                        $reader.NodeType,
-                                                                                                                        $reader.LocalName,
-                                                                                                                        $reader.Value)
-                                                                                                                } .Else {
-                                                                                                                    .Default(System.Void)
-                                                                                                                }
-                                                                                                            } .Else {
-                                                                                                                .Default(System.Void)
-                                                                                                            };
-                                                                                                            $valueAsString = $reader.Value;
-                                                                                                            .Call $reader.Read();
-                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                    .Constant<System.Byte>(0),
-                                                                                                                    $reader.NodeType,
-                                                                                                                    $reader.LocalName,
-                                                                                                                    $reader.Value)
-                                                                                                            } .Else {
-                                                                                                                .Default(System.Void)
-                                                                                                            }
-                                                                                                        }
-                                                                                                    }
-                                                                                                }
-                                                                                            };
-                                                                                            $Example._map_key = .Call System.Convert.ToInt32(
-                                                                                                $valueAsString,
-                                                                                                System.Globalization.CultureInfo.InvariantCulture)
-                                                                                        };
-                                                                                        .If (
-                                                                                            $isEmpty
-                                                                                        ) {
-                                                                                            False
-                                                                                        } .Else {
-                                                                                            .Block() {
-                                                                                                .Loop  {
-                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                        .Call $reader.Read()
-                                                                                                    } .Else {
-                                                                                                        .Break end { }
-                                                                                                    }
-                                                                                                }
-                                                                                                .LabelTarget end:;
-                                                                                                .Loop  {
-                                                                                                    .Block() {
-                                                                                                        .Call $reader.Read();
-                                                                                                        .If (
-                                                                                                            !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
-                                                                                                        ) {
-                                                                                                            .Break end { }
-                                                                                                        } .Else {
-                                                                                                            .Default(System.Void)
-                                                                                                        }
-                                                                                                    }
-                                                                                                }
-                                                                                                .LabelTarget end:;
-                                                                                                .If (
-                                                                                                    $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
-                                                                                                ) {
-                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                        .Constant<System.Byte>(0),
-                                                                                                        $reader.NodeType,
-                                                                                                        $reader.LocalName,
-                                                                                                        $reader.Value)
-                                                                                                } .Else {
-                                                                                                    .Default(System.Void)
-                                                                                                };
-                                                                                                $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
-                                                                                            }
-                                                                                        };
-                                                                                        .Block(System.String $valueAsString) {
-                                                                                            .If (
-                                                                                                $reader.IsEmptyElement
-                                                                                            ) {
-                                                                                                $valueAsString = System.String.Empty
-                                                                                            } .Else {
-                                                                                                .Block() {
-                                                                                                    .Call $reader.Read();
-                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                        $valueAsString = ""
-                                                                                                    } .Else {
-                                                                                                        .Block() {
-                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                        .Constant<System.Byte>(0),
-                                                                                                                        $reader.NodeType,
-                                                                                                                        $reader.LocalName,
-                                                                                                                        $reader.Value)
-                                                                                                                } .Else {
-                                                                                                                    .Default(System.Void)
-                                                                                                                }
-                                                                                                            } .Else {
-                                                                                                                .Default(System.Void)
-                                                                                                            };
-                                                                                                            $valueAsString = $reader.Value;
-                                                                                                            .Call $reader.Read();
-                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                    .Constant<System.Byte>(0),
-                                                                                                                    $reader.NodeType,
-                                                                                                                    $reader.LocalName,
-                                                                                                                    $reader.Value)
-                                                                                                            } .Else {
-                                                                                                                .Default(System.Void)
-                                                                                                            }
-                                                                                                        }
-                                                                                                    }
-                                                                                                }
-                                                                                            };
-                                                                                            $Example._map_value = .Call System.Convert.ToDouble(
-                                                                                                $valueAsString,
-                                                                                                System.Globalization.CultureInfo.InvariantCulture)
-                                                                                        };
-                                                                                        ($Example._map).Item[$Example._map_key] = $Example._map_value
-                                                                                    }
-                                                                                } .Else {
-                                                                                    .Break end { }
-                                                                                }
-                                                                            }
-                                                                            .LabelTarget end:
-                                                                        }
-                                                                    };
-                                                                    $state = .Constant<System.Byte>(3)
-                                                                }
-                                                            } .Else {
-                                                                .If (
-                                                                    .Call System.String.Equals(
-                                                                        $reader.LocalName,
-                                                                        "b",
-                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                        $reader.NamespaceURI,
-                                                                        System.String.Empty,
-                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                        $reader.NamespaceURI,
-                                                                        "urn:ExpressionsTest.Example",
-                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                ) {
-                                                                    .Block() {
-                                                                        .Block(System.Boolean $isEmpty) {
-                                                                            $isEmpty = $reader.IsEmptyElement;
-                                                                            .Block(
-                                                                                System.Int32 $index,
-                                                                                System.Byte[] $array) {
-                                                                                .Block(System.Int32 $Example.b_count) {
-                                                                                    $Example.b_count = 0;
-                                                                                    .Default(System.Void);
-                                                                                    .Block() {
-                                                                                        $index = 0;
-                                                                                        $array = .NewArray System.Byte[$Example.b_count]
-                                                                                    }
-                                                                                };
-                                                                                .Loop  {
-                                                                                    .If (
-                                                                                        .If (
-                                                                                            $isEmpty
-                                                                                        ) {
-                                                                                            False
-                                                                                        } .Else {
-                                                                                            .Block() {
-                                                                                                .Loop  {
-                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                        .Call $reader.Read()
-                                                                                                    } .Else {
-                                                                                                        .Break end { }
-                                                                                                    }
-                                                                                                }
-                                                                                                .LabelTarget end:;
-                                                                                                .Loop  {
-                                                                                                    .Block() {
-                                                                                                        .Call $reader.Read();
-                                                                                                        .If (
-                                                                                                            !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
-                                                                                                        ) {
-                                                                                                            .Break end { }
-                                                                                                        } .Else {
-                                                                                                            .Default(System.Void)
-                                                                                                        }
-                                                                                                    }
-                                                                                                }
-                                                                                                .LabelTarget end:;
-                                                                                                .If (
-                                                                                                    $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
-                                                                                                ) {
-                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                        .Constant<System.Byte>(0),
-                                                                                                        $reader.NodeType,
-                                                                                                        $reader.LocalName,
-                                                                                                        $reader.Value)
-                                                                                                } .Else {
-                                                                                                    .Default(System.Void)
-                                                                                                };
-                                                                                                $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
-                                                                                            }
-                                                                                        }
-                                                                                    ) {
-                                                                                        .Block() {
-                                                                                            .If ($index >= $array.Length) {
-                                                                                                .Call System.Array.Resize(
-                                                                                                    $array,
-                                                                                                    .If ($index > 512) {
-                                                                                                        $index * 2
-                                                                                                    } .Else {
-                                                                                                        1024
-                                                                                                    })
-                                                                                            } .Else {
-                                                                                                .Default(System.Void)
-                                                                                            };
-                                                                                            .Block(System.String $valueAsString) {
-                                                                                                .If (
-                                                                                                    $reader.IsEmptyElement
-                                                                                                ) {
-                                                                                                    $valueAsString = System.String.Empty
-                                                                                                } .Else {
-                                                                                                    .Block() {
-                                                                                                        .Call $reader.Read();
-                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                            $valueAsString = ""
-                                                                                                        } .Else {
-                                                                                                            .Block() {
-                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                            .Constant<System.Byte>(0),
-                                                                                                                            $reader.NodeType,
-                                                                                                                            $reader.LocalName,
-                                                                                                                            $reader.Value)
-                                                                                                                    } .Else {
-                                                                                                                        .Default(System.Void)
-                                                                                                                    }
-                                                                                                                } .Else {
-                                                                                                                    .Default(System.Void)
-                                                                                                                };
-                                                                                                                $valueAsString = $reader.Value;
-                                                                                                                .Call $reader.Read();
-                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                        .Constant<System.Byte>(0),
-                                                                                                                        $reader.NodeType,
-                                                                                                                        $reader.LocalName,
-                                                                                                                        $reader.Value)
-                                                                                                                } .Else {
-                                                                                                                    .Default(System.Void)
-                                                                                                                }
-                                                                                                            }
-                                                                                                        }
-                                                                                                    }
-                                                                                                };
-                                                                                                $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
-                                                                                                    $valueAsString,
-                                                                                                    System.Globalization.CultureInfo.InvariantCulture)
-                                                                                            }
-                                                                                        }
-                                                                                    } .Else {
-                                                                                        .Break end { }
-                                                                                    }
-                                                                                }
-                                                                                .LabelTarget end:;
-                                                                                $Example.b = .New System.ArraySegment`1[System.Byte](
-                                                                                    $array,
-                                                                                    0,
-                                                                                    $index)
-                                                                            }
-                                                                        };
-                                                                        $state = .Constant<System.Byte>(3)
-                                                                    }
-                                                                } .Else {
-                                                                    .If (
-                                                                        .Call System.String.Equals(
-                                                                            $reader.LocalName,
-                                                                            "_nestedVector",
-                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                            $reader.NamespaceURI,
-                                                                            System.String.Empty,
-                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                            $reader.NamespaceURI,
-                                                                            "urn:ExpressionsTest.Example",
-                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                    ) {
-                                                                        .Block() {
                                                                             .Block(System.Boolean $isEmpty) {
                                                                                 $isEmpty = $reader.IsEmptyElement;
-                                                                                .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
-                                                                                    .Default(System.Void);
+                                                                                .Block(
+                                                                                    System.Int32 $index,
+                                                                                    System.Byte[] $array) {
+                                                                                    .Block(System.Int32 $Example._decNullable_count) {
+                                                                                        $Example._decNullable_count = 0;
+                                                                                        .Default(System.Void);
+                                                                                        .Block() {
+                                                                                            $index = 0;
+                                                                                            $array = .NewArray System.Byte[$Example._decNullable_count]
+                                                                                        }
+                                                                                    };
                                                                                     .Loop  {
                                                                                         .If (
                                                                                             .If (
@@ -972,8 +337,1637 @@
                                                                                             }
                                                                                         ) {
                                                                                             .Block() {
+                                                                                                .If ($index >= $array.Length) {
+                                                                                                    .Call System.Array.Resize(
+                                                                                                        $array,
+                                                                                                        .If ($index > 512) {
+                                                                                                            $index * 2
+                                                                                                        } .Else {
+                                                                                                            1024
+                                                                                                        })
+                                                                                                } .Else {
+                                                                                                    .Default(System.Void)
+                                                                                                };
+                                                                                                .Block(System.String $valueAsString) {
+                                                                                                    .If (
+                                                                                                        $reader.IsEmptyElement
+                                                                                                    ) {
+                                                                                                        $valueAsString = System.String.Empty
+                                                                                                    } .Else {
+                                                                                                        .Block() {
+                                                                                                            .Call $reader.Read();
+                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                $valueAsString = ""
+                                                                                                            } .Else {
+                                                                                                                .Block() {
+                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                $reader.NodeType,
+                                                                                                                                $reader.LocalName,
+                                                                                                                                $reader.Value)
+                                                                                                                        } .Else {
+                                                                                                                            .Default(System.Void)
+                                                                                                                        }
+                                                                                                                    } .Else {
+                                                                                                                        .Default(System.Void)
+                                                                                                                    };
+                                                                                                                    $valueAsString = $reader.Value;
+                                                                                                                    .Call $reader.Read();
+                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                            $reader.NodeType,
+                                                                                                                            $reader.LocalName,
+                                                                                                                            $reader.Value)
+                                                                                                                    } .Else {
+                                                                                                                        .Default(System.Void)
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    };
+                                                                                                    $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                        $valueAsString,
+                                                                                                        System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                }
+                                                                                            }
+                                                                                        } .Else {
+                                                                                            .Break end { }
+                                                                                        }
+                                                                                    }
+                                                                                    .LabelTarget end:;
+                                                                                    $Example._decNullable = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                        .New System.ArraySegment`1[System.Byte](
+                                                                                            $array,
+                                                                                            0,
+                                                                                            $index),
+                                                                                        .Default(System.Decimal))
+                                                                                }
+                                                                            }
+                                                                        } .Else {
+                                                                            .Break end { }
+                                                                        }
+                                                                    }
+                                                                    .LabelTarget end:
+                                                                }
+                                                            };
+                                                            $state = .Constant<System.Byte>(3)
+                                                        }
+                                                    } .Else {
+                                                        .If (
+                                                            .Call System.String.Equals(
+                                                                $reader.LocalName,
+                                                                "_decMap",
+                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                $reader.NamespaceURI,
+                                                                System.String.Empty,
+                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                $reader.NamespaceURI,
+                                                                "urn:ExpressionsTest.Example",
+                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                        ) {
+                                                            .Block() {
+                                                                .Block(System.Boolean $isEmpty) {
+                                                                    $isEmpty = $reader.IsEmptyElement;
+                                                                    .Block(
+                                                                        System.Int32 $Example._decMap_key,
+                                                                        System.Decimal $Example._decMap_value) {
+                                                                        .Default(System.Void);
+                                                                        .Loop  {
+                                                                            .If (
+                                                                                .If (
+                                                                                    $isEmpty
+                                                                                ) {
+                                                                                    False
+                                                                                } .Else {
+                                                                                    .Block() {
+                                                                                        .Loop  {
+                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                .Call $reader.Read()
+                                                                                            } .Else {
+                                                                                                .Break end { }
+                                                                                            }
+                                                                                        }
+                                                                                        .LabelTarget end:;
+                                                                                        .Loop  {
+                                                                                            .Block() {
+                                                                                                .Call $reader.Read();
+                                                                                                .If (
+                                                                                                    !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                ) {
+                                                                                                    .Break end { }
+                                                                                                } .Else {
+                                                                                                    .Default(System.Void)
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                        .LabelTarget end:;
+                                                                                        .If (
+                                                                                            $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                        ) {
+                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                .Constant<System.Byte>(0),
+                                                                                                $reader.NodeType,
+                                                                                                $reader.LocalName,
+                                                                                                $reader.Value)
+                                                                                        } .Else {
+                                                                                            .Default(System.Void)
+                                                                                        };
+                                                                                        $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                    }
+                                                                                }
+                                                                            ) {
+                                                                                .Block() {
+                                                                                    .Block(System.String $valueAsString) {
+                                                                                        .If (
+                                                                                            $reader.IsEmptyElement
+                                                                                        ) {
+                                                                                            $valueAsString = System.String.Empty
+                                                                                        } .Else {
+                                                                                            .Block() {
+                                                                                                .Call $reader.Read();
+                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                    $valueAsString = ""
+                                                                                                } .Else {
+                                                                                                    .Block() {
+                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                    $reader.NodeType,
+                                                                                                                    $reader.LocalName,
+                                                                                                                    $reader.Value)
+                                                                                                            } .Else {
+                                                                                                                .Default(System.Void)
+                                                                                                            }
+                                                                                                        } .Else {
+                                                                                                            .Default(System.Void)
+                                                                                                        };
+                                                                                                        $valueAsString = $reader.Value;
+                                                                                                        .Call $reader.Read();
+                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                $reader.NodeType,
+                                                                                                                $reader.LocalName,
+                                                                                                                $reader.Value)
+                                                                                                        } .Else {
+                                                                                                            .Default(System.Void)
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        };
+                                                                                        $Example._decMap_key = .Call System.Convert.ToInt32(
+                                                                                            $valueAsString,
+                                                                                            System.Globalization.CultureInfo.InvariantCulture)
+                                                                                    };
+                                                                                    .If (
+                                                                                        $isEmpty
+                                                                                    ) {
+                                                                                        False
+                                                                                    } .Else {
+                                                                                        .Block() {
+                                                                                            .Loop  {
+                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                    .Call $reader.Read()
+                                                                                                } .Else {
+                                                                                                    .Break end { }
+                                                                                                }
+                                                                                            }
+                                                                                            .LabelTarget end:;
+                                                                                            .Loop  {
                                                                                                 .Block() {
-                                                                                                    $Example._nestedVector_item = .New ExpressionsTest.Nested();
+                                                                                                    .Call $reader.Read();
+                                                                                                    .If (
+                                                                                                        !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                    ) {
+                                                                                                        .Break end { }
+                                                                                                    } .Else {
+                                                                                                        .Default(System.Void)
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                            .LabelTarget end:;
+                                                                                            .If (
+                                                                                                $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                            ) {
+                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                    .Constant<System.Byte>(0),
+                                                                                                    $reader.NodeType,
+                                                                                                    $reader.LocalName,
+                                                                                                    $reader.Value)
+                                                                                            } .Else {
+                                                                                                .Default(System.Void)
+                                                                                            };
+                                                                                            $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                        }
+                                                                                    };
+                                                                                    .Block(System.Boolean $isEmpty) {
+                                                                                        $isEmpty = $reader.IsEmptyElement;
+                                                                                        .Block(
+                                                                                            System.Int32 $index,
+                                                                                            System.Byte[] $array) {
+                                                                                            .Block(System.Int32 $Example._decMap_value_count) {
+                                                                                                $Example._decMap_value_count = 0;
+                                                                                                .Default(System.Void);
+                                                                                                .Block() {
+                                                                                                    $index = 0;
+                                                                                                    $array = .NewArray System.Byte[$Example._decMap_value_count]
+                                                                                                }
+                                                                                            };
+                                                                                            .Loop  {
+                                                                                                .If (
+                                                                                                    .If (
+                                                                                                        $isEmpty
+                                                                                                    ) {
+                                                                                                        False
+                                                                                                    } .Else {
+                                                                                                        .Block() {
+                                                                                                            .Loop  {
+                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                    .Call $reader.Read()
+                                                                                                                } .Else {
+                                                                                                                    .Break end { }
+                                                                                                                }
+                                                                                                            }
+                                                                                                            .LabelTarget end:;
+                                                                                                            .Loop  {
+                                                                                                                .Block() {
+                                                                                                                    .Call $reader.Read();
+                                                                                                                    .If (
+                                                                                                                        !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                    ) {
+                                                                                                                        .Break end { }
+                                                                                                                    } .Else {
+                                                                                                                        .Default(System.Void)
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                            .LabelTarget end:;
+                                                                                                            .If (
+                                                                                                                $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                            ) {
+                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                    $reader.NodeType,
+                                                                                                                    $reader.LocalName,
+                                                                                                                    $reader.Value)
+                                                                                                            } .Else {
+                                                                                                                .Default(System.Void)
+                                                                                                            };
+                                                                                                            $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                        }
+                                                                                                    }
+                                                                                                ) {
+                                                                                                    .Block() {
+                                                                                                        .If ($index >= $array.Length) {
+                                                                                                            .Call System.Array.Resize(
+                                                                                                                $array,
+                                                                                                                .If ($index > 512) {
+                                                                                                                    $index * 2
+                                                                                                                } .Else {
+                                                                                                                    1024
+                                                                                                                })
+                                                                                                        } .Else {
+                                                                                                            .Default(System.Void)
+                                                                                                        };
+                                                                                                        .Block(System.String $valueAsString) {
+                                                                                                            .If (
+                                                                                                                $reader.IsEmptyElement
+                                                                                                            ) {
+                                                                                                                $valueAsString = System.String.Empty
+                                                                                                            } .Else {
+                                                                                                                .Block() {
+                                                                                                                    .Call $reader.Read();
+                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                        $valueAsString = ""
+                                                                                                                    } .Else {
+                                                                                                                        .Block() {
+                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                        $reader.NodeType,
+                                                                                                                                        $reader.LocalName,
+                                                                                                                                        $reader.Value)
+                                                                                                                                } .Else {
+                                                                                                                                    .Default(System.Void)
+                                                                                                                                }
+                                                                                                                            } .Else {
+                                                                                                                                .Default(System.Void)
+                                                                                                                            };
+                                                                                                                            $valueAsString = $reader.Value;
+                                                                                                                            .Call $reader.Read();
+                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                    $reader.NodeType,
+                                                                                                                                    $reader.LocalName,
+                                                                                                                                    $reader.Value)
+                                                                                                                            } .Else {
+                                                                                                                                .Default(System.Void)
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            };
+                                                                                                            $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                                $valueAsString,
+                                                                                                                System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                        }
+                                                                                                    }
+                                                                                                } .Else {
+                                                                                                    .Break end { }
+                                                                                                }
+                                                                                            }
+                                                                                            .LabelTarget end:;
+                                                                                            $Example._decMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                .New System.ArraySegment`1[System.Byte](
+                                                                                                    $array,
+                                                                                                    0,
+                                                                                                    $index),
+                                                                                                .Default(System.Decimal))
+                                                                                        }
+                                                                                    };
+                                                                                    ($Example._decMap).Item[$Example._decMap_key] = $Example._decMap_value
+                                                                                }
+                                                                            } .Else {
+                                                                                .Break end { }
+                                                                            }
+                                                                        }
+                                                                        .LabelTarget end:
+                                                                    }
+                                                                };
+                                                                $state = .Constant<System.Byte>(3)
+                                                            }
+                                                        } .Else {
+                                                            .If (
+                                                                .Call System.String.Equals(
+                                                                    $reader.LocalName,
+                                                                    "_decVector",
+                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                    $reader.NamespaceURI,
+                                                                    System.String.Empty,
+                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                    $reader.NamespaceURI,
+                                                                    "urn:ExpressionsTest.Example",
+                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                            ) {
+                                                                .Block() {
+                                                                    .Block(System.Boolean $isEmpty) {
+                                                                        $isEmpty = $reader.IsEmptyElement;
+                                                                        .Block(System.Decimal $Example._decVector_item) {
+                                                                            .Block(System.Int32 $Example._decVector_count) {
+                                                                                $Example._decVector_count = 0;
+                                                                                .Default(System.Void);
+                                                                                ($Example._decVector).Capacity = $Example._decVector_count
+                                                                            };
+                                                                            .Loop  {
+                                                                                .If (
+                                                                                    .If (
+                                                                                        $isEmpty
+                                                                                    ) {
+                                                                                        False
+                                                                                    } .Else {
+                                                                                        .Block() {
+                                                                                            .Loop  {
+                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                    .Call $reader.Read()
+                                                                                                } .Else {
+                                                                                                    .Break end { }
+                                                                                                }
+                                                                                            }
+                                                                                            .LabelTarget end:;
+                                                                                            .Loop  {
+                                                                                                .Block() {
+                                                                                                    .Call $reader.Read();
+                                                                                                    .If (
+                                                                                                        !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                    ) {
+                                                                                                        .Break end { }
+                                                                                                    } .Else {
+                                                                                                        .Default(System.Void)
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                            .LabelTarget end:;
+                                                                                            .If (
+                                                                                                $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                            ) {
+                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                    .Constant<System.Byte>(0),
+                                                                                                    $reader.NodeType,
+                                                                                                    $reader.LocalName,
+                                                                                                    $reader.Value)
+                                                                                            } .Else {
+                                                                                                .Default(System.Void)
+                                                                                            };
+                                                                                            $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                        }
+                                                                                    }
+                                                                                ) {
+                                                                                    .Block() {
+                                                                                        .Block(System.Boolean $isEmpty) {
+                                                                                            $isEmpty = $reader.IsEmptyElement;
+                                                                                            .Block(
+                                                                                                System.Int32 $index,
+                                                                                                System.Byte[] $array) {
+                                                                                                .Block(System.Int32 $Example._decVector_item_count) {
+                                                                                                    $Example._decVector_item_count = 0;
+                                                                                                    .Default(System.Void);
+                                                                                                    .Block() {
+                                                                                                        $index = 0;
+                                                                                                        $array = .NewArray System.Byte[$Example._decVector_item_count]
+                                                                                                    }
+                                                                                                };
+                                                                                                .Loop  {
+                                                                                                    .If (
+                                                                                                        .If (
+                                                                                                            $isEmpty
+                                                                                                        ) {
+                                                                                                            False
+                                                                                                        } .Else {
+                                                                                                            .Block() {
+                                                                                                                .Loop  {
+                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                        .Call $reader.Read()
+                                                                                                                    } .Else {
+                                                                                                                        .Break end { }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                                .LabelTarget end:;
+                                                                                                                .Loop  {
+                                                                                                                    .Block() {
+                                                                                                                        .Call $reader.Read();
+                                                                                                                        .If (
+                                                                                                                            !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                        ) {
+                                                                                                                            .Break end { }
+                                                                                                                        } .Else {
+                                                                                                                            .Default(System.Void)
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                                .LabelTarget end:;
+                                                                                                                .If (
+                                                                                                                    $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                ) {
+                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                        $reader.NodeType,
+                                                                                                                        $reader.LocalName,
+                                                                                                                        $reader.Value)
+                                                                                                                } .Else {
+                                                                                                                    .Default(System.Void)
+                                                                                                                };
+                                                                                                                $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                            }
+                                                                                                        }
+                                                                                                    ) {
+                                                                                                        .Block() {
+                                                                                                            .If ($index >= $array.Length) {
+                                                                                                                .Call System.Array.Resize(
+                                                                                                                    $array,
+                                                                                                                    .If ($index > 512) {
+                                                                                                                        $index * 2
+                                                                                                                    } .Else {
+                                                                                                                        1024
+                                                                                                                    })
+                                                                                                            } .Else {
+                                                                                                                .Default(System.Void)
+                                                                                                            };
+                                                                                                            .Block(System.String $valueAsString) {
+                                                                                                                .If (
+                                                                                                                    $reader.IsEmptyElement
+                                                                                                                ) {
+                                                                                                                    $valueAsString = System.String.Empty
+                                                                                                                } .Else {
+                                                                                                                    .Block() {
+                                                                                                                        .Call $reader.Read();
+                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                            $valueAsString = ""
+                                                                                                                        } .Else {
+                                                                                                                            .Block() {
+                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                            $reader.NodeType,
+                                                                                                                                            $reader.LocalName,
+                                                                                                                                            $reader.Value)
+                                                                                                                                    } .Else {
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                                } .Else {
+                                                                                                                                    .Default(System.Void)
+                                                                                                                                };
+                                                                                                                                $valueAsString = $reader.Value;
+                                                                                                                                .Call $reader.Read();
+                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                        $reader.NodeType,
+                                                                                                                                        $reader.LocalName,
+                                                                                                                                        $reader.Value)
+                                                                                                                                } .Else {
+                                                                                                                                    .Default(System.Void)
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                };
+                                                                                                                $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                                    $valueAsString,
+                                                                                                                    System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                            }
+                                                                                                        }
+                                                                                                    } .Else {
+                                                                                                        .Break end { }
+                                                                                                    }
+                                                                                                }
+                                                                                                .LabelTarget end:;
+                                                                                                $Example._decVector_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                    .New System.ArraySegment`1[System.Byte](
+                                                                                                        $array,
+                                                                                                        0,
+                                                                                                        $index),
+                                                                                                    .Default(System.Decimal))
+                                                                                            }
+                                                                                        };
+                                                                                        .Call ($Example._decVector).Add($Example._decVector_item)
+                                                                                    }
+                                                                                } .Else {
+                                                                                    .Break end { }
+                                                                                }
+                                                                            }
+                                                                            .LabelTarget end:;
+                                                                            .Default(System.Void)
+                                                                        }
+                                                                    };
+                                                                    $state = .Constant<System.Byte>(3)
+                                                                }
+                                                            } .Else {
+                                                                .If (
+                                                                    .Call System.String.Equals(
+                                                                        $reader.LocalName,
+                                                                        "_decList",
+                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                        $reader.NamespaceURI,
+                                                                        System.String.Empty,
+                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                        $reader.NamespaceURI,
+                                                                        "urn:ExpressionsTest.Example",
+                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                ) {
+                                                                    .Block() {
+                                                                        .Block(System.Boolean $isEmpty) {
+                                                                            $isEmpty = $reader.IsEmptyElement;
+                                                                            .Block(System.Decimal $Example._decList_item) {
+                                                                                .Default(System.Void);
+                                                                                .Loop  {
+                                                                                    .If (
+                                                                                        .If (
+                                                                                            $isEmpty
+                                                                                        ) {
+                                                                                            False
+                                                                                        } .Else {
+                                                                                            .Block() {
+                                                                                                .Loop  {
+                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                        .Call $reader.Read()
+                                                                                                    } .Else {
+                                                                                                        .Break end { }
+                                                                                                    }
+                                                                                                }
+                                                                                                .LabelTarget end:;
+                                                                                                .Loop  {
+                                                                                                    .Block() {
+                                                                                                        .Call $reader.Read();
+                                                                                                        .If (
+                                                                                                            !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                        ) {
+                                                                                                            .Break end { }
+                                                                                                        } .Else {
+                                                                                                            .Default(System.Void)
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                                .LabelTarget end:;
+                                                                                                .If (
+                                                                                                    $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                ) {
+                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                        .Constant<System.Byte>(0),
+                                                                                                        $reader.NodeType,
+                                                                                                        $reader.LocalName,
+                                                                                                        $reader.Value)
+                                                                                                } .Else {
+                                                                                                    .Default(System.Void)
+                                                                                                };
+                                                                                                $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                            }
+                                                                                        }
+                                                                                    ) {
+                                                                                        .Block() {
+                                                                                            .Block(System.Boolean $isEmpty) {
+                                                                                                $isEmpty = $reader.IsEmptyElement;
+                                                                                                .Block(
+                                                                                                    System.Int32 $index,
+                                                                                                    System.Byte[] $array) {
+                                                                                                    .Block(System.Int32 $Example._decList_item_count) {
+                                                                                                        $Example._decList_item_count = 0;
+                                                                                                        .Default(System.Void);
+                                                                                                        .Block() {
+                                                                                                            $index = 0;
+                                                                                                            $array = .NewArray System.Byte[$Example._decList_item_count]
+                                                                                                        }
+                                                                                                    };
+                                                                                                    .Loop  {
+                                                                                                        .If (
+                                                                                                            .If (
+                                                                                                                $isEmpty
+                                                                                                            ) {
+                                                                                                                False
+                                                                                                            } .Else {
+                                                                                                                .Block() {
+                                                                                                                    .Loop  {
+                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                            .Call $reader.Read()
+                                                                                                                        } .Else {
+                                                                                                                            .Break end { }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                    .LabelTarget end:;
+                                                                                                                    .Loop  {
+                                                                                                                        .Block() {
+                                                                                                                            .Call $reader.Read();
+                                                                                                                            .If (
+                                                                                                                                !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                            ) {
+                                                                                                                                .Break end { }
+                                                                                                                            } .Else {
+                                                                                                                                .Default(System.Void)
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                    .LabelTarget end:;
+                                                                                                                    .If (
+                                                                                                                        $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                    ) {
+                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                            $reader.NodeType,
+                                                                                                                            $reader.LocalName,
+                                                                                                                            $reader.Value)
+                                                                                                                    } .Else {
+                                                                                                                        .Default(System.Void)
+                                                                                                                    };
+                                                                                                                    $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ) {
+                                                                                                            .Block() {
+                                                                                                                .If ($index >= $array.Length) {
+                                                                                                                    .Call System.Array.Resize(
+                                                                                                                        $array,
+                                                                                                                        .If ($index > 512) {
+                                                                                                                            $index * 2
+                                                                                                                        } .Else {
+                                                                                                                            1024
+                                                                                                                        })
+                                                                                                                } .Else {
+                                                                                                                    .Default(System.Void)
+                                                                                                                };
+                                                                                                                .Block(System.String $valueAsString) {
+                                                                                                                    .If (
+                                                                                                                        $reader.IsEmptyElement
+                                                                                                                    ) {
+                                                                                                                        $valueAsString = System.String.Empty
+                                                                                                                    } .Else {
+                                                                                                                        .Block() {
+                                                                                                                            .Call $reader.Read();
+                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                $valueAsString = ""
+                                                                                                                            } .Else {
+                                                                                                                                .Block() {
+                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                $reader.NodeType,
+                                                                                                                                                $reader.LocalName,
+                                                                                                                                                $reader.Value)
+                                                                                                                                        } .Else {
+                                                                                                                                            .Default(System.Void)
+                                                                                                                                        }
+                                                                                                                                    } .Else {
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    };
+                                                                                                                                    $valueAsString = $reader.Value;
+                                                                                                                                    .Call $reader.Read();
+                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                            $reader.NodeType,
+                                                                                                                                            $reader.LocalName,
+                                                                                                                                            $reader.Value)
+                                                                                                                                    } .Else {
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    };
+                                                                                                                    $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                                        $valueAsString,
+                                                                                                                        System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                }
+                                                                                                            }
+                                                                                                        } .Else {
+                                                                                                            .Break end { }
+                                                                                                        }
+                                                                                                    }
+                                                                                                    .LabelTarget end:;
+                                                                                                    $Example._decList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                        .New System.ArraySegment`1[System.Byte](
+                                                                                                            $array,
+                                                                                                            0,
+                                                                                                            $index),
+                                                                                                        .Default(System.Decimal))
+                                                                                                }
+                                                                                            };
+                                                                                            .Call ($Example._decList).Add($Example._decList_item)
+                                                                                        }
+                                                                                    } .Else {
+                                                                                        .Break end { }
+                                                                                    }
+                                                                                }
+                                                                                .LabelTarget end:;
+                                                                                .Default(System.Void)
+                                                                            }
+                                                                        };
+                                                                        $state = .Constant<System.Byte>(3)
+                                                                    }
+                                                                } .Else {
+                                                                    .If (
+                                                                        .Call System.String.Equals(
+                                                                            $reader.LocalName,
+                                                                            "_decimal",
+                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                            $reader.NamespaceURI,
+                                                                            System.String.Empty,
+                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                            $reader.NamespaceURI,
+                                                                            "urn:ExpressionsTest.Example",
+                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                    ) {
+                                                                        .Block() {
+                                                                            .Block(System.Boolean $isEmpty) {
+                                                                                $isEmpty = $reader.IsEmptyElement;
+                                                                                .Block(
+                                                                                    System.Int32 $index,
+                                                                                    System.Byte[] $array) {
+                                                                                    .Block(System.Int32 $Example._decimal_count) {
+                                                                                        $Example._decimal_count = 0;
+                                                                                        .Default(System.Void);
+                                                                                        .Block() {
+                                                                                            $index = 0;
+                                                                                            $array = .NewArray System.Byte[$Example._decimal_count]
+                                                                                        }
+                                                                                    };
+                                                                                    .Loop  {
+                                                                                        .If (
+                                                                                            .If (
+                                                                                                $isEmpty
+                                                                                            ) {
+                                                                                                False
+                                                                                            } .Else {
+                                                                                                .Block() {
+                                                                                                    .Loop  {
+                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                            .Call $reader.Read()
+                                                                                                        } .Else {
+                                                                                                            .Break end { }
+                                                                                                        }
+                                                                                                    }
+                                                                                                    .LabelTarget end:;
+                                                                                                    .Loop  {
+                                                                                                        .Block() {
+                                                                                                            .Call $reader.Read();
+                                                                                                            .If (
+                                                                                                                !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                            ) {
+                                                                                                                .Break end { }
+                                                                                                            } .Else {
+                                                                                                                .Default(System.Void)
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                    .LabelTarget end:;
+                                                                                                    .If (
+                                                                                                        $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                    ) {
+                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                            .Constant<System.Byte>(0),
+                                                                                                            $reader.NodeType,
+                                                                                                            $reader.LocalName,
+                                                                                                            $reader.Value)
+                                                                                                    } .Else {
+                                                                                                        .Default(System.Void)
+                                                                                                    };
+                                                                                                    $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                }
+                                                                                            }
+                                                                                        ) {
+                                                                                            .Block() {
+                                                                                                .If ($index >= $array.Length) {
+                                                                                                    .Call System.Array.Resize(
+                                                                                                        $array,
+                                                                                                        .If ($index > 512) {
+                                                                                                            $index * 2
+                                                                                                        } .Else {
+                                                                                                            1024
+                                                                                                        })
+                                                                                                } .Else {
+                                                                                                    .Default(System.Void)
+                                                                                                };
+                                                                                                .Block(System.String $valueAsString) {
+                                                                                                    .If (
+                                                                                                        $reader.IsEmptyElement
+                                                                                                    ) {
+                                                                                                        $valueAsString = System.String.Empty
+                                                                                                    } .Else {
+                                                                                                        .Block() {
+                                                                                                            .Call $reader.Read();
+                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                $valueAsString = ""
+                                                                                                            } .Else {
+                                                                                                                .Block() {
+                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                $reader.NodeType,
+                                                                                                                                $reader.LocalName,
+                                                                                                                                $reader.Value)
+                                                                                                                        } .Else {
+                                                                                                                            .Default(System.Void)
+                                                                                                                        }
+                                                                                                                    } .Else {
+                                                                                                                        .Default(System.Void)
+                                                                                                                    };
+                                                                                                                    $valueAsString = $reader.Value;
+                                                                                                                    .Call $reader.Read();
+                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                            $reader.NodeType,
+                                                                                                                            $reader.LocalName,
+                                                                                                                            $reader.Value)
+                                                                                                                    } .Else {
+                                                                                                                        .Default(System.Void)
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    };
+                                                                                                    $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                        $valueAsString,
+                                                                                                        System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                }
+                                                                                            }
+                                                                                        } .Else {
+                                                                                            .Break end { }
+                                                                                        }
+                                                                                    }
+                                                                                    .LabelTarget end:;
+                                                                                    $Example._decimal = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                        .New System.ArraySegment`1[System.Byte](
+                                                                                            $array,
+                                                                                            0,
+                                                                                            $index),
+                                                                                        .Default(System.Decimal))
+                                                                                }
+                                                                            };
+                                                                            $state = .Constant<System.Byte>(3)
+                                                                        }
+                                                                    } .Else {
+                                                                        .If (
+                                                                            .Call System.String.Equals(
+                                                                                $reader.LocalName,
+                                                                                "_map",
+                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                $reader.NamespaceURI,
+                                                                                System.String.Empty,
+                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                $reader.NamespaceURI,
+                                                                                "urn:ExpressionsTest.Example",
+                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                        ) {
+                                                                            .Block() {
+                                                                                .Block(System.Boolean $isEmpty) {
+                                                                                    $isEmpty = $reader.IsEmptyElement;
+                                                                                    .Block(
+                                                                                        System.Int32 $Example._map_key,
+                                                                                        System.Double $Example._map_value) {
+                                                                                        .Default(System.Void);
+                                                                                        .Loop  {
+                                                                                            .If (
+                                                                                                .If (
+                                                                                                    $isEmpty
+                                                                                                ) {
+                                                                                                    False
+                                                                                                } .Else {
+                                                                                                    .Block() {
+                                                                                                        .Loop  {
+                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                .Call $reader.Read()
+                                                                                                            } .Else {
+                                                                                                                .Break end { }
+                                                                                                            }
+                                                                                                        }
+                                                                                                        .LabelTarget end:;
+                                                                                                        .Loop  {
+                                                                                                            .Block() {
+                                                                                                                .Call $reader.Read();
+                                                                                                                .If (
+                                                                                                                    !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                ) {
+                                                                                                                    .Break end { }
+                                                                                                                } .Else {
+                                                                                                                    .Default(System.Void)
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                        .LabelTarget end:;
+                                                                                                        .If (
+                                                                                                            $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                        ) {
+                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                $reader.NodeType,
+                                                                                                                $reader.LocalName,
+                                                                                                                $reader.Value)
+                                                                                                        } .Else {
+                                                                                                            .Default(System.Void)
+                                                                                                        };
+                                                                                                        $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                    }
+                                                                                                }
+                                                                                            ) {
+                                                                                                .Block() {
+                                                                                                    .Block(System.String $valueAsString) {
+                                                                                                        .If (
+                                                                                                            $reader.IsEmptyElement
+                                                                                                        ) {
+                                                                                                            $valueAsString = System.String.Empty
+                                                                                                        } .Else {
+                                                                                                            .Block() {
+                                                                                                                .Call $reader.Read();
+                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                    $valueAsString = ""
+                                                                                                                } .Else {
+                                                                                                                    .Block() {
+                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                    $reader.NodeType,
+                                                                                                                                    $reader.LocalName,
+                                                                                                                                    $reader.Value)
+                                                                                                                            } .Else {
+                                                                                                                                .Default(System.Void)
+                                                                                                                            }
+                                                                                                                        } .Else {
+                                                                                                                            .Default(System.Void)
+                                                                                                                        };
+                                                                                                                        $valueAsString = $reader.Value;
+                                                                                                                        .Call $reader.Read();
+                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                $reader.NodeType,
+                                                                                                                                $reader.LocalName,
+                                                                                                                                $reader.Value)
+                                                                                                                        } .Else {
+                                                                                                                            .Default(System.Void)
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        };
+                                                                                                        $Example._map_key = .Call System.Convert.ToInt32(
+                                                                                                            $valueAsString,
+                                                                                                            System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                    };
+                                                                                                    .If (
+                                                                                                        $isEmpty
+                                                                                                    ) {
+                                                                                                        False
+                                                                                                    } .Else {
+                                                                                                        .Block() {
+                                                                                                            .Loop  {
+                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                    .Call $reader.Read()
+                                                                                                                } .Else {
+                                                                                                                    .Break end { }
+                                                                                                                }
+                                                                                                            }
+                                                                                                            .LabelTarget end:;
+                                                                                                            .Loop  {
+                                                                                                                .Block() {
+                                                                                                                    .Call $reader.Read();
+                                                                                                                    .If (
+                                                                                                                        !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                    ) {
+                                                                                                                        .Break end { }
+                                                                                                                    } .Else {
+                                                                                                                        .Default(System.Void)
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                            .LabelTarget end:;
+                                                                                                            .If (
+                                                                                                                $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                            ) {
+                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                    $reader.NodeType,
+                                                                                                                    $reader.LocalName,
+                                                                                                                    $reader.Value)
+                                                                                                            } .Else {
+                                                                                                                .Default(System.Void)
+                                                                                                            };
+                                                                                                            $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                        }
+                                                                                                    };
+                                                                                                    .Block(System.String $valueAsString) {
+                                                                                                        .If (
+                                                                                                            $reader.IsEmptyElement
+                                                                                                        ) {
+                                                                                                            $valueAsString = System.String.Empty
+                                                                                                        } .Else {
+                                                                                                            .Block() {
+                                                                                                                .Call $reader.Read();
+                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                    $valueAsString = ""
+                                                                                                                } .Else {
+                                                                                                                    .Block() {
+                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                    $reader.NodeType,
+                                                                                                                                    $reader.LocalName,
+                                                                                                                                    $reader.Value)
+                                                                                                                            } .Else {
+                                                                                                                                .Default(System.Void)
+                                                                                                                            }
+                                                                                                                        } .Else {
+                                                                                                                            .Default(System.Void)
+                                                                                                                        };
+                                                                                                                        $valueAsString = $reader.Value;
+                                                                                                                        .Call $reader.Read();
+                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                $reader.NodeType,
+                                                                                                                                $reader.LocalName,
+                                                                                                                                $reader.Value)
+                                                                                                                        } .Else {
+                                                                                                                            .Default(System.Void)
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        };
+                                                                                                        $Example._map_value = .Call System.Convert.ToDouble(
+                                                                                                            $valueAsString,
+                                                                                                            System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                    };
+                                                                                                    ($Example._map).Item[$Example._map_key] = $Example._map_value
+                                                                                                }
+                                                                                            } .Else {
+                                                                                                .Break end { }
+                                                                                            }
+                                                                                        }
+                                                                                        .LabelTarget end:
+                                                                                    }
+                                                                                };
+                                                                                $state = .Constant<System.Byte>(3)
+                                                                            }
+                                                                        } .Else {
+                                                                            .If (
+                                                                                .Call System.String.Equals(
+                                                                                    $reader.LocalName,
+                                                                                    "b",
+                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                    $reader.NamespaceURI,
+                                                                                    System.String.Empty,
+                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                    $reader.NamespaceURI,
+                                                                                    "urn:ExpressionsTest.Example",
+                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                            ) {
+                                                                                .Block() {
+                                                                                    .Block(System.Boolean $isEmpty) {
+                                                                                        $isEmpty = $reader.IsEmptyElement;
+                                                                                        .Block(
+                                                                                            System.Int32 $index,
+                                                                                            System.Byte[] $array) {
+                                                                                            .Block(System.Int32 $Example.b_count) {
+                                                                                                $Example.b_count = 0;
+                                                                                                .Default(System.Void);
+                                                                                                .Block() {
+                                                                                                    $index = 0;
+                                                                                                    $array = .NewArray System.Byte[$Example.b_count]
+                                                                                                }
+                                                                                            };
+                                                                                            .Loop  {
+                                                                                                .If (
+                                                                                                    .If (
+                                                                                                        $isEmpty
+                                                                                                    ) {
+                                                                                                        False
+                                                                                                    } .Else {
+                                                                                                        .Block() {
+                                                                                                            .Loop  {
+                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                    .Call $reader.Read()
+                                                                                                                } .Else {
+                                                                                                                    .Break end { }
+                                                                                                                }
+                                                                                                            }
+                                                                                                            .LabelTarget end:;
+                                                                                                            .Loop  {
+                                                                                                                .Block() {
+                                                                                                                    .Call $reader.Read();
+                                                                                                                    .If (
+                                                                                                                        !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                    ) {
+                                                                                                                        .Break end { }
+                                                                                                                    } .Else {
+                                                                                                                        .Default(System.Void)
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                            .LabelTarget end:;
+                                                                                                            .If (
+                                                                                                                $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                            ) {
+                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                    $reader.NodeType,
+                                                                                                                    $reader.LocalName,
+                                                                                                                    $reader.Value)
+                                                                                                            } .Else {
+                                                                                                                .Default(System.Void)
+                                                                                                            };
+                                                                                                            $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                        }
+                                                                                                    }
+                                                                                                ) {
+                                                                                                    .Block() {
+                                                                                                        .If ($index >= $array.Length) {
+                                                                                                            .Call System.Array.Resize(
+                                                                                                                $array,
+                                                                                                                .If ($index > 512) {
+                                                                                                                    $index * 2
+                                                                                                                } .Else {
+                                                                                                                    1024
+                                                                                                                })
+                                                                                                        } .Else {
+                                                                                                            .Default(System.Void)
+                                                                                                        };
+                                                                                                        .Block(System.String $valueAsString) {
+                                                                                                            .If (
+                                                                                                                $reader.IsEmptyElement
+                                                                                                            ) {
+                                                                                                                $valueAsString = System.String.Empty
+                                                                                                            } .Else {
+                                                                                                                .Block() {
+                                                                                                                    .Call $reader.Read();
+                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                        $valueAsString = ""
+                                                                                                                    } .Else {
+                                                                                                                        .Block() {
+                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                        $reader.NodeType,
+                                                                                                                                        $reader.LocalName,
+                                                                                                                                        $reader.Value)
+                                                                                                                                } .Else {
+                                                                                                                                    .Default(System.Void)
+                                                                                                                                }
+                                                                                                                            } .Else {
+                                                                                                                                .Default(System.Void)
+                                                                                                                            };
+                                                                                                                            $valueAsString = $reader.Value;
+                                                                                                                            .Call $reader.Read();
+                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                    $reader.NodeType,
+                                                                                                                                    $reader.LocalName,
+                                                                                                                                    $reader.Value)
+                                                                                                                            } .Else {
+                                                                                                                                .Default(System.Void)
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            };
+                                                                                                            $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                                $valueAsString,
+                                                                                                                System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                        }
+                                                                                                    }
+                                                                                                } .Else {
+                                                                                                    .Break end { }
+                                                                                                }
+                                                                                            }
+                                                                                            .LabelTarget end:;
+                                                                                            $Example.b = .New System.ArraySegment`1[System.Byte](
+                                                                                                $array,
+                                                                                                0,
+                                                                                                $index)
+                                                                                        }
+                                                                                    };
+                                                                                    $state = .Constant<System.Byte>(3)
+                                                                                }
+                                                                            } .Else {
+                                                                                .If (
+                                                                                    .Call System.String.Equals(
+                                                                                        $reader.LocalName,
+                                                                                        "_nestedVector",
+                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                        $reader.NamespaceURI,
+                                                                                        System.String.Empty,
+                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                        $reader.NamespaceURI,
+                                                                                        "urn:ExpressionsTest.Example",
+                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                ) {
+                                                                                    .Block() {
+                                                                                        .Block(System.Boolean $isEmpty) {
+                                                                                            $isEmpty = $reader.IsEmptyElement;
+                                                                                            .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
+                                                                                                .Default(System.Void);
+                                                                                                .Loop  {
+                                                                                                    .If (
+                                                                                                        .If (
+                                                                                                            $isEmpty
+                                                                                                        ) {
+                                                                                                            False
+                                                                                                        } .Else {
+                                                                                                            .Block() {
+                                                                                                                .Loop  {
+                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                        .Call $reader.Read()
+                                                                                                                    } .Else {
+                                                                                                                        .Break end { }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                                .LabelTarget end:;
+                                                                                                                .Loop  {
+                                                                                                                    .Block() {
+                                                                                                                        .Call $reader.Read();
+                                                                                                                        .If (
+                                                                                                                            !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                        ) {
+                                                                                                                            .Break end { }
+                                                                                                                        } .Else {
+                                                                                                                            .Default(System.Void)
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                                .LabelTarget end:;
+                                                                                                                .If (
+                                                                                                                    $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                ) {
+                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                        $reader.NodeType,
+                                                                                                                        $reader.LocalName,
+                                                                                                                        $reader.Value)
+                                                                                                                } .Else {
+                                                                                                                    .Default(System.Void)
+                                                                                                                };
+                                                                                                                $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                            }
+                                                                                                        }
+                                                                                                    ) {
+                                                                                                        .Block() {
+                                                                                                            .Block() {
+                                                                                                                $Example._nestedVector_item = .New ExpressionsTest.Nested();
+                                                                                                                .Block() {
+                                                                                                                    .Call $reader.Read();
+                                                                                                                    .Block(
+                                                                                                                        System.Byte $state,
+                                                                                                                        Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
+                                                                                                                        .Default(System.Void);
+                                                                                                                        .Default(System.Void);
+                                                                                                                        $state = .Constant<System.Byte>(1);
+                                                                                                                        .Loop  {
+                                                                                                                            .If (
+                                                                                                                                !$reader.EOF && $state != .Constant<System.Byte>(4)
+                                                                                                                            ) {
+                                                                                                                                .Switch ($reader.NodeType) {
+                                                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(Element)):
+                                                                                                                                        .Switch ($state) {
+                                                                                                                                        .Case (.Constant<System.Byte>(1)):
+                                                                                                                                                .Block() {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .If (
+                                                                                                                                                            $reader.IsEmptyElement
+                                                                                                                                                        ) {
+                                                                                                                                                            $state = .Constant<System.Byte>(4)
+                                                                                                                                                        } .Else {
+                                                                                                                                                            $state = .Constant<System.Byte>(2)
+                                                                                                                                                        };
+                                                                                                                                                        .Call $reader.Read()
+                                                                                                                                                    };
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                }
+                                                                                                                                        .Case (.Constant<System.Byte>(2)):
+                                                                                                                                                .Block() {
+                                                                                                                                                    .If (
+                                                                                                                                                        .Call System.String.Equals(
+                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                            "_double",
+                                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                                                            $reader.NamespaceURI,
+                                                                                                                                                            System.String.Empty,
+                                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                                                            $reader.NamespaceURI,
+                                                                                                                                                            "urn:ExpressionsTest.Nested",
+                                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                                                    ) {
+                                                                                                                                                        .Block() {
+                                                                                                                                                            .Block(System.String $valueAsString) {
+                                                                                                                                                                .If (
+                                                                                                                                                                    $reader.IsEmptyElement
+                                                                                                                                                                ) {
+                                                                                                                                                                    $valueAsString = System.String.Empty
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Block() {
+                                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                            $valueAsString = ""
+                                                                                                                                                                        } .Else {
+                                                                                                                                                                            .Block() {
+                                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                                                            $reader.Value)
+                                                                                                                                                                                    } .Else {
+                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                    }
+                                                                                                                                                                                } .Else {
+                                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                                };
+                                                                                                                                                                                $valueAsString = $reader.Value;
+                                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                                                        $reader.Value)
+                                                                                                                                                                                } .Else {
+                                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                };
+                                                                                                                                                                $Example._nestedVector_item._double = .Call System.Convert.ToDouble(
+                                                                                                                                                                    $valueAsString,
+                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                                            };
+                                                                                                                                                            $state = .Constant<System.Byte>(3)
+                                                                                                                                                        }
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Block() {
+                                                                                                                                                            .Call $reader.Skip();
+                                                                                                                                                            $state = .Constant<System.Byte>(2)
+                                                                                                                                                        }
+                                                                                                                                                    };
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                }
+                                                                                                                                        .Case (.Constant<System.Byte>(3)):
+                                                                                                                                                .Block() {
+                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                    $state = .Constant<System.Byte>(2);
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                }
+                                                                                                                                        .Default:
+                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                    $state,
+                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                    $reader.Value)
+                                                                                                                                        }
+                                                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(EndElement)):
+                                                                                                                                        .Switch ($state) {
+                                                                                                                                        .Case (.Constant<System.Byte>(3)):
+                                                                                                                                                .Block() {
+                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                    $state = .Constant<System.Byte>(2);
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                }
+                                                                                                                                        .Case (.Constant<System.Byte>(2)):
+                                                                                                                                                .Block() {
+                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                    $state = .Constant<System.Byte>(4);
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                }
+                                                                                                                                        .Default:
+                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                    $state,
+                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                    $reader.Value)
+                                                                                                                                        }
+                                                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(Comment)):
+                                                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(Text)):
+                                                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(Whitespace)):
+                                                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(XmlDeclaration)):
+                                                                                                                                        .Block() {
+                                                                                                                                            .Call $reader.Read();
+                                                                                                                                            .Default(System.Void)
+                                                                                                                                        }
+                                                                                                                                .Default:
+                                                                                                                                        .Invoke (.Lambda #Lambda3<System.Action`1[System.Xml.XmlNodeType]>)($reader.NodeType)
+                                                                                                                                }
+                                                                                                                            } .Else {
+                                                                                                                                .Break endStateMachineLoop { }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                        .LabelTarget endStateMachineLoop:;
+                                                                                                                        .Default(System.Void);
+                                                                                                                        .Default(System.Void)
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            };
+                                                                                                            .Call ($Example._nestedVector).Add($Example._nestedVector_item)
+                                                                                                        }
+                                                                                                    } .Else {
+                                                                                                        .Break end { }
+                                                                                                    }
+                                                                                                }
+                                                                                                .LabelTarget end:;
+                                                                                                .Default(System.Void)
+                                                                                            }
+                                                                                        };
+                                                                                        $state = .Constant<System.Byte>(3)
+                                                                                    }
+                                                                                } .Else {
+                                                                                    .If (
+                                                                                        .Call System.String.Equals(
+                                                                                            $reader.LocalName,
+                                                                                            "_int32Vector",
+                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                            $reader.NamespaceURI,
+                                                                                            System.String.Empty,
+                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                            $reader.NamespaceURI,
+                                                                                            "urn:ExpressionsTest.Example",
+                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                    ) {
+                                                                                        .Block() {
+                                                                                            .Block(System.Boolean $isEmpty) {
+                                                                                                $isEmpty = $reader.IsEmptyElement;
+                                                                                                .Block(System.Int32 $Example._int32Vector_item) {
+                                                                                                    .Block(System.Int32 $Example._int32Vector_count) {
+                                                                                                        $Example._int32Vector_count = 0;
+                                                                                                        .Default(System.Void);
+                                                                                                        ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                                                                    };
+                                                                                                    .Loop  {
+                                                                                                        .If (
+                                                                                                            .If (
+                                                                                                                $isEmpty
+                                                                                                            ) {
+                                                                                                                False
+                                                                                                            } .Else {
+                                                                                                                .Block() {
+                                                                                                                    .Loop  {
+                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                            .Call $reader.Read()
+                                                                                                                        } .Else {
+                                                                                                                            .Break end { }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                    .LabelTarget end:;
+                                                                                                                    .Loop  {
+                                                                                                                        .Block() {
+                                                                                                                            .Call $reader.Read();
+                                                                                                                            .If (
+                                                                                                                                !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                            ) {
+                                                                                                                                .Break end { }
+                                                                                                                            } .Else {
+                                                                                                                                .Default(System.Void)
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                    .LabelTarget end:;
+                                                                                                                    .If (
+                                                                                                                        $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                    ) {
+                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                            $reader.NodeType,
+                                                                                                                            $reader.LocalName,
+                                                                                                                            $reader.Value)
+                                                                                                                    } .Else {
+                                                                                                                        .Default(System.Void)
+                                                                                                                    };
+                                                                                                                    $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ) {
+                                                                                                            .Block() {
+                                                                                                                .Block(System.String $valueAsString) {
+                                                                                                                    .If (
+                                                                                                                        $reader.IsEmptyElement
+                                                                                                                    ) {
+                                                                                                                        $valueAsString = System.String.Empty
+                                                                                                                    } .Else {
+                                                                                                                        .Block() {
+                                                                                                                            .Call $reader.Read();
+                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                $valueAsString = ""
+                                                                                                                            } .Else {
+                                                                                                                                .Block() {
+                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                $reader.NodeType,
+                                                                                                                                                $reader.LocalName,
+                                                                                                                                                $reader.Value)
+                                                                                                                                        } .Else {
+                                                                                                                                            .Default(System.Void)
+                                                                                                                                        }
+                                                                                                                                    } .Else {
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    };
+                                                                                                                                    $valueAsString = $reader.Value;
+                                                                                                                                    .Call $reader.Read();
+                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                            $reader.NodeType,
+                                                                                                                                            $reader.LocalName,
+                                                                                                                                            $reader.Value)
+                                                                                                                                    } .Else {
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    };
+                                                                                                                    $Example._int32Vector_item = .Call System.Convert.ToInt32(
+                                                                                                                        $valueAsString,
+                                                                                                                        System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                };
+                                                                                                                .Call ($Example._int32Vector).Add($Example._int32Vector_item)
+                                                                                                            }
+                                                                                                        } .Else {
+                                                                                                            .Break end { }
+                                                                                                        }
+                                                                                                    }
+                                                                                                    .LabelTarget end:;
+                                                                                                    .Default(System.Void)
+                                                                                                }
+                                                                                            };
+                                                                                            $state = .Constant<System.Byte>(3)
+                                                                                        }
+                                                                                    } .Else {
+                                                                                        .If (
+                                                                                            .Call System.String.Equals(
+                                                                                                $reader.LocalName,
+                                                                                                "guid",
+                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                $reader.NamespaceURI,
+                                                                                                System.String.Empty,
+                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                $reader.NamespaceURI,
+                                                                                                "urn:ExpressionsTest.Example",
+                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                        ) {
+                                                                                            .Block() {
+                                                                                                .Block() {
                                                                                                     .Block() {
                                                                                                         .Call $reader.Read();
                                                                                                         .Block(
@@ -1008,13 +2002,13 @@
                                                                                                                                         .If (
                                                                                                                                             .Call System.String.Equals(
                                                                                                                                                 $reader.LocalName,
-                                                                                                                                                "_double",
+                                                                                                                                                "Data4",
                                                                                                                                                 .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                                                                                 $reader.NamespaceURI,
                                                                                                                                                 System.String.Empty,
                                                                                                                                                 .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
                                                                                                                                                 $reader.NamespaceURI,
-                                                                                                                                                "urn:ExpressionsTest.Nested",
+                                                                                                                                                "urn:bond.GUID",
                                                                                                                                                 .Constant<System.StringComparison>(OrdinalIgnoreCase)))
                                                                                                                                         ) {
                                                                                                                                             .Block() {
@@ -1058,16 +2052,199 @@
                                                                                                                                                             }
                                                                                                                                                         }
                                                                                                                                                     };
-                                                                                                                                                    $Example._nestedVector_item._double = .Call System.Convert.ToDouble(
+                                                                                                                                                    ($Example.guid).Data4 = .Call System.Convert.ToUInt64(
                                                                                                                                                         $valueAsString,
                                                                                                                                                         System.Globalization.CultureInfo.InvariantCulture)
                                                                                                                                                 };
                                                                                                                                                 $state = .Constant<System.Byte>(3)
                                                                                                                                             }
                                                                                                                                         } .Else {
-                                                                                                                                            .Block() {
-                                                                                                                                                .Call $reader.Skip();
-                                                                                                                                                $state = .Constant<System.Byte>(2)
+                                                                                                                                            .If (
+                                                                                                                                                .Call System.String.Equals(
+                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                    "Data3",
+                                                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                                                    $reader.NamespaceURI,
+                                                                                                                                                    System.String.Empty,
+                                                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                                                    $reader.NamespaceURI,
+                                                                                                                                                    "urn:bond.GUID",
+                                                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                                            ) {
+                                                                                                                                                .Block() {
+                                                                                                                                                    .Block(System.String $valueAsString) {
+                                                                                                                                                        .If (
+                                                                                                                                                            $reader.IsEmptyElement
+                                                                                                                                                        ) {
+                                                                                                                                                            $valueAsString = System.String.Empty
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Block() {
+                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                    $valueAsString = ""
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Block() {
+                                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                                                    $reader.Value)
+                                                                                                                                                                            } .Else {
+                                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                                            }
+                                                                                                                                                                        } .Else {
+                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                        };
+                                                                                                                                                                        $valueAsString = $reader.Value;
+                                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                                                $reader.NodeType,
+                                                                                                                                                                                $reader.LocalName,
+                                                                                                                                                                                $reader.Value)
+                                                                                                                                                                        } .Else {
+                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        };
+                                                                                                                                                        ($Example.guid).Data3 = .Call System.Convert.ToUInt16(
+                                                                                                                                                            $valueAsString,
+                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                                    };
+                                                                                                                                                    $state = .Constant<System.Byte>(3)
+                                                                                                                                                }
+                                                                                                                                            } .Else {
+                                                                                                                                                .If (
+                                                                                                                                                    .Call System.String.Equals(
+                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                        "Data2",
+                                                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                                                        $reader.NamespaceURI,
+                                                                                                                                                        System.String.Empty,
+                                                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                                                        $reader.NamespaceURI,
+                                                                                                                                                        "urn:bond.GUID",
+                                                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                                                ) {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .Block(System.String $valueAsString) {
+                                                                                                                                                            .If (
+                                                                                                                                                                $reader.IsEmptyElement
+                                                                                                                                                            ) {
+                                                                                                                                                                $valueAsString = System.String.Empty
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Block() {
+                                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                        $valueAsString = ""
+                                                                                                                                                                    } .Else {
+                                                                                                                                                                        .Block() {
+                                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                                                        $reader.Value)
+                                                                                                                                                                                } .Else {
+                                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                                }
+                                                                                                                                                                            } .Else {
+                                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                                            };
+                                                                                                                                                                            $valueAsString = $reader.Value;
+                                                                                                                                                                            .Call $reader.Read();
+                                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                                                    $reader.Value)
+                                                                                                                                                                            } .Else {
+                                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                                            }
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            };
+                                                                                                                                                            ($Example.guid).Data2 = .Call System.Convert.ToUInt16(
+                                                                                                                                                                $valueAsString,
+                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                                        };
+                                                                                                                                                        $state = .Constant<System.Byte>(3)
+                                                                                                                                                    }
+                                                                                                                                                } .Else {
+                                                                                                                                                    .If (
+                                                                                                                                                        .Call System.String.Equals(
+                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                            "Data1",
+                                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                                                            $reader.NamespaceURI,
+                                                                                                                                                            System.String.Empty,
+                                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                                                            $reader.NamespaceURI,
+                                                                                                                                                            "urn:bond.GUID",
+                                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                                                    ) {
+                                                                                                                                                        .Block() {
+                                                                                                                                                            .Block(System.String $valueAsString) {
+                                                                                                                                                                .If (
+                                                                                                                                                                    $reader.IsEmptyElement
+                                                                                                                                                                ) {
+                                                                                                                                                                    $valueAsString = System.String.Empty
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Block() {
+                                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                            $valueAsString = ""
+                                                                                                                                                                        } .Else {
+                                                                                                                                                                            .Block() {
+                                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                                                            $reader.Value)
+                                                                                                                                                                                    } .Else {
+                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                    }
+                                                                                                                                                                                } .Else {
+                                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                                };
+                                                                                                                                                                                $valueAsString = $reader.Value;
+                                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                                                        $reader.Value)
+                                                                                                                                                                                } .Else {
+                                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                };
+                                                                                                                                                                ($Example.guid).Data1 = .Call System.Convert.ToUInt32(
+                                                                                                                                                                    $valueAsString,
+                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                                            };
+                                                                                                                                                            $state = .Constant<System.Byte>(3)
+                                                                                                                                                        }
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Block() {
+                                                                                                                                                            .Call $reader.Skip();
+                                                                                                                                                            $state = .Constant<System.Byte>(2)
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                }
                                                                                                                                             }
                                                                                                                                         };
                                                                                                                                         .Default(System.Void)
@@ -1127,682 +2304,13 @@
                                                                                                         }
                                                                                                     }
                                                                                                 };
-                                                                                                .Call ($Example._nestedVector).Add($Example._nestedVector_item)
-                                                                                            }
-                                                                                        } .Else {
-                                                                                            .Break end { }
-                                                                                        }
-                                                                                    }
-                                                                                    .LabelTarget end:;
-                                                                                    .Default(System.Void)
-                                                                                }
-                                                                            };
-                                                                            $state = .Constant<System.Byte>(3)
-                                                                        }
-                                                                    } .Else {
-                                                                        .If (
-                                                                            .Call System.String.Equals(
-                                                                                $reader.LocalName,
-                                                                                "_int32Vector",
-                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                $reader.NamespaceURI,
-                                                                                System.String.Empty,
-                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                $reader.NamespaceURI,
-                                                                                "urn:ExpressionsTest.Example",
-                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                        ) {
-                                                                            .Block() {
-                                                                                .Block(System.Boolean $isEmpty) {
-                                                                                    $isEmpty = $reader.IsEmptyElement;
-                                                                                    .Block(System.Int32 $Example._int32Vector_item) {
-                                                                                        .Block(System.Int32 $Example._int32Vector_count) {
-                                                                                            $Example._int32Vector_count = 0;
-                                                                                            .Default(System.Void);
-                                                                                            ($Example._int32Vector).Capacity = $Example._int32Vector_count
-                                                                                        };
-                                                                                        .Loop  {
-                                                                                            .If (
-                                                                                                .If (
-                                                                                                    $isEmpty
-                                                                                                ) {
-                                                                                                    False
-                                                                                                } .Else {
-                                                                                                    .Block() {
-                                                                                                        .Loop  {
-                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                .Call $reader.Read()
-                                                                                                            } .Else {
-                                                                                                                .Break end { }
-                                                                                                            }
-                                                                                                        }
-                                                                                                        .LabelTarget end:;
-                                                                                                        .Loop  {
-                                                                                                            .Block() {
-                                                                                                                .Call $reader.Read();
-                                                                                                                .If (
-                                                                                                                    !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
-                                                                                                                ) {
-                                                                                                                    .Break end { }
-                                                                                                                } .Else {
-                                                                                                                    .Default(System.Void)
-                                                                                                                }
-                                                                                                            }
-                                                                                                        }
-                                                                                                        .LabelTarget end:;
-                                                                                                        .If (
-                                                                                                            $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
-                                                                                                        ) {
-                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                .Constant<System.Byte>(0),
-                                                                                                                $reader.NodeType,
-                                                                                                                $reader.LocalName,
-                                                                                                                $reader.Value)
-                                                                                                        } .Else {
-                                                                                                            .Default(System.Void)
-                                                                                                        };
-                                                                                                        $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
-                                                                                                    }
-                                                                                                }
-                                                                                            ) {
-                                                                                                .Block() {
-                                                                                                    .Block(System.String $valueAsString) {
-                                                                                                        .If (
-                                                                                                            $reader.IsEmptyElement
-                                                                                                        ) {
-                                                                                                            $valueAsString = System.String.Empty
-                                                                                                        } .Else {
-                                                                                                            .Block() {
-                                                                                                                .Call $reader.Read();
-                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                    $valueAsString = ""
-                                                                                                                } .Else {
-                                                                                                                    .Block() {
-                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                    .Constant<System.Byte>(0),
-                                                                                                                                    $reader.NodeType,
-                                                                                                                                    $reader.LocalName,
-                                                                                                                                    $reader.Value)
-                                                                                                                            } .Else {
-                                                                                                                                .Default(System.Void)
-                                                                                                                            }
-                                                                                                                        } .Else {
-                                                                                                                            .Default(System.Void)
-                                                                                                                        };
-                                                                                                                        $valueAsString = $reader.Value;
-                                                                                                                        .Call $reader.Read();
-                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                .Constant<System.Byte>(0),
-                                                                                                                                $reader.NodeType,
-                                                                                                                                $reader.LocalName,
-                                                                                                                                $reader.Value)
-                                                                                                                        } .Else {
-                                                                                                                            .Default(System.Void)
-                                                                                                                        }
-                                                                                                                    }
-                                                                                                                }
-                                                                                                            }
-                                                                                                        };
-                                                                                                        $Example._int32Vector_item = .Call System.Convert.ToInt32(
-                                                                                                            $valueAsString,
-                                                                                                            System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                    };
-                                                                                                    .Call ($Example._int32Vector).Add($Example._int32Vector_item)
-                                                                                                }
-                                                                                            } .Else {
-                                                                                                .Break end { }
-                                                                                            }
-                                                                                        }
-                                                                                        .LabelTarget end:;
-                                                                                        .Default(System.Void)
-                                                                                    }
-                                                                                };
-                                                                                $state = .Constant<System.Byte>(3)
-                                                                            }
-                                                                        } .Else {
-                                                                            .If (
-                                                                                .Call System.String.Equals(
-                                                                                    $reader.LocalName,
-                                                                                    "guid",
-                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                    $reader.NamespaceURI,
-                                                                                    System.String.Empty,
-                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                    $reader.NamespaceURI,
-                                                                                    "urn:ExpressionsTest.Example",
-                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                            ) {
-                                                                                .Block() {
-                                                                                    .Block() {
-                                                                                        .Block() {
-                                                                                            .Call $reader.Read();
-                                                                                            .Block(
-                                                                                                System.Byte $state,
-                                                                                                Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
-                                                                                                .Default(System.Void);
-                                                                                                .Default(System.Void);
-                                                                                                $state = .Constant<System.Byte>(1);
-                                                                                                .Loop  {
-                                                                                                    .If (
-                                                                                                        !$reader.EOF && $state != .Constant<System.Byte>(4)
-                                                                                                    ) {
-                                                                                                        .Switch ($reader.NodeType) {
-                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(Element)):
-                                                                                                                .Switch ($state) {
-                                                                                                                .Case (.Constant<System.Byte>(1)):
-                                                                                                                        .Block() {
-                                                                                                                            .Block() {
-                                                                                                                                .If (
-                                                                                                                                    $reader.IsEmptyElement
-                                                                                                                                ) {
-                                                                                                                                    $state = .Constant<System.Byte>(4)
-                                                                                                                                } .Else {
-                                                                                                                                    $state = .Constant<System.Byte>(2)
-                                                                                                                                };
-                                                                                                                                .Call $reader.Read()
-                                                                                                                            };
-                                                                                                                            .Default(System.Void)
-                                                                                                                        }
-                                                                                                                .Case (.Constant<System.Byte>(2)):
-                                                                                                                        .Block() {
-                                                                                                                            .If (
-                                                                                                                                .Call System.String.Equals(
-                                                                                                                                    $reader.LocalName,
-                                                                                                                                    "Data4",
-                                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                                                                    $reader.NamespaceURI,
-                                                                                                                                    System.String.Empty,
-                                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                                                                    $reader.NamespaceURI,
-                                                                                                                                    "urn:bond.GUID",
-                                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                                                                            ) {
-                                                                                                                                .Block() {
-                                                                                                                                    .Block(System.String $valueAsString) {
-                                                                                                                                        .If (
-                                                                                                                                            $reader.IsEmptyElement
-                                                                                                                                        ) {
-                                                                                                                                            $valueAsString = System.String.Empty
-                                                                                                                                        } .Else {
-                                                                                                                                            .Block() {
-                                                                                                                                                .Call $reader.Read();
-                                                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                                    $valueAsString = ""
-                                                                                                                                                } .Else {
-                                                                                                                                                    .Block() {
-                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                                    .Constant<System.Byte>(0),
-                                                                                                                                                                    $reader.NodeType,
-                                                                                                                                                                    $reader.LocalName,
-                                                                                                                                                                    $reader.Value)
-                                                                                                                                                            } .Else {
-                                                                                                                                                                .Default(System.Void)
-                                                                                                                                                            }
-                                                                                                                                                        } .Else {
-                                                                                                                                                            .Default(System.Void)
-                                                                                                                                                        };
-                                                                                                                                                        $valueAsString = $reader.Value;
-                                                                                                                                                        .Call $reader.Read();
-                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                                .Constant<System.Byte>(0),
-                                                                                                                                                                $reader.NodeType,
-                                                                                                                                                                $reader.LocalName,
-                                                                                                                                                                $reader.Value)
-                                                                                                                                                        } .Else {
-                                                                                                                                                            .Default(System.Void)
-                                                                                                                                                        }
-                                                                                                                                                    }
-                                                                                                                                                }
-                                                                                                                                            }
-                                                                                                                                        };
-                                                                                                                                        ($Example.guid).Data4 = .Call System.Convert.ToUInt64(
-                                                                                                                                            $valueAsString,
-                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                                                    };
-                                                                                                                                    $state = .Constant<System.Byte>(3)
-                                                                                                                                }
-                                                                                                                            } .Else {
-                                                                                                                                .If (
-                                                                                                                                    .Call System.String.Equals(
-                                                                                                                                        $reader.LocalName,
-                                                                                                                                        "Data3",
-                                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                                                                        $reader.NamespaceURI,
-                                                                                                                                        System.String.Empty,
-                                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                                                                        $reader.NamespaceURI,
-                                                                                                                                        "urn:bond.GUID",
-                                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                                                                                ) {
-                                                                                                                                    .Block() {
-                                                                                                                                        .Block(System.String $valueAsString) {
-                                                                                                                                            .If (
-                                                                                                                                                $reader.IsEmptyElement
-                                                                                                                                            ) {
-                                                                                                                                                $valueAsString = System.String.Empty
-                                                                                                                                            } .Else {
-                                                                                                                                                .Block() {
-                                                                                                                                                    .Call $reader.Read();
-                                                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                                        $valueAsString = ""
-                                                                                                                                                    } .Else {
-                                                                                                                                                        .Block() {
-                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                                        .Constant<System.Byte>(0),
-                                                                                                                                                                        $reader.NodeType,
-                                                                                                                                                                        $reader.LocalName,
-                                                                                                                                                                        $reader.Value)
-                                                                                                                                                                } .Else {
-                                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                                }
-                                                                                                                                                            } .Else {
-                                                                                                                                                                .Default(System.Void)
-                                                                                                                                                            };
-                                                                                                                                                            $valueAsString = $reader.Value;
-                                                                                                                                                            .Call $reader.Read();
-                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                                    .Constant<System.Byte>(0),
-                                                                                                                                                                    $reader.NodeType,
-                                                                                                                                                                    $reader.LocalName,
-                                                                                                                                                                    $reader.Value)
-                                                                                                                                                            } .Else {
-                                                                                                                                                                .Default(System.Void)
-                                                                                                                                                            }
-                                                                                                                                                        }
-                                                                                                                                                    }
-                                                                                                                                                }
-                                                                                                                                            };
-                                                                                                                                            ($Example.guid).Data3 = .Call System.Convert.ToUInt16(
-                                                                                                                                                $valueAsString,
-                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                                                        };
-                                                                                                                                        $state = .Constant<System.Byte>(3)
-                                                                                                                                    }
-                                                                                                                                } .Else {
-                                                                                                                                    .If (
-                                                                                                                                        .Call System.String.Equals(
-                                                                                                                                            $reader.LocalName,
-                                                                                                                                            "Data2",
-                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                                                                            $reader.NamespaceURI,
-                                                                                                                                            System.String.Empty,
-                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                                                                            $reader.NamespaceURI,
-                                                                                                                                            "urn:bond.GUID",
-                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                                                                                    ) {
-                                                                                                                                        .Block() {
-                                                                                                                                            .Block(System.String $valueAsString) {
-                                                                                                                                                .If (
-                                                                                                                                                    $reader.IsEmptyElement
-                                                                                                                                                ) {
-                                                                                                                                                    $valueAsString = System.String.Empty
-                                                                                                                                                } .Else {
-                                                                                                                                                    .Block() {
-                                                                                                                                                        .Call $reader.Read();
-                                                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                                            $valueAsString = ""
-                                                                                                                                                        } .Else {
-                                                                                                                                                            .Block() {
-                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                                            .Constant<System.Byte>(0),
-                                                                                                                                                                            $reader.NodeType,
-                                                                                                                                                                            $reader.LocalName,
-                                                                                                                                                                            $reader.Value)
-                                                                                                                                                                    } .Else {
-                                                                                                                                                                        .Default(System.Void)
-                                                                                                                                                                    }
-                                                                                                                                                                } .Else {
-                                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                                };
-                                                                                                                                                                $valueAsString = $reader.Value;
-                                                                                                                                                                .Call $reader.Read();
-                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                                        .Constant<System.Byte>(0),
-                                                                                                                                                                        $reader.NodeType,
-                                                                                                                                                                        $reader.LocalName,
-                                                                                                                                                                        $reader.Value)
-                                                                                                                                                                } .Else {
-                                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                                }
-                                                                                                                                                            }
-                                                                                                                                                        }
-                                                                                                                                                    }
-                                                                                                                                                };
-                                                                                                                                                ($Example.guid).Data2 = .Call System.Convert.ToUInt16(
-                                                                                                                                                    $valueAsString,
-                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                                                            };
-                                                                                                                                            $state = .Constant<System.Byte>(3)
-                                                                                                                                        }
-                                                                                                                                    } .Else {
-                                                                                                                                        .If (
-                                                                                                                                            .Call System.String.Equals(
-                                                                                                                                                $reader.LocalName,
-                                                                                                                                                "Data1",
-                                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                                                                                $reader.NamespaceURI,
-                                                                                                                                                System.String.Empty,
-                                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                                                                                $reader.NamespaceURI,
-                                                                                                                                                "urn:bond.GUID",
-                                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                                                                                        ) {
-                                                                                                                                            .Block() {
-                                                                                                                                                .Block(System.String $valueAsString) {
-                                                                                                                                                    .If (
-                                                                                                                                                        $reader.IsEmptyElement
-                                                                                                                                                    ) {
-                                                                                                                                                        $valueAsString = System.String.Empty
-                                                                                                                                                    } .Else {
-                                                                                                                                                        .Block() {
-                                                                                                                                                            .Call $reader.Read();
-                                                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                                                $valueAsString = ""
-                                                                                                                                                            } .Else {
-                                                                                                                                                                .Block() {
-                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                                                .Constant<System.Byte>(0),
-                                                                                                                                                                                $reader.NodeType,
-                                                                                                                                                                                $reader.LocalName,
-                                                                                                                                                                                $reader.Value)
-                                                                                                                                                                        } .Else {
-                                                                                                                                                                            .Default(System.Void)
-                                                                                                                                                                        }
-                                                                                                                                                                    } .Else {
-                                                                                                                                                                        .Default(System.Void)
-                                                                                                                                                                    };
-                                                                                                                                                                    $valueAsString = $reader.Value;
-                                                                                                                                                                    .Call $reader.Read();
-                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                                            .Constant<System.Byte>(0),
-                                                                                                                                                                            $reader.NodeType,
-                                                                                                                                                                            $reader.LocalName,
-                                                                                                                                                                            $reader.Value)
-                                                                                                                                                                    } .Else {
-                                                                                                                                                                        .Default(System.Void)
-                                                                                                                                                                    }
-                                                                                                                                                                }
-                                                                                                                                                            }
-                                                                                                                                                        }
-                                                                                                                                                    };
-                                                                                                                                                    ($Example.guid).Data1 = .Call System.Convert.ToUInt32(
-                                                                                                                                                        $valueAsString,
-                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                                                                };
-                                                                                                                                                $state = .Constant<System.Byte>(3)
-                                                                                                                                            }
-                                                                                                                                        } .Else {
-                                                                                                                                            .Block() {
-                                                                                                                                                .Call $reader.Skip();
-                                                                                                                                                $state = .Constant<System.Byte>(2)
-                                                                                                                                            }
-                                                                                                                                        }
-                                                                                                                                    }
-                                                                                                                                }
-                                                                                                                            };
-                                                                                                                            .Default(System.Void)
-                                                                                                                        }
-                                                                                                                .Case (.Constant<System.Byte>(3)):
-                                                                                                                        .Block() {
-                                                                                                                            .Call $reader.Read();
-                                                                                                                            $state = .Constant<System.Byte>(2);
-                                                                                                                            .Default(System.Void)
-                                                                                                                        }
-                                                                                                                .Default:
-                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                            $state,
-                                                                                                                            $reader.NodeType,
-                                                                                                                            $reader.LocalName,
-                                                                                                                            $reader.Value)
-                                                                                                                }
-                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(EndElement)):
-                                                                                                                .Switch ($state) {
-                                                                                                                .Case (.Constant<System.Byte>(3)):
-                                                                                                                        .Block() {
-                                                                                                                            .Call $reader.Read();
-                                                                                                                            $state = .Constant<System.Byte>(2);
-                                                                                                                            .Default(System.Void)
-                                                                                                                        }
-                                                                                                                .Case (.Constant<System.Byte>(2)):
-                                                                                                                        .Block() {
-                                                                                                                            .Call $reader.Read();
-                                                                                                                            $state = .Constant<System.Byte>(4);
-                                                                                                                            .Default(System.Void)
-                                                                                                                        }
-                                                                                                                .Default:
-                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                            $state,
-                                                                                                                            $reader.NodeType,
-                                                                                                                            $reader.LocalName,
-                                                                                                                            $reader.Value)
-                                                                                                                }
-                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(Comment)):
-                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(Text)):
-                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(Whitespace)):
-                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(XmlDeclaration)):
-                                                                                                                .Block() {
-                                                                                                                    .Call $reader.Read();
-                                                                                                                    .Default(System.Void)
-                                                                                                                }
-                                                                                                        .Default:
-                                                                                                                .Invoke (.Lambda #Lambda3<System.Action`1[System.Xml.XmlNodeType]>)($reader.NodeType)
-                                                                                                        }
-                                                                                                    } .Else {
-                                                                                                        .Break endStateMachineLoop { }
-                                                                                                    }
-                                                                                                }
-                                                                                                .LabelTarget endStateMachineLoop:;
-                                                                                                .Default(System.Void);
-                                                                                                .Default(System.Void)
-                                                                                            }
-                                                                                        }
-                                                                                    };
-                                                                                    $state = .Constant<System.Byte>(3)
-                                                                                }
-                                                                            } .Else {
-                                                                                .If (
-                                                                                    .Call System.String.Equals(
-                                                                                        $reader.LocalName,
-                                                                                        "_double",
-                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                        $reader.NamespaceURI,
-                                                                                        System.String.Empty,
-                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                        $reader.NamespaceURI,
-                                                                                        "urn:ExpressionsTest.Example",
-                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                                ) {
-                                                                                    .Block() {
-                                                                                        .Block(System.String $valueAsString) {
-                                                                                            .If (
-                                                                                                $reader.IsEmptyElement
-                                                                                            ) {
-                                                                                                $valueAsString = System.String.Empty
-                                                                                            } .Else {
-                                                                                                .Block() {
-                                                                                                    .Call $reader.Read();
-                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                        $valueAsString = ""
-                                                                                                    } .Else {
-                                                                                                        .Block() {
-                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                        .Constant<System.Byte>(0),
-                                                                                                                        $reader.NodeType,
-                                                                                                                        $reader.LocalName,
-                                                                                                                        $reader.Value)
-                                                                                                                } .Else {
-                                                                                                                    .Default(System.Void)
-                                                                                                                }
-                                                                                                            } .Else {
-                                                                                                                .Default(System.Void)
-                                                                                                            };
-                                                                                                            $valueAsString = $reader.Value;
-                                                                                                            .Call $reader.Read();
-                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                    .Constant<System.Byte>(0),
-                                                                                                                    $reader.NodeType,
-                                                                                                                    $reader.LocalName,
-                                                                                                                    $reader.Value)
-                                                                                                            } .Else {
-                                                                                                                .Default(System.Void)
-                                                                                                            }
-                                                                                                        }
-                                                                                                    }
-                                                                                                }
-                                                                                            };
-                                                                                            $Example._double = .Call System.Convert.ToDouble(
-                                                                                                $valueAsString,
-                                                                                                System.Globalization.CultureInfo.InvariantCulture)
-                                                                                        };
-                                                                                        $state = .Constant<System.Byte>(3)
-                                                                                    }
-                                                                                } .Else {
-                                                                                    .If (
-                                                                                        .Call System.String.Equals(
-                                                                                            $reader.LocalName,
-                                                                                            "_int64",
-                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                            $reader.NamespaceURI,
-                                                                                            System.String.Empty,
-                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                            $reader.NamespaceURI,
-                                                                                            "urn:ExpressionsTest.Example",
-                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                                    ) {
-                                                                                        .Block() {
-                                                                                            .Block(System.String $valueAsString) {
-                                                                                                .If (
-                                                                                                    $reader.IsEmptyElement
-                                                                                                ) {
-                                                                                                    $valueAsString = System.String.Empty
-                                                                                                } .Else {
-                                                                                                    .Block() {
-                                                                                                        .Call $reader.Read();
-                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                            $valueAsString = ""
-                                                                                                        } .Else {
-                                                                                                            .Block() {
-                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                            .Constant<System.Byte>(0),
-                                                                                                                            $reader.NodeType,
-                                                                                                                            $reader.LocalName,
-                                                                                                                            $reader.Value)
-                                                                                                                    } .Else {
-                                                                                                                        .Default(System.Void)
-                                                                                                                    }
-                                                                                                                } .Else {
-                                                                                                                    .Default(System.Void)
-                                                                                                                };
-                                                                                                                $valueAsString = $reader.Value;
-                                                                                                                .Call $reader.Read();
-                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                        .Constant<System.Byte>(0),
-                                                                                                                        $reader.NodeType,
-                                                                                                                        $reader.LocalName,
-                                                                                                                        $reader.Value)
-                                                                                                                } .Else {
-                                                                                                                    .Default(System.Void)
-                                                                                                                }
-                                                                                                            }
-                                                                                                        }
-                                                                                                    }
-                                                                                                };
-                                                                                                $Example._int64 = .Call System.Convert.ToInt64(
-                                                                                                    $valueAsString,
-                                                                                                    System.Globalization.CultureInfo.InvariantCulture)
-                                                                                            };
-                                                                                            $state = .Constant<System.Byte>(3);
-                                                                                            .Call $requiredFields.Reset(
-                                                                                                0,
-                                                                                                1L)
-                                                                                        }
-                                                                                    } .Else {
-                                                                                        .If (
-                                                                                            .Call System.String.Equals(
-                                                                                                $reader.LocalName,
-                                                                                                "_int8",
-                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                                $reader.NamespaceURI,
-                                                                                                System.String.Empty,
-                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                                $reader.NamespaceURI,
-                                                                                                "urn:ExpressionsTest.Example",
-                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                                        ) {
-                                                                                            .Block() {
-                                                                                                .Block(System.String $valueAsString) {
-                                                                                                    .If (
-                                                                                                        $reader.IsEmptyElement
-                                                                                                    ) {
-                                                                                                        $valueAsString = System.String.Empty
-                                                                                                    } .Else {
-                                                                                                        .Block() {
-                                                                                                            .Call $reader.Read();
-                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                $valueAsString = ""
-                                                                                                            } .Else {
-                                                                                                                .Block() {
-                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                .Constant<System.Byte>(0),
-                                                                                                                                $reader.NodeType,
-                                                                                                                                $reader.LocalName,
-                                                                                                                                $reader.Value)
-                                                                                                                        } .Else {
-                                                                                                                            .Default(System.Void)
-                                                                                                                        }
-                                                                                                                    } .Else {
-                                                                                                                        .Default(System.Void)
-                                                                                                                    };
-                                                                                                                    $valueAsString = $reader.Value;
-                                                                                                                    .Call $reader.Read();
-                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                            .Constant<System.Byte>(0),
-                                                                                                                            $reader.NodeType,
-                                                                                                                            $reader.LocalName,
-                                                                                                                            $reader.Value)
-                                                                                                                    } .Else {
-                                                                                                                        .Default(System.Void)
-                                                                                                                    }
-                                                                                                                }
-                                                                                                            }
-                                                                                                        }
-                                                                                                    };
-                                                                                                    $Example._int8 = .Call System.Convert.ToSByte(
-                                                                                                        $valueAsString,
-                                                                                                        System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                };
                                                                                                 $state = .Constant<System.Byte>(3)
                                                                                             }
                                                                                         } .Else {
                                                                                             .If (
                                                                                                 .Call System.String.Equals(
                                                                                                     $reader.LocalName,
-                                                                                                    "_uint32",
+                                                                                                    "_double",
                                                                                                     .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                                     $reader.NamespaceURI,
                                                                                                     System.String.Empty,
@@ -1852,7 +2360,7 @@
                                                                                                                 }
                                                                                                             }
                                                                                                         };
-                                                                                                        $Example._uint32 = .Call System.Convert.ToUInt32(
+                                                                                                        $Example._double = .Call System.Convert.ToDouble(
                                                                                                             $valueAsString,
                                                                                                             System.Globalization.CultureInfo.InvariantCulture)
                                                                                                     };
@@ -1862,7 +2370,7 @@
                                                                                                 .If (
                                                                                                     .Call System.String.Equals(
                                                                                                         $reader.LocalName,
-                                                                                                        "_str",
+                                                                                                        "_int64",
                                                                                                         .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                                         $reader.NamespaceURI,
                                                                                                         System.String.Empty,
@@ -1912,15 +2420,20 @@
                                                                                                                     }
                                                                                                                 }
                                                                                                             };
-                                                                                                            $Example._str = $valueAsString
+                                                                                                            $Example._int64 = .Call System.Convert.ToInt64(
+                                                                                                                $valueAsString,
+                                                                                                                System.Globalization.CultureInfo.InvariantCulture)
                                                                                                         };
-                                                                                                        $state = .Constant<System.Byte>(3)
+                                                                                                        $state = .Constant<System.Byte>(3);
+                                                                                                        .Call $requiredFields.Reset(
+                                                                                                            0,
+                                                                                                            1L)
                                                                                                     }
                                                                                                 } .Else {
                                                                                                     .If (
                                                                                                         .Call System.String.Equals(
                                                                                                             $reader.LocalName,
-                                                                                                            "_bool",
+                                                                                                            "_int8",
                                                                                                             .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                                             $reader.NamespaceURI,
                                                                                                             System.String.Empty,
@@ -1970,16 +2483,197 @@
                                                                                                                         }
                                                                                                                     }
                                                                                                                 };
-                                                                                                                $Example._bool = .Call System.Convert.ToBoolean(
+                                                                                                                $Example._int8 = .Call System.Convert.ToSByte(
                                                                                                                     $valueAsString,
                                                                                                                     System.Globalization.CultureInfo.InvariantCulture)
                                                                                                             };
                                                                                                             $state = .Constant<System.Byte>(3)
                                                                                                         }
                                                                                                     } .Else {
-                                                                                                        .Block() {
-                                                                                                            .Call $reader.Skip();
-                                                                                                            $state = .Constant<System.Byte>(2)
+                                                                                                        .If (
+                                                                                                            .Call System.String.Equals(
+                                                                                                                $reader.LocalName,
+                                                                                                                "_uint32",
+                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                $reader.NamespaceURI,
+                                                                                                                System.String.Empty,
+                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                $reader.NamespaceURI,
+                                                                                                                "urn:ExpressionsTest.Example",
+                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                        ) {
+                                                                                                            .Block() {
+                                                                                                                .Block(System.String $valueAsString) {
+                                                                                                                    .If (
+                                                                                                                        $reader.IsEmptyElement
+                                                                                                                    ) {
+                                                                                                                        $valueAsString = System.String.Empty
+                                                                                                                    } .Else {
+                                                                                                                        .Block() {
+                                                                                                                            .Call $reader.Read();
+                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                $valueAsString = ""
+                                                                                                                            } .Else {
+                                                                                                                                .Block() {
+                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                $reader.NodeType,
+                                                                                                                                                $reader.LocalName,
+                                                                                                                                                $reader.Value)
+                                                                                                                                        } .Else {
+                                                                                                                                            .Default(System.Void)
+                                                                                                                                        }
+                                                                                                                                    } .Else {
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    };
+                                                                                                                                    $valueAsString = $reader.Value;
+                                                                                                                                    .Call $reader.Read();
+                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                            $reader.NodeType,
+                                                                                                                                            $reader.LocalName,
+                                                                                                                                            $reader.Value)
+                                                                                                                                    } .Else {
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    };
+                                                                                                                    $Example._uint32 = .Call System.Convert.ToUInt32(
+                                                                                                                        $valueAsString,
+                                                                                                                        System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                };
+                                                                                                                $state = .Constant<System.Byte>(3)
+                                                                                                            }
+                                                                                                        } .Else {
+                                                                                                            .If (
+                                                                                                                .Call System.String.Equals(
+                                                                                                                    $reader.LocalName,
+                                                                                                                    "_str",
+                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                    $reader.NamespaceURI,
+                                                                                                                    System.String.Empty,
+                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                    $reader.NamespaceURI,
+                                                                                                                    "urn:ExpressionsTest.Example",
+                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                            ) {
+                                                                                                                .Block() {
+                                                                                                                    .Block(System.String $valueAsString) {
+                                                                                                                        .If (
+                                                                                                                            $reader.IsEmptyElement
+                                                                                                                        ) {
+                                                                                                                            $valueAsString = System.String.Empty
+                                                                                                                        } .Else {
+                                                                                                                            .Block() {
+                                                                                                                                .Call $reader.Read();
+                                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                    $valueAsString = ""
+                                                                                                                                } .Else {
+                                                                                                                                    .Block() {
+                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                    $reader.Value)
+                                                                                                                                            } .Else {
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                            }
+                                                                                                                                        } .Else {
+                                                                                                                                            .Default(System.Void)
+                                                                                                                                        };
+                                                                                                                                        $valueAsString = $reader.Value;
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                $reader.NodeType,
+                                                                                                                                                $reader.LocalName,
+                                                                                                                                                $reader.Value)
+                                                                                                                                        } .Else {
+                                                                                                                                            .Default(System.Void)
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        };
+                                                                                                                        $Example._str = $valueAsString
+                                                                                                                    };
+                                                                                                                    $state = .Constant<System.Byte>(3)
+                                                                                                                }
+                                                                                                            } .Else {
+                                                                                                                .If (
+                                                                                                                    .Call System.String.Equals(
+                                                                                                                        $reader.LocalName,
+                                                                                                                        "_bool",
+                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                        $reader.NamespaceURI,
+                                                                                                                        System.String.Empty,
+                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                        $reader.NamespaceURI,
+                                                                                                                        "urn:ExpressionsTest.Example",
+                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                ) {
+                                                                                                                    .Block() {
+                                                                                                                        .Block(System.String $valueAsString) {
+                                                                                                                            .If (
+                                                                                                                                $reader.IsEmptyElement
+                                                                                                                            ) {
+                                                                                                                                $valueAsString = System.String.Empty
+                                                                                                                            } .Else {
+                                                                                                                                .Block() {
+                                                                                                                                    .Call $reader.Read();
+                                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                        $valueAsString = ""
+                                                                                                                                    } .Else {
+                                                                                                                                        .Block() {
+                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                        $reader.Value)
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                }
+                                                                                                                                            } .Else {
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                            };
+                                                                                                                                            $valueAsString = $reader.Value;
+                                                                                                                                            .Call $reader.Read();
+                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                    $reader.Value)
+                                                                                                                                            } .Else {
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            };
+                                                                                                                            $Example._bool = .Call System.Convert.ToBoolean(
+                                                                                                                                $valueAsString,
+                                                                                                                                System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                        };
+                                                                                                                        $state = .Constant<System.Byte>(3)
+                                                                                                                    }
+                                                                                                                } .Else {
+                                                                                                                    .Block() {
+                                                                                                                        .Call $reader.Skip();
+                                                                                                                        $state = .Constant<System.Byte>(2)
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
                                                                                                         }
                                                                                                     }
                                                                                                 }

--- a/cs/test/expressions/DeserializeXml.expressions
+++ b/cs/test/expressions/DeserializeXml.expressions
@@ -222,7 +222,7 @@
                                                     .If (
                                                         .Call System.String.Equals(
                                                             $reader.LocalName,
-                                                            "_decNullable",
+                                                            "_refNullable",
                                                             .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                             $reader.NamespaceURI,
                                                             System.String.Empty,
@@ -235,6 +235,7 @@
                                                             .Block(System.Boolean $isEmpty) {
                                                                 $isEmpty = $reader.IsEmptyElement;
                                                                 .Block() {
+                                                                    $Example._refNullable = .Default(ExpressionsTest.RefObject);
                                                                     .Loop  {
                                                                         .If (
                                                                             .If (
@@ -284,12 +285,12 @@
                                                                                 .Block(
                                                                                     System.Int32 $index,
                                                                                     System.Byte[] $array) {
-                                                                                    .Block(System.Int32 $Example._decNullable_count) {
-                                                                                        $Example._decNullable_count = 0;
+                                                                                    .Block(System.Int32 $Example._refNullable_count) {
+                                                                                        $Example._refNullable_count = 0;
                                                                                         .Default(System.Void);
                                                                                         .Block() {
                                                                                             $index = 0;
-                                                                                            $array = .NewArray System.Byte[$Example._decNullable_count]
+                                                                                            $array = .NewArray System.Byte[$Example._refNullable_count]
                                                                                         }
                                                                                     };
                                                                                     .Loop  {
@@ -398,12 +399,12 @@
                                                                                         }
                                                                                     }
                                                                                     .LabelTarget end:;
-                                                                                    $Example._decNullable = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                    $Example._refNullable = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                                                                                         .New System.ArraySegment`1[System.Byte](
                                                                                             $array,
                                                                                             0,
                                                                                             $index),
-                                                                                        .Default(System.Decimal))
+                                                                                        .Default(ExpressionsTest.RefObject))
                                                                                 }
                                                                             }
                                                                         } .Else {
@@ -419,7 +420,7 @@
                                                         .If (
                                                             .Call System.String.Equals(
                                                                 $reader.LocalName,
-                                                                "_decMap",
+                                                                "_refMap",
                                                                 .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                 $reader.NamespaceURI,
                                                                 System.String.Empty,
@@ -432,8 +433,8 @@
                                                                 .Block(System.Boolean $isEmpty) {
                                                                     $isEmpty = $reader.IsEmptyElement;
                                                                     .Block(
-                                                                        System.Int32 $Example._decMap_key,
-                                                                        System.Decimal $Example._decMap_value) {
+                                                                        System.Int32 $Example._refMap_key,
+                                                                        ExpressionsTest.RefObject $Example._refMap_value) {
                                                                         .Default(System.Void);
                                                                         .Loop  {
                                                                             .If (
@@ -520,7 +521,7 @@
                                                                                                 }
                                                                                             }
                                                                                         };
-                                                                                        $Example._decMap_key = .Call System.Convert.ToInt32(
+                                                                                        $Example._refMap_key = .Call System.Convert.ToInt32(
                                                                                             $valueAsString,
                                                                                             System.Globalization.CultureInfo.InvariantCulture)
                                                                                     };
@@ -570,12 +571,12 @@
                                                                                         .Block(
                                                                                             System.Int32 $index,
                                                                                             System.Byte[] $array) {
-                                                                                            .Block(System.Int32 $Example._decMap_value_count) {
-                                                                                                $Example._decMap_value_count = 0;
+                                                                                            .Block(System.Int32 $Example._refMap_value_count) {
+                                                                                                $Example._refMap_value_count = 0;
                                                                                                 .Default(System.Void);
                                                                                                 .Block() {
                                                                                                     $index = 0;
-                                                                                                    $array = .NewArray System.Byte[$Example._decMap_value_count]
+                                                                                                    $array = .NewArray System.Byte[$Example._refMap_value_count]
                                                                                                 }
                                                                                             };
                                                                                             .Loop  {
@@ -684,15 +685,15 @@
                                                                                                 }
                                                                                             }
                                                                                             .LabelTarget end:;
-                                                                                            $Example._decMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                            $Example._refMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                                                                                                 .New System.ArraySegment`1[System.Byte](
                                                                                                     $array,
                                                                                                     0,
                                                                                                     $index),
-                                                                                                .Default(System.Decimal))
+                                                                                                .Default(ExpressionsTest.RefObject))
                                                                                         }
                                                                                     };
-                                                                                    ($Example._decMap).Item[$Example._decMap_key] = $Example._decMap_value
+                                                                                    ($Example._refMap).Item[$Example._refMap_key] = $Example._refMap_value
                                                                                 }
                                                                             } .Else {
                                                                                 .Break end { }
@@ -707,7 +708,7 @@
                                                             .If (
                                                                 .Call System.String.Equals(
                                                                     $reader.LocalName,
-                                                                    "_decVector",
+                                                                    "_refVector",
                                                                     .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                     $reader.NamespaceURI,
                                                                     System.String.Empty,
@@ -719,11 +720,11 @@
                                                                 .Block() {
                                                                     .Block(System.Boolean $isEmpty) {
                                                                         $isEmpty = $reader.IsEmptyElement;
-                                                                        .Block(System.Decimal $Example._decVector_item) {
-                                                                            .Block(System.Int32 $Example._decVector_count) {
-                                                                                $Example._decVector_count = 0;
+                                                                        .Block(ExpressionsTest.RefObject $Example._refVector_item) {
+                                                                            .Block(System.Int32 $Example._refVector_count) {
+                                                                                $Example._refVector_count = 0;
                                                                                 .Default(System.Void);
-                                                                                ($Example._decVector).Capacity = $Example._decVector_count
+                                                                                ($Example._refVector).Capacity = $Example._refVector_count
                                                                             };
                                                                             .Loop  {
                                                                                 .If (
@@ -775,12 +776,12 @@
                                                                                             .Block(
                                                                                                 System.Int32 $index,
                                                                                                 System.Byte[] $array) {
-                                                                                                .Block(System.Int32 $Example._decVector_item_count) {
-                                                                                                    $Example._decVector_item_count = 0;
+                                                                                                .Block(System.Int32 $Example._refVector_item_count) {
+                                                                                                    $Example._refVector_item_count = 0;
                                                                                                     .Default(System.Void);
                                                                                                     .Block() {
                                                                                                         $index = 0;
-                                                                                                        $array = .NewArray System.Byte[$Example._decVector_item_count]
+                                                                                                        $array = .NewArray System.Byte[$Example._refVector_item_count]
                                                                                                     }
                                                                                                 };
                                                                                                 .Loop  {
@@ -889,15 +890,15 @@
                                                                                                     }
                                                                                                 }
                                                                                                 .LabelTarget end:;
-                                                                                                $Example._decVector_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                $Example._refVector_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                                                                                                     .New System.ArraySegment`1[System.Byte](
                                                                                                         $array,
                                                                                                         0,
                                                                                                         $index),
-                                                                                                    .Default(System.Decimal))
+                                                                                                    .Default(ExpressionsTest.RefObject))
                                                                                             }
                                                                                         };
-                                                                                        .Call ($Example._decVector).Add($Example._decVector_item)
+                                                                                        .Call ($Example._refVector).Add($Example._refVector_item)
                                                                                     }
                                                                                 } .Else {
                                                                                     .Break end { }
@@ -913,7 +914,7 @@
                                                                 .If (
                                                                     .Call System.String.Equals(
                                                                         $reader.LocalName,
-                                                                        "_decList",
+                                                                        "_refList",
                                                                         .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                         $reader.NamespaceURI,
                                                                         System.String.Empty,
@@ -925,7 +926,7 @@
                                                                     .Block() {
                                                                         .Block(System.Boolean $isEmpty) {
                                                                             $isEmpty = $reader.IsEmptyElement;
-                                                                            .Block(System.Decimal $Example._decList_item) {
+                                                                            .Block(ExpressionsTest.RefObject $Example._refList_item) {
                                                                                 .Default(System.Void);
                                                                                 .Loop  {
                                                                                     .If (
@@ -977,12 +978,12 @@
                                                                                                 .Block(
                                                                                                     System.Int32 $index,
                                                                                                     System.Byte[] $array) {
-                                                                                                    .Block(System.Int32 $Example._decList_item_count) {
-                                                                                                        $Example._decList_item_count = 0;
+                                                                                                    .Block(System.Int32 $Example._refList_item_count) {
+                                                                                                        $Example._refList_item_count = 0;
                                                                                                         .Default(System.Void);
                                                                                                         .Block() {
                                                                                                             $index = 0;
-                                                                                                            $array = .NewArray System.Byte[$Example._decList_item_count]
+                                                                                                            $array = .NewArray System.Byte[$Example._refList_item_count]
                                                                                                         }
                                                                                                     };
                                                                                                     .Loop  {
@@ -1091,15 +1092,15 @@
                                                                                                         }
                                                                                                     }
                                                                                                     .LabelTarget end:;
-                                                                                                    $Example._decList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                    $Example._refList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                                                                                                         .New System.ArraySegment`1[System.Byte](
                                                                                                             $array,
                                                                                                             0,
                                                                                                             $index),
-                                                                                                        .Default(System.Decimal))
+                                                                                                        .Default(ExpressionsTest.RefObject))
                                                                                                 }
                                                                                             };
-                                                                                            .Call ($Example._decList).Add($Example._decList_item)
+                                                                                            .Call ($Example._refList).Add($Example._refList_item)
                                                                                         }
                                                                                     } .Else {
                                                                                         .Break end { }
@@ -1115,7 +1116,7 @@
                                                                     .If (
                                                                         .Call System.String.Equals(
                                                                             $reader.LocalName,
-                                                                            "_decimal",
+                                                                            "_reference",
                                                                             .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                             $reader.NamespaceURI,
                                                                             System.String.Empty,
@@ -1130,12 +1131,12 @@
                                                                                 .Block(
                                                                                     System.Int32 $index,
                                                                                     System.Byte[] $array) {
-                                                                                    .Block(System.Int32 $Example._decimal_count) {
-                                                                                        $Example._decimal_count = 0;
+                                                                                    .Block(System.Int32 $Example._reference_count) {
+                                                                                        $Example._reference_count = 0;
                                                                                         .Default(System.Void);
                                                                                         .Block() {
                                                                                             $index = 0;
-                                                                                            $array = .NewArray System.Byte[$Example._decimal_count]
+                                                                                            $array = .NewArray System.Byte[$Example._reference_count]
                                                                                         }
                                                                                     };
                                                                                     .Loop  {
@@ -1244,12 +1245,12 @@
                                                                                         }
                                                                                     }
                                                                                     .LabelTarget end:;
-                                                                                    $Example._decimal = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                    $Example._reference = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                                                                                         .New System.ArraySegment`1[System.Byte](
                                                                                             $array,
                                                                                             0,
                                                                                             $index),
-                                                                                        .Default(System.Decimal))
+                                                                                        .Default(ExpressionsTest.RefObject))
                                                                                 }
                                                                             };
                                                                             $state = .Constant<System.Byte>(3)
@@ -1258,7 +1259,7 @@
                                                                         .If (
                                                                             .Call System.String.Equals(
                                                                                 $reader.LocalName,
-                                                                                "_map",
+                                                                                "_decNullable",
                                                                                 .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                 $reader.NamespaceURI,
                                                                                 System.String.Empty,
@@ -1270,10 +1271,7 @@
                                                                             .Block() {
                                                                                 .Block(System.Boolean $isEmpty) {
                                                                                     $isEmpty = $reader.IsEmptyElement;
-                                                                                    .Block(
-                                                                                        System.Int32 $Example._map_key,
-                                                                                        System.Double $Example._map_value) {
-                                                                                        .Default(System.Void);
+                                                                                    .Block() {
                                                                                         .Loop  {
                                                                                             .If (
                                                                                                 .If (
@@ -1318,35 +1316,51 @@
                                                                                                     }
                                                                                                 }
                                                                                             ) {
-                                                                                                .Block() {
-                                                                                                    .Block(System.String $valueAsString) {
-                                                                                                        .If (
-                                                                                                            $reader.IsEmptyElement
-                                                                                                        ) {
-                                                                                                            $valueAsString = System.String.Empty
-                                                                                                        } .Else {
+                                                                                                .Block(System.Boolean $isEmpty) {
+                                                                                                    $isEmpty = $reader.IsEmptyElement;
+                                                                                                    .Block(
+                                                                                                        System.Int32 $index,
+                                                                                                        System.Byte[] $array) {
+                                                                                                        .Block(System.Int32 $Example._decNullable_count) {
+                                                                                                            $Example._decNullable_count = 0;
+                                                                                                            .Default(System.Void);
                                                                                                             .Block() {
-                                                                                                                .Call $reader.Read();
-                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                    $valueAsString = ""
+                                                                                                                $index = 0;
+                                                                                                                $array = .NewArray System.Byte[$Example._decNullable_count]
+                                                                                                            }
+                                                                                                        };
+                                                                                                        .Loop  {
+                                                                                                            .If (
+                                                                                                                .If (
+                                                                                                                    $isEmpty
+                                                                                                                ) {
+                                                                                                                    False
                                                                                                                 } .Else {
                                                                                                                     .Block() {
-                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                    .Constant<System.Byte>(0),
-                                                                                                                                    $reader.NodeType,
-                                                                                                                                    $reader.LocalName,
-                                                                                                                                    $reader.Value)
+                                                                                                                        .Loop  {
+                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                .Call $reader.Read()
                                                                                                                             } .Else {
-                                                                                                                                .Default(System.Void)
+                                                                                                                                .Break end { }
                                                                                                                             }
-                                                                                                                        } .Else {
-                                                                                                                            .Default(System.Void)
-                                                                                                                        };
-                                                                                                                        $valueAsString = $reader.Value;
-                                                                                                                        .Call $reader.Read();
-                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                        }
+                                                                                                                        .LabelTarget end:;
+                                                                                                                        .Loop  {
+                                                                                                                            .Block() {
+                                                                                                                                .Call $reader.Read();
+                                                                                                                                .If (
+                                                                                                                                    !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                ) {
+                                                                                                                                    .Break end { }
+                                                                                                                                } .Else {
+                                                                                                                                    .Default(System.Void)
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                        .LabelTarget end:;
+                                                                                                                        .If (
+                                                                                                                            $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                        ) {
                                                                                                                             .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
                                                                                                                                 .Constant<System.Byte>(0),
                                                                                                                                 $reader.NodeType,
@@ -1354,101 +1368,80 @@
                                                                                                                                 $reader.Value)
                                                                                                                         } .Else {
                                                                                                                             .Default(System.Void)
-                                                                                                                        }
+                                                                                                                        };
+                                                                                                                        $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
                                                                                                                     }
                                                                                                                 }
-                                                                                                            }
-                                                                                                        };
-                                                                                                        $Example._map_key = .Call System.Convert.ToInt32(
-                                                                                                            $valueAsString,
-                                                                                                            System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                    };
-                                                                                                    .If (
-                                                                                                        $isEmpty
-                                                                                                    ) {
-                                                                                                        False
-                                                                                                    } .Else {
-                                                                                                        .Block() {
-                                                                                                            .Loop  {
-                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                    .Call $reader.Read()
-                                                                                                                } .Else {
-                                                                                                                    .Break end { }
-                                                                                                                }
-                                                                                                            }
-                                                                                                            .LabelTarget end:;
-                                                                                                            .Loop  {
+                                                                                                            ) {
                                                                                                                 .Block() {
-                                                                                                                    .Call $reader.Read();
-                                                                                                                    .If (
-                                                                                                                        !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
-                                                                                                                    ) {
-                                                                                                                        .Break end { }
+                                                                                                                    .If ($index >= $array.Length) {
+                                                                                                                        .Call System.Array.Resize(
+                                                                                                                            $array,
+                                                                                                                            .If ($index > 512) {
+                                                                                                                                $index * 2
+                                                                                                                            } .Else {
+                                                                                                                                1024
+                                                                                                                            })
                                                                                                                     } .Else {
                                                                                                                         .Default(System.Void)
-                                                                                                                    }
-                                                                                                                }
-                                                                                                            }
-                                                                                                            .LabelTarget end:;
-                                                                                                            .If (
-                                                                                                                $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
-                                                                                                            ) {
-                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                    .Constant<System.Byte>(0),
-                                                                                                                    $reader.NodeType,
-                                                                                                                    $reader.LocalName,
-                                                                                                                    $reader.Value)
-                                                                                                            } .Else {
-                                                                                                                .Default(System.Void)
-                                                                                                            };
-                                                                                                            $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
-                                                                                                        }
-                                                                                                    };
-                                                                                                    .Block(System.String $valueAsString) {
-                                                                                                        .If (
-                                                                                                            $reader.IsEmptyElement
-                                                                                                        ) {
-                                                                                                            $valueAsString = System.String.Empty
-                                                                                                        } .Else {
-                                                                                                            .Block() {
-                                                                                                                .Call $reader.Read();
-                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                    $valueAsString = ""
-                                                                                                                } .Else {
-                                                                                                                    .Block() {
-                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                    .Constant<System.Byte>(0),
-                                                                                                                                    $reader.NodeType,
-                                                                                                                                    $reader.LocalName,
-                                                                                                                                    $reader.Value)
-                                                                                                                            } .Else {
-                                                                                                                                .Default(System.Void)
+                                                                                                                    };
+                                                                                                                    .Block(System.String $valueAsString) {
+                                                                                                                        .If (
+                                                                                                                            $reader.IsEmptyElement
+                                                                                                                        ) {
+                                                                                                                            $valueAsString = System.String.Empty
+                                                                                                                        } .Else {
+                                                                                                                            .Block() {
+                                                                                                                                .Call $reader.Read();
+                                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                    $valueAsString = ""
+                                                                                                                                } .Else {
+                                                                                                                                    .Block() {
+                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                    $reader.Value)
+                                                                                                                                            } .Else {
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                            }
+                                                                                                                                        } .Else {
+                                                                                                                                            .Default(System.Void)
+                                                                                                                                        };
+                                                                                                                                        $valueAsString = $reader.Value;
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                $reader.NodeType,
+                                                                                                                                                $reader.LocalName,
+                                                                                                                                                $reader.Value)
+                                                                                                                                        } .Else {
+                                                                                                                                            .Default(System.Void)
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
                                                                                                                             }
-                                                                                                                        } .Else {
-                                                                                                                            .Default(System.Void)
                                                                                                                         };
-                                                                                                                        $valueAsString = $reader.Value;
-                                                                                                                        .Call $reader.Read();
-                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                .Constant<System.Byte>(0),
-                                                                                                                                $reader.NodeType,
-                                                                                                                                $reader.LocalName,
-                                                                                                                                $reader.Value)
-                                                                                                                        } .Else {
-                                                                                                                            .Default(System.Void)
-                                                                                                                        }
+                                                                                                                        $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                                            $valueAsString,
+                                                                                                                            System.Globalization.CultureInfo.InvariantCulture)
                                                                                                                     }
                                                                                                                 }
+                                                                                                            } .Else {
+                                                                                                                .Break end { }
                                                                                                             }
-                                                                                                        };
-                                                                                                        $Example._map_value = .Call System.Convert.ToDouble(
-                                                                                                            $valueAsString,
-                                                                                                            System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                    };
-                                                                                                    ($Example._map).Item[$Example._map_key] = $Example._map_value
+                                                                                                        }
+                                                                                                        .LabelTarget end:;
+                                                                                                        $Example._decNullable = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                            .New System.ArraySegment`1[System.Byte](
+                                                                                                                $array,
+                                                                                                                0,
+                                                                                                                $index),
+                                                                                                            .Default(System.Decimal))
+                                                                                                    }
                                                                                                 }
                                                                                             } .Else {
                                                                                                 .Break end { }
@@ -1463,7 +1456,7 @@
                                                                             .If (
                                                                                 .Call System.String.Equals(
                                                                                     $reader.LocalName,
-                                                                                    "b",
+                                                                                    "_decMap",
                                                                                     .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                     $reader.NamespaceURI,
                                                                                     System.String.Empty,
@@ -1476,16 +1469,9 @@
                                                                                     .Block(System.Boolean $isEmpty) {
                                                                                         $isEmpty = $reader.IsEmptyElement;
                                                                                         .Block(
-                                                                                            System.Int32 $index,
-                                                                                            System.Byte[] $array) {
-                                                                                            .Block(System.Int32 $Example.b_count) {
-                                                                                                $Example.b_count = 0;
-                                                                                                .Default(System.Void);
-                                                                                                .Block() {
-                                                                                                    $index = 0;
-                                                                                                    $array = .NewArray System.Byte[$Example.b_count]
-                                                                                                }
-                                                                                            };
+                                                                                            System.Int32 $Example._decMap_key,
+                                                                                            System.Decimal $Example._decMap_value) {
+                                                                                            .Default(System.Void);
                                                                                             .Loop  {
                                                                                                 .If (
                                                                                                     .If (
@@ -1531,17 +1517,6 @@
                                                                                                     }
                                                                                                 ) {
                                                                                                     .Block() {
-                                                                                                        .If ($index >= $array.Length) {
-                                                                                                            .Call System.Array.Resize(
-                                                                                                                $array,
-                                                                                                                .If ($index > 512) {
-                                                                                                                    $index * 2
-                                                                                                                } .Else {
-                                                                                                                    1024
-                                                                                                                })
-                                                                                                        } .Else {
-                                                                                                            .Default(System.Void)
-                                                                                                        };
                                                                                                         .Block(System.String $valueAsString) {
                                                                                                             .If (
                                                                                                                 $reader.IsEmptyElement
@@ -1582,20 +1557,185 @@
                                                                                                                     }
                                                                                                                 }
                                                                                                             };
-                                                                                                            $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                            $Example._decMap_key = .Call System.Convert.ToInt32(
                                                                                                                 $valueAsString,
                                                                                                                 System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                        }
+                                                                                                        };
+                                                                                                        .If (
+                                                                                                            $isEmpty
+                                                                                                        ) {
+                                                                                                            False
+                                                                                                        } .Else {
+                                                                                                            .Block() {
+                                                                                                                .Loop  {
+                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                        .Call $reader.Read()
+                                                                                                                    } .Else {
+                                                                                                                        .Break end { }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                                .LabelTarget end:;
+                                                                                                                .Loop  {
+                                                                                                                    .Block() {
+                                                                                                                        .Call $reader.Read();
+                                                                                                                        .If (
+                                                                                                                            !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                        ) {
+                                                                                                                            .Break end { }
+                                                                                                                        } .Else {
+                                                                                                                            .Default(System.Void)
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                                .LabelTarget end:;
+                                                                                                                .If (
+                                                                                                                    $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                ) {
+                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                        $reader.NodeType,
+                                                                                                                        $reader.LocalName,
+                                                                                                                        $reader.Value)
+                                                                                                                } .Else {
+                                                                                                                    .Default(System.Void)
+                                                                                                                };
+                                                                                                                $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                            }
+                                                                                                        };
+                                                                                                        .Block(System.Boolean $isEmpty) {
+                                                                                                            $isEmpty = $reader.IsEmptyElement;
+                                                                                                            .Block(
+                                                                                                                System.Int32 $index,
+                                                                                                                System.Byte[] $array) {
+                                                                                                                .Block(System.Int32 $Example._decMap_value_count) {
+                                                                                                                    $Example._decMap_value_count = 0;
+                                                                                                                    .Default(System.Void);
+                                                                                                                    .Block() {
+                                                                                                                        $index = 0;
+                                                                                                                        $array = .NewArray System.Byte[$Example._decMap_value_count]
+                                                                                                                    }
+                                                                                                                };
+                                                                                                                .Loop  {
+                                                                                                                    .If (
+                                                                                                                        .If (
+                                                                                                                            $isEmpty
+                                                                                                                        ) {
+                                                                                                                            False
+                                                                                                                        } .Else {
+                                                                                                                            .Block() {
+                                                                                                                                .Loop  {
+                                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                        .Call $reader.Read()
+                                                                                                                                    } .Else {
+                                                                                                                                        .Break end { }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                                .LabelTarget end:;
+                                                                                                                                .Loop  {
+                                                                                                                                    .Block() {
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        .If (
+                                                                                                                                            !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                        ) {
+                                                                                                                                            .Break end { }
+                                                                                                                                        } .Else {
+                                                                                                                                            .Default(System.Void)
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                                .LabelTarget end:;
+                                                                                                                                .If (
+                                                                                                                                    $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                                ) {
+                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                        $reader.NodeType,
+                                                                                                                                        $reader.LocalName,
+                                                                                                                                        $reader.Value)
+                                                                                                                                } .Else {
+                                                                                                                                    .Default(System.Void)
+                                                                                                                                };
+                                                                                                                                $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    ) {
+                                                                                                                        .Block() {
+                                                                                                                            .If ($index >= $array.Length) {
+                                                                                                                                .Call System.Array.Resize(
+                                                                                                                                    $array,
+                                                                                                                                    .If ($index > 512) {
+                                                                                                                                        $index * 2
+                                                                                                                                    } .Else {
+                                                                                                                                        1024
+                                                                                                                                    })
+                                                                                                                            } .Else {
+                                                                                                                                .Default(System.Void)
+                                                                                                                            };
+                                                                                                                            .Block(System.String $valueAsString) {
+                                                                                                                                .If (
+                                                                                                                                    $reader.IsEmptyElement
+                                                                                                                                ) {
+                                                                                                                                    $valueAsString = System.String.Empty
+                                                                                                                                } .Else {
+                                                                                                                                    .Block() {
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                            $valueAsString = ""
+                                                                                                                                        } .Else {
+                                                                                                                                            .Block() {
+                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                            $reader.Value)
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                    }
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                };
+                                                                                                                                                $valueAsString = $reader.Value;
+                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                        $reader.Value)
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                };
+                                                                                                                                $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                                                    $valueAsString,
+                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    } .Else {
+                                                                                                                        .Break end { }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                                .LabelTarget end:;
+                                                                                                                $Example._decMap_value = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                                    .New System.ArraySegment`1[System.Byte](
+                                                                                                                        $array,
+                                                                                                                        0,
+                                                                                                                        $index),
+                                                                                                                    .Default(System.Decimal))
+                                                                                                            }
+                                                                                                        };
+                                                                                                        ($Example._decMap).Item[$Example._decMap_key] = $Example._decMap_value
                                                                                                     }
                                                                                                 } .Else {
                                                                                                     .Break end { }
                                                                                                 }
                                                                                             }
-                                                                                            .LabelTarget end:;
-                                                                                            $Example.b = .New System.ArraySegment`1[System.Byte](
-                                                                                                $array,
-                                                                                                0,
-                                                                                                $index)
+                                                                                            .LabelTarget end:
                                                                                         }
                                                                                     };
                                                                                     $state = .Constant<System.Byte>(3)
@@ -1604,7 +1744,7 @@
                                                                                 .If (
                                                                                     .Call System.String.Equals(
                                                                                         $reader.LocalName,
-                                                                                        "_nestedVector",
+                                                                                        "_decVector",
                                                                                         .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                         $reader.NamespaceURI,
                                                                                         System.String.Empty,
@@ -1616,8 +1756,12 @@
                                                                                     .Block() {
                                                                                         .Block(System.Boolean $isEmpty) {
                                                                                             $isEmpty = $reader.IsEmptyElement;
-                                                                                            .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
-                                                                                                .Default(System.Void);
+                                                                                            .Block(System.Decimal $Example._decVector_item) {
+                                                                                                .Block(System.Int32 $Example._decVector_count) {
+                                                                                                    $Example._decVector_count = 0;
+                                                                                                    .Default(System.Void);
+                                                                                                    ($Example._decVector).Capacity = $Example._decVector_count
+                                                                                                };
                                                                                                 .Loop  {
                                                                                                     .If (
                                                                                                         .If (
@@ -1663,162 +1807,134 @@
                                                                                                         }
                                                                                                     ) {
                                                                                                         .Block() {
-                                                                                                            .Block() {
-                                                                                                                $Example._nestedVector_item = .New ExpressionsTest.Nested();
-                                                                                                                .Block() {
-                                                                                                                    .Call $reader.Read();
-                                                                                                                    .Block(
-                                                                                                                        System.Byte $state,
-                                                                                                                        Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
+                                                                                                            .Block(System.Boolean $isEmpty) {
+                                                                                                                $isEmpty = $reader.IsEmptyElement;
+                                                                                                                .Block(
+                                                                                                                    System.Int32 $index,
+                                                                                                                    System.Byte[] $array) {
+                                                                                                                    .Block(System.Int32 $Example._decVector_item_count) {
+                                                                                                                        $Example._decVector_item_count = 0;
                                                                                                                         .Default(System.Void);
-                                                                                                                        .Default(System.Void);
-                                                                                                                        $state = .Constant<System.Byte>(1);
-                                                                                                                        .Loop  {
+                                                                                                                        .Block() {
+                                                                                                                            $index = 0;
+                                                                                                                            $array = .NewArray System.Byte[$Example._decVector_item_count]
+                                                                                                                        }
+                                                                                                                    };
+                                                                                                                    .Loop  {
+                                                                                                                        .If (
                                                                                                                             .If (
-                                                                                                                                !$reader.EOF && $state != .Constant<System.Byte>(4)
+                                                                                                                                $isEmpty
                                                                                                                             ) {
-                                                                                                                                .Switch ($reader.NodeType) {
-                                                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(Element)):
-                                                                                                                                        .Switch ($state) {
-                                                                                                                                        .Case (.Constant<System.Byte>(1)):
-                                                                                                                                                .Block() {
-                                                                                                                                                    .Block() {
-                                                                                                                                                        .If (
-                                                                                                                                                            $reader.IsEmptyElement
-                                                                                                                                                        ) {
-                                                                                                                                                            $state = .Constant<System.Byte>(4)
-                                                                                                                                                        } .Else {
-                                                                                                                                                            $state = .Constant<System.Byte>(2)
-                                                                                                                                                        };
-                                                                                                                                                        .Call $reader.Read()
-                                                                                                                                                    };
-                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                }
-                                                                                                                                        .Case (.Constant<System.Byte>(2)):
-                                                                                                                                                .Block() {
-                                                                                                                                                    .If (
-                                                                                                                                                        .Call System.String.Equals(
-                                                                                                                                                            $reader.LocalName,
-                                                                                                                                                            "_double",
-                                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                                                                                            $reader.NamespaceURI,
-                                                                                                                                                            System.String.Empty,
-                                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                                                                                            $reader.NamespaceURI,
-                                                                                                                                                            "urn:ExpressionsTest.Nested",
-                                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                                                                                                    ) {
-                                                                                                                                                        .Block() {
-                                                                                                                                                            .Block(System.String $valueAsString) {
-                                                                                                                                                                .If (
-                                                                                                                                                                    $reader.IsEmptyElement
-                                                                                                                                                                ) {
-                                                                                                                                                                    $valueAsString = System.String.Empty
-                                                                                                                                                                } .Else {
-                                                                                                                                                                    .Block() {
-                                                                                                                                                                        .Call $reader.Read();
-                                                                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                                                            $valueAsString = ""
-                                                                                                                                                                        } .Else {
-                                                                                                                                                                            .Block() {
-                                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                                                            .Constant<System.Byte>(0),
-                                                                                                                                                                                            $reader.NodeType,
-                                                                                                                                                                                            $reader.LocalName,
-                                                                                                                                                                                            $reader.Value)
-                                                                                                                                                                                    } .Else {
-                                                                                                                                                                                        .Default(System.Void)
-                                                                                                                                                                                    }
-                                                                                                                                                                                } .Else {
-                                                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                                                };
-                                                                                                                                                                                $valueAsString = $reader.Value;
-                                                                                                                                                                                .Call $reader.Read();
-                                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                                                        .Constant<System.Byte>(0),
-                                                                                                                                                                                        $reader.NodeType,
-                                                                                                                                                                                        $reader.LocalName,
-                                                                                                                                                                                        $reader.Value)
-                                                                                                                                                                                } .Else {
-                                                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                                                }
-                                                                                                                                                                            }
-                                                                                                                                                                        }
-                                                                                                                                                                    }
-                                                                                                                                                                };
-                                                                                                                                                                $Example._nestedVector_item._double = .Call System.Convert.ToDouble(
-                                                                                                                                                                    $valueAsString,
-                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                                                                            };
-                                                                                                                                                            $state = .Constant<System.Byte>(3)
-                                                                                                                                                        }
-                                                                                                                                                    } .Else {
-                                                                                                                                                        .Block() {
-                                                                                                                                                            .Call $reader.Skip();
-                                                                                                                                                            $state = .Constant<System.Byte>(2)
-                                                                                                                                                        }
-                                                                                                                                                    };
-                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                }
-                                                                                                                                        .Case (.Constant<System.Byte>(3)):
-                                                                                                                                                .Block() {
-                                                                                                                                                    .Call $reader.Read();
-                                                                                                                                                    $state = .Constant<System.Byte>(2);
-                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                }
-                                                                                                                                        .Default:
-                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                    $state,
-                                                                                                                                                    $reader.NodeType,
-                                                                                                                                                    $reader.LocalName,
-                                                                                                                                                    $reader.Value)
+                                                                                                                                False
+                                                                                                                            } .Else {
+                                                                                                                                .Block() {
+                                                                                                                                    .Loop  {
+                                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                            .Call $reader.Read()
+                                                                                                                                        } .Else {
+                                                                                                                                            .Break end { }
                                                                                                                                         }
-                                                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(EndElement)):
-                                                                                                                                        .Switch ($state) {
-                                                                                                                                        .Case (.Constant<System.Byte>(3)):
-                                                                                                                                                .Block() {
-                                                                                                                                                    .Call $reader.Read();
-                                                                                                                                                    $state = .Constant<System.Byte>(2);
-                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                }
-                                                                                                                                        .Case (.Constant<System.Byte>(2)):
-                                                                                                                                                .Block() {
-                                                                                                                                                    .Call $reader.Read();
-                                                                                                                                                    $state = .Constant<System.Byte>(4);
-                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                }
-                                                                                                                                        .Default:
-                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                    $state,
-                                                                                                                                                    $reader.NodeType,
-                                                                                                                                                    $reader.LocalName,
-                                                                                                                                                    $reader.Value)
-                                                                                                                                        }
-                                                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(Comment)):
-                                                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(Text)):
-                                                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(Whitespace)):
-                                                                                                                                .Case (.Constant<System.Xml.XmlNodeType>(XmlDeclaration)):
+                                                                                                                                    }
+                                                                                                                                    .LabelTarget end:;
+                                                                                                                                    .Loop  {
                                                                                                                                         .Block() {
                                                                                                                                             .Call $reader.Read();
-                                                                                                                                            .Default(System.Void)
+                                                                                                                                            .If (
+                                                                                                                                                !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                            ) {
+                                                                                                                                                .Break end { }
+                                                                                                                                            } .Else {
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                            }
                                                                                                                                         }
-                                                                                                                                .Default:
-                                                                                                                                        .Invoke (.Lambda #Lambda3<System.Action`1[System.Xml.XmlNodeType]>)($reader.NodeType)
+                                                                                                                                    }
+                                                                                                                                    .LabelTarget end:;
+                                                                                                                                    .If (
+                                                                                                                                        $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                                    ) {
+                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                            $reader.NodeType,
+                                                                                                                                            $reader.LocalName,
+                                                                                                                                            $reader.Value)
+                                                                                                                                    } .Else {
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    };
+                                                                                                                                    $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
                                                                                                                                 }
-                                                                                                                            } .Else {
-                                                                                                                                .Break endStateMachineLoop { }
                                                                                                                             }
+                                                                                                                        ) {
+                                                                                                                            .Block() {
+                                                                                                                                .If ($index >= $array.Length) {
+                                                                                                                                    .Call System.Array.Resize(
+                                                                                                                                        $array,
+                                                                                                                                        .If ($index > 512) {
+                                                                                                                                            $index * 2
+                                                                                                                                        } .Else {
+                                                                                                                                            1024
+                                                                                                                                        })
+                                                                                                                                } .Else {
+                                                                                                                                    .Default(System.Void)
+                                                                                                                                };
+                                                                                                                                .Block(System.String $valueAsString) {
+                                                                                                                                    .If (
+                                                                                                                                        $reader.IsEmptyElement
+                                                                                                                                    ) {
+                                                                                                                                        $valueAsString = System.String.Empty
+                                                                                                                                    } .Else {
+                                                                                                                                        .Block() {
+                                                                                                                                            .Call $reader.Read();
+                                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                $valueAsString = ""
+                                                                                                                                            } .Else {
+                                                                                                                                                .Block() {
+                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                                $reader.NodeType,
+                                                                                                                                                                $reader.LocalName,
+                                                                                                                                                                $reader.Value)
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                        }
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                    };
+                                                                                                                                                    $valueAsString = $reader.Value;
+                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                            $reader.Value)
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    };
+                                                                                                                                    $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                                                        $valueAsString,
+                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        } .Else {
+                                                                                                                            .Break end { }
                                                                                                                         }
-                                                                                                                        .LabelTarget endStateMachineLoop:;
-                                                                                                                        .Default(System.Void);
-                                                                                                                        .Default(System.Void)
                                                                                                                     }
+                                                                                                                    .LabelTarget end:;
+                                                                                                                    $Example._decVector_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                                        .New System.ArraySegment`1[System.Byte](
+                                                                                                                            $array,
+                                                                                                                            0,
+                                                                                                                            $index),
+                                                                                                                        .Default(System.Decimal))
                                                                                                                 }
                                                                                                             };
-                                                                                                            .Call ($Example._nestedVector).Add($Example._nestedVector_item)
+                                                                                                            .Call ($Example._decVector).Add($Example._decVector_item)
                                                                                                         }
                                                                                                     } .Else {
                                                                                                         .Break end { }
@@ -1834,7 +1950,7 @@
                                                                                     .If (
                                                                                         .Call System.String.Equals(
                                                                                             $reader.LocalName,
-                                                                                            "_int32Vector",
+                                                                                            "_decList",
                                                                                             .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                             $reader.NamespaceURI,
                                                                                             System.String.Empty,
@@ -1846,12 +1962,8 @@
                                                                                         .Block() {
                                                                                             .Block(System.Boolean $isEmpty) {
                                                                                                 $isEmpty = $reader.IsEmptyElement;
-                                                                                                .Block(System.Int32 $Example._int32Vector_item) {
-                                                                                                    .Block(System.Int32 $Example._int32Vector_count) {
-                                                                                                        $Example._int32Vector_count = 0;
-                                                                                                        .Default(System.Void);
-                                                                                                        ($Example._int32Vector).Capacity = $Example._int32Vector_count
-                                                                                                    };
+                                                                                                .Block(System.Decimal $Example._decList_item) {
+                                                                                                    .Default(System.Void);
                                                                                                     .Loop  {
                                                                                                         .If (
                                                                                                             .If (
@@ -1897,20 +2009,51 @@
                                                                                                             }
                                                                                                         ) {
                                                                                                             .Block() {
-                                                                                                                .Block(System.String $valueAsString) {
-                                                                                                                    .If (
-                                                                                                                        $reader.IsEmptyElement
-                                                                                                                    ) {
-                                                                                                                        $valueAsString = System.String.Empty
-                                                                                                                    } .Else {
-                                                                                                                        .Block() {
-                                                                                                                            .Call $reader.Read();
-                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                $valueAsString = ""
-                                                                                                                            } .Else {
-                                                                                                                                .Block() {
-                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                .Block(System.Boolean $isEmpty) {
+                                                                                                                    $isEmpty = $reader.IsEmptyElement;
+                                                                                                                    .Block(
+                                                                                                                        System.Int32 $index,
+                                                                                                                        System.Byte[] $array) {
+                                                                                                                        .Block(System.Int32 $Example._decList_item_count) {
+                                                                                                                            $Example._decList_item_count = 0;
+                                                                                                                            .Default(System.Void);
+                                                                                                                            .Block() {
+                                                                                                                                $index = 0;
+                                                                                                                                $array = .NewArray System.Byte[$Example._decList_item_count]
+                                                                                                                            }
+                                                                                                                        };
+                                                                                                                        .Loop  {
+                                                                                                                            .If (
+                                                                                                                                .If (
+                                                                                                                                    $isEmpty
+                                                                                                                                ) {
+                                                                                                                                    False
+                                                                                                                                } .Else {
+                                                                                                                                    .Block() {
+                                                                                                                                        .Loop  {
+                                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                .Call $reader.Read()
+                                                                                                                                            } .Else {
+                                                                                                                                                .Break end { }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                        .LabelTarget end:;
+                                                                                                                                        .Loop  {
+                                                                                                                                            .Block() {
+                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                .If (
+                                                                                                                                                    !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                                ) {
+                                                                                                                                                    .Break end { }
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                        .LabelTarget end:;
+                                                                                                                                        .If (
+                                                                                                                                            $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                                        ) {
                                                                                                                                             .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
                                                                                                                                                 .Constant<System.Byte>(0),
                                                                                                                                                 $reader.NodeType,
@@ -1918,30 +2061,82 @@
                                                                                                                                                 $reader.Value)
                                                                                                                                         } .Else {
                                                                                                                                             .Default(System.Void)
-                                                                                                                                        }
+                                                                                                                                        };
+                                                                                                                                        $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            ) {
+                                                                                                                                .Block() {
+                                                                                                                                    .If ($index >= $array.Length) {
+                                                                                                                                        .Call System.Array.Resize(
+                                                                                                                                            $array,
+                                                                                                                                            .If ($index > 512) {
+                                                                                                                                                $index * 2
+                                                                                                                                            } .Else {
+                                                                                                                                                1024
+                                                                                                                                            })
                                                                                                                                     } .Else {
                                                                                                                                         .Default(System.Void)
                                                                                                                                     };
-                                                                                                                                    $valueAsString = $reader.Value;
-                                                                                                                                    .Call $reader.Read();
-                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                            .Constant<System.Byte>(0),
-                                                                                                                                            $reader.NodeType,
-                                                                                                                                            $reader.LocalName,
-                                                                                                                                            $reader.Value)
-                                                                                                                                    } .Else {
-                                                                                                                                        .Default(System.Void)
+                                                                                                                                    .Block(System.String $valueAsString) {
+                                                                                                                                        .If (
+                                                                                                                                            $reader.IsEmptyElement
+                                                                                                                                        ) {
+                                                                                                                                            $valueAsString = System.String.Empty
+                                                                                                                                        } .Else {
+                                                                                                                                            .Block() {
+                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                    $valueAsString = ""
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                                    $reader.Value)
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                            }
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                        };
+                                                                                                                                                        $valueAsString = $reader.Value;
+                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                                $reader.NodeType,
+                                                                                                                                                                $reader.LocalName,
+                                                                                                                                                                $reader.Value)
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        };
+                                                                                                                                        $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                                                            $valueAsString,
+                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture)
                                                                                                                                     }
                                                                                                                                 }
+                                                                                                                            } .Else {
+                                                                                                                                .Break end { }
                                                                                                                             }
                                                                                                                         }
-                                                                                                                    };
-                                                                                                                    $Example._int32Vector_item = .Call System.Convert.ToInt32(
-                                                                                                                        $valueAsString,
-                                                                                                                        System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                        .LabelTarget end:;
+                                                                                                                        $Example._decList_item = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                                            .New System.ArraySegment`1[System.Byte](
+                                                                                                                                $array,
+                                                                                                                                0,
+                                                                                                                                $index),
+                                                                                                                            .Default(System.Decimal))
+                                                                                                                    }
                                                                                                                 };
-                                                                                                                .Call ($Example._int32Vector).Add($Example._int32Vector_item)
+                                                                                                                .Call ($Example._decList).Add($Example._decList_item)
                                                                                                             }
                                                                                                         } .Else {
                                                                                                             .Break end { }
@@ -1957,7 +2152,7 @@
                                                                                         .If (
                                                                                             .Call System.String.Equals(
                                                                                                 $reader.LocalName,
-                                                                                                "guid",
+                                                                                                "_decimal",
                                                                                                 .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                                 $reader.NamespaceURI,
                                                                                                 System.String.Empty,
@@ -1967,48 +2162,2206 @@
                                                                                                 .Constant<System.StringComparison>(OrdinalIgnoreCase)))
                                                                                         ) {
                                                                                             .Block() {
+                                                                                                .Block(System.Boolean $isEmpty) {
+                                                                                                    $isEmpty = $reader.IsEmptyElement;
+                                                                                                    .Block(
+                                                                                                        System.Int32 $index,
+                                                                                                        System.Byte[] $array) {
+                                                                                                        .Block(System.Int32 $Example._decimal_count) {
+                                                                                                            $Example._decimal_count = 0;
+                                                                                                            .Default(System.Void);
+                                                                                                            .Block() {
+                                                                                                                $index = 0;
+                                                                                                                $array = .NewArray System.Byte[$Example._decimal_count]
+                                                                                                            }
+                                                                                                        };
+                                                                                                        .Loop  {
+                                                                                                            .If (
+                                                                                                                .If (
+                                                                                                                    $isEmpty
+                                                                                                                ) {
+                                                                                                                    False
+                                                                                                                } .Else {
+                                                                                                                    .Block() {
+                                                                                                                        .Loop  {
+                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                .Call $reader.Read()
+                                                                                                                            } .Else {
+                                                                                                                                .Break end { }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                        .LabelTarget end:;
+                                                                                                                        .Loop  {
+                                                                                                                            .Block() {
+                                                                                                                                .Call $reader.Read();
+                                                                                                                                .If (
+                                                                                                                                    !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                ) {
+                                                                                                                                    .Break end { }
+                                                                                                                                } .Else {
+                                                                                                                                    .Default(System.Void)
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                        .LabelTarget end:;
+                                                                                                                        .If (
+                                                                                                                            $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                        ) {
+                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                $reader.NodeType,
+                                                                                                                                $reader.LocalName,
+                                                                                                                                $reader.Value)
+                                                                                                                        } .Else {
+                                                                                                                            .Default(System.Void)
+                                                                                                                        };
+                                                                                                                        $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            ) {
+                                                                                                                .Block() {
+                                                                                                                    .If ($index >= $array.Length) {
+                                                                                                                        .Call System.Array.Resize(
+                                                                                                                            $array,
+                                                                                                                            .If ($index > 512) {
+                                                                                                                                $index * 2
+                                                                                                                            } .Else {
+                                                                                                                                1024
+                                                                                                                            })
+                                                                                                                    } .Else {
+                                                                                                                        .Default(System.Void)
+                                                                                                                    };
+                                                                                                                    .Block(System.String $valueAsString) {
+                                                                                                                        .If (
+                                                                                                                            $reader.IsEmptyElement
+                                                                                                                        ) {
+                                                                                                                            $valueAsString = System.String.Empty
+                                                                                                                        } .Else {
+                                                                                                                            .Block() {
+                                                                                                                                .Call $reader.Read();
+                                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                    $valueAsString = ""
+                                                                                                                                } .Else {
+                                                                                                                                    .Block() {
+                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                    $reader.Value)
+                                                                                                                                            } .Else {
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                            }
+                                                                                                                                        } .Else {
+                                                                                                                                            .Default(System.Void)
+                                                                                                                                        };
+                                                                                                                                        $valueAsString = $reader.Value;
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                $reader.NodeType,
+                                                                                                                                                $reader.LocalName,
+                                                                                                                                                $reader.Value)
+                                                                                                                                        } .Else {
+                                                                                                                                            .Default(System.Void)
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        };
+                                                                                                                        $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                                            $valueAsString,
+                                                                                                                            System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            } .Else {
+                                                                                                                .Break end { }
+                                                                                                            }
+                                                                                                        }
+                                                                                                        .LabelTarget end:;
+                                                                                                        $Example._decimal = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                                                                            .New System.ArraySegment`1[System.Byte](
+                                                                                                                $array,
+                                                                                                                0,
+                                                                                                                $index),
+                                                                                                            .Default(System.Decimal))
+                                                                                                    }
+                                                                                                };
+                                                                                                $state = .Constant<System.Byte>(3)
+                                                                                            }
+                                                                                        } .Else {
+                                                                                            .If (
+                                                                                                .Call System.String.Equals(
+                                                                                                    $reader.LocalName,
+                                                                                                    "_map",
+                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                    $reader.NamespaceURI,
+                                                                                                    System.String.Empty,
+                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                    $reader.NamespaceURI,
+                                                                                                    "urn:ExpressionsTest.Example",
+                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                            ) {
                                                                                                 .Block() {
-                                                                                                    .Block() {
-                                                                                                        .Call $reader.Read();
+                                                                                                    .Block(System.Boolean $isEmpty) {
+                                                                                                        $isEmpty = $reader.IsEmptyElement;
                                                                                                         .Block(
-                                                                                                            System.Byte $state,
-                                                                                                            Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
+                                                                                                            System.Int32 $Example._map_key,
+                                                                                                            System.Double $Example._map_value) {
                                                                                                             .Default(System.Void);
-                                                                                                            .Default(System.Void);
-                                                                                                            $state = .Constant<System.Byte>(1);
                                                                                                             .Loop  {
                                                                                                                 .If (
-                                                                                                                    !$reader.EOF && $state != .Constant<System.Byte>(4)
+                                                                                                                    .If (
+                                                                                                                        $isEmpty
+                                                                                                                    ) {
+                                                                                                                        False
+                                                                                                                    } .Else {
+                                                                                                                        .Block() {
+                                                                                                                            .Loop  {
+                                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                    .Call $reader.Read()
+                                                                                                                                } .Else {
+                                                                                                                                    .Break end { }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                            .LabelTarget end:;
+                                                                                                                            .Loop  {
+                                                                                                                                .Block() {
+                                                                                                                                    .Call $reader.Read();
+                                                                                                                                    .If (
+                                                                                                                                        !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                    ) {
+                                                                                                                                        .Break end { }
+                                                                                                                                    } .Else {
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                            .LabelTarget end:;
+                                                                                                                            .If (
+                                                                                                                                $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                            ) {
+                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                    $reader.NodeType,
+                                                                                                                                    $reader.LocalName,
+                                                                                                                                    $reader.Value)
+                                                                                                                            } .Else {
+                                                                                                                                .Default(System.Void)
+                                                                                                                            };
+                                                                                                                            $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                        }
+                                                                                                                    }
                                                                                                                 ) {
-                                                                                                                    .Switch ($reader.NodeType) {
-                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(Element)):
-                                                                                                                            .Switch ($state) {
-                                                                                                                            .Case (.Constant<System.Byte>(1)):
+                                                                                                                    .Block() {
+                                                                                                                        .Block(System.String $valueAsString) {
+                                                                                                                            .If (
+                                                                                                                                $reader.IsEmptyElement
+                                                                                                                            ) {
+                                                                                                                                $valueAsString = System.String.Empty
+                                                                                                                            } .Else {
+                                                                                                                                .Block() {
+                                                                                                                                    .Call $reader.Read();
+                                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                        $valueAsString = ""
+                                                                                                                                    } .Else {
+                                                                                                                                        .Block() {
+                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                        $reader.Value)
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                }
+                                                                                                                                            } .Else {
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                            };
+                                                                                                                                            $valueAsString = $reader.Value;
+                                                                                                                                            .Call $reader.Read();
+                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                    $reader.Value)
+                                                                                                                                            } .Else {
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            };
+                                                                                                                            $Example._map_key = .Call System.Convert.ToInt32(
+                                                                                                                                $valueAsString,
+                                                                                                                                System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                        };
+                                                                                                                        .If (
+                                                                                                                            $isEmpty
+                                                                                                                        ) {
+                                                                                                                            False
+                                                                                                                        } .Else {
+                                                                                                                            .Block() {
+                                                                                                                                .Loop  {
+                                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                        .Call $reader.Read()
+                                                                                                                                    } .Else {
+                                                                                                                                        .Break end { }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                                .LabelTarget end:;
+                                                                                                                                .Loop  {
+                                                                                                                                    .Block() {
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        .If (
+                                                                                                                                            !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                        ) {
+                                                                                                                                            .Break end { }
+                                                                                                                                        } .Else {
+                                                                                                                                            .Default(System.Void)
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                                .LabelTarget end:;
+                                                                                                                                .If (
+                                                                                                                                    $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                                ) {
+                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                        $reader.NodeType,
+                                                                                                                                        $reader.LocalName,
+                                                                                                                                        $reader.Value)
+                                                                                                                                } .Else {
+                                                                                                                                    .Default(System.Void)
+                                                                                                                                };
+                                                                                                                                $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                            }
+                                                                                                                        };
+                                                                                                                        .Block(System.String $valueAsString) {
+                                                                                                                            .If (
+                                                                                                                                $reader.IsEmptyElement
+                                                                                                                            ) {
+                                                                                                                                $valueAsString = System.String.Empty
+                                                                                                                            } .Else {
+                                                                                                                                .Block() {
+                                                                                                                                    .Call $reader.Read();
+                                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                        $valueAsString = ""
+                                                                                                                                    } .Else {
+                                                                                                                                        .Block() {
+                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                        $reader.Value)
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                }
+                                                                                                                                            } .Else {
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                            };
+                                                                                                                                            $valueAsString = $reader.Value;
+                                                                                                                                            .Call $reader.Read();
+                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                    $reader.Value)
+                                                                                                                                            } .Else {
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            };
+                                                                                                                            $Example._map_value = .Call System.Convert.ToDouble(
+                                                                                                                                $valueAsString,
+                                                                                                                                System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                        };
+                                                                                                                        ($Example._map).Item[$Example._map_key] = $Example._map_value
+                                                                                                                    }
+                                                                                                                } .Else {
+                                                                                                                    .Break end { }
+                                                                                                                }
+                                                                                                            }
+                                                                                                            .LabelTarget end:
+                                                                                                        }
+                                                                                                    };
+                                                                                                    $state = .Constant<System.Byte>(3)
+                                                                                                }
+                                                                                            } .Else {
+                                                                                                .If (
+                                                                                                    .Call System.String.Equals(
+                                                                                                        $reader.LocalName,
+                                                                                                        "_blobNullable",
+                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                        $reader.NamespaceURI,
+                                                                                                        System.String.Empty,
+                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                        $reader.NamespaceURI,
+                                                                                                        "urn:ExpressionsTest.Example",
+                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                ) {
+                                                                                                    .Block() {
+                                                                                                        .Block(System.Boolean $isEmpty) {
+                                                                                                            $isEmpty = $reader.IsEmptyElement;
+                                                                                                            .Block() {
+                                                                                                                .Loop  {
+                                                                                                                    .If (
+                                                                                                                        .If (
+                                                                                                                            $isEmpty
+                                                                                                                        ) {
+                                                                                                                            False
+                                                                                                                        } .Else {
+                                                                                                                            .Block() {
+                                                                                                                                .Loop  {
+                                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                        .Call $reader.Read()
+                                                                                                                                    } .Else {
+                                                                                                                                        .Break end { }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                                .LabelTarget end:;
+                                                                                                                                .Loop  {
+                                                                                                                                    .Block() {
+                                                                                                                                        .Call $reader.Read();
+                                                                                                                                        .If (
+                                                                                                                                            !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                        ) {
+                                                                                                                                            .Break end { }
+                                                                                                                                        } .Else {
+                                                                                                                                            .Default(System.Void)
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                                .LabelTarget end:;
+                                                                                                                                .If (
+                                                                                                                                    $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                                ) {
+                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                        $reader.NodeType,
+                                                                                                                                        $reader.LocalName,
+                                                                                                                                        $reader.Value)
+                                                                                                                                } .Else {
+                                                                                                                                    .Default(System.Void)
+                                                                                                                                };
+                                                                                                                                $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    ) {
+                                                                                                                        .Block(System.Boolean $isEmpty) {
+                                                                                                                            $isEmpty = $reader.IsEmptyElement;
+                                                                                                                            .Block(
+                                                                                                                                System.Int32 $index,
+                                                                                                                                System.Byte[] $array) {
+                                                                                                                                .Block(System.Int32 $Example._blobNullable_count) {
+                                                                                                                                    $Example._blobNullable_count = 0;
+                                                                                                                                    .Default(System.Void);
+                                                                                                                                    .Block() {
+                                                                                                                                        $index = 0;
+                                                                                                                                        $array = .NewArray System.Byte[$Example._blobNullable_count]
+                                                                                                                                    }
+                                                                                                                                };
+                                                                                                                                .Loop  {
+                                                                                                                                    .If (
+                                                                                                                                        .If (
+                                                                                                                                            $isEmpty
+                                                                                                                                        ) {
+                                                                                                                                            False
+                                                                                                                                        } .Else {
+                                                                                                                                            .Block() {
+                                                                                                                                                .Loop  {
+                                                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                        .Call $reader.Read()
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Break end { }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                                .LabelTarget end:;
+                                                                                                                                                .Loop  {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                        .If (
+                                                                                                                                                            !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                                        ) {
+                                                                                                                                                            .Break end { }
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                                .LabelTarget end:;
+                                                                                                                                                .If (
+                                                                                                                                                    $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                                                ) {
+                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                        $reader.Value)
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                };
+                                                                                                                                                $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    ) {
+                                                                                                                                        .Block() {
+                                                                                                                                            .If ($index >= $array.Length) {
+                                                                                                                                                .Call System.Array.Resize(
+                                                                                                                                                    $array,
+                                                                                                                                                    .If ($index > 512) {
+                                                                                                                                                        $index * 2
+                                                                                                                                                    } .Else {
+                                                                                                                                                        1024
+                                                                                                                                                    })
+                                                                                                                                            } .Else {
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                            };
+                                                                                                                                            .Block(System.String $valueAsString) {
+                                                                                                                                                .If (
+                                                                                                                                                    $reader.IsEmptyElement
+                                                                                                                                                ) {
+                                                                                                                                                    $valueAsString = System.String.Empty
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                            $valueAsString = ""
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Block() {
+                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                                            $reader.Value)
+                                                                                                                                                                    } .Else {
+                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                    }
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                };
+                                                                                                                                                                $valueAsString = $reader.Value;
+                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                                        $reader.Value)
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                };
+                                                                                                                                                $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                                                                    $valueAsString,
+                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    } .Else {
+                                                                                                                                        .Break end { }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                                .LabelTarget end:;
+                                                                                                                                $Example._blobNullable = .New System.ArraySegment`1[System.Byte](
+                                                                                                                                    $array,
+                                                                                                                                    0,
+                                                                                                                                    $index)
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    } .Else {
+                                                                                                                        .Break end { }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                                .LabelTarget end:
+                                                                                                            }
+                                                                                                        };
+                                                                                                        $state = .Constant<System.Byte>(3)
+                                                                                                    }
+                                                                                                } .Else {
+                                                                                                    .If (
+                                                                                                        .Call System.String.Equals(
+                                                                                                            $reader.LocalName,
+                                                                                                            "_blobMap",
+                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                            $reader.NamespaceURI,
+                                                                                                            System.String.Empty,
+                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                            $reader.NamespaceURI,
+                                                                                                            "urn:ExpressionsTest.Example",
+                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                    ) {
+                                                                                                        .Block() {
+                                                                                                            .Block(System.Boolean $isEmpty) {
+                                                                                                                $isEmpty = $reader.IsEmptyElement;
+                                                                                                                .Block(
+                                                                                                                    System.Int32 $Example._blobMap_key,
+                                                                                                                    System.ArraySegment`1[System.Byte] $Example._blobMap_value) {
+                                                                                                                    .Default(System.Void);
+                                                                                                                    .Loop  {
+                                                                                                                        .If (
+                                                                                                                            .If (
+                                                                                                                                $isEmpty
+                                                                                                                            ) {
+                                                                                                                                False
+                                                                                                                            } .Else {
+                                                                                                                                .Block() {
+                                                                                                                                    .Loop  {
+                                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                            .Call $reader.Read()
+                                                                                                                                        } .Else {
+                                                                                                                                            .Break end { }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                    .LabelTarget end:;
+                                                                                                                                    .Loop  {
+                                                                                                                                        .Block() {
+                                                                                                                                            .Call $reader.Read();
+                                                                                                                                            .If (
+                                                                                                                                                !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                            ) {
+                                                                                                                                                .Break end { }
+                                                                                                                                            } .Else {
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                    .LabelTarget end:;
+                                                                                                                                    .If (
+                                                                                                                                        $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                                    ) {
+                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                            $reader.NodeType,
+                                                                                                                                            $reader.LocalName,
+                                                                                                                                            $reader.Value)
+                                                                                                                                    } .Else {
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    };
+                                                                                                                                    $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ) {
+                                                                                                                            .Block() {
+                                                                                                                                .Block(System.String $valueAsString) {
+                                                                                                                                    .If (
+                                                                                                                                        $reader.IsEmptyElement
+                                                                                                                                    ) {
+                                                                                                                                        $valueAsString = System.String.Empty
+                                                                                                                                    } .Else {
+                                                                                                                                        .Block() {
+                                                                                                                                            .Call $reader.Read();
+                                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                $valueAsString = ""
+                                                                                                                                            } .Else {
+                                                                                                                                                .Block() {
+                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                                $reader.NodeType,
+                                                                                                                                                                $reader.LocalName,
+                                                                                                                                                                $reader.Value)
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                        }
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                    };
+                                                                                                                                                    $valueAsString = $reader.Value;
+                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                            $reader.Value)
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    };
+                                                                                                                                    $Example._blobMap_key = .Call System.Convert.ToInt32(
+                                                                                                                                        $valueAsString,
+                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                };
+                                                                                                                                .If (
+                                                                                                                                    $isEmpty
+                                                                                                                                ) {
+                                                                                                                                    False
+                                                                                                                                } .Else {
+                                                                                                                                    .Block() {
+                                                                                                                                        .Loop  {
+                                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                .Call $reader.Read()
+                                                                                                                                            } .Else {
+                                                                                                                                                .Break end { }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                        .LabelTarget end:;
+                                                                                                                                        .Loop  {
+                                                                                                                                            .Block() {
+                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                .If (
+                                                                                                                                                    !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                                ) {
+                                                                                                                                                    .Break end { }
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                        .LabelTarget end:;
+                                                                                                                                        .If (
+                                                                                                                                            $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                                        ) {
+                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                $reader.NodeType,
+                                                                                                                                                $reader.LocalName,
+                                                                                                                                                $reader.Value)
+                                                                                                                                        } .Else {
+                                                                                                                                            .Default(System.Void)
+                                                                                                                                        };
+                                                                                                                                        $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                                    }
+                                                                                                                                };
+                                                                                                                                .Block(System.Boolean $isEmpty) {
+                                                                                                                                    $isEmpty = $reader.IsEmptyElement;
+                                                                                                                                    .Block(
+                                                                                                                                        System.Int32 $index,
+                                                                                                                                        System.Byte[] $array) {
+                                                                                                                                        .Block(System.Int32 $Example._blobMap_value_count) {
+                                                                                                                                            $Example._blobMap_value_count = 0;
+                                                                                                                                            .Default(System.Void);
+                                                                                                                                            .Block() {
+                                                                                                                                                $index = 0;
+                                                                                                                                                $array = .NewArray System.Byte[$Example._blobMap_value_count]
+                                                                                                                                            }
+                                                                                                                                        };
+                                                                                                                                        .Loop  {
+                                                                                                                                            .If (
+                                                                                                                                                .If (
+                                                                                                                                                    $isEmpty
+                                                                                                                                                ) {
+                                                                                                                                                    False
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .Loop  {
+                                                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                .Call $reader.Read()
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Break end { }
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                        .LabelTarget end:;
+                                                                                                                                                        .Loop  {
+                                                                                                                                                            .Block() {
+                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                .If (
+                                                                                                                                                                    !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                                                ) {
+                                                                                                                                                                    .Break end { }
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                        .LabelTarget end:;
+                                                                                                                                                        .If (
+                                                                                                                                                            $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                                                        ) {
+                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                                $reader.NodeType,
+                                                                                                                                                                $reader.LocalName,
+                                                                                                                                                                $reader.Value)
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                        };
+                                                                                                                                                        $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            ) {
+                                                                                                                                                .Block() {
+                                                                                                                                                    .If ($index >= $array.Length) {
+                                                                                                                                                        .Call System.Array.Resize(
+                                                                                                                                                            $array,
+                                                                                                                                                            .If ($index > 512) {
+                                                                                                                                                                $index * 2
+                                                                                                                                                            } .Else {
+                                                                                                                                                                1024
+                                                                                                                                                            })
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                    };
+                                                                                                                                                    .Block(System.String $valueAsString) {
+                                                                                                                                                        .If (
+                                                                                                                                                            $reader.IsEmptyElement
+                                                                                                                                                        ) {
+                                                                                                                                                            $valueAsString = System.String.Empty
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Block() {
+                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                    $valueAsString = ""
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Block() {
+                                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                                                    $reader.Value)
+                                                                                                                                                                            } .Else {
+                                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                                            }
+                                                                                                                                                                        } .Else {
+                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                        };
+                                                                                                                                                                        $valueAsString = $reader.Value;
+                                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                                                $reader.NodeType,
+                                                                                                                                                                                $reader.LocalName,
+                                                                                                                                                                                $reader.Value)
+                                                                                                                                                                        } .Else {
+                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        };
+                                                                                                                                                        $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                                                                            $valueAsString,
+                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            } .Else {
+                                                                                                                                                .Break end { }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                        .LabelTarget end:;
+                                                                                                                                        $Example._blobMap_value = .New System.ArraySegment`1[System.Byte](
+                                                                                                                                            $array,
+                                                                                                                                            0,
+                                                                                                                                            $index)
+                                                                                                                                    }
+                                                                                                                                };
+                                                                                                                                ($Example._blobMap).Item[$Example._blobMap_key] = $Example._blobMap_value
+                                                                                                                            }
+                                                                                                                        } .Else {
+                                                                                                                            .Break end { }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                    .LabelTarget end:
+                                                                                                                }
+                                                                                                            };
+                                                                                                            $state = .Constant<System.Byte>(3)
+                                                                                                        }
+                                                                                                    } .Else {
+                                                                                                        .If (
+                                                                                                            .Call System.String.Equals(
+                                                                                                                $reader.LocalName,
+                                                                                                                "_blobVector",
+                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                $reader.NamespaceURI,
+                                                                                                                System.String.Empty,
+                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                $reader.NamespaceURI,
+                                                                                                                "urn:ExpressionsTest.Example",
+                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                        ) {
+                                                                                                            .Block() {
+                                                                                                                .Block(System.Boolean $isEmpty) {
+                                                                                                                    $isEmpty = $reader.IsEmptyElement;
+                                                                                                                    .Block(System.ArraySegment`1[System.Byte] $Example._blobVector_item) {
+                                                                                                                        .Block(System.Int32 $Example._blobVector_count) {
+                                                                                                                            $Example._blobVector_count = 0;
+                                                                                                                            .Default(System.Void);
+                                                                                                                            ($Example._blobVector).Capacity = $Example._blobVector_count
+                                                                                                                        };
+                                                                                                                        .Loop  {
+                                                                                                                            .If (
+                                                                                                                                .If (
+                                                                                                                                    $isEmpty
+                                                                                                                                ) {
+                                                                                                                                    False
+                                                                                                                                } .Else {
+                                                                                                                                    .Block() {
+                                                                                                                                        .Loop  {
+                                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                .Call $reader.Read()
+                                                                                                                                            } .Else {
+                                                                                                                                                .Break end { }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                        .LabelTarget end:;
+                                                                                                                                        .Loop  {
+                                                                                                                                            .Block() {
+                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                .If (
+                                                                                                                                                    !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                                ) {
+                                                                                                                                                    .Break end { }
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                        .LabelTarget end:;
+                                                                                                                                        .If (
+                                                                                                                                            $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                                        ) {
+                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                $reader.NodeType,
+                                                                                                                                                $reader.LocalName,
+                                                                                                                                                $reader.Value)
+                                                                                                                                        } .Else {
+                                                                                                                                            .Default(System.Void)
+                                                                                                                                        };
+                                                                                                                                        $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            ) {
+                                                                                                                                .Block() {
+                                                                                                                                    .Block(System.Boolean $isEmpty) {
+                                                                                                                                        $isEmpty = $reader.IsEmptyElement;
+                                                                                                                                        .Block(
+                                                                                                                                            System.Int32 $index,
+                                                                                                                                            System.Byte[] $array) {
+                                                                                                                                            .Block(System.Int32 $Example._blobVector_item_count) {
+                                                                                                                                                $Example._blobVector_item_count = 0;
+                                                                                                                                                .Default(System.Void);
+                                                                                                                                                .Block() {
+                                                                                                                                                    $index = 0;
+                                                                                                                                                    $array = .NewArray System.Byte[$Example._blobVector_item_count]
+                                                                                                                                                }
+                                                                                                                                            };
+                                                                                                                                            .Loop  {
+                                                                                                                                                .If (
+                                                                                                                                                    .If (
+                                                                                                                                                        $isEmpty
+                                                                                                                                                    ) {
+                                                                                                                                                        False
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Block() {
+                                                                                                                                                            .Loop  {
+                                                                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                    .Call $reader.Read()
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Break end { }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                            .LabelTarget end:;
+                                                                                                                                                            .Loop  {
+                                                                                                                                                                .Block() {
+                                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                                    .If (
+                                                                                                                                                                        !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                                                    ) {
+                                                                                                                                                                        .Break end { }
+                                                                                                                                                                    } .Else {
+                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                            .LabelTarget end:;
+                                                                                                                                                            .If (
+                                                                                                                                                                $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                                                            ) {
+                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                                    $reader.Value)
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                            };
+                                                                                                                                                            $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ) {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .If ($index >= $array.Length) {
+                                                                                                                                                            .Call System.Array.Resize(
+                                                                                                                                                                $array,
+                                                                                                                                                                .If ($index > 512) {
+                                                                                                                                                                    $index * 2
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    1024
+                                                                                                                                                                })
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                        };
+                                                                                                                                                        .Block(System.String $valueAsString) {
+                                                                                                                                                            .If (
+                                                                                                                                                                $reader.IsEmptyElement
+                                                                                                                                                            ) {
+                                                                                                                                                                $valueAsString = System.String.Empty
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Block() {
+                                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                        $valueAsString = ""
+                                                                                                                                                                    } .Else {
+                                                                                                                                                                        .Block() {
+                                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                                                        $reader.Value)
+                                                                                                                                                                                } .Else {
+                                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                                }
+                                                                                                                                                                            } .Else {
+                                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                                            };
+                                                                                                                                                                            $valueAsString = $reader.Value;
+                                                                                                                                                                            .Call $reader.Read();
+                                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                                                    $reader.Value)
+                                                                                                                                                                            } .Else {
+                                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                                            }
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            };
+                                                                                                                                                            $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                                                                                $valueAsString,
+                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Break end { }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                            .LabelTarget end:;
+                                                                                                                                            $Example._blobVector_item = .New System.ArraySegment`1[System.Byte](
+                                                                                                                                                $array,
+                                                                                                                                                0,
+                                                                                                                                                $index)
+                                                                                                                                        }
+                                                                                                                                    };
+                                                                                                                                    .Call ($Example._blobVector).Add($Example._blobVector_item)
+                                                                                                                                }
+                                                                                                                            } .Else {
+                                                                                                                                .Break end { }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                        .LabelTarget end:;
+                                                                                                                        .Default(System.Void)
+                                                                                                                    }
+                                                                                                                };
+                                                                                                                $state = .Constant<System.Byte>(3)
+                                                                                                            }
+                                                                                                        } .Else {
+                                                                                                            .If (
+                                                                                                                .Call System.String.Equals(
+                                                                                                                    $reader.LocalName,
+                                                                                                                    "_blobList",
+                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                    $reader.NamespaceURI,
+                                                                                                                    System.String.Empty,
+                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                    $reader.NamespaceURI,
+                                                                                                                    "urn:ExpressionsTest.Example",
+                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                            ) {
+                                                                                                                .Block() {
+                                                                                                                    .Block(System.Boolean $isEmpty) {
+                                                                                                                        $isEmpty = $reader.IsEmptyElement;
+                                                                                                                        .Block(System.ArraySegment`1[System.Byte] $Example._blobList_item) {
+                                                                                                                            .Default(System.Void);
+                                                                                                                            .Loop  {
+                                                                                                                                .If (
+                                                                                                                                    .If (
+                                                                                                                                        $isEmpty
+                                                                                                                                    ) {
+                                                                                                                                        False
+                                                                                                                                    } .Else {
+                                                                                                                                        .Block() {
+                                                                                                                                            .Loop  {
+                                                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                    .Call $reader.Read()
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Break end { }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                            .LabelTarget end:;
+                                                                                                                                            .Loop  {
+                                                                                                                                                .Block() {
+                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                    .If (
+                                                                                                                                                        !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                                    ) {
+                                                                                                                                                        .Break end { }
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                            .LabelTarget end:;
+                                                                                                                                            .If (
+                                                                                                                                                $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                                            ) {
+                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                    $reader.Value)
+                                                                                                                                            } .Else {
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                            };
+                                                                                                                                            $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ) {
+                                                                                                                                    .Block() {
+                                                                                                                                        .Block(System.Boolean $isEmpty) {
+                                                                                                                                            $isEmpty = $reader.IsEmptyElement;
+                                                                                                                                            .Block(
+                                                                                                                                                System.Int32 $index,
+                                                                                                                                                System.Byte[] $array) {
+                                                                                                                                                .Block(System.Int32 $Example._blobList_item_count) {
+                                                                                                                                                    $Example._blobList_item_count = 0;
+                                                                                                                                                    .Default(System.Void);
+                                                                                                                                                    .Block() {
+                                                                                                                                                        $index = 0;
+                                                                                                                                                        $array = .NewArray System.Byte[$Example._blobList_item_count]
+                                                                                                                                                    }
+                                                                                                                                                };
+                                                                                                                                                .Loop  {
+                                                                                                                                                    .If (
+                                                                                                                                                        .If (
+                                                                                                                                                            $isEmpty
+                                                                                                                                                        ) {
+                                                                                                                                                            False
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Block() {
+                                                                                                                                                                .Loop  {
+                                                                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                        .Call $reader.Read()
+                                                                                                                                                                    } .Else {
+                                                                                                                                                                        .Break end { }
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                                .LabelTarget end:;
+                                                                                                                                                                .Loop  {
+                                                                                                                                                                    .Block() {
+                                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                                        .If (
+                                                                                                                                                                            !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                                                        ) {
+                                                                                                                                                                            .Break end { }
+                                                                                                                                                                        } .Else {
+                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                                .LabelTarget end:;
+                                                                                                                                                                .If (
+                                                                                                                                                                    $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                                                                ) {
+                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                                        $reader.Value)
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                };
+                                                                                                                                                                $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    ) {
+                                                                                                                                                        .Block() {
+                                                                                                                                                            .If ($index >= $array.Length) {
+                                                                                                                                                                .Call System.Array.Resize(
+                                                                                                                                                                    $array,
+                                                                                                                                                                    .If ($index > 512) {
+                                                                                                                                                                        $index * 2
+                                                                                                                                                                    } .Else {
+                                                                                                                                                                        1024
+                                                                                                                                                                    })
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                            };
+                                                                                                                                                            .Block(System.String $valueAsString) {
+                                                                                                                                                                .If (
+                                                                                                                                                                    $reader.IsEmptyElement
+                                                                                                                                                                ) {
+                                                                                                                                                                    $valueAsString = System.String.Empty
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Block() {
+                                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                            $valueAsString = ""
+                                                                                                                                                                        } .Else {
+                                                                                                                                                                            .Block() {
+                                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                                                            $reader.Value)
+                                                                                                                                                                                    } .Else {
+                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                    }
+                                                                                                                                                                                } .Else {
+                                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                                };
+                                                                                                                                                                                $valueAsString = $reader.Value;
+                                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                                                        $reader.Value)
+                                                                                                                                                                                } .Else {
+                                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                };
+                                                                                                                                                                $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                                                                                    $valueAsString,
+                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Break end { }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                                .LabelTarget end:;
+                                                                                                                                                $Example._blobList_item = .New System.ArraySegment`1[System.Byte](
+                                                                                                                                                    $array,
+                                                                                                                                                    0,
+                                                                                                                                                    $index)
+                                                                                                                                            }
+                                                                                                                                        };
+                                                                                                                                        .Call ($Example._blobList).Add($Example._blobList_item)
+                                                                                                                                    }
+                                                                                                                                } .Else {
+                                                                                                                                    .Break end { }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                            .LabelTarget end:;
+                                                                                                                            .Default(System.Void)
+                                                                                                                        }
+                                                                                                                    };
+                                                                                                                    $state = .Constant<System.Byte>(3)
+                                                                                                                }
+                                                                                                            } .Else {
+                                                                                                                .If (
+                                                                                                                    .Call System.String.Equals(
+                                                                                                                        $reader.LocalName,
+                                                                                                                        "b",
+                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                        $reader.NamespaceURI,
+                                                                                                                        System.String.Empty,
+                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                        $reader.NamespaceURI,
+                                                                                                                        "urn:ExpressionsTest.Example",
+                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                ) {
+                                                                                                                    .Block() {
+                                                                                                                        .Block(System.Boolean $isEmpty) {
+                                                                                                                            $isEmpty = $reader.IsEmptyElement;
+                                                                                                                            .Block(
+                                                                                                                                System.Int32 $index,
+                                                                                                                                System.Byte[] $array) {
+                                                                                                                                .Block(System.Int32 $Example.b_count) {
+                                                                                                                                    $Example.b_count = 0;
+                                                                                                                                    .Default(System.Void);
+                                                                                                                                    .Block() {
+                                                                                                                                        $index = 0;
+                                                                                                                                        $array = .NewArray System.Byte[$Example.b_count]
+                                                                                                                                    }
+                                                                                                                                };
+                                                                                                                                .Loop  {
+                                                                                                                                    .If (
+                                                                                                                                        .If (
+                                                                                                                                            $isEmpty
+                                                                                                                                        ) {
+                                                                                                                                            False
+                                                                                                                                        } .Else {
+                                                                                                                                            .Block() {
+                                                                                                                                                .Loop  {
+                                                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                        .Call $reader.Read()
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Break end { }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                                .LabelTarget end:;
+                                                                                                                                                .Loop  {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                        .If (
+                                                                                                                                                            !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                                        ) {
+                                                                                                                                                            .Break end { }
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                                .LabelTarget end:;
+                                                                                                                                                .If (
+                                                                                                                                                    $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                                                ) {
+                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                        $reader.Value)
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                };
+                                                                                                                                                $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    ) {
+                                                                                                                                        .Block() {
+                                                                                                                                            .If ($index >= $array.Length) {
+                                                                                                                                                .Call System.Array.Resize(
+                                                                                                                                                    $array,
+                                                                                                                                                    .If ($index > 512) {
+                                                                                                                                                        $index * 2
+                                                                                                                                                    } .Else {
+                                                                                                                                                        1024
+                                                                                                                                                    })
+                                                                                                                                            } .Else {
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                            };
+                                                                                                                                            .Block(System.String $valueAsString) {
+                                                                                                                                                .If (
+                                                                                                                                                    $reader.IsEmptyElement
+                                                                                                                                                ) {
+                                                                                                                                                    $valueAsString = System.String.Empty
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                            $valueAsString = ""
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Block() {
+                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                                            $reader.Value)
+                                                                                                                                                                    } .Else {
+                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                    }
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                };
+                                                                                                                                                                $valueAsString = $reader.Value;
+                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                                        $reader.Value)
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                };
+                                                                                                                                                $array[$index++] = (System.Byte).Call System.Convert.ToSByte(
+                                                                                                                                                    $valueAsString,
+                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    } .Else {
+                                                                                                                                        .Break end { }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                                .LabelTarget end:;
+                                                                                                                                $Example.b = .New System.ArraySegment`1[System.Byte](
+                                                                                                                                    $array,
+                                                                                                                                    0,
+                                                                                                                                    $index)
+                                                                                                                            }
+                                                                                                                        };
+                                                                                                                        $state = .Constant<System.Byte>(3)
+                                                                                                                    }
+                                                                                                                } .Else {
+                                                                                                                    .If (
+                                                                                                                        .Call System.String.Equals(
+                                                                                                                            $reader.LocalName,
+                                                                                                                            "_nestedVector",
+                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                            $reader.NamespaceURI,
+                                                                                                                            System.String.Empty,
+                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                            $reader.NamespaceURI,
+                                                                                                                            "urn:ExpressionsTest.Example",
+                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                    ) {
+                                                                                                                        .Block() {
+                                                                                                                            .Block(System.Boolean $isEmpty) {
+                                                                                                                                $isEmpty = $reader.IsEmptyElement;
+                                                                                                                                .Block(ExpressionsTest.Nested $Example._nestedVector_item) {
+                                                                                                                                    .Default(System.Void);
+                                                                                                                                    .Loop  {
+                                                                                                                                        .If (
+                                                                                                                                            .If (
+                                                                                                                                                $isEmpty
+                                                                                                                                            ) {
+                                                                                                                                                False
+                                                                                                                                            } .Else {
+                                                                                                                                                .Block() {
+                                                                                                                                                    .Loop  {
+                                                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                            .Call $reader.Read()
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Break end { }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                    .LabelTarget end:;
+                                                                                                                                                    .Loop  {
+                                                                                                                                                        .Block() {
+                                                                                                                                                            .Call $reader.Read();
+                                                                                                                                                            .If (
+                                                                                                                                                                !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                                            ) {
+                                                                                                                                                                .Break end { }
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                    .LabelTarget end:;
+                                                                                                                                                    .If (
+                                                                                                                                                        $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                                                    ) {
+                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                            $reader.Value)
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                    };
+                                                                                                                                                    $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ) {
+                                                                                                                                            .Block() {
+                                                                                                                                                .Block() {
+                                                                                                                                                    $Example._nestedVector_item = .New ExpressionsTest.Nested();
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                        .Block(
+                                                                                                                                                            System.Byte $state,
+                                                                                                                                                            Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
+                                                                                                                                                            .Default(System.Void);
+                                                                                                                                                            .Default(System.Void);
+                                                                                                                                                            $state = .Constant<System.Byte>(1);
+                                                                                                                                                            .Loop  {
+                                                                                                                                                                .If (
+                                                                                                                                                                    !$reader.EOF && $state != .Constant<System.Byte>(4)
+                                                                                                                                                                ) {
+                                                                                                                                                                    .Switch ($reader.NodeType) {
+                                                                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(Element)):
+                                                                                                                                                                            .Switch ($state) {
+                                                                                                                                                                            .Case (.Constant<System.Byte>(1)):
+                                                                                                                                                                                    .Block() {
+                                                                                                                                                                                        .Block() {
+                                                                                                                                                                                            .If (
+                                                                                                                                                                                                $reader.IsEmptyElement
+                                                                                                                                                                                            ) {
+                                                                                                                                                                                                $state = .Constant<System.Byte>(4)
+                                                                                                                                                                                            } .Else {
+                                                                                                                                                                                                $state = .Constant<System.Byte>(2)
+                                                                                                                                                                                            };
+                                                                                                                                                                                            .Call $reader.Read()
+                                                                                                                                                                                        };
+                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                    }
+                                                                                                                                                                            .Case (.Constant<System.Byte>(2)):
+                                                                                                                                                                                    .Block() {
+                                                                                                                                                                                        .If (
+                                                                                                                                                                                            .Call System.String.Equals(
+                                                                                                                                                                                                $reader.LocalName,
+                                                                                                                                                                                                "_double",
+                                                                                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                                                                                                $reader.NamespaceURI,
+                                                                                                                                                                                                System.String.Empty,
+                                                                                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                                                                                                $reader.NamespaceURI,
+                                                                                                                                                                                                "urn:ExpressionsTest.Nested",
+                                                                                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                                                                                        ) {
+                                                                                                                                                                                            .Block() {
+                                                                                                                                                                                                .Block(System.String $valueAsString) {
+                                                                                                                                                                                                    .If (
+                                                                                                                                                                                                        $reader.IsEmptyElement
+                                                                                                                                                                                                    ) {
+                                                                                                                                                                                                        $valueAsString = System.String.Empty
+                                                                                                                                                                                                    } .Else {
+                                                                                                                                                                                                        .Block() {
+                                                                                                                                                                                                            .Call $reader.Read();
+                                                                                                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                                                                $valueAsString = ""
+                                                                                                                                                                                                            } .Else {
+                                                                                                                                                                                                                .Block() {
+                                                                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                                                                                                $reader.NodeType,
+                                                                                                                                                                                                                                $reader.LocalName,
+                                                                                                                                                                                                                                $reader.Value)
+                                                                                                                                                                                                                        } .Else {
+                                                                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    } .Else {
+                                                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                                                    };
+                                                                                                                                                                                                                    $valueAsString = $reader.Value;
+                                                                                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                                                                                            $reader.Value)
+                                                                                                                                                                                                                    } .Else {
+                                                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    };
+                                                                                                                                                                                                    $Example._nestedVector_item._double = .Call System.Convert.ToDouble(
+                                                                                                                                                                                                        $valueAsString,
+                                                                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                                                                                };
+                                                                                                                                                                                                $state = .Constant<System.Byte>(3)
+                                                                                                                                                                                            }
+                                                                                                                                                                                        } .Else {
+                                                                                                                                                                                            .Block() {
+                                                                                                                                                                                                .Call $reader.Skip();
+                                                                                                                                                                                                $state = .Constant<System.Byte>(2)
+                                                                                                                                                                                            }
+                                                                                                                                                                                        };
+                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                    }
+                                                                                                                                                                            .Case (.Constant<System.Byte>(3)):
+                                                                                                                                                                                    .Block() {
+                                                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                                                        $state = .Constant<System.Byte>(2);
+                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                    }
+                                                                                                                                                                            .Default:
+                                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                        $state,
+                                                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                                                        $reader.Value)
+                                                                                                                                                                            }
+                                                                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(EndElement)):
+                                                                                                                                                                            .Switch ($state) {
+                                                                                                                                                                            .Case (.Constant<System.Byte>(3)):
+                                                                                                                                                                                    .Block() {
+                                                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                                                        $state = .Constant<System.Byte>(2);
+                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                    }
+                                                                                                                                                                            .Case (.Constant<System.Byte>(2)):
+                                                                                                                                                                                    .Block() {
+                                                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                                                        $state = .Constant<System.Byte>(4);
+                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                    }
+                                                                                                                                                                            .Default:
+                                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                        $state,
+                                                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                                                        $reader.Value)
+                                                                                                                                                                            }
+                                                                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(Comment)):
+                                                                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(Text)):
+                                                                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(Whitespace)):
+                                                                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(XmlDeclaration)):
+                                                                                                                                                                            .Block() {
+                                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                                            }
+                                                                                                                                                                    .Default:
+                                                                                                                                                                            .Invoke (.Lambda #Lambda3<System.Action`1[System.Xml.XmlNodeType]>)($reader.NodeType)
+                                                                                                                                                                    }
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Break endStateMachineLoop { }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                            .LabelTarget endStateMachineLoop:;
+                                                                                                                                                            .Default(System.Void);
+                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                };
+                                                                                                                                                .Call ($Example._nestedVector).Add($Example._nestedVector_item)
+                                                                                                                                            }
+                                                                                                                                        } .Else {
+                                                                                                                                            .Break end { }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                    .LabelTarget end:;
+                                                                                                                                    .Default(System.Void)
+                                                                                                                                }
+                                                                                                                            };
+                                                                                                                            $state = .Constant<System.Byte>(3)
+                                                                                                                        }
+                                                                                                                    } .Else {
+                                                                                                                        .If (
+                                                                                                                            .Call System.String.Equals(
+                                                                                                                                $reader.LocalName,
+                                                                                                                                "_int32Vector",
+                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                                $reader.NamespaceURI,
+                                                                                                                                System.String.Empty,
+                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                                $reader.NamespaceURI,
+                                                                                                                                "urn:ExpressionsTest.Example",
+                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                        ) {
+                                                                                                                            .Block() {
+                                                                                                                                .Block(System.Boolean $isEmpty) {
+                                                                                                                                    $isEmpty = $reader.IsEmptyElement;
+                                                                                                                                    .Block(System.Int32 $Example._int32Vector_item) {
+                                                                                                                                        .Block(System.Int32 $Example._int32Vector_count) {
+                                                                                                                                            $Example._int32Vector_count = 0;
+                                                                                                                                            .Default(System.Void);
+                                                                                                                                            ($Example._int32Vector).Capacity = $Example._int32Vector_count
+                                                                                                                                        };
+                                                                                                                                        .Loop  {
+                                                                                                                                            .If (
+                                                                                                                                                .If (
+                                                                                                                                                    $isEmpty
+                                                                                                                                                ) {
+                                                                                                                                                    False
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .Loop  {
+                                                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                .Call $reader.Read()
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Break end { }
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                        .LabelTarget end:;
+                                                                                                                                                        .Loop  {
+                                                                                                                                                            .Block() {
+                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                .If (
+                                                                                                                                                                    !($reader.NodeType == .Constant<System.Xml.XmlNodeType>(Whitespace))
+                                                                                                                                                                ) {
+                                                                                                                                                                    .Break end { }
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                        .LabelTarget end:;
+                                                                                                                                                        .If (
+                                                                                                                                                            $reader.NodeType == .Constant<System.Xml.XmlNodeType>(Element) && $reader.LocalName != "Item"
+                                                                                                                                                        ) {
+                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                                $reader.NodeType,
+                                                                                                                                                                $reader.LocalName,
+                                                                                                                                                                $reader.Value)
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                        };
+                                                                                                                                                        $reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            ) {
+                                                                                                                                                .Block() {
+                                                                                                                                                    .Block(System.String $valueAsString) {
+                                                                                                                                                        .If (
+                                                                                                                                                            $reader.IsEmptyElement
+                                                                                                                                                        ) {
+                                                                                                                                                            $valueAsString = System.String.Empty
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Block() {
+                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                    $valueAsString = ""
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Block() {
+                                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                                                    $reader.Value)
+                                                                                                                                                                            } .Else {
+                                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                                            }
+                                                                                                                                                                        } .Else {
+                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                        };
+                                                                                                                                                                        $valueAsString = $reader.Value;
+                                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                                                $reader.NodeType,
+                                                                                                                                                                                $reader.LocalName,
+                                                                                                                                                                                $reader.Value)
+                                                                                                                                                                        } .Else {
+                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        };
+                                                                                                                                                        $Example._int32Vector_item = .Call System.Convert.ToInt32(
+                                                                                                                                                            $valueAsString,
+                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                                    };
+                                                                                                                                                    .Call ($Example._int32Vector).Add($Example._int32Vector_item)
+                                                                                                                                                }
+                                                                                                                                            } .Else {
+                                                                                                                                                .Break end { }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                        .LabelTarget end:;
+                                                                                                                                        .Default(System.Void)
+                                                                                                                                    }
+                                                                                                                                };
+                                                                                                                                $state = .Constant<System.Byte>(3)
+                                                                                                                            }
+                                                                                                                        } .Else {
+                                                                                                                            .If (
+                                                                                                                                .Call System.String.Equals(
+                                                                                                                                    $reader.LocalName,
+                                                                                                                                    "guid",
+                                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                                    $reader.NamespaceURI,
+                                                                                                                                    System.String.Empty,
+                                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                                    $reader.NamespaceURI,
+                                                                                                                                    "urn:ExpressionsTest.Example",
+                                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                            ) {
+                                                                                                                                .Block() {
                                                                                                                                     .Block() {
                                                                                                                                         .Block() {
+                                                                                                                                            .Call $reader.Read();
+                                                                                                                                            .Block(
+                                                                                                                                                System.Byte $state,
+                                                                                                                                                Bond.Expressions.RequiredFields+Bitmap $requiredFields) {
+                                                                                                                                                .Default(System.Void);
+                                                                                                                                                .Default(System.Void);
+                                                                                                                                                $state = .Constant<System.Byte>(1);
+                                                                                                                                                .Loop  {
+                                                                                                                                                    .If (
+                                                                                                                                                        !$reader.EOF && $state != .Constant<System.Byte>(4)
+                                                                                                                                                    ) {
+                                                                                                                                                        .Switch ($reader.NodeType) {
+                                                                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(Element)):
+                                                                                                                                                                .Switch ($state) {
+                                                                                                                                                                .Case (.Constant<System.Byte>(1)):
+                                                                                                                                                                        .Block() {
+                                                                                                                                                                            .Block() {
+                                                                                                                                                                                .If (
+                                                                                                                                                                                    $reader.IsEmptyElement
+                                                                                                                                                                                ) {
+                                                                                                                                                                                    $state = .Constant<System.Byte>(4)
+                                                                                                                                                                                } .Else {
+                                                                                                                                                                                    $state = .Constant<System.Byte>(2)
+                                                                                                                                                                                };
+                                                                                                                                                                                .Call $reader.Read()
+                                                                                                                                                                            };
+                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                        }
+                                                                                                                                                                .Case (.Constant<System.Byte>(2)):
+                                                                                                                                                                        .Block() {
+                                                                                                                                                                            .If (
+                                                                                                                                                                                .Call System.String.Equals(
+                                                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                                                    "Data4",
+                                                                                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                                                                                    $reader.NamespaceURI,
+                                                                                                                                                                                    System.String.Empty,
+                                                                                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                                                                                    $reader.NamespaceURI,
+                                                                                                                                                                                    "urn:bond.GUID",
+                                                                                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                                                                            ) {
+                                                                                                                                                                                .Block() {
+                                                                                                                                                                                    .Block(System.String $valueAsString) {
+                                                                                                                                                                                        .If (
+                                                                                                                                                                                            $reader.IsEmptyElement
+                                                                                                                                                                                        ) {
+                                                                                                                                                                                            $valueAsString = System.String.Empty
+                                                                                                                                                                                        } .Else {
+                                                                                                                                                                                            .Block() {
+                                                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                                                    $valueAsString = ""
+                                                                                                                                                                                                } .Else {
+                                                                                                                                                                                                    .Block() {
+                                                                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                                                                                    $reader.Value)
+                                                                                                                                                                                                            } .Else {
+                                                                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        } .Else {
+                                                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                                                        };
+                                                                                                                                                                                                        $valueAsString = $reader.Value;
+                                                                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                                                                                $reader.NodeType,
+                                                                                                                                                                                                                $reader.LocalName,
+                                                                                                                                                                                                                $reader.Value)
+                                                                                                                                                                                                        } .Else {
+                                                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        };
+                                                                                                                                                                                        ($Example.guid).Data4 = .Call System.Convert.ToUInt64(
+                                                                                                                                                                                            $valueAsString,
+                                                                                                                                                                                            System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                                                                    };
+                                                                                                                                                                                    $state = .Constant<System.Byte>(3)
+                                                                                                                                                                                }
+                                                                                                                                                                            } .Else {
+                                                                                                                                                                                .If (
+                                                                                                                                                                                    .Call System.String.Equals(
+                                                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                                                        "Data3",
+                                                                                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                                                                                        $reader.NamespaceURI,
+                                                                                                                                                                                        System.String.Empty,
+                                                                                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                                                                                        $reader.NamespaceURI,
+                                                                                                                                                                                        "urn:bond.GUID",
+                                                                                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                                                                                ) {
+                                                                                                                                                                                    .Block() {
+                                                                                                                                                                                        .Block(System.String $valueAsString) {
+                                                                                                                                                                                            .If (
+                                                                                                                                                                                                $reader.IsEmptyElement
+                                                                                                                                                                                            ) {
+                                                                                                                                                                                                $valueAsString = System.String.Empty
+                                                                                                                                                                                            } .Else {
+                                                                                                                                                                                                .Block() {
+                                                                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                                                        $valueAsString = ""
+                                                                                                                                                                                                    } .Else {
+                                                                                                                                                                                                        .Block() {
+                                                                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                                                                                        $reader.Value)
+                                                                                                                                                                                                                } .Else {
+                                                                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            } .Else {
+                                                                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                                                                            };
+                                                                                                                                                                                                            $valueAsString = $reader.Value;
+                                                                                                                                                                                                            .Call $reader.Read();
+                                                                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                                                                                    $reader.Value)
+                                                                                                                                                                                                            } .Else {
+                                                                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                }
+                                                                                                                                                                                            };
+                                                                                                                                                                                            ($Example.guid).Data3 = .Call System.Convert.ToUInt16(
+                                                                                                                                                                                                $valueAsString,
+                                                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                                                                        };
+                                                                                                                                                                                        $state = .Constant<System.Byte>(3)
+                                                                                                                                                                                    }
+                                                                                                                                                                                } .Else {
+                                                                                                                                                                                    .If (
+                                                                                                                                                                                        .Call System.String.Equals(
+                                                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                                                            "Data2",
+                                                                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                                                                                            $reader.NamespaceURI,
+                                                                                                                                                                                            System.String.Empty,
+                                                                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                                                                                            $reader.NamespaceURI,
+                                                                                                                                                                                            "urn:bond.GUID",
+                                                                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                                                                                    ) {
+                                                                                                                                                                                        .Block() {
+                                                                                                                                                                                            .Block(System.String $valueAsString) {
+                                                                                                                                                                                                .If (
+                                                                                                                                                                                                    $reader.IsEmptyElement
+                                                                                                                                                                                                ) {
+                                                                                                                                                                                                    $valueAsString = System.String.Empty
+                                                                                                                                                                                                } .Else {
+                                                                                                                                                                                                    .Block() {
+                                                                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                                                            $valueAsString = ""
+                                                                                                                                                                                                        } .Else {
+                                                                                                                                                                                                            .Block() {
+                                                                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                                                                                            $reader.Value)
+                                                                                                                                                                                                                    } .Else {
+                                                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                } .Else {
+                                                                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                                                                };
+                                                                                                                                                                                                                $valueAsString = $reader.Value;
+                                                                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                                                                                        $reader.Value)
+                                                                                                                                                                                                                } .Else {
+                                                                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                };
+                                                                                                                                                                                                ($Example.guid).Data2 = .Call System.Convert.ToUInt16(
+                                                                                                                                                                                                    $valueAsString,
+                                                                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                                                                            };
+                                                                                                                                                                                            $state = .Constant<System.Byte>(3)
+                                                                                                                                                                                        }
+                                                                                                                                                                                    } .Else {
+                                                                                                                                                                                        .If (
+                                                                                                                                                                                            .Call System.String.Equals(
+                                                                                                                                                                                                $reader.LocalName,
+                                                                                                                                                                                                "Data1",
+                                                                                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                                                                                                $reader.NamespaceURI,
+                                                                                                                                                                                                System.String.Empty,
+                                                                                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                                                                                                $reader.NamespaceURI,
+                                                                                                                                                                                                "urn:bond.GUID",
+                                                                                                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                                                                                        ) {
+                                                                                                                                                                                            .Block() {
+                                                                                                                                                                                                .Block(System.String $valueAsString) {
+                                                                                                                                                                                                    .If (
+                                                                                                                                                                                                        $reader.IsEmptyElement
+                                                                                                                                                                                                    ) {
+                                                                                                                                                                                                        $valueAsString = System.String.Empty
+                                                                                                                                                                                                    } .Else {
+                                                                                                                                                                                                        .Block() {
+                                                                                                                                                                                                            .Call $reader.Read();
+                                                                                                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                                                                $valueAsString = ""
+                                                                                                                                                                                                            } .Else {
+                                                                                                                                                                                                                .Block() {
+                                                                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                                                                .Constant<System.Byte>(0),
+                                                                                                                                                                                                                                $reader.NodeType,
+                                                                                                                                                                                                                                $reader.LocalName,
+                                                                                                                                                                                                                                $reader.Value)
+                                                                                                                                                                                                                        } .Else {
+                                                                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    } .Else {
+                                                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                                                    };
+                                                                                                                                                                                                                    $valueAsString = $reader.Value;
+                                                                                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                                                                                            $reader.Value)
+                                                                                                                                                                                                                    } .Else {
+                                                                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    };
+                                                                                                                                                                                                    ($Example.guid).Data1 = .Call System.Convert.ToUInt32(
+                                                                                                                                                                                                        $valueAsString,
+                                                                                                                                                                                                        System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                                                                                };
+                                                                                                                                                                                                $state = .Constant<System.Byte>(3)
+                                                                                                                                                                                            }
+                                                                                                                                                                                        } .Else {
+                                                                                                                                                                                            .Block() {
+                                                                                                                                                                                                .Call $reader.Skip();
+                                                                                                                                                                                                $state = .Constant<System.Byte>(2)
+                                                                                                                                                                                            }
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                }
+                                                                                                                                                                            };
+                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                        }
+                                                                                                                                                                .Case (.Constant<System.Byte>(3)):
+                                                                                                                                                                        .Block() {
+                                                                                                                                                                            .Call $reader.Read();
+                                                                                                                                                                            $state = .Constant<System.Byte>(2);
+                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                        }
+                                                                                                                                                                .Default:
+                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                            $state,
+                                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                                            $reader.Value)
+                                                                                                                                                                }
+                                                                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(EndElement)):
+                                                                                                                                                                .Switch ($state) {
+                                                                                                                                                                .Case (.Constant<System.Byte>(3)):
+                                                                                                                                                                        .Block() {
+                                                                                                                                                                            .Call $reader.Read();
+                                                                                                                                                                            $state = .Constant<System.Byte>(2);
+                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                        }
+                                                                                                                                                                .Case (.Constant<System.Byte>(2)):
+                                                                                                                                                                        .Block() {
+                                                                                                                                                                            .Call $reader.Read();
+                                                                                                                                                                            $state = .Constant<System.Byte>(4);
+                                                                                                                                                                            .Default(System.Void)
+                                                                                                                                                                        }
+                                                                                                                                                                .Default:
+                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                            $state,
+                                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                                            $reader.Value)
+                                                                                                                                                                }
+                                                                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(Comment)):
+                                                                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(Text)):
+                                                                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(Whitespace)):
+                                                                                                                                                        .Case (.Constant<System.Xml.XmlNodeType>(XmlDeclaration)):
+                                                                                                                                                                .Block() {
+                                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                }
+                                                                                                                                                        .Default:
+                                                                                                                                                                .Invoke (.Lambda #Lambda3<System.Action`1[System.Xml.XmlNodeType]>)($reader.NodeType)
+                                                                                                                                                        }
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Break endStateMachineLoop { }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                                .LabelTarget endStateMachineLoop:;
+                                                                                                                                                .Default(System.Void);
+                                                                                                                                                .Default(System.Void)
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    };
+                                                                                                                                    $state = .Constant<System.Byte>(3)
+                                                                                                                                }
+                                                                                                                            } .Else {
+                                                                                                                                .If (
+                                                                                                                                    .Call System.String.Equals(
+                                                                                                                                        $reader.LocalName,
+                                                                                                                                        "_double",
+                                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                                        $reader.NamespaceURI,
+                                                                                                                                        System.String.Empty,
+                                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                                        $reader.NamespaceURI,
+                                                                                                                                        "urn:ExpressionsTest.Example",
+                                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                                ) {
+                                                                                                                                    .Block() {
+                                                                                                                                        .Block(System.String $valueAsString) {
                                                                                                                                             .If (
                                                                                                                                                 $reader.IsEmptyElement
                                                                                                                                             ) {
-                                                                                                                                                $state = .Constant<System.Byte>(4)
+                                                                                                                                                $valueAsString = System.String.Empty
                                                                                                                                             } .Else {
-                                                                                                                                                $state = .Constant<System.Byte>(2)
+                                                                                                                                                .Block() {
+                                                                                                                                                    .Call $reader.Read();
+                                                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                        $valueAsString = ""
+                                                                                                                                                    } .Else {
+                                                                                                                                                        .Block() {
+                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                                        $reader.Value)
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                }
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                            };
+                                                                                                                                                            $valueAsString = $reader.Value;
+                                                                                                                                                            .Call $reader.Read();
+                                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                    .Constant<System.Byte>(0),
+                                                                                                                                                                    $reader.NodeType,
+                                                                                                                                                                    $reader.LocalName,
+                                                                                                                                                                    $reader.Value)
+                                                                                                                                                            } .Else {
+                                                                                                                                                                .Default(System.Void)
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                }
                                                                                                                                             };
-                                                                                                                                            .Call $reader.Read()
+                                                                                                                                            $Example._double = .Call System.Convert.ToDouble(
+                                                                                                                                                $valueAsString,
+                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture)
                                                                                                                                         };
-                                                                                                                                        .Default(System.Void)
+                                                                                                                                        $state = .Constant<System.Byte>(3)
                                                                                                                                     }
-                                                                                                                            .Case (.Constant<System.Byte>(2)):
-                                                                                                                                    .Block() {
+                                                                                                                                } .Else {
+                                                                                                                                    .If (
+                                                                                                                                        .Call System.String.Equals(
+                                                                                                                                            $reader.LocalName,
+                                                                                                                                            "_int64",
+                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
+                                                                                                                                            $reader.NamespaceURI,
+                                                                                                                                            System.String.Empty,
+                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
+                                                                                                                                            $reader.NamespaceURI,
+                                                                                                                                            "urn:ExpressionsTest.Example",
+                                                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)))
+                                                                                                                                    ) {
+                                                                                                                                        .Block() {
+                                                                                                                                            .Block(System.String $valueAsString) {
+                                                                                                                                                .If (
+                                                                                                                                                    $reader.IsEmptyElement
+                                                                                                                                                ) {
+                                                                                                                                                    $valueAsString = System.String.Empty
+                                                                                                                                                } .Else {
+                                                                                                                                                    .Block() {
+                                                                                                                                                        .Call $reader.Read();
+                                                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                            $valueAsString = ""
+                                                                                                                                                        } .Else {
+                                                                                                                                                            .Block() {
+                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
+                                                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
+                                                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                            .Constant<System.Byte>(0),
+                                                                                                                                                                            $reader.NodeType,
+                                                                                                                                                                            $reader.LocalName,
+                                                                                                                                                                            $reader.Value)
+                                                                                                                                                                    } .Else {
+                                                                                                                                                                        .Default(System.Void)
+                                                                                                                                                                    }
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                };
+                                                                                                                                                                $valueAsString = $reader.Value;
+                                                                                                                                                                .Call $reader.Read();
+                                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
+                                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
+                                                                                                                                                                        .Constant<System.Byte>(0),
+                                                                                                                                                                        $reader.NodeType,
+                                                                                                                                                                        $reader.LocalName,
+                                                                                                                                                                        $reader.Value)
+                                                                                                                                                                } .Else {
+                                                                                                                                                                    .Default(System.Void)
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                };
+                                                                                                                                                $Example._int64 = .Call System.Convert.ToInt64(
+                                                                                                                                                    $valueAsString,
+                                                                                                                                                    System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                            };
+                                                                                                                                            $state = .Constant<System.Byte>(3);
+                                                                                                                                            .Call $requiredFields.Reset(
+                                                                                                                                                0,
+                                                                                                                                                1L)
+                                                                                                                                        }
+                                                                                                                                    } .Else {
                                                                                                                                         .If (
                                                                                                                                             .Call System.String.Equals(
                                                                                                                                                 $reader.LocalName,
-                                                                                                                                                "Data4",
+                                                                                                                                                "_int8",
                                                                                                                                                 .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                                                                                 $reader.NamespaceURI,
                                                                                                                                                 System.String.Empty,
                                                                                                                                                 .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
                                                                                                                                                 $reader.NamespaceURI,
-                                                                                                                                                "urn:bond.GUID",
+                                                                                                                                                "urn:ExpressionsTest.Example",
                                                                                                                                                 .Constant<System.StringComparison>(OrdinalIgnoreCase)))
                                                                                                                                         ) {
                                                                                                                                             .Block() {
@@ -2052,7 +4405,7 @@
                                                                                                                                                             }
                                                                                                                                                         }
                                                                                                                                                     };
-                                                                                                                                                    ($Example.guid).Data4 = .Call System.Convert.ToUInt64(
+                                                                                                                                                    $Example._int8 = .Call System.Convert.ToSByte(
                                                                                                                                                         $valueAsString,
                                                                                                                                                         System.Globalization.CultureInfo.InvariantCulture)
                                                                                                                                                 };
@@ -2062,13 +4415,13 @@
                                                                                                                                             .If (
                                                                                                                                                 .Call System.String.Equals(
                                                                                                                                                     $reader.LocalName,
-                                                                                                                                                    "Data3",
+                                                                                                                                                    "_uint32",
                                                                                                                                                     .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                                                                                     $reader.NamespaceURI,
                                                                                                                                                     System.String.Empty,
                                                                                                                                                     .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
                                                                                                                                                     $reader.NamespaceURI,
-                                                                                                                                                    "urn:bond.GUID",
+                                                                                                                                                    "urn:ExpressionsTest.Example",
                                                                                                                                                     .Constant<System.StringComparison>(OrdinalIgnoreCase)))
                                                                                                                                             ) {
                                                                                                                                                 .Block() {
@@ -2112,7 +4465,7 @@
                                                                                                                                                                 }
                                                                                                                                                             }
                                                                                                                                                         };
-                                                                                                                                                        ($Example.guid).Data3 = .Call System.Convert.ToUInt16(
+                                                                                                                                                        $Example._uint32 = .Call System.Convert.ToUInt32(
                                                                                                                                                             $valueAsString,
                                                                                                                                                             System.Globalization.CultureInfo.InvariantCulture)
                                                                                                                                                     };
@@ -2122,13 +4475,13 @@
                                                                                                                                                 .If (
                                                                                                                                                     .Call System.String.Equals(
                                                                                                                                                         $reader.LocalName,
-                                                                                                                                                        "Data2",
+                                                                                                                                                        "_str",
                                                                                                                                                         .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                                                                                         $reader.NamespaceURI,
                                                                                                                                                         System.String.Empty,
                                                                                                                                                         .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
                                                                                                                                                         $reader.NamespaceURI,
-                                                                                                                                                        "urn:bond.GUID",
+                                                                                                                                                        "urn:ExpressionsTest.Example",
                                                                                                                                                         .Constant<System.StringComparison>(OrdinalIgnoreCase)))
                                                                                                                                                 ) {
                                                                                                                                                     .Block() {
@@ -2172,9 +4525,7 @@
                                                                                                                                                                     }
                                                                                                                                                                 }
                                                                                                                                                             };
-                                                                                                                                                            ($Example.guid).Data2 = .Call System.Convert.ToUInt16(
-                                                                                                                                                                $valueAsString,
-                                                                                                                                                                System.Globalization.CultureInfo.InvariantCulture)
+                                                                                                                                                            $Example._str = $valueAsString
                                                                                                                                                         };
                                                                                                                                                         $state = .Constant<System.Byte>(3)
                                                                                                                                                     }
@@ -2182,13 +4533,13 @@
                                                                                                                                                     .If (
                                                                                                                                                         .Call System.String.Equals(
                                                                                                                                                             $reader.LocalName,
-                                                                                                                                                            "Data1",
+                                                                                                                                                            "_bool",
                                                                                                                                                             .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
                                                                                                                                                             $reader.NamespaceURI,
                                                                                                                                                             System.String.Empty,
                                                                                                                                                             .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
                                                                                                                                                             $reader.NamespaceURI,
-                                                                                                                                                            "urn:bond.GUID",
+                                                                                                                                                            "urn:ExpressionsTest.Example",
                                                                                                                                                             .Constant<System.StringComparison>(OrdinalIgnoreCase)))
                                                                                                                                                     ) {
                                                                                                                                                         .Block() {
@@ -2232,7 +4583,7 @@
                                                                                                                                                                         }
                                                                                                                                                                     }
                                                                                                                                                                 };
-                                                                                                                                                                ($Example.guid).Data1 = .Call System.Convert.ToUInt32(
+                                                                                                                                                                $Example._bool = .Call System.Convert.ToBoolean(
                                                                                                                                                                     $valueAsString,
                                                                                                                                                                     System.Globalization.CultureInfo.InvariantCulture)
                                                                                                                                                             };
@@ -2246,431 +4597,11 @@
                                                                                                                                                     }
                                                                                                                                                 }
                                                                                                                                             }
-                                                                                                                                        };
-                                                                                                                                        .Default(System.Void)
-                                                                                                                                    }
-                                                                                                                            .Case (.Constant<System.Byte>(3)):
-                                                                                                                                    .Block() {
-                                                                                                                                        .Call $reader.Read();
-                                                                                                                                        $state = .Constant<System.Byte>(2);
-                                                                                                                                        .Default(System.Void)
-                                                                                                                                    }
-                                                                                                                            .Default:
-                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                        $state,
-                                                                                                                                        $reader.NodeType,
-                                                                                                                                        $reader.LocalName,
-                                                                                                                                        $reader.Value)
-                                                                                                                            }
-                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(EndElement)):
-                                                                                                                            .Switch ($state) {
-                                                                                                                            .Case (.Constant<System.Byte>(3)):
-                                                                                                                                    .Block() {
-                                                                                                                                        .Call $reader.Read();
-                                                                                                                                        $state = .Constant<System.Byte>(2);
-                                                                                                                                        .Default(System.Void)
-                                                                                                                                    }
-                                                                                                                            .Case (.Constant<System.Byte>(2)):
-                                                                                                                                    .Block() {
-                                                                                                                                        .Call $reader.Read();
-                                                                                                                                        $state = .Constant<System.Byte>(4);
-                                                                                                                                        .Default(System.Void)
-                                                                                                                                    }
-                                                                                                                            .Default:
-                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                        $state,
-                                                                                                                                        $reader.NodeType,
-                                                                                                                                        $reader.LocalName,
-                                                                                                                                        $reader.Value)
-                                                                                                                            }
-                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(Comment)):
-                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(Text)):
-                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(Whitespace)):
-                                                                                                                    .Case (.Constant<System.Xml.XmlNodeType>(XmlDeclaration)):
-                                                                                                                            .Block() {
-                                                                                                                                .Call $reader.Read();
-                                                                                                                                .Default(System.Void)
-                                                                                                                            }
-                                                                                                                    .Default:
-                                                                                                                            .Invoke (.Lambda #Lambda3<System.Action`1[System.Xml.XmlNodeType]>)($reader.NodeType)
-                                                                                                                    }
-                                                                                                                } .Else {
-                                                                                                                    .Break endStateMachineLoop { }
-                                                                                                                }
-                                                                                                            }
-                                                                                                            .LabelTarget endStateMachineLoop:;
-                                                                                                            .Default(System.Void);
-                                                                                                            .Default(System.Void)
-                                                                                                        }
-                                                                                                    }
-                                                                                                };
-                                                                                                $state = .Constant<System.Byte>(3)
-                                                                                            }
-                                                                                        } .Else {
-                                                                                            .If (
-                                                                                                .Call System.String.Equals(
-                                                                                                    $reader.LocalName,
-                                                                                                    "_double",
-                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                                    $reader.NamespaceURI,
-                                                                                                    System.String.Empty,
-                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                                    $reader.NamespaceURI,
-                                                                                                    "urn:ExpressionsTest.Example",
-                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                                            ) {
-                                                                                                .Block() {
-                                                                                                    .Block(System.String $valueAsString) {
-                                                                                                        .If (
-                                                                                                            $reader.IsEmptyElement
-                                                                                                        ) {
-                                                                                                            $valueAsString = System.String.Empty
-                                                                                                        } .Else {
-                                                                                                            .Block() {
-                                                                                                                .Call $reader.Read();
-                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                    $valueAsString = ""
-                                                                                                                } .Else {
-                                                                                                                    .Block() {
-                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                    .Constant<System.Byte>(0),
-                                                                                                                                    $reader.NodeType,
-                                                                                                                                    $reader.LocalName,
-                                                                                                                                    $reader.Value)
-                                                                                                                            } .Else {
-                                                                                                                                .Default(System.Void)
-                                                                                                                            }
-                                                                                                                        } .Else {
-                                                                                                                            .Default(System.Void)
-                                                                                                                        };
-                                                                                                                        $valueAsString = $reader.Value;
-                                                                                                                        .Call $reader.Read();
-                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                .Constant<System.Byte>(0),
-                                                                                                                                $reader.NodeType,
-                                                                                                                                $reader.LocalName,
-                                                                                                                                $reader.Value)
-                                                                                                                        } .Else {
-                                                                                                                            .Default(System.Void)
-                                                                                                                        }
-                                                                                                                    }
-                                                                                                                }
-                                                                                                            }
-                                                                                                        };
-                                                                                                        $Example._double = .Call System.Convert.ToDouble(
-                                                                                                            $valueAsString,
-                                                                                                            System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                    };
-                                                                                                    $state = .Constant<System.Byte>(3)
-                                                                                                }
-                                                                                            } .Else {
-                                                                                                .If (
-                                                                                                    .Call System.String.Equals(
-                                                                                                        $reader.LocalName,
-                                                                                                        "_int64",
-                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                                        $reader.NamespaceURI,
-                                                                                                        System.String.Empty,
-                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                                        $reader.NamespaceURI,
-                                                                                                        "urn:ExpressionsTest.Example",
-                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                                                ) {
-                                                                                                    .Block() {
-                                                                                                        .Block(System.String $valueAsString) {
-                                                                                                            .If (
-                                                                                                                $reader.IsEmptyElement
-                                                                                                            ) {
-                                                                                                                $valueAsString = System.String.Empty
-                                                                                                            } .Else {
-                                                                                                                .Block() {
-                                                                                                                    .Call $reader.Read();
-                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                        $valueAsString = ""
-                                                                                                                    } .Else {
-                                                                                                                        .Block() {
-                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                        .Constant<System.Byte>(0),
-                                                                                                                                        $reader.NodeType,
-                                                                                                                                        $reader.LocalName,
-                                                                                                                                        $reader.Value)
-                                                                                                                                } .Else {
-                                                                                                                                    .Default(System.Void)
-                                                                                                                                }
-                                                                                                                            } .Else {
-                                                                                                                                .Default(System.Void)
-                                                                                                                            };
-                                                                                                                            $valueAsString = $reader.Value;
-                                                                                                                            .Call $reader.Read();
-                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                    .Constant<System.Byte>(0),
-                                                                                                                                    $reader.NodeType,
-                                                                                                                                    $reader.LocalName,
-                                                                                                                                    $reader.Value)
-                                                                                                                            } .Else {
-                                                                                                                                .Default(System.Void)
-                                                                                                                            }
-                                                                                                                        }
-                                                                                                                    }
-                                                                                                                }
-                                                                                                            };
-                                                                                                            $Example._int64 = .Call System.Convert.ToInt64(
-                                                                                                                $valueAsString,
-                                                                                                                System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                        };
-                                                                                                        $state = .Constant<System.Byte>(3);
-                                                                                                        .Call $requiredFields.Reset(
-                                                                                                            0,
-                                                                                                            1L)
-                                                                                                    }
-                                                                                                } .Else {
-                                                                                                    .If (
-                                                                                                        .Call System.String.Equals(
-                                                                                                            $reader.LocalName,
-                                                                                                            "_int8",
-                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                                            $reader.NamespaceURI,
-                                                                                                            System.String.Empty,
-                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                                            $reader.NamespaceURI,
-                                                                                                            "urn:ExpressionsTest.Example",
-                                                                                                            .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                                                    ) {
-                                                                                                        .Block() {
-                                                                                                            .Block(System.String $valueAsString) {
-                                                                                                                .If (
-                                                                                                                    $reader.IsEmptyElement
-                                                                                                                ) {
-                                                                                                                    $valueAsString = System.String.Empty
-                                                                                                                } .Else {
-                                                                                                                    .Block() {
-                                                                                                                        .Call $reader.Read();
-                                                                                                                        .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                            $valueAsString = ""
-                                                                                                                        } .Else {
-                                                                                                                            .Block() {
-                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                            .Constant<System.Byte>(0),
-                                                                                                                                            $reader.NodeType,
-                                                                                                                                            $reader.LocalName,
-                                                                                                                                            $reader.Value)
-                                                                                                                                    } .Else {
-                                                                                                                                        .Default(System.Void)
-                                                                                                                                    }
-                                                                                                                                } .Else {
-                                                                                                                                    .Default(System.Void)
-                                                                                                                                };
-                                                                                                                                $valueAsString = $reader.Value;
-                                                                                                                                .Call $reader.Read();
-                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                        .Constant<System.Byte>(0),
-                                                                                                                                        $reader.NodeType,
-                                                                                                                                        $reader.LocalName,
-                                                                                                                                        $reader.Value)
-                                                                                                                                } .Else {
-                                                                                                                                    .Default(System.Void)
-                                                                                                                                }
-                                                                                                                            }
-                                                                                                                        }
-                                                                                                                    }
-                                                                                                                };
-                                                                                                                $Example._int8 = .Call System.Convert.ToSByte(
-                                                                                                                    $valueAsString,
-                                                                                                                    System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                            };
-                                                                                                            $state = .Constant<System.Byte>(3)
-                                                                                                        }
-                                                                                                    } .Else {
-                                                                                                        .If (
-                                                                                                            .Call System.String.Equals(
-                                                                                                                $reader.LocalName,
-                                                                                                                "_uint32",
-                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                                                $reader.NamespaceURI,
-                                                                                                                System.String.Empty,
-                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                                                $reader.NamespaceURI,
-                                                                                                                "urn:ExpressionsTest.Example",
-                                                                                                                .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                                                        ) {
-                                                                                                            .Block() {
-                                                                                                                .Block(System.String $valueAsString) {
-                                                                                                                    .If (
-                                                                                                                        $reader.IsEmptyElement
-                                                                                                                    ) {
-                                                                                                                        $valueAsString = System.String.Empty
-                                                                                                                    } .Else {
-                                                                                                                        .Block() {
-                                                                                                                            .Call $reader.Read();
-                                                                                                                            .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                $valueAsString = ""
-                                                                                                                            } .Else {
-                                                                                                                                .Block() {
-                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                .Constant<System.Byte>(0),
-                                                                                                                                                $reader.NodeType,
-                                                                                                                                                $reader.LocalName,
-                                                                                                                                                $reader.Value)
-                                                                                                                                        } .Else {
-                                                                                                                                            .Default(System.Void)
-                                                                                                                                        }
-                                                                                                                                    } .Else {
-                                                                                                                                        .Default(System.Void)
-                                                                                                                                    };
-                                                                                                                                    $valueAsString = $reader.Value;
-                                                                                                                                    .Call $reader.Read();
-                                                                                                                                    .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                        .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                            .Constant<System.Byte>(0),
-                                                                                                                                            $reader.NodeType,
-                                                                                                                                            $reader.LocalName,
-                                                                                                                                            $reader.Value)
-                                                                                                                                    } .Else {
-                                                                                                                                        .Default(System.Void)
-                                                                                                                                    }
-                                                                                                                                }
-                                                                                                                            }
-                                                                                                                        }
-                                                                                                                    };
-                                                                                                                    $Example._uint32 = .Call System.Convert.ToUInt32(
-                                                                                                                        $valueAsString,
-                                                                                                                        System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                                };
-                                                                                                                $state = .Constant<System.Byte>(3)
-                                                                                                            }
-                                                                                                        } .Else {
-                                                                                                            .If (
-                                                                                                                .Call System.String.Equals(
-                                                                                                                    $reader.LocalName,
-                                                                                                                    "_str",
-                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                                                    $reader.NamespaceURI,
-                                                                                                                    System.String.Empty,
-                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                                                    $reader.NamespaceURI,
-                                                                                                                    "urn:ExpressionsTest.Example",
-                                                                                                                    .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                                                            ) {
-                                                                                                                .Block() {
-                                                                                                                    .Block(System.String $valueAsString) {
-                                                                                                                        .If (
-                                                                                                                            $reader.IsEmptyElement
-                                                                                                                        ) {
-                                                                                                                            $valueAsString = System.String.Empty
-                                                                                                                        } .Else {
-                                                                                                                            .Block() {
-                                                                                                                                .Call $reader.Read();
-                                                                                                                                .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                    $valueAsString = ""
-                                                                                                                                } .Else {
-                                                                                                                                    .Block() {
-                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                    .Constant<System.Byte>(0),
-                                                                                                                                                    $reader.NodeType,
-                                                                                                                                                    $reader.LocalName,
-                                                                                                                                                    $reader.Value)
-                                                                                                                                            } .Else {
-                                                                                                                                                .Default(System.Void)
-                                                                                                                                            }
-                                                                                                                                        } .Else {
-                                                                                                                                            .Default(System.Void)
-                                                                                                                                        };
-                                                                                                                                        $valueAsString = $reader.Value;
-                                                                                                                                        .Call $reader.Read();
-                                                                                                                                        .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                            .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                .Constant<System.Byte>(0),
-                                                                                                                                                $reader.NodeType,
-                                                                                                                                                $reader.LocalName,
-                                                                                                                                                $reader.Value)
-                                                                                                                                        } .Else {
-                                                                                                                                            .Default(System.Void)
                                                                                                                                         }
                                                                                                                                     }
                                                                                                                                 }
                                                                                                                             }
-                                                                                                                        };
-                                                                                                                        $Example._str = $valueAsString
-                                                                                                                    };
-                                                                                                                    $state = .Constant<System.Byte>(3)
-                                                                                                                }
-                                                                                                            } .Else {
-                                                                                                                .If (
-                                                                                                                    .Call System.String.Equals(
-                                                                                                                        $reader.LocalName,
-                                                                                                                        "_bool",
-                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) && (.Call System.String.Equals(
-                                                                                                                        $reader.NamespaceURI,
-                                                                                                                        System.String.Empty,
-                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)) || .Call System.String.Equals(
-                                                                                                                        $reader.NamespaceURI,
-                                                                                                                        "urn:ExpressionsTest.Example",
-                                                                                                                        .Constant<System.StringComparison>(OrdinalIgnoreCase)))
-                                                                                                                ) {
-                                                                                                                    .Block() {
-                                                                                                                        .Block(System.String $valueAsString) {
-                                                                                                                            .If (
-                                                                                                                                $reader.IsEmptyElement
-                                                                                                                            ) {
-                                                                                                                                $valueAsString = System.String.Empty
-                                                                                                                            } .Else {
-                                                                                                                                .Block() {
-                                                                                                                                    .Call $reader.Read();
-                                                                                                                                    .If ($reader.NodeType == .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                        $valueAsString = ""
-                                                                                                                                    } .Else {
-                                                                                                                                        .Block() {
-                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Text)) {
-                                                                                                                                                .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(Whitespace)) {
-                                                                                                                                                    .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                        .Constant<System.Byte>(0),
-                                                                                                                                                        $reader.NodeType,
-                                                                                                                                                        $reader.LocalName,
-                                                                                                                                                        $reader.Value)
-                                                                                                                                                } .Else {
-                                                                                                                                                    .Default(System.Void)
-                                                                                                                                                }
-                                                                                                                                            } .Else {
-                                                                                                                                                .Default(System.Void)
-                                                                                                                                            };
-                                                                                                                                            $valueAsString = $reader.Value;
-                                                                                                                                            .Call $reader.Read();
-                                                                                                                                            .If ($reader.NodeType != .Constant<System.Xml.XmlNodeType>(EndElement)) {
-                                                                                                                                                .Invoke (.Lambda #Lambda2<System.Action`4[System.Byte,System.Xml.XmlNodeType,System.String,System.String]>)(
-                                                                                                                                                    .Constant<System.Byte>(0),
-                                                                                                                                                    $reader.NodeType,
-                                                                                                                                                    $reader.LocalName,
-                                                                                                                                                    $reader.Value)
-                                                                                                                                            } .Else {
-                                                                                                                                                .Default(System.Void)
-                                                                                                                                            }
-                                                                                                                                        }
-                                                                                                                                    }
-                                                                                                                                }
-                                                                                                                            };
-                                                                                                                            $Example._bool = .Call System.Convert.ToBoolean(
-                                                                                                                                $valueAsString,
-                                                                                                                                System.Globalization.CultureInfo.InvariantCulture)
-                                                                                                                        };
-                                                                                                                        $state = .Constant<System.Byte>(3)
-                                                                                                                    }
-                                                                                                                } .Else {
-                                                                                                                    .Block() {
-                                                                                                                        .Call $reader.Skip();
-                                                                                                                        $state = .Constant<System.Byte>(2)
+                                                                                                                        }
                                                                                                                     }
                                                                                                                 }
                                                                                                             }

--- a/cs/test/expressions/Expressions.csproj
+++ b/cs/test/expressions/Expressions.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ExpressionsTest</RootNamespace>
     <AssemblyName>Bond.ExpressionsTest</AssemblyName>
-    <BondOptions>--using="decimal=decimal"</BondOptions>
+    <BondOptions>--using="reference=ExpressionsTest.RefObject" --using="decimal=decimal"</BondOptions>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/cs/test/expressions/Expressions.csproj
+++ b/cs/test/expressions/Expressions.csproj
@@ -8,6 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ExpressionsTest</RootNamespace>
     <AssemblyName>Bond.ExpressionsTest</AssemblyName>
+    <BondOptions>--using="decimal=decimal"</BondOptions>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/cs/test/expressions/Program.cs
+++ b/cs/test/expressions/Program.cs
@@ -108,6 +108,26 @@
         string IDebugView.DebugView { get { return debugView; } }
     }
 
+    public static class BondTypeAliasConverter
+    {
+        public static decimal Convert(ArraySegment<byte> value, decimal unused)
+        {
+            var bits = new int[value.Count / sizeof(int)];
+            Buffer.BlockCopy(value.Array, value.Offset, bits, 0, bits.Length * sizeof(int));
+
+            return new decimal(bits);
+        }
+
+        public static ArraySegment<byte> Convert(decimal value, ArraySegment<byte> unused)
+        {
+            var bits = decimal.GetBits(value);
+            var data = new byte[bits.Length * sizeof(int)];
+            Buffer.BlockCopy(bits, 0, data, 0, data.Length);
+
+            return new ArraySegment<byte>(data);
+        }
+    }
+
     static class Program
     {
         static void Write(string name, IDebugView codegen)

--- a/cs/test/expressions/Program.cs
+++ b/cs/test/expressions/Program.cs
@@ -5,6 +5,7 @@
     using System.IO;
     using System.Linq;
     using System.Linq.Expressions;
+    using System.Net;
     using System.Reflection;
 
     using Bond;
@@ -12,6 +13,7 @@
     using Bond.Protocols;
     using Bond.IO.Unsafe;
     using Bond.Internal.Reflection;
+    using System.Text;
 
     internal static class DebugViewHelper
     {
@@ -108,6 +110,49 @@
         string IDebugView.DebugView { get { return debugView; } }
     }
 
+    public class RefObject : IEquatable<RefObject>
+    {
+        public RefObject()
+            : this("")
+        { }
+
+        public RefObject(string value)
+        {
+            Value = value;
+        }
+
+        public string Value { get; }
+
+        public bool Equals(RefObject other)
+        {
+            if (ReferenceEquals(other, null))
+                return false;
+            if (ReferenceEquals(other, this))
+                return true;
+
+            return this.Value == other.Value;
+        }
+
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as RefObject);
+        }
+
+        public static bool operator ==(RefObject left, RefObject right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(RefObject left, RefObject right)
+        {
+            return !(left == right);
+        }
+    }
+
     public static class BondTypeAliasConverter
     {
         public static decimal Convert(ArraySegment<byte> value, decimal unused)
@@ -125,6 +170,16 @@
             Buffer.BlockCopy(bits, 0, data, 0, data.Length);
 
             return new ArraySegment<byte>(data);
+        }
+
+        public static RefObject Convert(ArraySegment<byte> value, RefObject unused)
+        {
+            return new RefObject(Encoding.ASCII.GetString(value.Array, value.Offset, value.Count));
+        }
+
+        public static ArraySegment<byte> Convert(RefObject value, ArraySegment<byte> unused)
+        {
+            return new ArraySegment<byte>(Encoding.ASCII.GetBytes(value.Value));
         }
     }
 

--- a/cs/test/expressions/SerializeCB.expressions
+++ b/cs/test/expressions/SerializeCB.expressions
@@ -327,36 +327,39 @@
                 .Constant<System.UInt16>(40),
                 .Constant<Bond.Metadata>(_nestedVector))
         };
-        .If ($Example.b != .Default(System.ArraySegment`1[System.Byte])) {
-            .Block() {
-                .Call $writer.WriteFieldBegin(
+        .Block(System.ArraySegment`1[System.Byte] $convertedBlob) {
+            $convertedBlob = $Example.b;
+            .If ($convertedBlob != .Default(System.ArraySegment`1[System.Byte])) {
+                .Block() {
+                    .Call $writer.WriteFieldBegin(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(50),
+                        .Constant<Bond.Metadata>(b));
+                    .Block(
+                        System.ArraySegment`1[System.Byte] $arraySegment,
+                        System.Int32 $count,
+                        System.Int32 $index,
+                        System.Int32 $end) {
+                        $arraySegment = $Example.b;
+                        $index = $arraySegment.Offset;
+                        $count = $arraySegment.Count;
+                        $end = $index + $count;
+                        .Block() {
+                            .Call $writer.WriteContainerBegin(
+                                $count,
+                                .Constant<Bond.BondDataType>(BT_INT8));
+                            .Call $writer.WriteBytes($arraySegment);
+                            .Call $writer.WriteContainerEnd()
+                        }
+                    };
+                    .Call $writer.WriteFieldEnd()
+                }
+            } .Else {
+                .Call $writer.WriteFieldOmitted(
                     .Constant<Bond.BondDataType>(BT_LIST),
                     .Constant<System.UInt16>(50),
-                    .Constant<Bond.Metadata>(b));
-                .Block(
-                    System.ArraySegment`1[System.Byte] $arraySegment,
-                    System.Int32 $count,
-                    System.Int32 $index,
-                    System.Int32 $end) {
-                    $arraySegment = $Example.b;
-                    $index = $arraySegment.Offset;
-                    $count = $arraySegment.Count;
-                    $end = $index + $count;
-                    .Block() {
-                        .Call $writer.WriteContainerBegin(
-                            $count,
-                            .Constant<Bond.BondDataType>(BT_INT8));
-                        .Call $writer.WriteBytes($Example.b);
-                        .Call $writer.WriteContainerEnd()
-                    }
-                };
-                .Call $writer.WriteFieldEnd()
+                    .Constant<Bond.Metadata>(b))
             }
-        } .Else {
-            .Call $writer.WriteFieldOmitted(
-                .Constant<Bond.BondDataType>(BT_LIST),
-                .Constant<System.UInt16>(50),
-                .Constant<Bond.Metadata>(b))
         };
         .If (($Example._map).Count != 0) {
             .Block() {
@@ -401,42 +404,41 @@
                 .Constant<System.UInt16>(60),
                 .Constant<Bond.Metadata>(_map))
         };
-        .If (.Call ExpressionsTest.BondTypeAliasConverter.Convert(
-            $Example._decimal,
-            .Default(System.ArraySegment`1[System.Byte])) != .Default(System.ArraySegment`1[System.Byte])) {
-            .Block() {
-                .Call $writer.WriteFieldBegin(
+        .Block(System.ArraySegment`1[System.Byte] $convertedBlob) {
+            $convertedBlob = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                $Example._decimal,
+                .Default(System.ArraySegment`1[System.Byte]));
+            .If ($convertedBlob != .Default(System.ArraySegment`1[System.Byte])) {
+                .Block() {
+                    .Call $writer.WriteFieldBegin(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(70),
+                        .Constant<Bond.Metadata>(_decimal));
+                    .Block(
+                        System.ArraySegment`1[System.Byte] $arraySegment,
+                        System.Int32 $count,
+                        System.Int32 $index,
+                        System.Int32 $end) {
+                        $arraySegment = $convertedBlob;
+                        $index = $arraySegment.Offset;
+                        $count = $arraySegment.Count;
+                        $end = $index + $count;
+                        .Block() {
+                            .Call $writer.WriteContainerBegin(
+                                $count,
+                                .Constant<Bond.BondDataType>(BT_INT8));
+                            .Call $writer.WriteBytes($arraySegment);
+                            .Call $writer.WriteContainerEnd()
+                        }
+                    };
+                    .Call $writer.WriteFieldEnd()
+                }
+            } .Else {
+                .Call $writer.WriteFieldOmitted(
                     .Constant<Bond.BondDataType>(BT_LIST),
                     .Constant<System.UInt16>(70),
-                    .Constant<Bond.Metadata>(_decimal));
-                .Block(
-                    System.ArraySegment`1[System.Byte] $arraySegment,
-                    System.Int32 $count,
-                    System.Int32 $index,
-                    System.Int32 $end) {
-                    $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
-                        $Example._decimal,
-                        .Default(System.ArraySegment`1[System.Byte]));
-                    $index = $arraySegment.Offset;
-                    $count = $arraySegment.Count;
-                    $end = $index + $count;
-                    .Block() {
-                        .Call $writer.WriteContainerBegin(
-                            $count,
-                            .Constant<Bond.BondDataType>(BT_INT8));
-                        .Call $writer.WriteBytes(.Call ExpressionsTest.BondTypeAliasConverter.Convert(
-                                $Example._decimal,
-                                .Default(System.ArraySegment`1[System.Byte])));
-                        .Call $writer.WriteContainerEnd()
-                    }
-                };
-                .Call $writer.WriteFieldEnd()
+                    .Constant<Bond.Metadata>(_decimal))
             }
-        } .Else {
-            .Call $writer.WriteFieldOmitted(
-                .Constant<Bond.BondDataType>(BT_LIST),
-                .Constant<System.UInt16>(70),
-                .Constant<Bond.Metadata>(_decimal))
         };
         .If (($Example._decList).Count != 0) {
             .Block() {
@@ -473,9 +475,7 @@
                                             .Call $writer.WriteContainerBegin(
                                                 $count,
                                                 .Constant<Bond.BondDataType>(BT_INT8));
-                                            .Call $writer.WriteBytes(.Call ExpressionsTest.BondTypeAliasConverter.Convert(
-                                                    $node.Value,
-                                                    .Default(System.ArraySegment`1[System.Byte])));
+                                            .Call $writer.WriteBytes($arraySegment);
                                             .Call $writer.WriteContainerEnd()
                                         }
                                     };
@@ -496,6 +496,185 @@
                 .Constant<Bond.BondDataType>(BT_LIST),
                 .Constant<System.UInt16>(71),
                 .Constant<Bond.Metadata>(_decList))
+        };
+        .If (($Example._decVector).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(72),
+                    .Constant<Bond.Metadata>(_decVector));
+                .Block(
+                    System.Int32 $index,
+                    System.Int32 $count) {
+                    $index = -1;
+                    $count = ($Example._decVector).Count;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (++$index < $count) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            ($Example._decVector).Item[$index],
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(72),
+                .Constant<Bond.Metadata>(_decVector))
+        };
+        .If (($Example._decMap).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_MAP),
+                    .Constant<System.UInt16>(73),
+                    .Constant<Bond.Metadata>(_decMap));
+                .Block(System.Collections.Generic.IEnumerator`1[System.Collections.Generic.KeyValuePair`2[System.Int32,System.Decimal]] $enumerator)
+                 {
+                    $enumerator = .Call ($Example._decMap).GetEnumerator();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._decMap).Count,
+                            .Constant<Bond.BondDataType>(BT_INT32),
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (
+                                .Call $enumerator.MoveNext()
+                            ) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Call $writer.WriteInt32(($enumerator.Current).Key);
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            ($enumerator.Current).Value,
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_MAP),
+                .Constant<System.UInt16>(73),
+                .Constant<Bond.Metadata>(_decMap))
+        };
+        .If ($Example._decNullable != 0M) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(74),
+                    .Constant<Bond.Metadata>(_decNullable));
+                .Block(
+                    System.ArraySegment`1[System.Byte] $arraySegment,
+                    System.Int32 $count) {
+                    $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                        $Example._decNullable,
+                        .Default(System.ArraySegment`1[System.Byte]));
+                    $count = .If ($arraySegment.Array != null) {
+                        1
+                    } .Else {
+                        0
+                    };
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- != 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            $Example._decNullable,
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(74),
+                .Constant<Bond.Metadata>(_decNullable))
         };
         .Call $writer.WriteStructEnd()
     }

--- a/cs/test/expressions/SerializeCB.expressions
+++ b/cs/test/expressions/SerializeCB.expressions
@@ -621,12 +621,12 @@
                     .Constant<System.UInt16>(74),
                     .Constant<Bond.Metadata>(_decNullable));
                 .Block(
-                    System.ArraySegment`1[System.Byte] $arraySegment,
+                    System.ArraySegment`1[System.Byte] $convertedBlob,
                     System.Int32 $count) {
-                    $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                    $convertedBlob = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                         $Example._decNullable,
                         .Default(System.ArraySegment`1[System.Byte]));
-                    $count = .If ($arraySegment.Array != null) {
+                    $count = .If ($convertedBlob.Array != null) {
                         1
                     } .Else {
                         0
@@ -644,9 +644,7 @@
                                         System.Int32 $count,
                                         System.Int32 $index,
                                         System.Int32 $end) {
-                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
-                                            $Example._decNullable,
-                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $arraySegment = $convertedBlob;
                                         $index = $arraySegment.Offset;
                                         $count = $arraySegment.Count;
                                         $end = $index + $count;

--- a/cs/test/expressions/SerializeCB.expressions
+++ b/cs/test/expressions/SerializeCB.expressions
@@ -361,6 +361,232 @@
                     .Constant<Bond.Metadata>(b))
             }
         };
+        .If (($Example._blobList).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(51),
+                    .Constant<Bond.Metadata>(_blobList));
+                .Block(System.Collections.Generic.LinkedListNode`1[System.ArraySegment`1[System.Byte]] $node) {
+                    $node = null;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._blobList).Count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (.If ($node == null) {
+                                $node = ($Example._blobList).First
+                            } .Else {
+                                $node = $node.Next
+                            } != null) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = $node.Value;
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(51),
+                .Constant<Bond.Metadata>(_blobList))
+        };
+        .If (($Example._blobVector).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(52),
+                    .Constant<Bond.Metadata>(_blobVector));
+                .Block(
+                    System.Int32 $index,
+                    System.Int32 $count) {
+                    $index = -1;
+                    $count = ($Example._blobVector).Count;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (++$index < $count) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = ($Example._blobVector).Item[$index];
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(52),
+                .Constant<Bond.Metadata>(_blobVector))
+        };
+        .If (($Example._blobMap).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_MAP),
+                    .Constant<System.UInt16>(53),
+                    .Constant<Bond.Metadata>(_blobMap));
+                .Block(System.Collections.Generic.IEnumerator`1[System.Collections.Generic.KeyValuePair`2[System.Int32,System.ArraySegment`1[System.Byte]]] $enumerator)
+                 {
+                    $enumerator = .Call ($Example._blobMap).GetEnumerator();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._blobMap).Count,
+                            .Constant<Bond.BondDataType>(BT_INT32),
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (
+                                .Call $enumerator.MoveNext()
+                            ) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Call $writer.WriteInt32(($enumerator.Current).Key);
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = ($enumerator.Current).Value;
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_MAP),
+                .Constant<System.UInt16>(53),
+                .Constant<Bond.Metadata>(_blobMap))
+        };
+        .If ($Example._blobNullable != .Constant<System.ArraySegment`1[System.Byte]>(System.ArraySegment`1[System.Byte])) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(54),
+                    .Constant<Bond.Metadata>(_blobNullable));
+                .Block(
+                    System.ArraySegment`1[System.Byte] $convertedBlob,
+                    System.Int32 $count) {
+                    $convertedBlob = $Example._blobNullable;
+                    $count = .If ($convertedBlob.Array != null) {
+                        1
+                    } .Else {
+                        0
+                    };
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- != 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = $convertedBlob;
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(54),
+                .Constant<Bond.Metadata>(_blobNullable))
+        };
         .If (($Example._map).Count != 0) {
             .Block() {
                 .Call $writer.WriteFieldBegin(
@@ -673,6 +899,276 @@
                 .Constant<Bond.BondDataType>(BT_LIST),
                 .Constant<System.UInt16>(74),
                 .Constant<Bond.Metadata>(_decNullable))
+        };
+        .Block(System.ArraySegment`1[System.Byte] $convertedBlob) {
+            $convertedBlob = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                $Example._reference,
+                .Default(System.ArraySegment`1[System.Byte]));
+            .If ($convertedBlob != .Default(System.ArraySegment`1[System.Byte])) {
+                .Block() {
+                    .Call $writer.WriteFieldBegin(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(80),
+                        .Constant<Bond.Metadata>(_reference));
+                    .Block(
+                        System.ArraySegment`1[System.Byte] $arraySegment,
+                        System.Int32 $count,
+                        System.Int32 $index,
+                        System.Int32 $end) {
+                        $arraySegment = $convertedBlob;
+                        $index = $arraySegment.Offset;
+                        $count = $arraySegment.Count;
+                        $end = $index + $count;
+                        .Block() {
+                            .Call $writer.WriteContainerBegin(
+                                $count,
+                                .Constant<Bond.BondDataType>(BT_INT8));
+                            .Call $writer.WriteBytes($arraySegment);
+                            .Call $writer.WriteContainerEnd()
+                        }
+                    };
+                    .Call $writer.WriteFieldEnd()
+                }
+            } .Else {
+                .Call $writer.WriteFieldOmitted(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(80),
+                    .Constant<Bond.Metadata>(_reference))
+            }
+        };
+        .If (($Example._refList).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(81),
+                    .Constant<Bond.Metadata>(_refList));
+                .Block(System.Collections.Generic.LinkedListNode`1[ExpressionsTest.RefObject] $node) {
+                    $node = null;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._refList).Count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (.If ($node == null) {
+                                $node = ($Example._refList).First
+                            } .Else {
+                                $node = $node.Next
+                            } != null) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            $node.Value,
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(81),
+                .Constant<Bond.Metadata>(_refList))
+        };
+        .If (($Example._refVector).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(82),
+                    .Constant<Bond.Metadata>(_refVector));
+                .Block(
+                    System.Int32 $index,
+                    System.Int32 $count) {
+                    $index = -1;
+                    $count = ($Example._refVector).Count;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (++$index < $count) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            ($Example._refVector).Item[$index],
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(82),
+                .Constant<Bond.Metadata>(_refVector))
+        };
+        .If (($Example._refMap).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_MAP),
+                    .Constant<System.UInt16>(83),
+                    .Constant<Bond.Metadata>(_refMap));
+                .Block(System.Collections.Generic.IEnumerator`1[System.Collections.Generic.KeyValuePair`2[System.Int32,ExpressionsTest.RefObject]] $enumerator)
+                 {
+                    $enumerator = .Call ($Example._refMap).GetEnumerator();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._refMap).Count,
+                            .Constant<Bond.BondDataType>(BT_INT32),
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (
+                                .Call $enumerator.MoveNext()
+                            ) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Call $writer.WriteInt32(($enumerator.Current).Key);
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            ($enumerator.Current).Value,
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_MAP),
+                .Constant<System.UInt16>(83),
+                .Constant<Bond.Metadata>(_refMap))
+        };
+        .If ($Example._refNullable != null) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(84),
+                    .Constant<Bond.Metadata>(_refNullable));
+                .Block(
+                    System.ArraySegment`1[System.Byte] $convertedBlob,
+                    System.Int32 $count) {
+                    $convertedBlob = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                        $Example._refNullable,
+                        .Default(System.ArraySegment`1[System.Byte]));
+                    $count = .If ($convertedBlob.Array != null) {
+                        1
+                    } .Else {
+                        0
+                    };
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- != 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = $convertedBlob;
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(84),
+                .Constant<Bond.Metadata>(_refNullable))
         };
         .Call $writer.WriteStructEnd()
     }

--- a/cs/test/expressions/SerializeCB.expressions
+++ b/cs/test/expressions/SerializeCB.expressions
@@ -401,6 +401,102 @@
                 .Constant<System.UInt16>(60),
                 .Constant<Bond.Metadata>(_map))
         };
+        .If (.Call ExpressionsTest.BondTypeAliasConverter.Convert(
+            $Example._decimal,
+            .Default(System.ArraySegment`1[System.Byte])) != .Default(System.ArraySegment`1[System.Byte])) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(70),
+                    .Constant<Bond.Metadata>(_decimal));
+                .Block(
+                    System.ArraySegment`1[System.Byte] $arraySegment,
+                    System.Int32 $count,
+                    System.Int32 $index,
+                    System.Int32 $end) {
+                    $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                        $Example._decimal,
+                        .Default(System.ArraySegment`1[System.Byte]));
+                    $index = $arraySegment.Offset;
+                    $count = $arraySegment.Count;
+                    $end = $index + $count;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_INT8));
+                        .Call $writer.WriteBytes(.Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                $Example._decimal,
+                                .Default(System.ArraySegment`1[System.Byte])));
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(70),
+                .Constant<Bond.Metadata>(_decimal))
+        };
+        .If (($Example._decList).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(71),
+                    .Constant<Bond.Metadata>(_decList));
+                .Block(System.Collections.Generic.LinkedListNode`1[System.Decimal] $node) {
+                    $node = null;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._decList).Count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (.If ($node == null) {
+                                $node = ($Example._decList).First
+                            } .Else {
+                                $node = $node.Next
+                            } != null) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            $node.Value,
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes(.Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                    $node.Value,
+                                                    .Default(System.ArraySegment`1[System.Byte])));
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(71),
+                .Constant<Bond.Metadata>(_decList))
+        };
         .Call $writer.WriteStructEnd()
     }
 }

--- a/cs/test/expressions/SerializeSP.expressions
+++ b/cs/test/expressions/SerializeSP.expressions
@@ -327,36 +327,39 @@
                 .Constant<System.UInt16>(40),
                 .Constant<Bond.Metadata>(_nestedVector))
         };
-        .If ($Example.b != .Default(System.ArraySegment`1[System.Byte])) {
-            .Block() {
-                .Call $writer.WriteFieldBegin(
+        .Block(System.ArraySegment`1[System.Byte] $convertedBlob) {
+            $convertedBlob = $Example.b;
+            .If ($convertedBlob != .Default(System.ArraySegment`1[System.Byte])) {
+                .Block() {
+                    .Call $writer.WriteFieldBegin(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(50),
+                        .Constant<Bond.Metadata>(b));
+                    .Block(
+                        System.ArraySegment`1[System.Byte] $arraySegment,
+                        System.Int32 $count,
+                        System.Int32 $index,
+                        System.Int32 $end) {
+                        $arraySegment = $Example.b;
+                        $index = $arraySegment.Offset;
+                        $count = $arraySegment.Count;
+                        $end = $index + $count;
+                        .Block() {
+                            .Call $writer.WriteContainerBegin(
+                                $count,
+                                .Constant<Bond.BondDataType>(BT_INT8));
+                            .Call $writer.WriteBytes($arraySegment);
+                            .Call $writer.WriteContainerEnd()
+                        }
+                    };
+                    .Call $writer.WriteFieldEnd()
+                }
+            } .Else {
+                .Call $writer.WriteFieldOmitted(
                     .Constant<Bond.BondDataType>(BT_LIST),
                     .Constant<System.UInt16>(50),
-                    .Constant<Bond.Metadata>(b));
-                .Block(
-                    System.ArraySegment`1[System.Byte] $arraySegment,
-                    System.Int32 $count,
-                    System.Int32 $index,
-                    System.Int32 $end) {
-                    $arraySegment = $Example.b;
-                    $index = $arraySegment.Offset;
-                    $count = $arraySegment.Count;
-                    $end = $index + $count;
-                    .Block() {
-                        .Call $writer.WriteContainerBegin(
-                            $count,
-                            .Constant<Bond.BondDataType>(BT_INT8));
-                        .Call $writer.WriteBytes($Example.b);
-                        .Call $writer.WriteContainerEnd()
-                    }
-                };
-                .Call $writer.WriteFieldEnd()
+                    .Constant<Bond.Metadata>(b))
             }
-        } .Else {
-            .Call $writer.WriteFieldOmitted(
-                .Constant<Bond.BondDataType>(BT_LIST),
-                .Constant<System.UInt16>(50),
-                .Constant<Bond.Metadata>(b))
         };
         .If (($Example._map).Count != 0) {
             .Block() {
@@ -401,42 +404,41 @@
                 .Constant<System.UInt16>(60),
                 .Constant<Bond.Metadata>(_map))
         };
-        .If (.Call ExpressionsTest.BondTypeAliasConverter.Convert(
-            $Example._decimal,
-            .Default(System.ArraySegment`1[System.Byte])) != .Default(System.ArraySegment`1[System.Byte])) {
-            .Block() {
-                .Call $writer.WriteFieldBegin(
+        .Block(System.ArraySegment`1[System.Byte] $convertedBlob) {
+            $convertedBlob = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                $Example._decimal,
+                .Default(System.ArraySegment`1[System.Byte]));
+            .If ($convertedBlob != .Default(System.ArraySegment`1[System.Byte])) {
+                .Block() {
+                    .Call $writer.WriteFieldBegin(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(70),
+                        .Constant<Bond.Metadata>(_decimal));
+                    .Block(
+                        System.ArraySegment`1[System.Byte] $arraySegment,
+                        System.Int32 $count,
+                        System.Int32 $index,
+                        System.Int32 $end) {
+                        $arraySegment = $convertedBlob;
+                        $index = $arraySegment.Offset;
+                        $count = $arraySegment.Count;
+                        $end = $index + $count;
+                        .Block() {
+                            .Call $writer.WriteContainerBegin(
+                                $count,
+                                .Constant<Bond.BondDataType>(BT_INT8));
+                            .Call $writer.WriteBytes($arraySegment);
+                            .Call $writer.WriteContainerEnd()
+                        }
+                    };
+                    .Call $writer.WriteFieldEnd()
+                }
+            } .Else {
+                .Call $writer.WriteFieldOmitted(
                     .Constant<Bond.BondDataType>(BT_LIST),
                     .Constant<System.UInt16>(70),
-                    .Constant<Bond.Metadata>(_decimal));
-                .Block(
-                    System.ArraySegment`1[System.Byte] $arraySegment,
-                    System.Int32 $count,
-                    System.Int32 $index,
-                    System.Int32 $end) {
-                    $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
-                        $Example._decimal,
-                        .Default(System.ArraySegment`1[System.Byte]));
-                    $index = $arraySegment.Offset;
-                    $count = $arraySegment.Count;
-                    $end = $index + $count;
-                    .Block() {
-                        .Call $writer.WriteContainerBegin(
-                            $count,
-                            .Constant<Bond.BondDataType>(BT_INT8));
-                        .Call $writer.WriteBytes(.Call ExpressionsTest.BondTypeAliasConverter.Convert(
-                                $Example._decimal,
-                                .Default(System.ArraySegment`1[System.Byte])));
-                        .Call $writer.WriteContainerEnd()
-                    }
-                };
-                .Call $writer.WriteFieldEnd()
+                    .Constant<Bond.Metadata>(_decimal))
             }
-        } .Else {
-            .Call $writer.WriteFieldOmitted(
-                .Constant<Bond.BondDataType>(BT_LIST),
-                .Constant<System.UInt16>(70),
-                .Constant<Bond.Metadata>(_decimal))
         };
         .If (($Example._decList).Count != 0) {
             .Block() {
@@ -473,9 +475,7 @@
                                             .Call $writer.WriteContainerBegin(
                                                 $count,
                                                 .Constant<Bond.BondDataType>(BT_INT8));
-                                            .Call $writer.WriteBytes(.Call ExpressionsTest.BondTypeAliasConverter.Convert(
-                                                    $node.Value,
-                                                    .Default(System.ArraySegment`1[System.Byte])));
+                                            .Call $writer.WriteBytes($arraySegment);
                                             .Call $writer.WriteContainerEnd()
                                         }
                                     };
@@ -496,6 +496,185 @@
                 .Constant<Bond.BondDataType>(BT_LIST),
                 .Constant<System.UInt16>(71),
                 .Constant<Bond.Metadata>(_decList))
+        };
+        .If (($Example._decVector).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(72),
+                    .Constant<Bond.Metadata>(_decVector));
+                .Block(
+                    System.Int32 $index,
+                    System.Int32 $count) {
+                    $index = -1;
+                    $count = ($Example._decVector).Count;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (++$index < $count) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            ($Example._decVector).Item[$index],
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(72),
+                .Constant<Bond.Metadata>(_decVector))
+        };
+        .If (($Example._decMap).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_MAP),
+                    .Constant<System.UInt16>(73),
+                    .Constant<Bond.Metadata>(_decMap));
+                .Block(System.Collections.Generic.IEnumerator`1[System.Collections.Generic.KeyValuePair`2[System.Int32,System.Decimal]] $enumerator)
+                 {
+                    $enumerator = .Call ($Example._decMap).GetEnumerator();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._decMap).Count,
+                            .Constant<Bond.BondDataType>(BT_INT32),
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (
+                                .Call $enumerator.MoveNext()
+                            ) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Call $writer.WriteInt32(($enumerator.Current).Key);
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            ($enumerator.Current).Value,
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_MAP),
+                .Constant<System.UInt16>(73),
+                .Constant<Bond.Metadata>(_decMap))
+        };
+        .If ($Example._decNullable != 0M) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(74),
+                    .Constant<Bond.Metadata>(_decNullable));
+                .Block(
+                    System.ArraySegment`1[System.Byte] $arraySegment,
+                    System.Int32 $count) {
+                    $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                        $Example._decNullable,
+                        .Default(System.ArraySegment`1[System.Byte]));
+                    $count = .If ($arraySegment.Array != null) {
+                        1
+                    } .Else {
+                        0
+                    };
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- != 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            $Example._decNullable,
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(74),
+                .Constant<Bond.Metadata>(_decNullable))
         };
         .Call $writer.WriteStructEnd()
     }

--- a/cs/test/expressions/SerializeSP.expressions
+++ b/cs/test/expressions/SerializeSP.expressions
@@ -621,12 +621,12 @@
                     .Constant<System.UInt16>(74),
                     .Constant<Bond.Metadata>(_decNullable));
                 .Block(
-                    System.ArraySegment`1[System.Byte] $arraySegment,
+                    System.ArraySegment`1[System.Byte] $convertedBlob,
                     System.Int32 $count) {
-                    $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                    $convertedBlob = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                         $Example._decNullable,
                         .Default(System.ArraySegment`1[System.Byte]));
-                    $count = .If ($arraySegment.Array != null) {
+                    $count = .If ($convertedBlob.Array != null) {
                         1
                     } .Else {
                         0
@@ -644,9 +644,7 @@
                                         System.Int32 $count,
                                         System.Int32 $index,
                                         System.Int32 $end) {
-                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
-                                            $Example._decNullable,
-                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $arraySegment = $convertedBlob;
                                         $index = $arraySegment.Offset;
                                         $count = $arraySegment.Count;
                                         $end = $index + $count;

--- a/cs/test/expressions/SerializeSP.expressions
+++ b/cs/test/expressions/SerializeSP.expressions
@@ -361,6 +361,232 @@
                     .Constant<Bond.Metadata>(b))
             }
         };
+        .If (($Example._blobList).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(51),
+                    .Constant<Bond.Metadata>(_blobList));
+                .Block(System.Collections.Generic.LinkedListNode`1[System.ArraySegment`1[System.Byte]] $node) {
+                    $node = null;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._blobList).Count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (.If ($node == null) {
+                                $node = ($Example._blobList).First
+                            } .Else {
+                                $node = $node.Next
+                            } != null) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = $node.Value;
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(51),
+                .Constant<Bond.Metadata>(_blobList))
+        };
+        .If (($Example._blobVector).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(52),
+                    .Constant<Bond.Metadata>(_blobVector));
+                .Block(
+                    System.Int32 $index,
+                    System.Int32 $count) {
+                    $index = -1;
+                    $count = ($Example._blobVector).Count;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (++$index < $count) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = ($Example._blobVector).Item[$index];
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(52),
+                .Constant<Bond.Metadata>(_blobVector))
+        };
+        .If (($Example._blobMap).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_MAP),
+                    .Constant<System.UInt16>(53),
+                    .Constant<Bond.Metadata>(_blobMap));
+                .Block(System.Collections.Generic.IEnumerator`1[System.Collections.Generic.KeyValuePair`2[System.Int32,System.ArraySegment`1[System.Byte]]] $enumerator)
+                 {
+                    $enumerator = .Call ($Example._blobMap).GetEnumerator();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._blobMap).Count,
+                            .Constant<Bond.BondDataType>(BT_INT32),
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (
+                                .Call $enumerator.MoveNext()
+                            ) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Call $writer.WriteInt32(($enumerator.Current).Key);
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = ($enumerator.Current).Value;
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_MAP),
+                .Constant<System.UInt16>(53),
+                .Constant<Bond.Metadata>(_blobMap))
+        };
+        .If ($Example._blobNullable != .Constant<System.ArraySegment`1[System.Byte]>(System.ArraySegment`1[System.Byte])) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(54),
+                    .Constant<Bond.Metadata>(_blobNullable));
+                .Block(
+                    System.ArraySegment`1[System.Byte] $convertedBlob,
+                    System.Int32 $count) {
+                    $convertedBlob = $Example._blobNullable;
+                    $count = .If ($convertedBlob.Array != null) {
+                        1
+                    } .Else {
+                        0
+                    };
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- != 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = $convertedBlob;
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(54),
+                .Constant<Bond.Metadata>(_blobNullable))
+        };
         .If (($Example._map).Count != 0) {
             .Block() {
                 .Call $writer.WriteFieldBegin(
@@ -673,6 +899,276 @@
                 .Constant<Bond.BondDataType>(BT_LIST),
                 .Constant<System.UInt16>(74),
                 .Constant<Bond.Metadata>(_decNullable))
+        };
+        .Block(System.ArraySegment`1[System.Byte] $convertedBlob) {
+            $convertedBlob = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                $Example._reference,
+                .Default(System.ArraySegment`1[System.Byte]));
+            .If ($convertedBlob != .Default(System.ArraySegment`1[System.Byte])) {
+                .Block() {
+                    .Call $writer.WriteFieldBegin(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(80),
+                        .Constant<Bond.Metadata>(_reference));
+                    .Block(
+                        System.ArraySegment`1[System.Byte] $arraySegment,
+                        System.Int32 $count,
+                        System.Int32 $index,
+                        System.Int32 $end) {
+                        $arraySegment = $convertedBlob;
+                        $index = $arraySegment.Offset;
+                        $count = $arraySegment.Count;
+                        $end = $index + $count;
+                        .Block() {
+                            .Call $writer.WriteContainerBegin(
+                                $count,
+                                .Constant<Bond.BondDataType>(BT_INT8));
+                            .Call $writer.WriteBytes($arraySegment);
+                            .Call $writer.WriteContainerEnd()
+                        }
+                    };
+                    .Call $writer.WriteFieldEnd()
+                }
+            } .Else {
+                .Call $writer.WriteFieldOmitted(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(80),
+                    .Constant<Bond.Metadata>(_reference))
+            }
+        };
+        .If (($Example._refList).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(81),
+                    .Constant<Bond.Metadata>(_refList));
+                .Block(System.Collections.Generic.LinkedListNode`1[ExpressionsTest.RefObject] $node) {
+                    $node = null;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._refList).Count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (.If ($node == null) {
+                                $node = ($Example._refList).First
+                            } .Else {
+                                $node = $node.Next
+                            } != null) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            $node.Value,
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(81),
+                .Constant<Bond.Metadata>(_refList))
+        };
+        .If (($Example._refVector).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(82),
+                    .Constant<Bond.Metadata>(_refVector));
+                .Block(
+                    System.Int32 $index,
+                    System.Int32 $count) {
+                    $index = -1;
+                    $count = ($Example._refVector).Count;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (++$index < $count) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            ($Example._refVector).Item[$index],
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(82),
+                .Constant<Bond.Metadata>(_refVector))
+        };
+        .If (($Example._refMap).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_MAP),
+                    .Constant<System.UInt16>(83),
+                    .Constant<Bond.Metadata>(_refMap));
+                .Block(System.Collections.Generic.IEnumerator`1[System.Collections.Generic.KeyValuePair`2[System.Int32,ExpressionsTest.RefObject]] $enumerator)
+                 {
+                    $enumerator = .Call ($Example._refMap).GetEnumerator();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._refMap).Count,
+                            .Constant<Bond.BondDataType>(BT_INT32),
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (
+                                .Call $enumerator.MoveNext()
+                            ) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Call $writer.WriteInt32(($enumerator.Current).Key);
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            ($enumerator.Current).Value,
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_MAP),
+                .Constant<System.UInt16>(83),
+                .Constant<Bond.Metadata>(_refMap))
+        };
+        .If ($Example._refNullable != null) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(84),
+                    .Constant<Bond.Metadata>(_refNullable));
+                .Block(
+                    System.ArraySegment`1[System.Byte] $convertedBlob,
+                    System.Int32 $count) {
+                    $convertedBlob = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                        $Example._refNullable,
+                        .Default(System.ArraySegment`1[System.Byte]));
+                    $count = .If ($convertedBlob.Array != null) {
+                        1
+                    } .Else {
+                        0
+                    };
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- != 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = $convertedBlob;
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(84),
+                .Constant<Bond.Metadata>(_refNullable))
         };
         .Call $writer.WriteStructEnd()
     }

--- a/cs/test/expressions/SerializeSP.expressions
+++ b/cs/test/expressions/SerializeSP.expressions
@@ -401,6 +401,102 @@
                 .Constant<System.UInt16>(60),
                 .Constant<Bond.Metadata>(_map))
         };
+        .If (.Call ExpressionsTest.BondTypeAliasConverter.Convert(
+            $Example._decimal,
+            .Default(System.ArraySegment`1[System.Byte])) != .Default(System.ArraySegment`1[System.Byte])) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(70),
+                    .Constant<Bond.Metadata>(_decimal));
+                .Block(
+                    System.ArraySegment`1[System.Byte] $arraySegment,
+                    System.Int32 $count,
+                    System.Int32 $index,
+                    System.Int32 $end) {
+                    $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                        $Example._decimal,
+                        .Default(System.ArraySegment`1[System.Byte]));
+                    $index = $arraySegment.Offset;
+                    $count = $arraySegment.Count;
+                    $end = $index + $count;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_INT8));
+                        .Call $writer.WriteBytes(.Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                $Example._decimal,
+                                .Default(System.ArraySegment`1[System.Byte])));
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(70),
+                .Constant<Bond.Metadata>(_decimal))
+        };
+        .If (($Example._decList).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(71),
+                    .Constant<Bond.Metadata>(_decList));
+                .Block(System.Collections.Generic.LinkedListNode`1[System.Decimal] $node) {
+                    $node = null;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._decList).Count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (.If ($node == null) {
+                                $node = ($Example._decList).First
+                            } .Else {
+                                $node = $node.Next
+                            } != null) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            $node.Value,
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes(.Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                    $node.Value,
+                                                    .Default(System.ArraySegment`1[System.Byte])));
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(71),
+                .Constant<Bond.Metadata>(_decList))
+        };
         .Call $writer.WriteStructEnd()
     }
 }

--- a/cs/test/expressions/SerializeXml.expressions
+++ b/cs/test/expressions/SerializeXml.expressions
@@ -401,6 +401,102 @@
                 .Constant<System.UInt16>(60),
                 .Constant<Bond.Metadata>(_map))
         };
+        .If (.Call ExpressionsTest.BondTypeAliasConverter.Convert(
+            $Example._decimal,
+            .Default(System.ArraySegment`1[System.Byte])) != .Default(System.ArraySegment`1[System.Byte])) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(70),
+                    .Constant<Bond.Metadata>(_decimal));
+                .Block(
+                    System.ArraySegment`1[System.Byte] $arraySegment,
+                    System.Int32 $count,
+                    System.Int32 $index,
+                    System.Int32 $end) {
+                    $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                        $Example._decimal,
+                        .Default(System.ArraySegment`1[System.Byte]));
+                    $index = $arraySegment.Offset;
+                    $count = $arraySegment.Count;
+                    $end = $index + $count;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_INT8));
+                        .Call $writer.WriteBytes(.Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                $Example._decimal,
+                                .Default(System.ArraySegment`1[System.Byte])));
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(70),
+                .Constant<Bond.Metadata>(_decimal))
+        };
+        .If (($Example._decList).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(71),
+                    .Constant<Bond.Metadata>(_decList));
+                .Block(System.Collections.Generic.LinkedListNode`1[System.Decimal] $node) {
+                    $node = null;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._decList).Count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (.If ($node == null) {
+                                $node = ($Example._decList).First
+                            } .Else {
+                                $node = $node.Next
+                            } != null) {
+                                .Block() {
+                                    .Call $writer.WriteItemBegin();
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            $node.Value,
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes(.Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                                    $node.Value,
+                                                    .Default(System.ArraySegment`1[System.Byte])));
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Call $writer.WriteItemEnd()
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(71),
+                .Constant<Bond.Metadata>(_decList))
+        };
         .Call $writer.WriteStructEnd()
     }
 }

--- a/cs/test/expressions/SerializeXml.expressions
+++ b/cs/test/expressions/SerializeXml.expressions
@@ -327,36 +327,39 @@
                 .Constant<System.UInt16>(40),
                 .Constant<Bond.Metadata>(_nestedVector))
         };
-        .If ($Example.b != .Default(System.ArraySegment`1[System.Byte])) {
-            .Block() {
-                .Call $writer.WriteFieldBegin(
+        .Block(System.ArraySegment`1[System.Byte] $convertedBlob) {
+            $convertedBlob = $Example.b;
+            .If ($convertedBlob != .Default(System.ArraySegment`1[System.Byte])) {
+                .Block() {
+                    .Call $writer.WriteFieldBegin(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(50),
+                        .Constant<Bond.Metadata>(b));
+                    .Block(
+                        System.ArraySegment`1[System.Byte] $arraySegment,
+                        System.Int32 $count,
+                        System.Int32 $index,
+                        System.Int32 $end) {
+                        $arraySegment = $Example.b;
+                        $index = $arraySegment.Offset;
+                        $count = $arraySegment.Count;
+                        $end = $index + $count;
+                        .Block() {
+                            .Call $writer.WriteContainerBegin(
+                                $count,
+                                .Constant<Bond.BondDataType>(BT_INT8));
+                            .Call $writer.WriteBytes($arraySegment);
+                            .Call $writer.WriteContainerEnd()
+                        }
+                    };
+                    .Call $writer.WriteFieldEnd()
+                }
+            } .Else {
+                .Call $writer.WriteFieldOmitted(
                     .Constant<Bond.BondDataType>(BT_LIST),
                     .Constant<System.UInt16>(50),
-                    .Constant<Bond.Metadata>(b));
-                .Block(
-                    System.ArraySegment`1[System.Byte] $arraySegment,
-                    System.Int32 $count,
-                    System.Int32 $index,
-                    System.Int32 $end) {
-                    $arraySegment = $Example.b;
-                    $index = $arraySegment.Offset;
-                    $count = $arraySegment.Count;
-                    $end = $index + $count;
-                    .Block() {
-                        .Call $writer.WriteContainerBegin(
-                            $count,
-                            .Constant<Bond.BondDataType>(BT_INT8));
-                        .Call $writer.WriteBytes($Example.b);
-                        .Call $writer.WriteContainerEnd()
-                    }
-                };
-                .Call $writer.WriteFieldEnd()
+                    .Constant<Bond.Metadata>(b))
             }
-        } .Else {
-            .Call $writer.WriteFieldOmitted(
-                .Constant<Bond.BondDataType>(BT_LIST),
-                .Constant<System.UInt16>(50),
-                .Constant<Bond.Metadata>(b))
         };
         .If (($Example._map).Count != 0) {
             .Block() {
@@ -401,42 +404,41 @@
                 .Constant<System.UInt16>(60),
                 .Constant<Bond.Metadata>(_map))
         };
-        .If (.Call ExpressionsTest.BondTypeAliasConverter.Convert(
-            $Example._decimal,
-            .Default(System.ArraySegment`1[System.Byte])) != .Default(System.ArraySegment`1[System.Byte])) {
-            .Block() {
-                .Call $writer.WriteFieldBegin(
+        .Block(System.ArraySegment`1[System.Byte] $convertedBlob) {
+            $convertedBlob = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                $Example._decimal,
+                .Default(System.ArraySegment`1[System.Byte]));
+            .If ($convertedBlob != .Default(System.ArraySegment`1[System.Byte])) {
+                .Block() {
+                    .Call $writer.WriteFieldBegin(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(70),
+                        .Constant<Bond.Metadata>(_decimal));
+                    .Block(
+                        System.ArraySegment`1[System.Byte] $arraySegment,
+                        System.Int32 $count,
+                        System.Int32 $index,
+                        System.Int32 $end) {
+                        $arraySegment = $convertedBlob;
+                        $index = $arraySegment.Offset;
+                        $count = $arraySegment.Count;
+                        $end = $index + $count;
+                        .Block() {
+                            .Call $writer.WriteContainerBegin(
+                                $count,
+                                .Constant<Bond.BondDataType>(BT_INT8));
+                            .Call $writer.WriteBytes($arraySegment);
+                            .Call $writer.WriteContainerEnd()
+                        }
+                    };
+                    .Call $writer.WriteFieldEnd()
+                }
+            } .Else {
+                .Call $writer.WriteFieldOmitted(
                     .Constant<Bond.BondDataType>(BT_LIST),
                     .Constant<System.UInt16>(70),
-                    .Constant<Bond.Metadata>(_decimal));
-                .Block(
-                    System.ArraySegment`1[System.Byte] $arraySegment,
-                    System.Int32 $count,
-                    System.Int32 $index,
-                    System.Int32 $end) {
-                    $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
-                        $Example._decimal,
-                        .Default(System.ArraySegment`1[System.Byte]));
-                    $index = $arraySegment.Offset;
-                    $count = $arraySegment.Count;
-                    $end = $index + $count;
-                    .Block() {
-                        .Call $writer.WriteContainerBegin(
-                            $count,
-                            .Constant<Bond.BondDataType>(BT_INT8));
-                        .Call $writer.WriteBytes(.Call ExpressionsTest.BondTypeAliasConverter.Convert(
-                                $Example._decimal,
-                                .Default(System.ArraySegment`1[System.Byte])));
-                        .Call $writer.WriteContainerEnd()
-                    }
-                };
-                .Call $writer.WriteFieldEnd()
+                    .Constant<Bond.Metadata>(_decimal))
             }
-        } .Else {
-            .Call $writer.WriteFieldOmitted(
-                .Constant<Bond.BondDataType>(BT_LIST),
-                .Constant<System.UInt16>(70),
-                .Constant<Bond.Metadata>(_decimal))
         };
         .If (($Example._decList).Count != 0) {
             .Block() {
@@ -473,9 +475,7 @@
                                             .Call $writer.WriteContainerBegin(
                                                 $count,
                                                 .Constant<Bond.BondDataType>(BT_INT8));
-                                            .Call $writer.WriteBytes(.Call ExpressionsTest.BondTypeAliasConverter.Convert(
-                                                    $node.Value,
-                                                    .Default(System.ArraySegment`1[System.Byte])));
+                                            .Call $writer.WriteBytes($arraySegment);
                                             .Call $writer.WriteContainerEnd()
                                         }
                                     };
@@ -496,6 +496,185 @@
                 .Constant<Bond.BondDataType>(BT_LIST),
                 .Constant<System.UInt16>(71),
                 .Constant<Bond.Metadata>(_decList))
+        };
+        .If (($Example._decVector).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(72),
+                    .Constant<Bond.Metadata>(_decVector));
+                .Block(
+                    System.Int32 $index,
+                    System.Int32 $count) {
+                    $index = -1;
+                    $count = ($Example._decVector).Count;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (++$index < $count) {
+                                .Block() {
+                                    .Call $writer.WriteItemBegin();
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            ($Example._decVector).Item[$index],
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Call $writer.WriteItemEnd()
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(72),
+                .Constant<Bond.Metadata>(_decVector))
+        };
+        .If (($Example._decMap).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_MAP),
+                    .Constant<System.UInt16>(73),
+                    .Constant<Bond.Metadata>(_decMap));
+                .Block(System.Collections.Generic.IEnumerator`1[System.Collections.Generic.KeyValuePair`2[System.Int32,System.Decimal]] $enumerator)
+                 {
+                    $enumerator = .Call ($Example._decMap).GetEnumerator();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._decMap).Count,
+                            .Constant<Bond.BondDataType>(BT_INT32),
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (
+                                .Call $enumerator.MoveNext()
+                            ) {
+                                .Block() {
+                                    .Call $writer.WriteItemBegin();
+                                    .Call $writer.WriteInt32(($enumerator.Current).Key);
+                                    .Call $writer.WriteItemEnd();
+                                    .Default(System.Void);
+                                    .Call $writer.WriteItemBegin();
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            ($enumerator.Current).Value,
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Call $writer.WriteItemEnd()
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_MAP),
+                .Constant<System.UInt16>(73),
+                .Constant<Bond.Metadata>(_decMap))
+        };
+        .If ($Example._decNullable != 0M) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(74),
+                    .Constant<Bond.Metadata>(_decNullable));
+                .Block(
+                    System.ArraySegment`1[System.Byte] $arraySegment,
+                    System.Int32 $count) {
+                    $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                        $Example._decNullable,
+                        .Default(System.ArraySegment`1[System.Byte]));
+                    $count = .If ($arraySegment.Array != null) {
+                        1
+                    } .Else {
+                        0
+                    };
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- != 0) {
+                                .Block() {
+                                    .Call $writer.WriteItemBegin();
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            $Example._decNullable,
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Call $writer.WriteItemEnd()
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(74),
+                .Constant<Bond.Metadata>(_decNullable))
         };
         .Call $writer.WriteStructEnd()
     }

--- a/cs/test/expressions/SerializeXml.expressions
+++ b/cs/test/expressions/SerializeXml.expressions
@@ -621,12 +621,12 @@
                     .Constant<System.UInt16>(74),
                     .Constant<Bond.Metadata>(_decNullable));
                 .Block(
-                    System.ArraySegment`1[System.Byte] $arraySegment,
+                    System.ArraySegment`1[System.Byte] $convertedBlob,
                     System.Int32 $count) {
-                    $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                    $convertedBlob = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
                         $Example._decNullable,
                         .Default(System.ArraySegment`1[System.Byte]));
-                    $count = .If ($arraySegment.Array != null) {
+                    $count = .If ($convertedBlob.Array != null) {
                         1
                     } .Else {
                         0
@@ -644,9 +644,7 @@
                                         System.Int32 $count,
                                         System.Int32 $index,
                                         System.Int32 $end) {
-                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
-                                            $Example._decNullable,
-                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $arraySegment = $convertedBlob;
                                         $index = $arraySegment.Offset;
                                         $count = $arraySegment.Count;
                                         $end = $index + $count;

--- a/cs/test/expressions/SerializeXml.expressions
+++ b/cs/test/expressions/SerializeXml.expressions
@@ -361,6 +361,232 @@
                     .Constant<Bond.Metadata>(b))
             }
         };
+        .If (($Example._blobList).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(51),
+                    .Constant<Bond.Metadata>(_blobList));
+                .Block(System.Collections.Generic.LinkedListNode`1[System.ArraySegment`1[System.Byte]] $node) {
+                    $node = null;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._blobList).Count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (.If ($node == null) {
+                                $node = ($Example._blobList).First
+                            } .Else {
+                                $node = $node.Next
+                            } != null) {
+                                .Block() {
+                                    .Call $writer.WriteItemBegin();
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = $node.Value;
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Call $writer.WriteItemEnd()
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(51),
+                .Constant<Bond.Metadata>(_blobList))
+        };
+        .If (($Example._blobVector).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(52),
+                    .Constant<Bond.Metadata>(_blobVector));
+                .Block(
+                    System.Int32 $index,
+                    System.Int32 $count) {
+                    $index = -1;
+                    $count = ($Example._blobVector).Count;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (++$index < $count) {
+                                .Block() {
+                                    .Call $writer.WriteItemBegin();
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = ($Example._blobVector).Item[$index];
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Call $writer.WriteItemEnd()
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(52),
+                .Constant<Bond.Metadata>(_blobVector))
+        };
+        .If (($Example._blobMap).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_MAP),
+                    .Constant<System.UInt16>(53),
+                    .Constant<Bond.Metadata>(_blobMap));
+                .Block(System.Collections.Generic.IEnumerator`1[System.Collections.Generic.KeyValuePair`2[System.Int32,System.ArraySegment`1[System.Byte]]] $enumerator)
+                 {
+                    $enumerator = .Call ($Example._blobMap).GetEnumerator();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._blobMap).Count,
+                            .Constant<Bond.BondDataType>(BT_INT32),
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (
+                                .Call $enumerator.MoveNext()
+                            ) {
+                                .Block() {
+                                    .Call $writer.WriteItemBegin();
+                                    .Call $writer.WriteInt32(($enumerator.Current).Key);
+                                    .Call $writer.WriteItemEnd();
+                                    .Default(System.Void);
+                                    .Call $writer.WriteItemBegin();
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = ($enumerator.Current).Value;
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Call $writer.WriteItemEnd()
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_MAP),
+                .Constant<System.UInt16>(53),
+                .Constant<Bond.Metadata>(_blobMap))
+        };
+        .If ($Example._blobNullable != .Constant<System.ArraySegment`1[System.Byte]>(System.ArraySegment`1[System.Byte])) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(54),
+                    .Constant<Bond.Metadata>(_blobNullable));
+                .Block(
+                    System.ArraySegment`1[System.Byte] $convertedBlob,
+                    System.Int32 $count) {
+                    $convertedBlob = $Example._blobNullable;
+                    $count = .If ($convertedBlob.Array != null) {
+                        1
+                    } .Else {
+                        0
+                    };
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- != 0) {
+                                .Block() {
+                                    .Call $writer.WriteItemBegin();
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = $convertedBlob;
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Call $writer.WriteItemEnd()
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(54),
+                .Constant<Bond.Metadata>(_blobNullable))
+        };
         .If (($Example._map).Count != 0) {
             .Block() {
                 .Call $writer.WriteFieldBegin(
@@ -673,6 +899,276 @@
                 .Constant<Bond.BondDataType>(BT_LIST),
                 .Constant<System.UInt16>(74),
                 .Constant<Bond.Metadata>(_decNullable))
+        };
+        .Block(System.ArraySegment`1[System.Byte] $convertedBlob) {
+            $convertedBlob = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                $Example._reference,
+                .Default(System.ArraySegment`1[System.Byte]));
+            .If ($convertedBlob != .Default(System.ArraySegment`1[System.Byte])) {
+                .Block() {
+                    .Call $writer.WriteFieldBegin(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(80),
+                        .Constant<Bond.Metadata>(_reference));
+                    .Block(
+                        System.ArraySegment`1[System.Byte] $arraySegment,
+                        System.Int32 $count,
+                        System.Int32 $index,
+                        System.Int32 $end) {
+                        $arraySegment = $convertedBlob;
+                        $index = $arraySegment.Offset;
+                        $count = $arraySegment.Count;
+                        $end = $index + $count;
+                        .Block() {
+                            .Call $writer.WriteContainerBegin(
+                                $count,
+                                .Constant<Bond.BondDataType>(BT_INT8));
+                            .Call $writer.WriteBytes($arraySegment);
+                            .Call $writer.WriteContainerEnd()
+                        }
+                    };
+                    .Call $writer.WriteFieldEnd()
+                }
+            } .Else {
+                .Call $writer.WriteFieldOmitted(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(80),
+                    .Constant<Bond.Metadata>(_reference))
+            }
+        };
+        .If (($Example._refList).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(81),
+                    .Constant<Bond.Metadata>(_refList));
+                .Block(System.Collections.Generic.LinkedListNode`1[ExpressionsTest.RefObject] $node) {
+                    $node = null;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._refList).Count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (.If ($node == null) {
+                                $node = ($Example._refList).First
+                            } .Else {
+                                $node = $node.Next
+                            } != null) {
+                                .Block() {
+                                    .Call $writer.WriteItemBegin();
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            $node.Value,
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Call $writer.WriteItemEnd()
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(81),
+                .Constant<Bond.Metadata>(_refList))
+        };
+        .If (($Example._refVector).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(82),
+                    .Constant<Bond.Metadata>(_refVector));
+                .Block(
+                    System.Int32 $index,
+                    System.Int32 $count) {
+                    $index = -1;
+                    $count = ($Example._refVector).Count;
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (++$index < $count) {
+                                .Block() {
+                                    .Call $writer.WriteItemBegin();
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            ($Example._refVector).Item[$index],
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Call $writer.WriteItemEnd()
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(82),
+                .Constant<Bond.Metadata>(_refVector))
+        };
+        .If (($Example._refMap).Count != 0) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_MAP),
+                    .Constant<System.UInt16>(83),
+                    .Constant<Bond.Metadata>(_refMap));
+                .Block(System.Collections.Generic.IEnumerator`1[System.Collections.Generic.KeyValuePair`2[System.Int32,ExpressionsTest.RefObject]] $enumerator)
+                 {
+                    $enumerator = .Call ($Example._refMap).GetEnumerator();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            ($Example._refMap).Count,
+                            .Constant<Bond.BondDataType>(BT_INT32),
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If (
+                                .Call $enumerator.MoveNext()
+                            ) {
+                                .Block() {
+                                    .Call $writer.WriteItemBegin();
+                                    .Call $writer.WriteInt32(($enumerator.Current).Key);
+                                    .Call $writer.WriteItemEnd();
+                                    .Default(System.Void);
+                                    .Call $writer.WriteItemBegin();
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                                            ($enumerator.Current).Value,
+                                            .Default(System.ArraySegment`1[System.Byte]));
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Call $writer.WriteItemEnd()
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_MAP),
+                .Constant<System.UInt16>(83),
+                .Constant<Bond.Metadata>(_refMap))
+        };
+        .If ($Example._refNullable != null) {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(84),
+                    .Constant<Bond.Metadata>(_refNullable));
+                .Block(
+                    System.ArraySegment`1[System.Byte] $convertedBlob,
+                    System.Int32 $count) {
+                    $convertedBlob = .Call ExpressionsTest.BondTypeAliasConverter.Convert(
+                        $Example._refNullable,
+                        .Default(System.ArraySegment`1[System.Byte]));
+                    $count = .If ($convertedBlob.Array != null) {
+                        1
+                    } .Else {
+                        0
+                    };
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- != 0) {
+                                .Block() {
+                                    .Call $writer.WriteItemBegin();
+                                    .Block(
+                                        System.ArraySegment`1[System.Byte] $arraySegment,
+                                        System.Int32 $count,
+                                        System.Int32 $index,
+                                        System.Int32 $end) {
+                                        $arraySegment = $convertedBlob;
+                                        $index = $arraySegment.Offset;
+                                        $count = $arraySegment.Count;
+                                        $end = $index + $count;
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes($arraySegment);
+                                            .Call $writer.WriteContainerEnd()
+                                        }
+                                    };
+                                    .Call $writer.WriteItemEnd()
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        } .Else {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(84),
+                .Constant<Bond.Metadata>(_refNullable))
         };
         .Call $writer.WriteStructEnd()
     }

--- a/cs/test/expressions/TranscodeCBSP.expressions
+++ b/cs/test/expressions/TranscodeCBSP.expressions
@@ -1432,6 +1432,222 @@
         }
         .LabelTarget end:;
         .Loop  {
+            .If ((System.Int32)$fieldType > 1) {
+                .Block() {
+                    .If ($fieldId == .Constant<System.UInt16>(70)) {
+                        .Block() {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    .Constant<System.UInt16>(70),
+                                    .Constant<Bond.Metadata>(_decimal));
+                                .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                    $reader,
+                                    $writer,
+                                    10);
+                                .Call $writer.WriteFieldEnd()
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .Break end { }
+                        }
+                    } .Else {
+                        .If ($fieldId > .Constant<System.UInt16>(70)) {
+                            .Block() {
+                                .Call $writer.WriteFieldOmitted(
+                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                    .Constant<System.UInt16>(70),
+                                    .Constant<Bond.Metadata>(_decimal));
+                                .Break end { }
+                            }
+                        } .Else {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    $fieldId,
+                                    null);
+                                .Switch ($fieldType) {
+                                .Case (.Constant<Bond.BondDataType>(BT_LIST)):
+                                .Case (.Constant<Bond.BondDataType>(BT_SET)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            3)
+                                .Case (.Constant<Bond.BondDataType>(BT_MAP)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            4)
+                                .Case (.Constant<Bond.BondDataType>(BT_STRUCT)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            5)
+                                .Case (.Constant<Bond.BondDataType>(BT_BOOL)):
+                                        .Call $writer.WriteBool(.Call $reader.ReadBool())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT8)):
+                                        .Call $writer.WriteUInt8(.Call $reader.ReadUInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT16)):
+                                        .Call $writer.WriteUInt16(.Call $reader.ReadUInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT32)):
+                                        .Call $writer.WriteUInt32(.Call $reader.ReadUInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT64)):
+                                        .Call $writer.WriteUInt64(.Call $reader.ReadUInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_FLOAT)):
+                                        .Call $writer.WriteFloat(.Call $reader.ReadFloat())
+                                .Case (.Constant<Bond.BondDataType>(BT_DOUBLE)):
+                                        .Call $writer.WriteDouble(.Call $reader.ReadDouble())
+                                .Case (.Constant<Bond.BondDataType>(BT_STRING)):
+                                        .Call $writer.WriteString(.Call $reader.ReadString())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT8)):
+                                        .Call $writer.WriteInt8(.Call $reader.ReadInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT16)):
+                                        .Call $writer.WriteInt16(.Call $reader.ReadInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT32)):
+                                        .Call $writer.WriteInt32(.Call $reader.ReadInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT64)):
+                                        .Call $writer.WriteInt64(.Call $reader.ReadInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_WSTRING)):
+                                        .Call $writer.WriteWString(.Call $reader.ReadWString())
+                                .Default:
+                                        .Invoke (.Lambda #Lambda3<System.Action`1[Bond.BondDataType]>)($fieldType)
+                                };
+                                .Call $writer.WriteFieldEnd()
+                            }
+                        }
+                    };
+                    .Call $reader.ReadFieldEnd();
+                    .Call $reader.ReadFieldBegin(
+                        $fieldType,
+                        $fieldId);
+                    .If ($fieldId > .Constant<System.UInt16>(70)) {
+                        .Break end { }
+                    } .Else {
+                        .Default(System.Void)
+                    }
+                }
+            } .Else {
+                .Block() {
+                    .Call $writer.WriteFieldOmitted(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(70),
+                        .Constant<Bond.Metadata>(_decimal));
+                    .Break end { }
+                }
+            }
+        }
+        .LabelTarget end:;
+        .Loop  {
+            .If ((System.Int32)$fieldType > 1) {
+                .Block() {
+                    .If ($fieldId == .Constant<System.UInt16>(71)) {
+                        .Block() {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    .Constant<System.UInt16>(71),
+                                    .Constant<Bond.Metadata>(_decList));
+                                .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                    $reader,
+                                    $writer,
+                                    12);
+                                .Call $writer.WriteFieldEnd()
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .Break end { }
+                        }
+                    } .Else {
+                        .If ($fieldId > .Constant<System.UInt16>(71)) {
+                            .Block() {
+                                .Call $writer.WriteFieldOmitted(
+                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                    .Constant<System.UInt16>(71),
+                                    .Constant<Bond.Metadata>(_decList));
+                                .Break end { }
+                            }
+                        } .Else {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    $fieldId,
+                                    null);
+                                .Switch ($fieldType) {
+                                .Case (.Constant<Bond.BondDataType>(BT_LIST)):
+                                .Case (.Constant<Bond.BondDataType>(BT_SET)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            3)
+                                .Case (.Constant<Bond.BondDataType>(BT_MAP)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            4)
+                                .Case (.Constant<Bond.BondDataType>(BT_STRUCT)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            5)
+                                .Case (.Constant<Bond.BondDataType>(BT_BOOL)):
+                                        .Call $writer.WriteBool(.Call $reader.ReadBool())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT8)):
+                                        .Call $writer.WriteUInt8(.Call $reader.ReadUInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT16)):
+                                        .Call $writer.WriteUInt16(.Call $reader.ReadUInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT32)):
+                                        .Call $writer.WriteUInt32(.Call $reader.ReadUInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT64)):
+                                        .Call $writer.WriteUInt64(.Call $reader.ReadUInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_FLOAT)):
+                                        .Call $writer.WriteFloat(.Call $reader.ReadFloat())
+                                .Case (.Constant<Bond.BondDataType>(BT_DOUBLE)):
+                                        .Call $writer.WriteDouble(.Call $reader.ReadDouble())
+                                .Case (.Constant<Bond.BondDataType>(BT_STRING)):
+                                        .Call $writer.WriteString(.Call $reader.ReadString())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT8)):
+                                        .Call $writer.WriteInt8(.Call $reader.ReadInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT16)):
+                                        .Call $writer.WriteInt16(.Call $reader.ReadInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT32)):
+                                        .Call $writer.WriteInt32(.Call $reader.ReadInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT64)):
+                                        .Call $writer.WriteInt64(.Call $reader.ReadInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_WSTRING)):
+                                        .Call $writer.WriteWString(.Call $reader.ReadWString())
+                                .Default:
+                                        .Invoke (.Lambda #Lambda3<System.Action`1[Bond.BondDataType]>)($fieldType)
+                                };
+                                .Call $writer.WriteFieldEnd()
+                            }
+                        }
+                    };
+                    .Call $reader.ReadFieldEnd();
+                    .Call $reader.ReadFieldBegin(
+                        $fieldType,
+                        $fieldId);
+                    .If ($fieldId > .Constant<System.UInt16>(71)) {
+                        .Break end { }
+                    } .Else {
+                        .Default(System.Void)
+                    }
+                }
+            } .Else {
+                .Block() {
+                    .Call $writer.WriteFieldOmitted(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(71),
+                        .Constant<Bond.Metadata>(_decList));
+                    .Break end { }
+                }
+            }
+        }
+        .LabelTarget end:;
+        .Loop  {
             .If ($fieldType != .Constant<Bond.BondDataType>(BT_STOP)) {
                 .Block() {
                     .If ($fieldType == .Constant<Bond.BondDataType>(BT_STOP_BASE)) {
@@ -3168,6 +3384,61 @@
 }
 
 .Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>(
+    Bond.BondDataType $e,
+    Bond.BondDataType $a) {
+    .Call Bond.Expressions.ThrowExpression.ThrowInvalidTypeException(
+        $e,
+        $a)
+}.Lambda #Lambda1<System.Action`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]>(
+    Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream] $reader,
+    Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream] $writer) {
+    .Block(
+        System.Int32 $count,
+        Bond.BondDataType $elementType) {
+        .Call $reader.ReadContainerBegin(
+            $count,
+            $elementType);
+        .If ($elementType == .Constant<Bond.BondDataType>(BT_LIST)) {
+            .Block() {
+                .Call $writer.WriteContainerBegin(
+                    $count,
+                    .Constant<Bond.BondDataType>(BT_LIST));
+                .Loop  {
+                    .If ($count-- > 0) {
+                        .Block() {
+                            .Default(System.Void);
+                            .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                $reader,
+                                $writer,
+                                10);
+                            .Default(System.Void)
+                        }
+                    } .Else {
+                        .Break end { }
+                    }
+                }
+                .LabelTarget end:;
+                .Call $writer.WriteContainerEnd()
+            }
+        } .Else {
+            .Invoke (.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                $elementType)
+        };
+        .Call $reader.ReadContainerEnd()
+    }
+}
+
+.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>(
+    Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream] $r,
+    Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream] $w,
+    System.Int32 $i) {
+    .Invoke ((.Constant<ExpressionsTest.Transcoder`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]>(ExpressionsTest.Transcoder`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]).transcode)[$i])(
+        $r,
+        $w)
+}
+
+.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>(
     Bond.BondDataType $e,
     Bond.BondDataType $a) {
     .Call Bond.Expressions.ThrowExpression.ThrowInvalidTypeException(

--- a/cs/test/expressions/TranscodeCBSP.expressions
+++ b/cs/test/expressions/TranscodeCBSP.expressions
@@ -1648,6 +1648,330 @@
         }
         .LabelTarget end:;
         .Loop  {
+            .If ((System.Int32)$fieldType > 1) {
+                .Block() {
+                    .If ($fieldId == .Constant<System.UInt16>(72)) {
+                        .Block() {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    .Constant<System.UInt16>(72),
+                                    .Constant<Bond.Metadata>(_decVector));
+                                .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                    $reader,
+                                    $writer,
+                                    12);
+                                .Call $writer.WriteFieldEnd()
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .Break end { }
+                        }
+                    } .Else {
+                        .If ($fieldId > .Constant<System.UInt16>(72)) {
+                            .Block() {
+                                .Call $writer.WriteFieldOmitted(
+                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                    .Constant<System.UInt16>(72),
+                                    .Constant<Bond.Metadata>(_decVector));
+                                .Break end { }
+                            }
+                        } .Else {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    $fieldId,
+                                    null);
+                                .Switch ($fieldType) {
+                                .Case (.Constant<Bond.BondDataType>(BT_LIST)):
+                                .Case (.Constant<Bond.BondDataType>(BT_SET)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            3)
+                                .Case (.Constant<Bond.BondDataType>(BT_MAP)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            4)
+                                .Case (.Constant<Bond.BondDataType>(BT_STRUCT)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            5)
+                                .Case (.Constant<Bond.BondDataType>(BT_BOOL)):
+                                        .Call $writer.WriteBool(.Call $reader.ReadBool())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT8)):
+                                        .Call $writer.WriteUInt8(.Call $reader.ReadUInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT16)):
+                                        .Call $writer.WriteUInt16(.Call $reader.ReadUInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT32)):
+                                        .Call $writer.WriteUInt32(.Call $reader.ReadUInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT64)):
+                                        .Call $writer.WriteUInt64(.Call $reader.ReadUInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_FLOAT)):
+                                        .Call $writer.WriteFloat(.Call $reader.ReadFloat())
+                                .Case (.Constant<Bond.BondDataType>(BT_DOUBLE)):
+                                        .Call $writer.WriteDouble(.Call $reader.ReadDouble())
+                                .Case (.Constant<Bond.BondDataType>(BT_STRING)):
+                                        .Call $writer.WriteString(.Call $reader.ReadString())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT8)):
+                                        .Call $writer.WriteInt8(.Call $reader.ReadInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT16)):
+                                        .Call $writer.WriteInt16(.Call $reader.ReadInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT32)):
+                                        .Call $writer.WriteInt32(.Call $reader.ReadInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT64)):
+                                        .Call $writer.WriteInt64(.Call $reader.ReadInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_WSTRING)):
+                                        .Call $writer.WriteWString(.Call $reader.ReadWString())
+                                .Default:
+                                        .Invoke (.Lambda #Lambda3<System.Action`1[Bond.BondDataType]>)($fieldType)
+                                };
+                                .Call $writer.WriteFieldEnd()
+                            }
+                        }
+                    };
+                    .Call $reader.ReadFieldEnd();
+                    .Call $reader.ReadFieldBegin(
+                        $fieldType,
+                        $fieldId);
+                    .If ($fieldId > .Constant<System.UInt16>(72)) {
+                        .Break end { }
+                    } .Else {
+                        .Default(System.Void)
+                    }
+                }
+            } .Else {
+                .Block() {
+                    .Call $writer.WriteFieldOmitted(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(72),
+                        .Constant<Bond.Metadata>(_decVector));
+                    .Break end { }
+                }
+            }
+        }
+        .LabelTarget end:;
+        .Loop  {
+            .If ((System.Int32)$fieldType > 1) {
+                .Block() {
+                    .If ($fieldId == .Constant<System.UInt16>(73)) {
+                        .Block() {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    .Constant<System.UInt16>(73),
+                                    .Constant<Bond.Metadata>(_decMap));
+                                .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                    $reader,
+                                    $writer,
+                                    13);
+                                .Call $writer.WriteFieldEnd()
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .Break end { }
+                        }
+                    } .Else {
+                        .If ($fieldId > .Constant<System.UInt16>(73)) {
+                            .Block() {
+                                .Call $writer.WriteFieldOmitted(
+                                    .Constant<Bond.BondDataType>(BT_MAP),
+                                    .Constant<System.UInt16>(73),
+                                    .Constant<Bond.Metadata>(_decMap));
+                                .Break end { }
+                            }
+                        } .Else {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    $fieldId,
+                                    null);
+                                .Switch ($fieldType) {
+                                .Case (.Constant<Bond.BondDataType>(BT_LIST)):
+                                .Case (.Constant<Bond.BondDataType>(BT_SET)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            3)
+                                .Case (.Constant<Bond.BondDataType>(BT_MAP)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            4)
+                                .Case (.Constant<Bond.BondDataType>(BT_STRUCT)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            5)
+                                .Case (.Constant<Bond.BondDataType>(BT_BOOL)):
+                                        .Call $writer.WriteBool(.Call $reader.ReadBool())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT8)):
+                                        .Call $writer.WriteUInt8(.Call $reader.ReadUInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT16)):
+                                        .Call $writer.WriteUInt16(.Call $reader.ReadUInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT32)):
+                                        .Call $writer.WriteUInt32(.Call $reader.ReadUInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT64)):
+                                        .Call $writer.WriteUInt64(.Call $reader.ReadUInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_FLOAT)):
+                                        .Call $writer.WriteFloat(.Call $reader.ReadFloat())
+                                .Case (.Constant<Bond.BondDataType>(BT_DOUBLE)):
+                                        .Call $writer.WriteDouble(.Call $reader.ReadDouble())
+                                .Case (.Constant<Bond.BondDataType>(BT_STRING)):
+                                        .Call $writer.WriteString(.Call $reader.ReadString())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT8)):
+                                        .Call $writer.WriteInt8(.Call $reader.ReadInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT16)):
+                                        .Call $writer.WriteInt16(.Call $reader.ReadInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT32)):
+                                        .Call $writer.WriteInt32(.Call $reader.ReadInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT64)):
+                                        .Call $writer.WriteInt64(.Call $reader.ReadInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_WSTRING)):
+                                        .Call $writer.WriteWString(.Call $reader.ReadWString())
+                                .Default:
+                                        .Invoke (.Lambda #Lambda3<System.Action`1[Bond.BondDataType]>)($fieldType)
+                                };
+                                .Call $writer.WriteFieldEnd()
+                            }
+                        }
+                    };
+                    .Call $reader.ReadFieldEnd();
+                    .Call $reader.ReadFieldBegin(
+                        $fieldType,
+                        $fieldId);
+                    .If ($fieldId > .Constant<System.UInt16>(73)) {
+                        .Break end { }
+                    } .Else {
+                        .Default(System.Void)
+                    }
+                }
+            } .Else {
+                .Block() {
+                    .Call $writer.WriteFieldOmitted(
+                        .Constant<Bond.BondDataType>(BT_MAP),
+                        .Constant<System.UInt16>(73),
+                        .Constant<Bond.Metadata>(_decMap));
+                    .Break end { }
+                }
+            }
+        }
+        .LabelTarget end:;
+        .Loop  {
+            .If ((System.Int32)$fieldType > 1) {
+                .Block() {
+                    .If ($fieldId == .Constant<System.UInt16>(74)) {
+                        .Block() {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    .Constant<System.UInt16>(74),
+                                    .Constant<Bond.Metadata>(_decNullable));
+                                .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                    $reader,
+                                    $writer,
+                                    12);
+                                .Call $writer.WriteFieldEnd()
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .Break end { }
+                        }
+                    } .Else {
+                        .If ($fieldId > .Constant<System.UInt16>(74)) {
+                            .Block() {
+                                .Call $writer.WriteFieldOmitted(
+                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                    .Constant<System.UInt16>(74),
+                                    .Constant<Bond.Metadata>(_decNullable));
+                                .Break end { }
+                            }
+                        } .Else {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    $fieldId,
+                                    null);
+                                .Switch ($fieldType) {
+                                .Case (.Constant<Bond.BondDataType>(BT_LIST)):
+                                .Case (.Constant<Bond.BondDataType>(BT_SET)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            3)
+                                .Case (.Constant<Bond.BondDataType>(BT_MAP)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            4)
+                                .Case (.Constant<Bond.BondDataType>(BT_STRUCT)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            5)
+                                .Case (.Constant<Bond.BondDataType>(BT_BOOL)):
+                                        .Call $writer.WriteBool(.Call $reader.ReadBool())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT8)):
+                                        .Call $writer.WriteUInt8(.Call $reader.ReadUInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT16)):
+                                        .Call $writer.WriteUInt16(.Call $reader.ReadUInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT32)):
+                                        .Call $writer.WriteUInt32(.Call $reader.ReadUInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT64)):
+                                        .Call $writer.WriteUInt64(.Call $reader.ReadUInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_FLOAT)):
+                                        .Call $writer.WriteFloat(.Call $reader.ReadFloat())
+                                .Case (.Constant<Bond.BondDataType>(BT_DOUBLE)):
+                                        .Call $writer.WriteDouble(.Call $reader.ReadDouble())
+                                .Case (.Constant<Bond.BondDataType>(BT_STRING)):
+                                        .Call $writer.WriteString(.Call $reader.ReadString())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT8)):
+                                        .Call $writer.WriteInt8(.Call $reader.ReadInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT16)):
+                                        .Call $writer.WriteInt16(.Call $reader.ReadInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT32)):
+                                        .Call $writer.WriteInt32(.Call $reader.ReadInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT64)):
+                                        .Call $writer.WriteInt64(.Call $reader.ReadInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_WSTRING)):
+                                        .Call $writer.WriteWString(.Call $reader.ReadWString())
+                                .Default:
+                                        .Invoke (.Lambda #Lambda3<System.Action`1[Bond.BondDataType]>)($fieldType)
+                                };
+                                .Call $writer.WriteFieldEnd()
+                            }
+                        }
+                    };
+                    .Call $reader.ReadFieldEnd();
+                    .Call $reader.ReadFieldBegin(
+                        $fieldType,
+                        $fieldId);
+                    .If ($fieldId > .Constant<System.UInt16>(74)) {
+                        .Break end { }
+                    } .Else {
+                        .Default(System.Void)
+                    }
+                }
+            } .Else {
+                .Block() {
+                    .Call $writer.WriteFieldOmitted(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(74),
+                        .Constant<Bond.Metadata>(_decNullable));
+                    .Break end { }
+                }
+            }
+        }
+        .LabelTarget end:;
+        .Loop  {
             .If ($fieldType != .Constant<Bond.BondDataType>(BT_STOP)) {
                 .Block() {
                     .If ($fieldType == .Constant<Bond.BondDataType>(BT_STOP_BASE)) {
@@ -3424,6 +3748,144 @@
             .Invoke (.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
                 .Constant<Bond.BondDataType>(BT_LIST),
                 $elementType)
+        };
+        .Call $reader.ReadContainerEnd()
+    }
+}
+
+.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>(
+    Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream] $r,
+    Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream] $w,
+    System.Int32 $i) {
+    .Invoke ((.Constant<ExpressionsTest.Transcoder`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]>(ExpressionsTest.Transcoder`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]).transcode)[$i])(
+        $r,
+        $w)
+}
+
+.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>(
+    Bond.BondDataType $e,
+    Bond.BondDataType $a) {
+    .Call Bond.Expressions.ThrowExpression.ThrowInvalidTypeException(
+        $e,
+        $a)
+}.Lambda #Lambda1<System.Action`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]>(
+    Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream] $reader,
+    Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream] $writer) {
+    .Block(
+        System.Int32 $count,
+        Bond.BondDataType $keyType,
+        Bond.BondDataType $valueType) {
+        .Call $reader.ReadContainerBegin(
+            $count,
+            $keyType,
+            $valueType);
+        .If ($keyType == .Constant<Bond.BondDataType>(BT_INT32)) {
+            .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                .Block() {
+                    .Call $writer.WriteContainerBegin(
+                        $count,
+                        .Constant<Bond.BondDataType>(BT_INT32),
+                        .Constant<Bond.BondDataType>(BT_LIST));
+                    .Loop  {
+                        .If ($count-- > 0) {
+                            .Block() {
+                                .Default(System.Void);
+                                .Call $writer.WriteInt32(.Call $reader.ReadInt32());
+                                .Default(System.Void);
+                                .Default(System.Void);
+                                .Default(System.Void);
+                                .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                    $reader,
+                                    $writer,
+                                    10);
+                                .Default(System.Void)
+                            }
+                        } .Else {
+                            .Break end { }
+                        }
+                    }
+                    .LabelTarget end:;
+                    .Call $writer.WriteContainerEnd()
+                }
+            } .Else {
+                .Invoke (.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    $valueType)
+            }
+        } .Else {
+            .If ($keyType == .Constant<Bond.BondDataType>(BT_INT16)) {
+                .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_INT16),
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- > 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Call $writer.WriteInt32((System.Int32).Call $reader.ReadInt16());
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                        $reader,
+                                        $writer,
+                                        10);
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                } .Else {
+                    .Invoke (.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        $valueType)
+                }
+            } .Else {
+                .If ($keyType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                    .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                        .Block() {
+                            .Call $writer.WriteContainerBegin(
+                                $count,
+                                .Constant<Bond.BondDataType>(BT_INT8),
+                                .Constant<Bond.BondDataType>(BT_LIST));
+                            .Loop  {
+                                .If ($count-- > 0) {
+                                    .Block() {
+                                        .Default(System.Void);
+                                        .Call $writer.WriteInt32((System.Int32).Call $reader.ReadInt8());
+                                        .Default(System.Void);
+                                        .Default(System.Void);
+                                        .Default(System.Void);
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            10);
+                                        .Default(System.Void)
+                                    }
+                                } .Else {
+                                    .Break end { }
+                                }
+                            }
+                            .LabelTarget end:;
+                            .Call $writer.WriteContainerEnd()
+                        }
+                    } .Else {
+                        .Invoke (.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                            .Constant<Bond.BondDataType>(BT_LIST),
+                            $valueType)
+                    }
+                } .Else {
+                    .Invoke (.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                        .Constant<Bond.BondDataType>(BT_INT32),
+                        $keyType)
+                }
+            }
         };
         .Call $reader.ReadContainerEnd()
     }

--- a/cs/test/expressions/TranscodeCBSP.expressions
+++ b/cs/test/expressions/TranscodeCBSP.expressions
@@ -1326,6 +1326,438 @@
         .Loop  {
             .If ((System.Int32)$fieldType > 1) {
                 .Block() {
+                    .If ($fieldId == .Constant<System.UInt16>(51)) {
+                        .Block() {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    .Constant<System.UInt16>(51),
+                                    .Constant<Bond.Metadata>(_blobList));
+                                .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                    $reader,
+                                    $writer,
+                                    11);
+                                .Call $writer.WriteFieldEnd()
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .Break end { }
+                        }
+                    } .Else {
+                        .If ($fieldId > .Constant<System.UInt16>(51)) {
+                            .Block() {
+                                .Call $writer.WriteFieldOmitted(
+                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                    .Constant<System.UInt16>(51),
+                                    .Constant<Bond.Metadata>(_blobList));
+                                .Break end { }
+                            }
+                        } .Else {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    $fieldId,
+                                    null);
+                                .Switch ($fieldType) {
+                                .Case (.Constant<Bond.BondDataType>(BT_LIST)):
+                                .Case (.Constant<Bond.BondDataType>(BT_SET)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            3)
+                                .Case (.Constant<Bond.BondDataType>(BT_MAP)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            4)
+                                .Case (.Constant<Bond.BondDataType>(BT_STRUCT)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            5)
+                                .Case (.Constant<Bond.BondDataType>(BT_BOOL)):
+                                        .Call $writer.WriteBool(.Call $reader.ReadBool())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT8)):
+                                        .Call $writer.WriteUInt8(.Call $reader.ReadUInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT16)):
+                                        .Call $writer.WriteUInt16(.Call $reader.ReadUInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT32)):
+                                        .Call $writer.WriteUInt32(.Call $reader.ReadUInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT64)):
+                                        .Call $writer.WriteUInt64(.Call $reader.ReadUInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_FLOAT)):
+                                        .Call $writer.WriteFloat(.Call $reader.ReadFloat())
+                                .Case (.Constant<Bond.BondDataType>(BT_DOUBLE)):
+                                        .Call $writer.WriteDouble(.Call $reader.ReadDouble())
+                                .Case (.Constant<Bond.BondDataType>(BT_STRING)):
+                                        .Call $writer.WriteString(.Call $reader.ReadString())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT8)):
+                                        .Call $writer.WriteInt8(.Call $reader.ReadInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT16)):
+                                        .Call $writer.WriteInt16(.Call $reader.ReadInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT32)):
+                                        .Call $writer.WriteInt32(.Call $reader.ReadInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT64)):
+                                        .Call $writer.WriteInt64(.Call $reader.ReadInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_WSTRING)):
+                                        .Call $writer.WriteWString(.Call $reader.ReadWString())
+                                .Default:
+                                        .Invoke (.Lambda #Lambda3<System.Action`1[Bond.BondDataType]>)($fieldType)
+                                };
+                                .Call $writer.WriteFieldEnd()
+                            }
+                        }
+                    };
+                    .Call $reader.ReadFieldEnd();
+                    .Call $reader.ReadFieldBegin(
+                        $fieldType,
+                        $fieldId);
+                    .If ($fieldId > .Constant<System.UInt16>(51)) {
+                        .Break end { }
+                    } .Else {
+                        .Default(System.Void)
+                    }
+                }
+            } .Else {
+                .Block() {
+                    .Call $writer.WriteFieldOmitted(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(51),
+                        .Constant<Bond.Metadata>(_blobList));
+                    .Break end { }
+                }
+            }
+        }
+        .LabelTarget end:;
+        .Loop  {
+            .If ((System.Int32)$fieldType > 1) {
+                .Block() {
+                    .If ($fieldId == .Constant<System.UInt16>(52)) {
+                        .Block() {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    .Constant<System.UInt16>(52),
+                                    .Constant<Bond.Metadata>(_blobVector));
+                                .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                    $reader,
+                                    $writer,
+                                    11);
+                                .Call $writer.WriteFieldEnd()
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .Break end { }
+                        }
+                    } .Else {
+                        .If ($fieldId > .Constant<System.UInt16>(52)) {
+                            .Block() {
+                                .Call $writer.WriteFieldOmitted(
+                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                    .Constant<System.UInt16>(52),
+                                    .Constant<Bond.Metadata>(_blobVector));
+                                .Break end { }
+                            }
+                        } .Else {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    $fieldId,
+                                    null);
+                                .Switch ($fieldType) {
+                                .Case (.Constant<Bond.BondDataType>(BT_LIST)):
+                                .Case (.Constant<Bond.BondDataType>(BT_SET)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            3)
+                                .Case (.Constant<Bond.BondDataType>(BT_MAP)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            4)
+                                .Case (.Constant<Bond.BondDataType>(BT_STRUCT)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            5)
+                                .Case (.Constant<Bond.BondDataType>(BT_BOOL)):
+                                        .Call $writer.WriteBool(.Call $reader.ReadBool())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT8)):
+                                        .Call $writer.WriteUInt8(.Call $reader.ReadUInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT16)):
+                                        .Call $writer.WriteUInt16(.Call $reader.ReadUInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT32)):
+                                        .Call $writer.WriteUInt32(.Call $reader.ReadUInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT64)):
+                                        .Call $writer.WriteUInt64(.Call $reader.ReadUInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_FLOAT)):
+                                        .Call $writer.WriteFloat(.Call $reader.ReadFloat())
+                                .Case (.Constant<Bond.BondDataType>(BT_DOUBLE)):
+                                        .Call $writer.WriteDouble(.Call $reader.ReadDouble())
+                                .Case (.Constant<Bond.BondDataType>(BT_STRING)):
+                                        .Call $writer.WriteString(.Call $reader.ReadString())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT8)):
+                                        .Call $writer.WriteInt8(.Call $reader.ReadInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT16)):
+                                        .Call $writer.WriteInt16(.Call $reader.ReadInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT32)):
+                                        .Call $writer.WriteInt32(.Call $reader.ReadInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT64)):
+                                        .Call $writer.WriteInt64(.Call $reader.ReadInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_WSTRING)):
+                                        .Call $writer.WriteWString(.Call $reader.ReadWString())
+                                .Default:
+                                        .Invoke (.Lambda #Lambda3<System.Action`1[Bond.BondDataType]>)($fieldType)
+                                };
+                                .Call $writer.WriteFieldEnd()
+                            }
+                        }
+                    };
+                    .Call $reader.ReadFieldEnd();
+                    .Call $reader.ReadFieldBegin(
+                        $fieldType,
+                        $fieldId);
+                    .If ($fieldId > .Constant<System.UInt16>(52)) {
+                        .Break end { }
+                    } .Else {
+                        .Default(System.Void)
+                    }
+                }
+            } .Else {
+                .Block() {
+                    .Call $writer.WriteFieldOmitted(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(52),
+                        .Constant<Bond.Metadata>(_blobVector));
+                    .Break end { }
+                }
+            }
+        }
+        .LabelTarget end:;
+        .Loop  {
+            .If ((System.Int32)$fieldType > 1) {
+                .Block() {
+                    .If ($fieldId == .Constant<System.UInt16>(53)) {
+                        .Block() {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    .Constant<System.UInt16>(53),
+                                    .Constant<Bond.Metadata>(_blobMap));
+                                .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                    $reader,
+                                    $writer,
+                                    12);
+                                .Call $writer.WriteFieldEnd()
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .Break end { }
+                        }
+                    } .Else {
+                        .If ($fieldId > .Constant<System.UInt16>(53)) {
+                            .Block() {
+                                .Call $writer.WriteFieldOmitted(
+                                    .Constant<Bond.BondDataType>(BT_MAP),
+                                    .Constant<System.UInt16>(53),
+                                    .Constant<Bond.Metadata>(_blobMap));
+                                .Break end { }
+                            }
+                        } .Else {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    $fieldId,
+                                    null);
+                                .Switch ($fieldType) {
+                                .Case (.Constant<Bond.BondDataType>(BT_LIST)):
+                                .Case (.Constant<Bond.BondDataType>(BT_SET)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            3)
+                                .Case (.Constant<Bond.BondDataType>(BT_MAP)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            4)
+                                .Case (.Constant<Bond.BondDataType>(BT_STRUCT)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            5)
+                                .Case (.Constant<Bond.BondDataType>(BT_BOOL)):
+                                        .Call $writer.WriteBool(.Call $reader.ReadBool())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT8)):
+                                        .Call $writer.WriteUInt8(.Call $reader.ReadUInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT16)):
+                                        .Call $writer.WriteUInt16(.Call $reader.ReadUInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT32)):
+                                        .Call $writer.WriteUInt32(.Call $reader.ReadUInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT64)):
+                                        .Call $writer.WriteUInt64(.Call $reader.ReadUInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_FLOAT)):
+                                        .Call $writer.WriteFloat(.Call $reader.ReadFloat())
+                                .Case (.Constant<Bond.BondDataType>(BT_DOUBLE)):
+                                        .Call $writer.WriteDouble(.Call $reader.ReadDouble())
+                                .Case (.Constant<Bond.BondDataType>(BT_STRING)):
+                                        .Call $writer.WriteString(.Call $reader.ReadString())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT8)):
+                                        .Call $writer.WriteInt8(.Call $reader.ReadInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT16)):
+                                        .Call $writer.WriteInt16(.Call $reader.ReadInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT32)):
+                                        .Call $writer.WriteInt32(.Call $reader.ReadInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT64)):
+                                        .Call $writer.WriteInt64(.Call $reader.ReadInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_WSTRING)):
+                                        .Call $writer.WriteWString(.Call $reader.ReadWString())
+                                .Default:
+                                        .Invoke (.Lambda #Lambda3<System.Action`1[Bond.BondDataType]>)($fieldType)
+                                };
+                                .Call $writer.WriteFieldEnd()
+                            }
+                        }
+                    };
+                    .Call $reader.ReadFieldEnd();
+                    .Call $reader.ReadFieldBegin(
+                        $fieldType,
+                        $fieldId);
+                    .If ($fieldId > .Constant<System.UInt16>(53)) {
+                        .Break end { }
+                    } .Else {
+                        .Default(System.Void)
+                    }
+                }
+            } .Else {
+                .Block() {
+                    .Call $writer.WriteFieldOmitted(
+                        .Constant<Bond.BondDataType>(BT_MAP),
+                        .Constant<System.UInt16>(53),
+                        .Constant<Bond.Metadata>(_blobMap));
+                    .Break end { }
+                }
+            }
+        }
+        .LabelTarget end:;
+        .Loop  {
+            .If ((System.Int32)$fieldType > 1) {
+                .Block() {
+                    .If ($fieldId == .Constant<System.UInt16>(54)) {
+                        .Block() {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    .Constant<System.UInt16>(54),
+                                    .Constant<Bond.Metadata>(_blobNullable));
+                                .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                    $reader,
+                                    $writer,
+                                    11);
+                                .Call $writer.WriteFieldEnd()
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .Break end { }
+                        }
+                    } .Else {
+                        .If ($fieldId > .Constant<System.UInt16>(54)) {
+                            .Block() {
+                                .Call $writer.WriteFieldOmitted(
+                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                    .Constant<System.UInt16>(54),
+                                    .Constant<Bond.Metadata>(_blobNullable));
+                                .Break end { }
+                            }
+                        } .Else {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    $fieldId,
+                                    null);
+                                .Switch ($fieldType) {
+                                .Case (.Constant<Bond.BondDataType>(BT_LIST)):
+                                .Case (.Constant<Bond.BondDataType>(BT_SET)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            3)
+                                .Case (.Constant<Bond.BondDataType>(BT_MAP)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            4)
+                                .Case (.Constant<Bond.BondDataType>(BT_STRUCT)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            5)
+                                .Case (.Constant<Bond.BondDataType>(BT_BOOL)):
+                                        .Call $writer.WriteBool(.Call $reader.ReadBool())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT8)):
+                                        .Call $writer.WriteUInt8(.Call $reader.ReadUInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT16)):
+                                        .Call $writer.WriteUInt16(.Call $reader.ReadUInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT32)):
+                                        .Call $writer.WriteUInt32(.Call $reader.ReadUInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT64)):
+                                        .Call $writer.WriteUInt64(.Call $reader.ReadUInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_FLOAT)):
+                                        .Call $writer.WriteFloat(.Call $reader.ReadFloat())
+                                .Case (.Constant<Bond.BondDataType>(BT_DOUBLE)):
+                                        .Call $writer.WriteDouble(.Call $reader.ReadDouble())
+                                .Case (.Constant<Bond.BondDataType>(BT_STRING)):
+                                        .Call $writer.WriteString(.Call $reader.ReadString())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT8)):
+                                        .Call $writer.WriteInt8(.Call $reader.ReadInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT16)):
+                                        .Call $writer.WriteInt16(.Call $reader.ReadInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT32)):
+                                        .Call $writer.WriteInt32(.Call $reader.ReadInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT64)):
+                                        .Call $writer.WriteInt64(.Call $reader.ReadInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_WSTRING)):
+                                        .Call $writer.WriteWString(.Call $reader.ReadWString())
+                                .Default:
+                                        .Invoke (.Lambda #Lambda3<System.Action`1[Bond.BondDataType]>)($fieldType)
+                                };
+                                .Call $writer.WriteFieldEnd()
+                            }
+                        }
+                    };
+                    .Call $reader.ReadFieldEnd();
+                    .Call $reader.ReadFieldBegin(
+                        $fieldType,
+                        $fieldId);
+                    .If ($fieldId > .Constant<System.UInt16>(54)) {
+                        .Break end { }
+                    } .Else {
+                        .Default(System.Void)
+                    }
+                }
+            } .Else {
+                .Block() {
+                    .Call $writer.WriteFieldOmitted(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(54),
+                        .Constant<Bond.Metadata>(_blobNullable));
+                    .Break end { }
+                }
+            }
+        }
+        .LabelTarget end:;
+        .Loop  {
+            .If ((System.Int32)$fieldType > 1) {
+                .Block() {
                     .If ($fieldId == .Constant<System.UInt16>(60)) {
                         .Block() {
                             .Block() {
@@ -1336,7 +1768,7 @@
                                 .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
                                     $reader,
                                     $writer,
-                                    11);
+                                    13);
                                 .Call $writer.WriteFieldEnd()
                             };
                             .Call $reader.ReadFieldEnd();
@@ -1552,7 +1984,7 @@
                                 .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
                                     $reader,
                                     $writer,
-                                    12);
+                                    11);
                                 .Call $writer.WriteFieldEnd()
                             };
                             .Call $reader.ReadFieldEnd();
@@ -1660,7 +2092,7 @@
                                 .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
                                     $reader,
                                     $writer,
-                                    12);
+                                    11);
                                 .Call $writer.WriteFieldEnd()
                             };
                             .Call $reader.ReadFieldEnd();
@@ -1768,7 +2200,7 @@
                                 .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
                                     $reader,
                                     $writer,
-                                    13);
+                                    12);
                                 .Call $writer.WriteFieldEnd()
                             };
                             .Call $reader.ReadFieldEnd();
@@ -1876,7 +2308,7 @@
                                 .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
                                     $reader,
                                     $writer,
-                                    12);
+                                    11);
                                 .Call $writer.WriteFieldEnd()
                             };
                             .Call $reader.ReadFieldEnd();
@@ -1966,6 +2398,546 @@
                         .Constant<Bond.BondDataType>(BT_LIST),
                         .Constant<System.UInt16>(74),
                         .Constant<Bond.Metadata>(_decNullable));
+                    .Break end { }
+                }
+            }
+        }
+        .LabelTarget end:;
+        .Loop  {
+            .If ((System.Int32)$fieldType > 1) {
+                .Block() {
+                    .If ($fieldId == .Constant<System.UInt16>(80)) {
+                        .Block() {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    .Constant<System.UInt16>(80),
+                                    .Constant<Bond.Metadata>(_reference));
+                                .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                    $reader,
+                                    $writer,
+                                    10);
+                                .Call $writer.WriteFieldEnd()
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .Break end { }
+                        }
+                    } .Else {
+                        .If ($fieldId > .Constant<System.UInt16>(80)) {
+                            .Block() {
+                                .Call $writer.WriteFieldOmitted(
+                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                    .Constant<System.UInt16>(80),
+                                    .Constant<Bond.Metadata>(_reference));
+                                .Break end { }
+                            }
+                        } .Else {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    $fieldId,
+                                    null);
+                                .Switch ($fieldType) {
+                                .Case (.Constant<Bond.BondDataType>(BT_LIST)):
+                                .Case (.Constant<Bond.BondDataType>(BT_SET)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            3)
+                                .Case (.Constant<Bond.BondDataType>(BT_MAP)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            4)
+                                .Case (.Constant<Bond.BondDataType>(BT_STRUCT)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            5)
+                                .Case (.Constant<Bond.BondDataType>(BT_BOOL)):
+                                        .Call $writer.WriteBool(.Call $reader.ReadBool())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT8)):
+                                        .Call $writer.WriteUInt8(.Call $reader.ReadUInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT16)):
+                                        .Call $writer.WriteUInt16(.Call $reader.ReadUInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT32)):
+                                        .Call $writer.WriteUInt32(.Call $reader.ReadUInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT64)):
+                                        .Call $writer.WriteUInt64(.Call $reader.ReadUInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_FLOAT)):
+                                        .Call $writer.WriteFloat(.Call $reader.ReadFloat())
+                                .Case (.Constant<Bond.BondDataType>(BT_DOUBLE)):
+                                        .Call $writer.WriteDouble(.Call $reader.ReadDouble())
+                                .Case (.Constant<Bond.BondDataType>(BT_STRING)):
+                                        .Call $writer.WriteString(.Call $reader.ReadString())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT8)):
+                                        .Call $writer.WriteInt8(.Call $reader.ReadInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT16)):
+                                        .Call $writer.WriteInt16(.Call $reader.ReadInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT32)):
+                                        .Call $writer.WriteInt32(.Call $reader.ReadInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT64)):
+                                        .Call $writer.WriteInt64(.Call $reader.ReadInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_WSTRING)):
+                                        .Call $writer.WriteWString(.Call $reader.ReadWString())
+                                .Default:
+                                        .Invoke (.Lambda #Lambda3<System.Action`1[Bond.BondDataType]>)($fieldType)
+                                };
+                                .Call $writer.WriteFieldEnd()
+                            }
+                        }
+                    };
+                    .Call $reader.ReadFieldEnd();
+                    .Call $reader.ReadFieldBegin(
+                        $fieldType,
+                        $fieldId);
+                    .If ($fieldId > .Constant<System.UInt16>(80)) {
+                        .Break end { }
+                    } .Else {
+                        .Default(System.Void)
+                    }
+                }
+            } .Else {
+                .Block() {
+                    .Call $writer.WriteFieldOmitted(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(80),
+                        .Constant<Bond.Metadata>(_reference));
+                    .Break end { }
+                }
+            }
+        }
+        .LabelTarget end:;
+        .Loop  {
+            .If ((System.Int32)$fieldType > 1) {
+                .Block() {
+                    .If ($fieldId == .Constant<System.UInt16>(81)) {
+                        .Block() {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    .Constant<System.UInt16>(81),
+                                    .Constant<Bond.Metadata>(_refList));
+                                .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                    $reader,
+                                    $writer,
+                                    11);
+                                .Call $writer.WriteFieldEnd()
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .Break end { }
+                        }
+                    } .Else {
+                        .If ($fieldId > .Constant<System.UInt16>(81)) {
+                            .Block() {
+                                .Call $writer.WriteFieldOmitted(
+                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                    .Constant<System.UInt16>(81),
+                                    .Constant<Bond.Metadata>(_refList));
+                                .Break end { }
+                            }
+                        } .Else {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    $fieldId,
+                                    null);
+                                .Switch ($fieldType) {
+                                .Case (.Constant<Bond.BondDataType>(BT_LIST)):
+                                .Case (.Constant<Bond.BondDataType>(BT_SET)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            3)
+                                .Case (.Constant<Bond.BondDataType>(BT_MAP)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            4)
+                                .Case (.Constant<Bond.BondDataType>(BT_STRUCT)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            5)
+                                .Case (.Constant<Bond.BondDataType>(BT_BOOL)):
+                                        .Call $writer.WriteBool(.Call $reader.ReadBool())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT8)):
+                                        .Call $writer.WriteUInt8(.Call $reader.ReadUInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT16)):
+                                        .Call $writer.WriteUInt16(.Call $reader.ReadUInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT32)):
+                                        .Call $writer.WriteUInt32(.Call $reader.ReadUInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT64)):
+                                        .Call $writer.WriteUInt64(.Call $reader.ReadUInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_FLOAT)):
+                                        .Call $writer.WriteFloat(.Call $reader.ReadFloat())
+                                .Case (.Constant<Bond.BondDataType>(BT_DOUBLE)):
+                                        .Call $writer.WriteDouble(.Call $reader.ReadDouble())
+                                .Case (.Constant<Bond.BondDataType>(BT_STRING)):
+                                        .Call $writer.WriteString(.Call $reader.ReadString())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT8)):
+                                        .Call $writer.WriteInt8(.Call $reader.ReadInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT16)):
+                                        .Call $writer.WriteInt16(.Call $reader.ReadInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT32)):
+                                        .Call $writer.WriteInt32(.Call $reader.ReadInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT64)):
+                                        .Call $writer.WriteInt64(.Call $reader.ReadInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_WSTRING)):
+                                        .Call $writer.WriteWString(.Call $reader.ReadWString())
+                                .Default:
+                                        .Invoke (.Lambda #Lambda3<System.Action`1[Bond.BondDataType]>)($fieldType)
+                                };
+                                .Call $writer.WriteFieldEnd()
+                            }
+                        }
+                    };
+                    .Call $reader.ReadFieldEnd();
+                    .Call $reader.ReadFieldBegin(
+                        $fieldType,
+                        $fieldId);
+                    .If ($fieldId > .Constant<System.UInt16>(81)) {
+                        .Break end { }
+                    } .Else {
+                        .Default(System.Void)
+                    }
+                }
+            } .Else {
+                .Block() {
+                    .Call $writer.WriteFieldOmitted(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(81),
+                        .Constant<Bond.Metadata>(_refList));
+                    .Break end { }
+                }
+            }
+        }
+        .LabelTarget end:;
+        .Loop  {
+            .If ((System.Int32)$fieldType > 1) {
+                .Block() {
+                    .If ($fieldId == .Constant<System.UInt16>(82)) {
+                        .Block() {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    .Constant<System.UInt16>(82),
+                                    .Constant<Bond.Metadata>(_refVector));
+                                .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                    $reader,
+                                    $writer,
+                                    11);
+                                .Call $writer.WriteFieldEnd()
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .Break end { }
+                        }
+                    } .Else {
+                        .If ($fieldId > .Constant<System.UInt16>(82)) {
+                            .Block() {
+                                .Call $writer.WriteFieldOmitted(
+                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                    .Constant<System.UInt16>(82),
+                                    .Constant<Bond.Metadata>(_refVector));
+                                .Break end { }
+                            }
+                        } .Else {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    $fieldId,
+                                    null);
+                                .Switch ($fieldType) {
+                                .Case (.Constant<Bond.BondDataType>(BT_LIST)):
+                                .Case (.Constant<Bond.BondDataType>(BT_SET)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            3)
+                                .Case (.Constant<Bond.BondDataType>(BT_MAP)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            4)
+                                .Case (.Constant<Bond.BondDataType>(BT_STRUCT)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            5)
+                                .Case (.Constant<Bond.BondDataType>(BT_BOOL)):
+                                        .Call $writer.WriteBool(.Call $reader.ReadBool())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT8)):
+                                        .Call $writer.WriteUInt8(.Call $reader.ReadUInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT16)):
+                                        .Call $writer.WriteUInt16(.Call $reader.ReadUInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT32)):
+                                        .Call $writer.WriteUInt32(.Call $reader.ReadUInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT64)):
+                                        .Call $writer.WriteUInt64(.Call $reader.ReadUInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_FLOAT)):
+                                        .Call $writer.WriteFloat(.Call $reader.ReadFloat())
+                                .Case (.Constant<Bond.BondDataType>(BT_DOUBLE)):
+                                        .Call $writer.WriteDouble(.Call $reader.ReadDouble())
+                                .Case (.Constant<Bond.BondDataType>(BT_STRING)):
+                                        .Call $writer.WriteString(.Call $reader.ReadString())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT8)):
+                                        .Call $writer.WriteInt8(.Call $reader.ReadInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT16)):
+                                        .Call $writer.WriteInt16(.Call $reader.ReadInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT32)):
+                                        .Call $writer.WriteInt32(.Call $reader.ReadInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT64)):
+                                        .Call $writer.WriteInt64(.Call $reader.ReadInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_WSTRING)):
+                                        .Call $writer.WriteWString(.Call $reader.ReadWString())
+                                .Default:
+                                        .Invoke (.Lambda #Lambda3<System.Action`1[Bond.BondDataType]>)($fieldType)
+                                };
+                                .Call $writer.WriteFieldEnd()
+                            }
+                        }
+                    };
+                    .Call $reader.ReadFieldEnd();
+                    .Call $reader.ReadFieldBegin(
+                        $fieldType,
+                        $fieldId);
+                    .If ($fieldId > .Constant<System.UInt16>(82)) {
+                        .Break end { }
+                    } .Else {
+                        .Default(System.Void)
+                    }
+                }
+            } .Else {
+                .Block() {
+                    .Call $writer.WriteFieldOmitted(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(82),
+                        .Constant<Bond.Metadata>(_refVector));
+                    .Break end { }
+                }
+            }
+        }
+        .LabelTarget end:;
+        .Loop  {
+            .If ((System.Int32)$fieldType > 1) {
+                .Block() {
+                    .If ($fieldId == .Constant<System.UInt16>(83)) {
+                        .Block() {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    .Constant<System.UInt16>(83),
+                                    .Constant<Bond.Metadata>(_refMap));
+                                .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                    $reader,
+                                    $writer,
+                                    12);
+                                .Call $writer.WriteFieldEnd()
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .Break end { }
+                        }
+                    } .Else {
+                        .If ($fieldId > .Constant<System.UInt16>(83)) {
+                            .Block() {
+                                .Call $writer.WriteFieldOmitted(
+                                    .Constant<Bond.BondDataType>(BT_MAP),
+                                    .Constant<System.UInt16>(83),
+                                    .Constant<Bond.Metadata>(_refMap));
+                                .Break end { }
+                            }
+                        } .Else {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    $fieldId,
+                                    null);
+                                .Switch ($fieldType) {
+                                .Case (.Constant<Bond.BondDataType>(BT_LIST)):
+                                .Case (.Constant<Bond.BondDataType>(BT_SET)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            3)
+                                .Case (.Constant<Bond.BondDataType>(BT_MAP)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            4)
+                                .Case (.Constant<Bond.BondDataType>(BT_STRUCT)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            5)
+                                .Case (.Constant<Bond.BondDataType>(BT_BOOL)):
+                                        .Call $writer.WriteBool(.Call $reader.ReadBool())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT8)):
+                                        .Call $writer.WriteUInt8(.Call $reader.ReadUInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT16)):
+                                        .Call $writer.WriteUInt16(.Call $reader.ReadUInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT32)):
+                                        .Call $writer.WriteUInt32(.Call $reader.ReadUInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT64)):
+                                        .Call $writer.WriteUInt64(.Call $reader.ReadUInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_FLOAT)):
+                                        .Call $writer.WriteFloat(.Call $reader.ReadFloat())
+                                .Case (.Constant<Bond.BondDataType>(BT_DOUBLE)):
+                                        .Call $writer.WriteDouble(.Call $reader.ReadDouble())
+                                .Case (.Constant<Bond.BondDataType>(BT_STRING)):
+                                        .Call $writer.WriteString(.Call $reader.ReadString())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT8)):
+                                        .Call $writer.WriteInt8(.Call $reader.ReadInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT16)):
+                                        .Call $writer.WriteInt16(.Call $reader.ReadInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT32)):
+                                        .Call $writer.WriteInt32(.Call $reader.ReadInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT64)):
+                                        .Call $writer.WriteInt64(.Call $reader.ReadInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_WSTRING)):
+                                        .Call $writer.WriteWString(.Call $reader.ReadWString())
+                                .Default:
+                                        .Invoke (.Lambda #Lambda3<System.Action`1[Bond.BondDataType]>)($fieldType)
+                                };
+                                .Call $writer.WriteFieldEnd()
+                            }
+                        }
+                    };
+                    .Call $reader.ReadFieldEnd();
+                    .Call $reader.ReadFieldBegin(
+                        $fieldType,
+                        $fieldId);
+                    .If ($fieldId > .Constant<System.UInt16>(83)) {
+                        .Break end { }
+                    } .Else {
+                        .Default(System.Void)
+                    }
+                }
+            } .Else {
+                .Block() {
+                    .Call $writer.WriteFieldOmitted(
+                        .Constant<Bond.BondDataType>(BT_MAP),
+                        .Constant<System.UInt16>(83),
+                        .Constant<Bond.Metadata>(_refMap));
+                    .Break end { }
+                }
+            }
+        }
+        .LabelTarget end:;
+        .Loop  {
+            .If ((System.Int32)$fieldType > 1) {
+                .Block() {
+                    .If ($fieldId == .Constant<System.UInt16>(84)) {
+                        .Block() {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    .Constant<System.UInt16>(84),
+                                    .Constant<Bond.Metadata>(_refNullable));
+                                .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                    $reader,
+                                    $writer,
+                                    11);
+                                .Call $writer.WriteFieldEnd()
+                            };
+                            .Call $reader.ReadFieldEnd();
+                            .Call $reader.ReadFieldBegin(
+                                $fieldType,
+                                $fieldId);
+                            .Break end { }
+                        }
+                    } .Else {
+                        .If ($fieldId > .Constant<System.UInt16>(84)) {
+                            .Block() {
+                                .Call $writer.WriteFieldOmitted(
+                                    .Constant<Bond.BondDataType>(BT_LIST),
+                                    .Constant<System.UInt16>(84),
+                                    .Constant<Bond.Metadata>(_refNullable));
+                                .Break end { }
+                            }
+                        } .Else {
+                            .Block() {
+                                .Call $writer.WriteFieldBegin(
+                                    $fieldType,
+                                    $fieldId,
+                                    null);
+                                .Switch ($fieldType) {
+                                .Case (.Constant<Bond.BondDataType>(BT_LIST)):
+                                .Case (.Constant<Bond.BondDataType>(BT_SET)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            3)
+                                .Case (.Constant<Bond.BondDataType>(BT_MAP)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            4)
+                                .Case (.Constant<Bond.BondDataType>(BT_STRUCT)):
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            5)
+                                .Case (.Constant<Bond.BondDataType>(BT_BOOL)):
+                                        .Call $writer.WriteBool(.Call $reader.ReadBool())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT8)):
+                                        .Call $writer.WriteUInt8(.Call $reader.ReadUInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT16)):
+                                        .Call $writer.WriteUInt16(.Call $reader.ReadUInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT32)):
+                                        .Call $writer.WriteUInt32(.Call $reader.ReadUInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_UINT64)):
+                                        .Call $writer.WriteUInt64(.Call $reader.ReadUInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_FLOAT)):
+                                        .Call $writer.WriteFloat(.Call $reader.ReadFloat())
+                                .Case (.Constant<Bond.BondDataType>(BT_DOUBLE)):
+                                        .Call $writer.WriteDouble(.Call $reader.ReadDouble())
+                                .Case (.Constant<Bond.BondDataType>(BT_STRING)):
+                                        .Call $writer.WriteString(.Call $reader.ReadString())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT8)):
+                                        .Call $writer.WriteInt8(.Call $reader.ReadInt8())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT16)):
+                                        .Call $writer.WriteInt16(.Call $reader.ReadInt16())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT32)):
+                                        .Call $writer.WriteInt32(.Call $reader.ReadInt32())
+                                .Case (.Constant<Bond.BondDataType>(BT_INT64)):
+                                        .Call $writer.WriteInt64(.Call $reader.ReadInt64())
+                                .Case (.Constant<Bond.BondDataType>(BT_WSTRING)):
+                                        .Call $writer.WriteWString(.Call $reader.ReadWString())
+                                .Default:
+                                        .Invoke (.Lambda #Lambda3<System.Action`1[Bond.BondDataType]>)($fieldType)
+                                };
+                                .Call $writer.WriteFieldEnd()
+                            }
+                        }
+                    };
+                    .Call $reader.ReadFieldEnd();
+                    .Call $reader.ReadFieldBegin(
+                        $fieldType,
+                        $fieldId);
+                    .If ($fieldId > .Constant<System.UInt16>(84)) {
+                        .Break end { }
+                    } .Else {
+                        .Default(System.Void)
+                    }
+                }
+            } .Else {
+                .Block() {
+                    .Call $writer.WriteFieldOmitted(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        .Constant<System.UInt16>(84),
+                        .Constant<Bond.Metadata>(_refNullable));
                     .Break end { }
                 }
             }
@@ -3520,6 +4492,199 @@
     Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream] $writer) {
     .Block(
         System.Int32 $count,
+        Bond.BondDataType $elementType) {
+        .Call $reader.ReadContainerBegin(
+            $count,
+            $elementType);
+        .If ($elementType == .Constant<Bond.BondDataType>(BT_LIST)) {
+            .Block() {
+                .Call $writer.WriteContainerBegin(
+                    $count,
+                    .Constant<Bond.BondDataType>(BT_LIST));
+                .Loop  {
+                    .If ($count-- > 0) {
+                        .Block() {
+                            .Default(System.Void);
+                            .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                $reader,
+                                $writer,
+                                10);
+                            .Default(System.Void)
+                        }
+                    } .Else {
+                        .Break end { }
+                    }
+                }
+                .LabelTarget end:;
+                .Call $writer.WriteContainerEnd()
+            }
+        } .Else {
+            .Invoke (.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                $elementType)
+        };
+        .Call $reader.ReadContainerEnd()
+    }
+}
+
+.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>(
+    Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream] $r,
+    Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream] $w,
+    System.Int32 $i) {
+    .Invoke ((.Constant<ExpressionsTest.Transcoder`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]>(ExpressionsTest.Transcoder`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]).transcode)[$i])(
+        $r,
+        $w)
+}
+
+.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>(
+    Bond.BondDataType $e,
+    Bond.BondDataType $a) {
+    .Call Bond.Expressions.ThrowExpression.ThrowInvalidTypeException(
+        $e,
+        $a)
+}.Lambda #Lambda1<System.Action`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]>(
+    Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream] $reader,
+    Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream] $writer) {
+    .Block(
+        System.Int32 $count,
+        Bond.BondDataType $keyType,
+        Bond.BondDataType $valueType) {
+        .Call $reader.ReadContainerBegin(
+            $count,
+            $keyType,
+            $valueType);
+        .If ($keyType == .Constant<Bond.BondDataType>(BT_INT32)) {
+            .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                .Block() {
+                    .Call $writer.WriteContainerBegin(
+                        $count,
+                        .Constant<Bond.BondDataType>(BT_INT32),
+                        .Constant<Bond.BondDataType>(BT_LIST));
+                    .Loop  {
+                        .If ($count-- > 0) {
+                            .Block() {
+                                .Default(System.Void);
+                                .Call $writer.WriteInt32(.Call $reader.ReadInt32());
+                                .Default(System.Void);
+                                .Default(System.Void);
+                                .Default(System.Void);
+                                .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                    $reader,
+                                    $writer,
+                                    10);
+                                .Default(System.Void)
+                            }
+                        } .Else {
+                            .Break end { }
+                        }
+                    }
+                    .LabelTarget end:;
+                    .Call $writer.WriteContainerEnd()
+                }
+            } .Else {
+                .Invoke (.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    $valueType)
+            }
+        } .Else {
+            .If ($keyType == .Constant<Bond.BondDataType>(BT_INT16)) {
+                .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_INT16),
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- > 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Call $writer.WriteInt32((System.Int32).Call $reader.ReadInt16());
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                        $reader,
+                                        $writer,
+                                        10);
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    }
+                } .Else {
+                    .Invoke (.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                        .Constant<Bond.BondDataType>(BT_LIST),
+                        $valueType)
+                }
+            } .Else {
+                .If ($keyType == .Constant<Bond.BondDataType>(BT_INT8)) {
+                    .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
+                        .Block() {
+                            .Call $writer.WriteContainerBegin(
+                                $count,
+                                .Constant<Bond.BondDataType>(BT_INT8),
+                                .Constant<Bond.BondDataType>(BT_LIST));
+                            .Loop  {
+                                .If ($count-- > 0) {
+                                    .Block() {
+                                        .Default(System.Void);
+                                        .Call $writer.WriteInt32((System.Int32).Call $reader.ReadInt8());
+                                        .Default(System.Void);
+                                        .Default(System.Void);
+                                        .Default(System.Void);
+                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
+                                            $reader,
+                                            $writer,
+                                            10);
+                                        .Default(System.Void)
+                                    }
+                                } .Else {
+                                    .Break end { }
+                                }
+                            }
+                            .LabelTarget end:;
+                            .Call $writer.WriteContainerEnd()
+                        }
+                    } .Else {
+                        .Invoke (.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                            .Constant<Bond.BondDataType>(BT_LIST),
+                            $valueType)
+                    }
+                } .Else {
+                    .Invoke (.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
+                        .Constant<Bond.BondDataType>(BT_INT32),
+                        $keyType)
+                }
+            }
+        };
+        .Call $reader.ReadContainerEnd()
+    }
+}
+
+.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>(
+    Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream] $r,
+    Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream] $w,
+    System.Int32 $i) {
+    .Invoke ((.Constant<ExpressionsTest.Transcoder`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]>(ExpressionsTest.Transcoder`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]).transcode)[$i])(
+        $r,
+        $w)
+}
+
+.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>(
+    Bond.BondDataType $e,
+    Bond.BondDataType $a) {
+    .Call Bond.Expressions.ThrowExpression.ThrowInvalidTypeException(
+        $e,
+        $a)
+}.Lambda #Lambda1<System.Action`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]>(
+    Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream] $reader,
+    Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream] $writer) {
+    .Block(
+        System.Int32 $count,
         Bond.BondDataType $keyType,
         Bond.BondDataType $valueType) {
         .Call $reader.ReadContainerBegin(
@@ -3708,199 +4873,6 @@
 }
 
 .Lambda #Lambda2<System.Action`2[Bond.BondDataType,Bond.BondDataType]>(
-    Bond.BondDataType $e,
-    Bond.BondDataType $a) {
-    .Call Bond.Expressions.ThrowExpression.ThrowInvalidTypeException(
-        $e,
-        $a)
-}.Lambda #Lambda1<System.Action`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]>(
-    Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream] $reader,
-    Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream] $writer) {
-    .Block(
-        System.Int32 $count,
-        Bond.BondDataType $elementType) {
-        .Call $reader.ReadContainerBegin(
-            $count,
-            $elementType);
-        .If ($elementType == .Constant<Bond.BondDataType>(BT_LIST)) {
-            .Block() {
-                .Call $writer.WriteContainerBegin(
-                    $count,
-                    .Constant<Bond.BondDataType>(BT_LIST));
-                .Loop  {
-                    .If ($count-- > 0) {
-                        .Block() {
-                            .Default(System.Void);
-                            .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
-                                $reader,
-                                $writer,
-                                10);
-                            .Default(System.Void)
-                        }
-                    } .Else {
-                        .Break end { }
-                    }
-                }
-                .LabelTarget end:;
-                .Call $writer.WriteContainerEnd()
-            }
-        } .Else {
-            .Invoke (.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
-                .Constant<Bond.BondDataType>(BT_LIST),
-                $elementType)
-        };
-        .Call $reader.ReadContainerEnd()
-    }
-}
-
-.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>(
-    Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream] $r,
-    Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream] $w,
-    System.Int32 $i) {
-    .Invoke ((.Constant<ExpressionsTest.Transcoder`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]>(ExpressionsTest.Transcoder`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]).transcode)[$i])(
-        $r,
-        $w)
-}
-
-.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>(
-    Bond.BondDataType $e,
-    Bond.BondDataType $a) {
-    .Call Bond.Expressions.ThrowExpression.ThrowInvalidTypeException(
-        $e,
-        $a)
-}.Lambda #Lambda1<System.Action`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]>(
-    Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream] $reader,
-    Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream] $writer) {
-    .Block(
-        System.Int32 $count,
-        Bond.BondDataType $keyType,
-        Bond.BondDataType $valueType) {
-        .Call $reader.ReadContainerBegin(
-            $count,
-            $keyType,
-            $valueType);
-        .If ($keyType == .Constant<Bond.BondDataType>(BT_INT32)) {
-            .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
-                .Block() {
-                    .Call $writer.WriteContainerBegin(
-                        $count,
-                        .Constant<Bond.BondDataType>(BT_INT32),
-                        .Constant<Bond.BondDataType>(BT_LIST));
-                    .Loop  {
-                        .If ($count-- > 0) {
-                            .Block() {
-                                .Default(System.Void);
-                                .Call $writer.WriteInt32(.Call $reader.ReadInt32());
-                                .Default(System.Void);
-                                .Default(System.Void);
-                                .Default(System.Void);
-                                .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
-                                    $reader,
-                                    $writer,
-                                    10);
-                                .Default(System.Void)
-                            }
-                        } .Else {
-                            .Break end { }
-                        }
-                    }
-                    .LabelTarget end:;
-                    .Call $writer.WriteContainerEnd()
-                }
-            } .Else {
-                .Invoke (.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
-                    .Constant<Bond.BondDataType>(BT_LIST),
-                    $valueType)
-            }
-        } .Else {
-            .If ($keyType == .Constant<Bond.BondDataType>(BT_INT16)) {
-                .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
-                    .Block() {
-                        .Call $writer.WriteContainerBegin(
-                            $count,
-                            .Constant<Bond.BondDataType>(BT_INT16),
-                            .Constant<Bond.BondDataType>(BT_LIST));
-                        .Loop  {
-                            .If ($count-- > 0) {
-                                .Block() {
-                                    .Default(System.Void);
-                                    .Call $writer.WriteInt32((System.Int32).Call $reader.ReadInt16());
-                                    .Default(System.Void);
-                                    .Default(System.Void);
-                                    .Default(System.Void);
-                                    .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
-                                        $reader,
-                                        $writer,
-                                        10);
-                                    .Default(System.Void)
-                                }
-                            } .Else {
-                                .Break end { }
-                            }
-                        }
-                        .LabelTarget end:;
-                        .Call $writer.WriteContainerEnd()
-                    }
-                } .Else {
-                    .Invoke (.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
-                        .Constant<Bond.BondDataType>(BT_LIST),
-                        $valueType)
-                }
-            } .Else {
-                .If ($keyType == .Constant<Bond.BondDataType>(BT_INT8)) {
-                    .If ($valueType == .Constant<Bond.BondDataType>(BT_LIST)) {
-                        .Block() {
-                            .Call $writer.WriteContainerBegin(
-                                $count,
-                                .Constant<Bond.BondDataType>(BT_INT8),
-                                .Constant<Bond.BondDataType>(BT_LIST));
-                            .Loop  {
-                                .If ($count-- > 0) {
-                                    .Block() {
-                                        .Default(System.Void);
-                                        .Call $writer.WriteInt32((System.Int32).Call $reader.ReadInt8());
-                                        .Default(System.Void);
-                                        .Default(System.Void);
-                                        .Default(System.Void);
-                                        .Invoke (.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>)(
-                                            $reader,
-                                            $writer,
-                                            10);
-                                        .Default(System.Void)
-                                    }
-                                } .Else {
-                                    .Break end { }
-                                }
-                            }
-                            .LabelTarget end:;
-                            .Call $writer.WriteContainerEnd()
-                        }
-                    } .Else {
-                        .Invoke (.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
-                            .Constant<Bond.BondDataType>(BT_LIST),
-                            $valueType)
-                    }
-                } .Else {
-                    .Invoke (.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>)(
-                        .Constant<Bond.BondDataType>(BT_INT32),
-                        $keyType)
-                }
-            }
-        };
-        .Call $reader.ReadContainerEnd()
-    }
-}
-
-.Lambda #Lambda2<System.Action`3[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream],System.Int32]>(
-    Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream] $r,
-    Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream] $w,
-    System.Int32 $i) {
-    .Invoke ((.Constant<ExpressionsTest.Transcoder`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]>(ExpressionsTest.Transcoder`2[Bond.Protocols.CompactBinaryReader`1[Bond.IO.Unsafe.InputStream],Bond.Protocols.SimpleBinaryWriter`1[Bond.IO.Unsafe.OutputStream]]).transcode)[$i])(
-        $r,
-        $w)
-}
-
-.Lambda #Lambda3<System.Action`2[Bond.BondDataType,Bond.BondDataType]>(
     Bond.BondDataType $e,
     Bond.BondDataType $a) {
     .Call Bond.Expressions.ThrowExpression.ThrowInvalidTypeException(

--- a/cs/test/expressions/TranscodeSPCB.expressions
+++ b/cs/test/expressions/TranscodeSPCB.expressions
@@ -422,6 +422,81 @@
                 .Call $writer.WriteFieldEnd()
             }
         };
+        .If (
+            .Call $reader.ReadFieldOmitted()
+        ) {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(70),
+                .Constant<Bond.Metadata>(_decimal))
+        } .Else {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(70),
+                    .Constant<Bond.Metadata>(_decimal));
+                .Block(System.Int32 $count) {
+                    $count = .Call $reader.ReadContainerBegin();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_INT8));
+                        .Call $writer.WriteBytes(.Call $reader.ReadBytes($count));
+                        .Call $writer.WriteContainerEnd()
+                    };
+                    .Call $reader.ReadContainerEnd()
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        };
+        .If (
+            .Call $reader.ReadFieldOmitted()
+        ) {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(71),
+                .Constant<Bond.Metadata>(_decList))
+        } .Else {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(71),
+                    .Constant<Bond.Metadata>(_decList));
+                .Block(System.Int32 $count) {
+                    $count = .Call $reader.ReadContainerBegin();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- > 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(System.Int32 $count) {
+                                        $count = .Call $reader.ReadContainerBegin();
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes(.Call $reader.ReadBytes($count));
+                                            .Call $writer.WriteContainerEnd()
+                                        };
+                                        .Call $reader.ReadContainerEnd()
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    };
+                    .Call $reader.ReadContainerEnd()
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        };
         .Call $writer.WriteStructEnd()
     }
 }

--- a/cs/test/expressions/TranscodeSPCB.expressions
+++ b/cs/test/expressions/TranscodeSPCB.expressions
@@ -497,6 +497,155 @@
                 .Call $writer.WriteFieldEnd()
             }
         };
+        .If (
+            .Call $reader.ReadFieldOmitted()
+        ) {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(72),
+                .Constant<Bond.Metadata>(_decVector))
+        } .Else {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(72),
+                    .Constant<Bond.Metadata>(_decVector));
+                .Block(System.Int32 $count) {
+                    $count = .Call $reader.ReadContainerBegin();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- > 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(System.Int32 $count) {
+                                        $count = .Call $reader.ReadContainerBegin();
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes(.Call $reader.ReadBytes($count));
+                                            .Call $writer.WriteContainerEnd()
+                                        };
+                                        .Call $reader.ReadContainerEnd()
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    };
+                    .Call $reader.ReadContainerEnd()
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        };
+        .If (
+            .Call $reader.ReadFieldOmitted()
+        ) {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_MAP),
+                .Constant<System.UInt16>(73),
+                .Constant<Bond.Metadata>(_decMap))
+        } .Else {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_MAP),
+                    .Constant<System.UInt16>(73),
+                    .Constant<Bond.Metadata>(_decMap));
+                .Block(System.Int32 $count) {
+                    $count = .Call $reader.ReadContainerBegin();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_INT32),
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- > 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Call $writer.WriteInt32(.Call $reader.ReadInt32());
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Block(System.Int32 $count) {
+                                        $count = .Call $reader.ReadContainerBegin();
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes(.Call $reader.ReadBytes($count));
+                                            .Call $writer.WriteContainerEnd()
+                                        };
+                                        .Call $reader.ReadContainerEnd()
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    };
+                    .Call $reader.ReadContainerEnd()
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        };
+        .If (
+            .Call $reader.ReadFieldOmitted()
+        ) {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(74),
+                .Constant<Bond.Metadata>(_decNullable))
+        } .Else {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(74),
+                    .Constant<Bond.Metadata>(_decNullable));
+                .Block(System.Int32 $count) {
+                    $count = .Call $reader.ReadContainerBegin();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- > 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(System.Int32 $count) {
+                                        $count = .Call $reader.ReadContainerBegin();
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes(.Call $reader.ReadBytes($count));
+                                            .Call $writer.WriteContainerEnd()
+                                        };
+                                        .Call $reader.ReadContainerEnd()
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    };
+                    .Call $reader.ReadContainerEnd()
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        };
         .Call $writer.WriteStructEnd()
     }
 }

--- a/cs/test/expressions/TranscodeSPCB.expressions
+++ b/cs/test/expressions/TranscodeSPCB.expressions
@@ -383,6 +383,203 @@
             .Call $reader.ReadFieldOmitted()
         ) {
             .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(51),
+                .Constant<Bond.Metadata>(_blobList))
+        } .Else {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(51),
+                    .Constant<Bond.Metadata>(_blobList));
+                .Block(System.Int32 $count) {
+                    $count = .Call $reader.ReadContainerBegin();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- > 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(System.Int32 $count) {
+                                        $count = .Call $reader.ReadContainerBegin();
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes(.Call $reader.ReadBytes($count));
+                                            .Call $writer.WriteContainerEnd()
+                                        };
+                                        .Call $reader.ReadContainerEnd()
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    };
+                    .Call $reader.ReadContainerEnd()
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        };
+        .If (
+            .Call $reader.ReadFieldOmitted()
+        ) {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(52),
+                .Constant<Bond.Metadata>(_blobVector))
+        } .Else {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(52),
+                    .Constant<Bond.Metadata>(_blobVector));
+                .Block(System.Int32 $count) {
+                    $count = .Call $reader.ReadContainerBegin();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- > 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(System.Int32 $count) {
+                                        $count = .Call $reader.ReadContainerBegin();
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes(.Call $reader.ReadBytes($count));
+                                            .Call $writer.WriteContainerEnd()
+                                        };
+                                        .Call $reader.ReadContainerEnd()
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    };
+                    .Call $reader.ReadContainerEnd()
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        };
+        .If (
+            .Call $reader.ReadFieldOmitted()
+        ) {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_MAP),
+                .Constant<System.UInt16>(53),
+                .Constant<Bond.Metadata>(_blobMap))
+        } .Else {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_MAP),
+                    .Constant<System.UInt16>(53),
+                    .Constant<Bond.Metadata>(_blobMap));
+                .Block(System.Int32 $count) {
+                    $count = .Call $reader.ReadContainerBegin();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_INT32),
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- > 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Call $writer.WriteInt32(.Call $reader.ReadInt32());
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Block(System.Int32 $count) {
+                                        $count = .Call $reader.ReadContainerBegin();
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes(.Call $reader.ReadBytes($count));
+                                            .Call $writer.WriteContainerEnd()
+                                        };
+                                        .Call $reader.ReadContainerEnd()
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    };
+                    .Call $reader.ReadContainerEnd()
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        };
+        .If (
+            .Call $reader.ReadFieldOmitted()
+        ) {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(54),
+                .Constant<Bond.Metadata>(_blobNullable))
+        } .Else {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(54),
+                    .Constant<Bond.Metadata>(_blobNullable));
+                .Block(System.Int32 $count) {
+                    $count = .Call $reader.ReadContainerBegin();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- > 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(System.Int32 $count) {
+                                        $count = .Call $reader.ReadContainerBegin();
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes(.Call $reader.ReadBytes($count));
+                                            .Call $writer.WriteContainerEnd()
+                                        };
+                                        .Call $reader.ReadContainerEnd()
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    };
+                    .Call $reader.ReadContainerEnd()
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        };
+        .If (
+            .Call $reader.ReadFieldOmitted()
+        ) {
+            .Call $writer.WriteFieldOmitted(
                 .Constant<Bond.BondDataType>(BT_MAP),
                 .Constant<System.UInt16>(60),
                 .Constant<Bond.Metadata>(_map))
@@ -611,6 +808,230 @@
                     .Constant<Bond.BondDataType>(BT_LIST),
                     .Constant<System.UInt16>(74),
                     .Constant<Bond.Metadata>(_decNullable));
+                .Block(System.Int32 $count) {
+                    $count = .Call $reader.ReadContainerBegin();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- > 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(System.Int32 $count) {
+                                        $count = .Call $reader.ReadContainerBegin();
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes(.Call $reader.ReadBytes($count));
+                                            .Call $writer.WriteContainerEnd()
+                                        };
+                                        .Call $reader.ReadContainerEnd()
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    };
+                    .Call $reader.ReadContainerEnd()
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        };
+        .If (
+            .Call $reader.ReadFieldOmitted()
+        ) {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(80),
+                .Constant<Bond.Metadata>(_reference))
+        } .Else {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(80),
+                    .Constant<Bond.Metadata>(_reference));
+                .Block(System.Int32 $count) {
+                    $count = .Call $reader.ReadContainerBegin();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_INT8));
+                        .Call $writer.WriteBytes(.Call $reader.ReadBytes($count));
+                        .Call $writer.WriteContainerEnd()
+                    };
+                    .Call $reader.ReadContainerEnd()
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        };
+        .If (
+            .Call $reader.ReadFieldOmitted()
+        ) {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(81),
+                .Constant<Bond.Metadata>(_refList))
+        } .Else {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(81),
+                    .Constant<Bond.Metadata>(_refList));
+                .Block(System.Int32 $count) {
+                    $count = .Call $reader.ReadContainerBegin();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- > 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(System.Int32 $count) {
+                                        $count = .Call $reader.ReadContainerBegin();
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes(.Call $reader.ReadBytes($count));
+                                            .Call $writer.WriteContainerEnd()
+                                        };
+                                        .Call $reader.ReadContainerEnd()
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    };
+                    .Call $reader.ReadContainerEnd()
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        };
+        .If (
+            .Call $reader.ReadFieldOmitted()
+        ) {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(82),
+                .Constant<Bond.Metadata>(_refVector))
+        } .Else {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(82),
+                    .Constant<Bond.Metadata>(_refVector));
+                .Block(System.Int32 $count) {
+                    $count = .Call $reader.ReadContainerBegin();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- > 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Block(System.Int32 $count) {
+                                        $count = .Call $reader.ReadContainerBegin();
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes(.Call $reader.ReadBytes($count));
+                                            .Call $writer.WriteContainerEnd()
+                                        };
+                                        .Call $reader.ReadContainerEnd()
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    };
+                    .Call $reader.ReadContainerEnd()
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        };
+        .If (
+            .Call $reader.ReadFieldOmitted()
+        ) {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_MAP),
+                .Constant<System.UInt16>(83),
+                .Constant<Bond.Metadata>(_refMap))
+        } .Else {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_MAP),
+                    .Constant<System.UInt16>(83),
+                    .Constant<Bond.Metadata>(_refMap));
+                .Block(System.Int32 $count) {
+                    $count = .Call $reader.ReadContainerBegin();
+                    .Block() {
+                        .Call $writer.WriteContainerBegin(
+                            $count,
+                            .Constant<Bond.BondDataType>(BT_INT32),
+                            .Constant<Bond.BondDataType>(BT_LIST));
+                        .Loop  {
+                            .If ($count-- > 0) {
+                                .Block() {
+                                    .Default(System.Void);
+                                    .Call $writer.WriteInt32(.Call $reader.ReadInt32());
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Default(System.Void);
+                                    .Block(System.Int32 $count) {
+                                        $count = .Call $reader.ReadContainerBegin();
+                                        .Block() {
+                                            .Call $writer.WriteContainerBegin(
+                                                $count,
+                                                .Constant<Bond.BondDataType>(BT_INT8));
+                                            .Call $writer.WriteBytes(.Call $reader.ReadBytes($count));
+                                            .Call $writer.WriteContainerEnd()
+                                        };
+                                        .Call $reader.ReadContainerEnd()
+                                    };
+                                    .Default(System.Void)
+                                }
+                            } .Else {
+                                .Break end { }
+                            }
+                        }
+                        .LabelTarget end:;
+                        .Call $writer.WriteContainerEnd()
+                    };
+                    .Call $reader.ReadContainerEnd()
+                };
+                .Call $writer.WriteFieldEnd()
+            }
+        };
+        .If (
+            .Call $reader.ReadFieldOmitted()
+        ) {
+            .Call $writer.WriteFieldOmitted(
+                .Constant<Bond.BondDataType>(BT_LIST),
+                .Constant<System.UInt16>(84),
+                .Constant<Bond.Metadata>(_refNullable))
+        } .Else {
+            .Block() {
+                .Call $writer.WriteFieldBegin(
+                    .Constant<Bond.BondDataType>(BT_LIST),
+                    .Constant<System.UInt16>(84),
+                    .Constant<Bond.Metadata>(_refNullable));
                 .Block(System.Int32 $count) {
                     $count = .Call $reader.ReadContainerBegin();
                     .Block() {

--- a/cs/test/expressions/schemas.bond
+++ b/cs/test/expressions/schemas.bond
@@ -13,6 +13,7 @@ struct Nested
 }
 
 using decimal = blob;
+using reference = blob;
 
 struct Example : Base
 {
@@ -27,10 +28,19 @@ struct Example : Base
     30: vector<int32> _int32Vector;
     40: list<Nested> _nestedVector;
     50: blob b;
+    51: list<blob> _blobList;
+    52: vector<blob> _blobVector;
+    53: map<int32, blob> _blobMap;
+    54: nullable<blob> _blobNullable;
     60: map<int32, double> _map;
     70: decimal _decimal;
     71: list<decimal> _decList;
     72: vector<decimal> _decVector;
     73: map<int32, decimal> _decMap;
     74: nullable<decimal> _decNullable;
+    80: reference _reference;
+    81: list<reference> _refList;
+    82: vector<reference> _refVector;
+    83: map<int32, reference> _refMap;
+    84: nullable<reference> _refNullable;
 };

--- a/cs/test/expressions/schemas.bond
+++ b/cs/test/expressions/schemas.bond
@@ -12,7 +12,7 @@ struct Nested
     0: double _double;
 }
 
-using decimal = int32;
+using decimal = blob;
 
 struct Example : Base
 {

--- a/cs/test/expressions/schemas.bond
+++ b/cs/test/expressions/schemas.bond
@@ -12,6 +12,8 @@ struct Nested
     0: double _double;
 }
 
+using decimal = blob;
+
 struct Example : Base
 {
      0: bool _bool;
@@ -26,4 +28,6 @@ struct Example : Base
     40: list<Nested> _nestedVector;
     50: blob b;
     60: map<int32, double> _map;
+    70: decimal _decimal;
+    71: list<decimal> _decList;
 };

--- a/cs/test/expressions/schemas.bond
+++ b/cs/test/expressions/schemas.bond
@@ -12,7 +12,7 @@ struct Nested
     0: double _double;
 }
 
-using decimal = blob;
+using decimal = int32;
 
 struct Example : Base
 {
@@ -30,4 +30,7 @@ struct Example : Base
     60: map<int32, double> _map;
     70: decimal _decimal;
     71: list<decimal> _decList;
+    72: vector<decimal> _decVector;
+    73: map<int32, decimal> _decMap;
+    74: nullable<decimal> _decNullable;
 };


### PR DESCRIPTION
There were extra conversions of aliased blobs during serialization. Now each blob is only converted once.

Also, updated the expressions tests to include aliased blobs.