### PR TITLE
java core: Implement j.io.Serializable for concrete types.

### DIFF
--- a/compiler/src/Language/Bond/Codegen/Java/Class_java.hs
+++ b/compiler/src/Language/Bond/Codegen/Java/Class_java.hs
@@ -494,7 +494,7 @@ javaNativeSerializationGlue declName = [lt|
     @Override
     public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
         final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
-        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 1);
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
@@ -506,7 +506,7 @@ javaNativeSerializationGlue declName = [lt|
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
-        final int bytesRead = in.read(marshalled);
+        in.readFully(marshalled);
 
         final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
         this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();

--- a/compiler/src/Language/Bond/Codegen/Java/Class_java.hs
+++ b/compiler/src/Language/Bond/Codegen/Java/Class_java.hs
@@ -498,12 +498,14 @@ javaNativeSerializationGlue declName = [lt|
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
+        out.write(0);   // This type is not generic and has zero type parameters.
         out.writeInt(marshalled.length);
         out.write(marshalled);
     }
 
     @Override
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        if (!(in.read() == 0)) throw new java.io.IOException("type is not generic, but serialized data has type parameters.");
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
         in.readFully(marshalled);

--- a/compiler/src/Language/Bond/Codegen/Java/Class_java.hs
+++ b/compiler/src/Language/Bond/Codegen/Java/Class_java.hs
@@ -505,7 +505,7 @@ javaNativeSerializationGlue declName = [lt|
 
     @Override
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
-        if (!(in.read() == 0)) throw new java.io.IOException("type is not generic, but serialized data has type parameters.");
+        if (in.read() != 0) throw new java.io.IOException("type is not generic, but serialized data has type parameters.");
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
         in.readFully(marshalled);

--- a/compiler/src/Language/Bond/Codegen/Java/Class_java.hs
+++ b/compiler/src/Language/Bond/Codegen/Java/Class_java.hs
@@ -473,6 +473,70 @@ object_hashCode fields structBase = [lt|@Override
         hashCode _ f          = [lt|#{f} == null ? 0 : #{f}.hashCode()|]
 
 
+-- We implement Externalizable, rather than Serializable, so that
+-- ser/deserialization will result in a single call on the most derived class,
+-- rather than one call for each type in the inheritance chain. By reading into
+-- a byte[] instead of trying to deserialize from the ObjectInput{,Stream} we're
+-- passed, we can start from a ByteArrayInputStream, which we already know how
+-- to clone for Bonded fields.
+--
+-- We write the length of the serialized data because we can't assume the
+-- ObjectInput{,Stream} actually ends after the object we care about.
+--
+-- serialVersionUID is always 0 so that Java will always delegate compatibility
+-- checking of serialized data against current deserialization code to us.
+javaNativeSerializationGlue :: String -> Text
+javaNativeSerializationGlue declName = [lt|
+    // Java native serialization
+    private static final long serialVersionUID = 0L;
+    private #{declName} __deserializedInstance;
+
+    @Override
+    public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
+        final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        org.bondlib.Marshal.marshal(this, writer);
+
+        final byte[] marshalled = outStream.toByteArray();
+        out.writeInt(marshalled.length);
+        out.write(marshalled);
+    }
+
+    @Override
+    public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        final int marshalledLength = in.readInt();
+        final byte[] marshalled = new byte[marshalledLength];
+        final int bytesRead = in.read(marshalled);
+
+        final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
+        this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();
+    }
+
+    private Object readResolve() throws java.io.ObjectStreamException {
+        return this.__deserializedInstance;
+    }
+    // end Java native serialization
+    |]
+
+
+javaNativeSerializationUnimpl :: Text
+javaNativeSerializationUnimpl = [lt|
+    // Java native serialization
+    @Override
+    public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
+        throw new java.lang.IllegalArgumentException("java.io.Serializable support is not implemented for generic types");
+    }
+
+    @Override
+    public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        // This may actually fail before reaching this line with an InvalidClassException because
+        // generic types don't have the nullary constructor required by the Java serialization
+        // framework.
+        throw new java.lang.IllegalArgumentException("java.io.Serializable support is not implemented for generic types");
+    }
+    // end Java native serialization
+    |]
+
 -- Template for struct -> Java class.
 class_java :: MappingContext -> [Import] -> Declaration -> Text
 class_java java _ declaration = [lt|
@@ -534,6 +598,8 @@ public class #{typeNameWithParams declName declParams}#{maybe interface baseClas
         initializeBondType();
     }
     #{bondTypeDescriptorInstanceVariableDecl}
