### PR TITLE
[c++] Surround macro parameters with parenthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ different versioning scheme, following the Haskell community's
   generated-type's default constructor if it is used. The default
   constructor is now a templated constructor that is invokable with zero
   arguments.)
+* Fixed some macro uses that did not have sufficient parenthesis around
+  parameters and resulted in compiler errors.
 * Provide compile-time access to metadata about gRPC services and methods.
 * Using `bond::ext::gRPC::wait_callback` no longer causes a shared_ptr cycle
   and the resulting resource leak.

--- a/cpp/inc/bond/core/detail/mpl.h
+++ b/cpp/inc/bond/core/detail/mpl.h
@@ -11,6 +11,7 @@
 #include <boost/static_assert.hpp>
 #include <initializer_list>
 #include <type_traits>
+#include <utility>
 
 
 namespace bond

--- a/cpp/inc/bond/core/detail/mpl.h
+++ b/cpp/inc/bond/core/detail/mpl.h
@@ -16,7 +16,7 @@
 namespace bond
 {
 
-namespace detail {namespace mpl
+namespace detail { namespace mpl
 {
 
 template <typename T> struct
@@ -25,6 +25,12 @@ identity
     using type = T;
 };
 
+
+/// Always evaluates to false, but depends on T, so can be used when
+/// type-based always-false-ness is needed.
+template <typename T>
+struct always_false
+    : std::false_type {};
 
 /// @brief Represents a type list.
 template <typename... T> struct
@@ -115,6 +121,6 @@ inline auto try_apply(F&& f)
 }
 
 
-}} // namespace mpl {namespace detail
+}} // namespace mpl { namespace detail
 
 } // namespace bond

--- a/cpp/inc/bond/core/detail/mpl.h
+++ b/cpp/inc/bond/core/detail/mpl.h
@@ -109,7 +109,7 @@ inline auto try_apply(F&& f)
     -> decltype(try_apply(std::forward<F>(f), List{}))
 #endif
 {
-    BOOST_STATIC_ASSERT(!std::is_same<List, list<> >::value);
+    BOOST_STATIC_ASSERT((!std::is_same<List, list<> >::value));
 
     return try_apply(std::forward<F>(f), List{});
 }

--- a/cpp/inc/bond/core/traits.h
+++ b/cpp/inc/bond/core/traits.h
@@ -23,6 +23,8 @@
 #include <memory>
 #endif
 
+#include <utility>
+
 namespace bond
 {
 

--- a/cpp/inc/bond/core/traits.h
+++ b/cpp/inc/bond/core/traits.h
@@ -4,8 +4,9 @@
 #pragma once
 
 #include "config.h"
-#include "scalar_interface.h"
 #include "bond_fwd.h"
+#include "detail/mpl.h"
+#include "scalar_interface.h"
 #include <boost/type_traits/has_nothrow_copy.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/static_assert.hpp>
@@ -193,7 +194,9 @@ is_reader<Input, T, typename boost::enable_if<is_class<typename Input::Parser> >
 template <typename T> struct
 buffer_magic
 {
-    BOOST_STATIC_ASSERT_MSG((!is_same<T, T>::value), "Undefined buffer.");
+    BOOST_STATIC_ASSERT_MSG(
+        detail::mpl::always_false<T>::value,
+        "buffer_magic is undefined for this buffer. Make sure buffer_magic is specialized for this buffer type.");
 };
 
 template <typename T> struct

--- a/cpp/inc/bond/core/traits.h
+++ b/cpp/inc/bond/core/traits.h
@@ -193,7 +193,7 @@ is_reader<Input, T, typename boost::enable_if<is_class<typename Input::Parser> >
 template <typename T> struct
 buffer_magic
 {
-    BOOST_STATIC_ASSERT_MSG(!is_same<T, T>::value, "Undefined buffer.");
+    BOOST_STATIC_ASSERT_MSG((!is_same<T, T>::value), "Undefined buffer.");
 };
 
 template <typename T> struct

--- a/cpp/inc/bond/stream/stream_interface.h
+++ b/cpp/inc/bond/stream/stream_interface.h
@@ -4,21 +4,13 @@
 #pragma once
 
 #include <bond/core/blob.h>
+#include <bond/core/detail/mpl.h>
 #include <boost/static_assert.hpp>
 #include <type_traits>
 
 
 namespace bond
 {
-namespace detail
-{
-
-template <typename T>
-struct always_false
-    : std::false_type {};
-
-} // namespace detail
-
 
 //
 // input stream concept
@@ -58,7 +50,9 @@ public:
 template <typename InputBuffer>
 BOND_NORETURN inline blob GetCurrentBuffer(const InputBuffer& /*input*/)
 {
-    BOOST_STATIC_ASSERT_MSG(detail::always_false<InputBuffer>::value, "GetCurrentBuffer is undefined.");
+    BOOST_STATIC_ASSERT_MSG(
+        detail::mpl::always_false<InputBuffer>::value,
+        "GetCurrentBuffer is undefined.");
 }
 
 
@@ -71,7 +65,9 @@ BOND_NORETURN inline blob GetCurrentBuffer(const InputBuffer& /*input*/)
 template <typename Blob>
 BOND_NORETURN inline Blob GetBufferRange(const Blob& /*begin*/, const Blob& /*end*/)
 {
-    BOOST_STATIC_ASSERT_MSG(detail::always_false<Blob>::value, "GetBufferRange is undefined.");
+    BOOST_STATIC_ASSERT_MSG(
+        detail::mpl::always_false<Blob>::value,
+        "GetBufferRange is undefined.");
 }
 
 
@@ -109,7 +105,9 @@ public:
 template <typename OutputBuffer>
 BOND_NORETURN inline OutputBuffer CreateOutputBuffer(const OutputBuffer& /*other*/)
 {
-    BOOST_STATIC_ASSERT_MSG(detail::always_false<OutputBuffer>::value, "CreateOutputBuffer is undefined.");
+    BOOST_STATIC_ASSERT_MSG(
+        detail::mpl::always_false<OutputBuffer>::value,
+        "CreateOutputBuffer is undefined.");
 }
 
 

--- a/cpp/test/core/numeric_conversions.h
+++ b/cpp/test/core/numeric_conversions.h
@@ -94,7 +94,7 @@ struct NumericConverterFail
     template <typename Num2>
     void operator()(const Num2&)
     {
-        BOOST_STATIC_ASSERT(!(bond::is_matching_basic<Num1, Num2>::value));
+        BOOST_STATIC_ASSERT((!bond::is_matching_basic<Num1, Num2>::value));
         BOOST_STATIC_ASSERT(boost::is_arithmetic<Num1>::value || boost::is_enum<Num1>::value);
         BOOST_STATIC_ASSERT(boost::is_arithmetic<Num2>::value || boost::is_enum<Num2>::value);
 


### PR DESCRIPTION
Macro parameters with commas in them, like "std::map<int, std::string>"
need to be surrounded with parenthesis so they are treated as one
parameter instead of as two parameters to the macro.

Standardize where the ! is in parthensized parameters.