+
+    #{ifThenElse (null declParams) (javaNativeSerializationGlue declName) javaNativeSerializationUnimpl}
 
     #{doubleLineSep 1 publicFieldDecl structFields}
     #{publicConstructorDecl}

--- a/compiler/tests/generated/aliases_concatenated.java
+++ b/compiler/tests/generated/aliases_concatenated.java
@@ -138,6 +138,23 @@ public class Foo<T> implements org.bondlib.BondSerializable {
     }
     private final StructBondTypeImpl<T> __genericType;
 
+    
+    // Java native serialization
+    @Override
+    public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
+        throw new java.lang.IllegalArgumentException("java.io.Serializable support is not implemented for generic types");
+    }
+
+    @Override
+    public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        // This may actually fail before reaching this line with an InvalidClassException because
+        // generic types don't have the nullary constructor required by the Java serialization
+        // framework.
+        throw new java.lang.IllegalArgumentException("java.io.Serializable support is not implemented for generic types");
+    }
+    // end Java native serialization
+    
+
     public java.util.List<java.util.List<T>> aa;
     
 public Foo(org.bondlib.StructBondType<Foo<T>> genericType) {
@@ -355,6 +372,38 @@ public class WrappingAnEnum implements org.bondlib.BondSerializable {
     static {
         initializeBondType();
     }
+    
+
+    
+    // Java native serialization
+    private static final long serialVersionUID = 0L;
+    private WrappingAnEnum __deserializedInstance;
+
+    @Override
+    public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
+        final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        org.bondlib.Marshal.marshal(this, writer);
+
+        final byte[] marshalled = outStream.toByteArray();
+        out.writeInt(marshalled.length);
+        out.write(marshalled);
+    }
+
+    @Override
+    public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        final int marshalledLength = in.readInt();
+        final byte[] marshalled = new byte[marshalledLength];
+        final int bytesRead = in.read(marshalled);
+
+        final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
+        this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();
+    }
+
+    private Object readResolve() throws java.io.ObjectStreamException {
+        return this.__deserializedInstance;
+    }
+    // end Java native serialization
     
 
     public tests.EnumToWrap aWrappedEnum;

--- a/compiler/tests/generated/aliases_concatenated.java
+++ b/compiler/tests/generated/aliases_concatenated.java
@@ -382,7 +382,7 @@ public class WrappingAnEnum implements org.bondlib.BondSerializable {
     @Override
     public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
         final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
-        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 1);
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
@@ -394,7 +394,7 @@ public class WrappingAnEnum implements org.bondlib.BondSerializable {
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
-        final int bytesRead = in.read(marshalled);
+        in.readFully(marshalled);
 
         final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
         this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();

--- a/compiler/tests/generated/aliases_concatenated.java
+++ b/compiler/tests/generated/aliases_concatenated.java
@@ -386,12 +386,14 @@ public class WrappingAnEnum implements org.bondlib.BondSerializable {
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
+        out.write(0);   // This type is not generic and has zero type parameters.
         out.writeInt(marshalled.length);
         out.write(marshalled);
     }
 
     @Override
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        if (in.read() != 0) throw new java.io.IOException("type is not generic, but serialized data has type parameters.");
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
         in.readFully(marshalled);

--- a/compiler/tests/generated/attributes_concatenated.java
+++ b/compiler/tests/generated/attributes_concatenated.java
@@ -194,7 +194,7 @@ public class Foo implements org.bondlib.BondSerializable {
     @Override
     public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
         final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
-        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 1);
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
@@ -206,7 +206,7 @@ public class Foo implements org.bondlib.BondSerializable {
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
-        final int bytesRead = in.read(marshalled);
+        in.readFully(marshalled);
 
         final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
         this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();

--- a/compiler/tests/generated/attributes_concatenated.java
+++ b/compiler/tests/generated/attributes_concatenated.java
@@ -198,12 +198,14 @@ public class Foo implements org.bondlib.BondSerializable {
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
+        out.write(0);   // This type is not generic and has zero type parameters.
         out.writeInt(marshalled.length);
         out.write(marshalled);
     }
 
     @Override
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        if (in.read() != 0) throw new java.io.IOException("type is not generic, but serialized data has type parameters.");
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
         in.readFully(marshalled);

--- a/compiler/tests/generated/attributes_concatenated.java
+++ b/compiler/tests/generated/attributes_concatenated.java
@@ -186,6 +186,38 @@ public class Foo implements org.bondlib.BondSerializable {
     }
     
 
+    
+    // Java native serialization
+    private static final long serialVersionUID = 0L;
+    private Foo __deserializedInstance;
+
+    @Override
+    public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
+        final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        org.bondlib.Marshal.marshal(this, writer);
+
+        final byte[] marshalled = outStream.toByteArray();
+        out.writeInt(marshalled.length);
+        out.write(marshalled);
+    }
+
+    @Override
+    public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        final int marshalledLength = in.readInt();
+        final byte[] marshalled = new byte[marshalledLength];
+        final int bytesRead = in.read(marshalled);
+
+        final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
+        this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();
+    }
+
+    private Object readResolve() throws java.io.ObjectStreamException {
+        return this.__deserializedInstance;
+    }
+    // end Java native serialization
+    
+
     public java.lang.String f;
     
     public Foo() {

--- a/compiler/tests/generated/basic_types_concatenated.java
+++ b/compiler/tests/generated/basic_types_concatenated.java
@@ -358,7 +358,7 @@ public class BasicTypes implements org.bondlib.BondSerializable {
     @Override
     public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
         final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
-        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 1);
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
@@ -370,7 +370,7 @@ public class BasicTypes implements org.bondlib.BondSerializable {
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
-        final int bytesRead = in.read(marshalled);
+        in.readFully(marshalled);
 
         final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
         this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();

--- a/compiler/tests/generated/basic_types_concatenated.java
+++ b/compiler/tests/generated/basic_types_concatenated.java
@@ -350,6 +350,38 @@ public class BasicTypes implements org.bondlib.BondSerializable {
     }
     
 
+    
+    // Java native serialization
+    private static final long serialVersionUID = 0L;
+    private BasicTypes __deserializedInstance;
+
+    @Override
+    public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
+        final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        org.bondlib.Marshal.marshal(this, writer);
+
+        final byte[] marshalled = outStream.toByteArray();
+        out.writeInt(marshalled.length);
+        out.write(marshalled);
+    }
+
+    @Override
+    public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        final int marshalledLength = in.readInt();
+        final byte[] marshalled = new byte[marshalledLength];
+        final int bytesRead = in.read(marshalled);
+
+        final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
+        this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();
+    }
+
+    private Object readResolve() throws java.io.ObjectStreamException {
+        return this.__deserializedInstance;
+    }
+    // end Java native serialization
+    
+
     public boolean _bool;
 
     public java.lang.String _str;

--- a/compiler/tests/generated/basic_types_concatenated.java
+++ b/compiler/tests/generated/basic_types_concatenated.java
@@ -362,12 +362,14 @@ public class BasicTypes implements org.bondlib.BondSerializable {
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
+        out.write(0);   // This type is not generic and has zero type parameters.
         out.writeInt(marshalled.length);
         out.write(marshalled);
     }
 
     @Override
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        if (in.read() != 0) throw new java.io.IOException("type is not generic, but serialized data has type parameters.");
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
         in.readFully(marshalled);

--- a/compiler/tests/generated/basic_types_nsmapped_concatenated.java
+++ b/compiler/tests/generated/basic_types_nsmapped_concatenated.java
@@ -358,7 +358,7 @@ public class BasicTypes implements org.bondlib.BondSerializable {
     @Override
     public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
         final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
-        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 1);
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
@@ -370,7 +370,7 @@ public class BasicTypes implements org.bondlib.BondSerializable {
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
-        final int bytesRead = in.read(marshalled);
+        in.readFully(marshalled);
 
         final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
         this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();

--- a/compiler/tests/generated/basic_types_nsmapped_concatenated.java
+++ b/compiler/tests/generated/basic_types_nsmapped_concatenated.java
@@ -350,6 +350,38 @@ public class BasicTypes implements org.bondlib.BondSerializable {
     }
     
 
+    
+    // Java native serialization
+    private static final long serialVersionUID = 0L;
+    private BasicTypes __deserializedInstance;
+
+    @Override
+    public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
+        final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        org.bondlib.Marshal.marshal(this, writer);
+
+        final byte[] marshalled = outStream.toByteArray();
+        out.writeInt(marshalled.length);
+        out.write(marshalled);
+    }
+
+    @Override
+    public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        final int marshalledLength = in.readInt();
+        final byte[] marshalled = new byte[marshalledLength];
+        final int bytesRead = in.read(marshalled);
+
+        final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
+        this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();
+    }
+
+    private Object readResolve() throws java.io.ObjectStreamException {
+        return this.__deserializedInstance;
+    }
+    // end Java native serialization
+    
+
     public boolean _bool;
 
     public java.lang.String _str;

--- a/compiler/tests/generated/basic_types_nsmapped_concatenated.java
+++ b/compiler/tests/generated/basic_types_nsmapped_concatenated.java
@@ -362,12 +362,14 @@ public class BasicTypes implements org.bondlib.BondSerializable {
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
+        out.write(0);   // This type is not generic and has zero type parameters.
         out.writeInt(marshalled.length);
         out.write(marshalled);
     }
 
     @Override
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        if (in.read() != 0) throw new java.io.IOException("type is not generic, but serialized data has type parameters.");
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
         in.readFully(marshalled);

--- a/compiler/tests/generated/bond_meta_concatenated.java
+++ b/compiler/tests/generated/bond_meta_concatenated.java
@@ -146,12 +146,14 @@ public class HasMetaFields implements org.bondlib.BondSerializable {
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
+        out.write(0);   // This type is not generic and has zero type parameters.
         out.writeInt(marshalled.length);
         out.write(marshalled);
     }
 
     @Override
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        if (in.read() != 0) throw new java.io.IOException("type is not generic, but serialized data has type parameters.");
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
         in.readFully(marshalled);

--- a/compiler/tests/generated/bond_meta_concatenated.java
+++ b/compiler/tests/generated/bond_meta_concatenated.java
@@ -142,7 +142,7 @@ public class HasMetaFields implements org.bondlib.BondSerializable {
     @Override
     public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
         final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
-        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 1);
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
@@ -154,7 +154,7 @@ public class HasMetaFields implements org.bondlib.BondSerializable {
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
-        final int bytesRead = in.read(marshalled);
+        in.readFully(marshalled);
 
         final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
         this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();

--- a/compiler/tests/generated/bond_meta_concatenated.java
+++ b/compiler/tests/generated/bond_meta_concatenated.java
@@ -134,6 +134,38 @@ public class HasMetaFields implements org.bondlib.BondSerializable {
     }
     
 
+    
+    // Java native serialization
+    private static final long serialVersionUID = 0L;
+    private HasMetaFields __deserializedInstance;
+
+    @Override
+    public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
+        final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        org.bondlib.Marshal.marshal(this, writer);
+
+        final byte[] marshalled = outStream.toByteArray();
+        out.writeInt(marshalled.length);
+        out.write(marshalled);
+    }
+
+    @Override
+    public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        final int marshalledLength = in.readInt();
+        final byte[] marshalled = new byte[marshalledLength];
+        final int bytesRead = in.read(marshalled);
+
+        final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
+        this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();
+    }
+
+    private Object readResolve() throws java.io.ObjectStreamException {
+        return this.__deserializedInstance;
+    }
+    // end Java native serialization
+    
+
     public java.lang.String full_name;
 
     public java.lang.String name;

--- a/compiler/tests/generated/complex_types_concatenated.java
+++ b/compiler/tests/generated/complex_types_concatenated.java
@@ -108,7 +108,7 @@ public class Foo implements org.bondlib.BondSerializable {
     @Override
     public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
         final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
-        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 1);
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
@@ -120,7 +120,7 @@ public class Foo implements org.bondlib.BondSerializable {
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
-        final int bytesRead = in.read(marshalled);
+        in.readFully(marshalled);
 
         final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
         this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();
@@ -394,7 +394,7 @@ public class ComplexTypes implements org.bondlib.BondSerializable {
     @Override
     public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
         final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
-        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 1);
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
@@ -406,7 +406,7 @@ public class ComplexTypes implements org.bondlib.BondSerializable {
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
-        final int bytesRead = in.read(marshalled);
+        in.readFully(marshalled);
 
         final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
         this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();

--- a/compiler/tests/generated/complex_types_concatenated.java
+++ b/compiler/tests/generated/complex_types_concatenated.java
@@ -101,6 +101,38 @@ public class Foo implements org.bondlib.BondSerializable {
     
 
     
+    // Java native serialization
+    private static final long serialVersionUID = 0L;
+    private Foo __deserializedInstance;
+
+    @Override
+    public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
+        final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        org.bondlib.Marshal.marshal(this, writer);
+
+        final byte[] marshalled = outStream.toByteArray();
+        out.writeInt(marshalled.length);
+        out.write(marshalled);
+    }
+
+    @Override
+    public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        final int marshalledLength = in.readInt();
+        final byte[] marshalled = new byte[marshalledLength];
+        final int bytesRead = in.read(marshalled);
+
+        final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
+        this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();
+    }
+
+    private Object readResolve() throws java.io.ObjectStreamException {
+        return this.__deserializedInstance;
+    }
+    // end Java native serialization
+    
+
+    
     
     public Foo() {
         super();
@@ -352,6 +384,38 @@ public class ComplexTypes implements org.bondlib.BondSerializable {
     static {
         initializeBondType();
     }
+    
+
+    
+    // Java native serialization
+    private static final long serialVersionUID = 0L;
+    private ComplexTypes __deserializedInstance;
+
+    @Override
+    public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
+        final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        org.bondlib.Marshal.marshal(this, writer);
+
+        final byte[] marshalled = outStream.toByteArray();
+        out.writeInt(marshalled.length);
+        out.write(marshalled);
+    }
+
+    @Override
+    public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        final int marshalledLength = in.readInt();
+        final byte[] marshalled = new byte[marshalledLength];
+        final int bytesRead = in.read(marshalled);
+
+        final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
+        this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();
+    }
+
+    private Object readResolve() throws java.io.ObjectStreamException {
+        return this.__deserializedInstance;
+    }
+    // end Java native serialization
     
 
     public java.util.List<java.lang.Byte> li8;

--- a/compiler/tests/generated/complex_types_concatenated.java
+++ b/compiler/tests/generated/complex_types_concatenated.java
@@ -112,12 +112,14 @@ public class Foo implements org.bondlib.BondSerializable {
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
+        out.write(0);   // This type is not generic and has zero type parameters.
         out.writeInt(marshalled.length);
         out.write(marshalled);
     }
 
     @Override
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        if (in.read() != 0) throw new java.io.IOException("type is not generic, but serialized data has type parameters.");
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
         in.readFully(marshalled);
@@ -398,12 +400,14 @@ public class ComplexTypes implements org.bondlib.BondSerializable {
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
+        out.write(0);   // This type is not generic and has zero type parameters.
         out.writeInt(marshalled.length);
         out.write(marshalled);
     }
 
     @Override
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        if (in.read() != 0) throw new java.io.IOException("type is not generic, but serialized data has type parameters.");
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
         in.readFully(marshalled);

--- a/compiler/tests/generated/defaults_concatenated.java
+++ b/compiler/tests/generated/defaults_concatenated.java
@@ -872,7 +872,7 @@ public class Foo implements org.bondlib.BondSerializable {
     @Override
     public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
         final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
-        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 1);
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
@@ -884,7 +884,7 @@ public class Foo implements org.bondlib.BondSerializable {
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
-        final int bytesRead = in.read(marshalled);
+        in.readFully(marshalled);
 
         final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
         this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();

--- a/compiler/tests/generated/defaults_concatenated.java
+++ b/compiler/tests/generated/defaults_concatenated.java
@@ -876,12 +876,14 @@ public class Foo implements org.bondlib.BondSerializable {
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
+        out.write(0);   // This type is not generic and has zero type parameters.
         out.writeInt(marshalled.length);
         out.write(marshalled);
     }
 
     @Override
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        if (in.read() != 0) throw new java.io.IOException("type is not generic, but serialized data has type parameters.");
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
         in.readFully(marshalled);

--- a/compiler/tests/generated/defaults_concatenated.java
+++ b/compiler/tests/generated/defaults_concatenated.java
@@ -864,6 +864,38 @@ public class Foo implements org.bondlib.BondSerializable {
     }
     
 
+    
+    // Java native serialization
+    private static final long serialVersionUID = 0L;
+    private Foo __deserializedInstance;
+
+    @Override
+    public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
+        final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        org.bondlib.Marshal.marshal(this, writer);
+
+        final byte[] marshalled = outStream.toByteArray();
+        out.writeInt(marshalled.length);
+        out.write(marshalled);
+    }
+
+    @Override
+    public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        final int marshalledLength = in.readInt();
+        final byte[] marshalled = new byte[marshalledLength];
+        final int bytesRead = in.read(marshalled);
+
+        final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
+        this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();
+    }
+
+    private Object readResolve() throws java.io.ObjectStreamException {
+        return this.__deserializedInstance;
+    }
+    // end Java native serialization
+    
+
     public boolean m_bool_1;
 
     public boolean m_bool_2;

--- a/compiler/tests/generated/field_modifiers_concatenated.java
+++ b/compiler/tests/generated/field_modifiers_concatenated.java
@@ -164,12 +164,14 @@ public class Foo implements org.bondlib.BondSerializable {
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
+        out.write(0);   // This type is not generic and has zero type parameters.
         out.writeInt(marshalled.length);
         out.write(marshalled);
     }
 
     @Override
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        if (in.read() != 0) throw new java.io.IOException("type is not generic, but serialized data has type parameters.");
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
         in.readFully(marshalled);

--- a/compiler/tests/generated/field_modifiers_concatenated.java
+++ b/compiler/tests/generated/field_modifiers_concatenated.java
@@ -160,7 +160,7 @@ public class Foo implements org.bondlib.BondSerializable {
     @Override
     public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
         final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
-        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 1);
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
@@ -172,7 +172,7 @@ public class Foo implements org.bondlib.BondSerializable {
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
-        final int bytesRead = in.read(marshalled);
+        in.readFully(marshalled);
 
         final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
         this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();

--- a/compiler/tests/generated/field_modifiers_concatenated.java
+++ b/compiler/tests/generated/field_modifiers_concatenated.java
@@ -152,6 +152,38 @@ public class Foo implements org.bondlib.BondSerializable {
     }
     
 
+    
+    // Java native serialization
+    private static final long serialVersionUID = 0L;
+    private Foo __deserializedInstance;
+
+    @Override
+    public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
+        final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        org.bondlib.Marshal.marshal(this, writer);
+
+        final byte[] marshalled = outStream.toByteArray();
+        out.writeInt(marshalled.length);
+        out.write(marshalled);
+    }
+
+    @Override
+    public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        final int marshalledLength = in.readInt();
+        final byte[] marshalled = new byte[marshalledLength];
+        final int bytesRead = in.read(marshalled);
+
+        final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
+        this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();
+    }
+
+    private Object readResolve() throws java.io.ObjectStreamException {
+        return this.__deserializedInstance;
+    }
+    // end Java native serialization
+    
+
     public boolean o;
 
     public short r;

--- a/compiler/tests/generated/generics_concatenated.java
+++ b/compiler/tests/generated/generics_concatenated.java
@@ -158,6 +158,23 @@ public class Foo<T1, T2> implements org.bondlib.BondSerializable {
     }
     private final StructBondTypeImpl<T1, T2> __genericType;
 
+    
+    // Java native serialization
+    @Override
+    public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
+        throw new java.lang.IllegalArgumentException("java.io.Serializable support is not implemented for generic types");
+    }
+
+    @Override
+    public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        // This may actually fail before reaching this line with an InvalidClassException because
+        // generic types don't have the nullary constructor required by the Java serialization
+        // framework.
+        throw new java.lang.IllegalArgumentException("java.io.Serializable support is not implemented for generic types");
+    }
+    // end Java native serialization
+    
+
     public T2 t2;
 
     public tests.Foo<T1, java.lang.Boolean> n;

--- a/compiler/tests/generated/inheritance_concatenated.java
+++ b/compiler/tests/generated/inheritance_concatenated.java
@@ -128,12 +128,14 @@ public class Base implements org.bondlib.BondSerializable {
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
+        out.write(0);   // This type is not generic and has zero type parameters.
         out.writeInt(marshalled.length);
         out.write(marshalled);
     }
 
     @Override
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        if (in.read() != 0) throw new java.io.IOException("type is not generic, but serialized data has type parameters.");
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
         in.readFully(marshalled);
@@ -308,12 +310,14 @@ public class Foo extends tests.Base {
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
+        out.write(0);   // This type is not generic and has zero type parameters.
         out.writeInt(marshalled.length);
         out.write(marshalled);
     }
 
     @Override
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        if (in.read() != 0) throw new java.io.IOException("type is not generic, but serialized data has type parameters.");
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
         in.readFully(marshalled);

--- a/compiler/tests/generated/inheritance_concatenated.java
+++ b/compiler/tests/generated/inheritance_concatenated.java
@@ -124,7 +124,7 @@ public class Base implements org.bondlib.BondSerializable {
     @Override
     public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
         final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
-        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 1);
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
@@ -136,7 +136,7 @@ public class Base implements org.bondlib.BondSerializable {
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
-        final int bytesRead = in.read(marshalled);
+        in.readFully(marshalled);
 
         final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
         this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();
@@ -304,7 +304,7 @@ public class Foo extends tests.Base {
     @Override
     public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
         final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
-        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 1);
         org.bondlib.Marshal.marshal(this, writer);
 
         final byte[] marshalled = outStream.toByteArray();
@@ -316,7 +316,7 @@ public class Foo extends tests.Base {
     public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
         final int marshalledLength = in.readInt();
         final byte[] marshalled = new byte[marshalledLength];
-        final int bytesRead = in.read(marshalled);
+        in.readFully(marshalled);
 
         final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
         this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();

--- a/compiler/tests/generated/inheritance_concatenated.java
+++ b/compiler/tests/generated/inheritance_concatenated.java
@@ -116,6 +116,38 @@ public class Base implements org.bondlib.BondSerializable {
     }
     
 
+    
+    // Java native serialization
+    private static final long serialVersionUID = 0L;
+    private Base __deserializedInstance;
+
+    @Override
+    public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
+        final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        org.bondlib.Marshal.marshal(this, writer);
+
+        final byte[] marshalled = outStream.toByteArray();
+        out.writeInt(marshalled.length);
+        out.write(marshalled);
+    }
+
+    @Override
+    public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        final int marshalledLength = in.readInt();
+        final byte[] marshalled = new byte[marshalledLength];
+        final int bytesRead = in.read(marshalled);
+
+        final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
+        this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();
+    }
+
+    private Object readResolve() throws java.io.ObjectStreamException {
+        return this.__deserializedInstance;
+    }
+    // end Java native serialization
+    
+
     public int x;
     
     public Base() {
@@ -262,6 +294,38 @@ public class Foo extends tests.Base {
     static {
         initializeBondType();
     }
+    
+
+    
+    // Java native serialization
+    private static final long serialVersionUID = 0L;
+    private Foo __deserializedInstance;
+
+    @Override
+    public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
+        final java.io.ByteArrayOutputStream outStream = new java.io.ByteArrayOutputStream();
+        final org.bondlib.ProtocolWriter writer = new org.bondlib.CompactBinaryWriter(outStream, 2);
+        org.bondlib.Marshal.marshal(this, writer);
+
+        final byte[] marshalled = outStream.toByteArray();
+        out.writeInt(marshalled.length);
+        out.write(marshalled);
+    }
+
+    @Override
+    public void readExternal(java.io.ObjectInput in) throws java.io.IOException, java.lang.ClassNotFoundException {
+        final int marshalledLength = in.readInt();
+        final byte[] marshalled = new byte[marshalledLength];
+        final int bytesRead = in.read(marshalled);
+
+        final java.io.ByteArrayInputStream inStream = new java.io.ByteArrayInputStream(marshalled);
+        this.__deserializedInstance = org.bondlib.Unmarshal.unmarshal(inStream, getBondType()).deserialize();
+    }
+
+    private Object readResolve() throws java.io.ObjectStreamException {
+        return this.__deserializedInstance;
+    }
+    // end Java native serialization
     
 
     public int x;

--- a/java/core/src/main/java/org/bondlib/BondSerializable.java
+++ b/java/core/src/main/java/org/bondlib/BondSerializable.java
@@ -3,11 +3,13 @@
 
 package org.bondlib;
 
+import java.io.Externalizable;
+
 /**
  * Denotes a Bond struct type.
  * All generated Bond struct classes implement this interface.
  */
-public interface BondSerializable {
+public interface BondSerializable extends Externalizable {
 
     /**
      * Returns the {@link BondType} type descriptor for the current struct type.

--- a/java/core/src/test/bond/generic.bond
+++ b/java/core/src/test/bond/generic.bond
@@ -1,3 +1,5 @@
+import "common.bond"
+
 namespace org.bondlib.test
 
 struct GenericValueContainer<T> {
@@ -50,4 +52,8 @@ struct GenericContainerOfContainersForCollections<T> {
     1: GenericNullableContainer<T> nullableContainer;
     2: GenericVectorContainer<T> vectorContainer;
     3: GenericListContainer<T> listContainer;
+}
+
+struct ConcreteWithGenericField {
+    0: GenericValueContainer<Base> concreteContainerField;
 }

--- a/java/core/src/test/java/org/bondlib/JavaNativeSerializationTests.java
+++ b/java/core/src/test/java/org/bondlib/JavaNativeSerializationTests.java
@@ -1,0 +1,90 @@
+package org.bondlib;
+
+import org.bondlib.test.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.*;
+
+public class JavaNativeSerializationTests {
+    private ByteArrayOutputStream baos;
+    private ObjectOutputStream oos;
+
+    @Before
+    public void setup() throws IOException {
+        this.baos = new ByteArrayOutputStream();
+        this.oos = new ObjectOutputStream(baos);
+    }
+
+    @Test
+    public void generatedTypesAreExternalizable() {
+        //noinspection ConstantConditions
+        Assert.assertTrue(new Base() instanceof Externalizable);
+    }
+
+    @Test
+    public void simple() throws IOException, ClassNotFoundException {
+        final Base baseIn = new Base();
+        baseIn.baseInt = 1;
+        oos.writeObject(baseIn);
+
+        final ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
+        final Base baseOut = (Base) ois.readObject();
+        Assert.assertEquals(baseIn, baseOut);
+    }
+
+    @Test
+    public void inheritance() throws IOException, ClassNotFoundException {
+        final Derived derivedIn = new Derived();
+        derivedIn.baseInt = 1;
+        derivedIn.derivedInt = 2;
+        oos.writeObject(derivedIn);
+
+        final ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
+        final Derived derivedOut = (Derived) ois.readObject();
+        Assert.assertEquals(derivedIn, derivedOut);
+    }
+
+    @Test
+    public void bonded() throws IOException, ClassNotFoundException, IllegalAccessException {
+        final Base baseIn = new Base();
+        baseIn.baseInt = 1;
+        final HasBondedField hbfIn = new HasBondedField();
+        hbfIn.bondedField = Bonded.fromObject(baseIn, Base.BOND_TYPE);
+        oos.writeObject(hbfIn);
+
+        final ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
+        final HasBondedField hbfOut = (HasBondedField) ois.readObject();
+        TestHelper.assertStructMemberwiseEquals(hbfIn, hbfOut);
+    }
+
+    @Test
+    public void concreteGenericField() throws IOException, ClassNotFoundException, IllegalAccessException {
+        final ConcreteWithGenericField concreteIn = new ConcreteWithGenericField();
+        concreteIn.concreteContainerField.valueField.baseInt = 1;
+        oos.writeObject(concreteIn);
+
+        final ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
+        final ConcreteWithGenericField concreteOut = (ConcreteWithGenericField) ois.readObject();
+        TestHelper.assertStructMemberwiseEquals(concreteIn, concreteOut);
+    }
+
+    @Test
+    public void genericThrows() throws IOException, ClassNotFoundException, IllegalAccessException {
+        final StructBondType<GenericValueContainer<Integer>> containerBondType =
+            GenericValueContainer.BOND_TYPE.makeGenericType(Int32BondType.INSTANCE);
+        final GenericValueContainer<Integer> containerIn = new GenericValueContainer<Integer>(containerBondType);
+        containerIn.valueField = 1;
+        try {
+            oos.writeObject(containerIn);
+            Assert.fail("serializing a generic should have thrown");
+        } catch (IllegalArgumentException ignored) {}
+
+        final ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
+        try {
+            ois.readObject();
+            Assert.fail("deserializing a generic should have thrown");
+        } catch (InvalidClassException ignored) {}
+    }
+}


### PR DESCRIPTION
The actual serialization is CBv1 marshalling. With this commit, attempting to put a generic Bond-generated type through an API expecting a Serializable will throw.

I checked whether we could get rid of `serialVersionUID` - looks like the header and the fqcn/sVUID matching logic are the same between `Serializable` and `Externalizable`. See more [here](http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4094702).