### PR TITLE
[c++ grpc] Fix multi-slice deser. memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ different versioning scheme, following the Haskell community's
 * The CMake build now enforces a minimum Boost version of 1.58. The build
   has required Boost 1.58 or later since version 5.2.0, but this was not
   enforced.
+* Fixed a memory leak when deserializing Bond-over-gRPC messages that were
+  stored as multiple slices.
 
 ## 7.0.1: 2017-10-26 ##
 * `gbc` & compiler library: 0.10.1.0

--- a/cpp/inc/bond/ext/grpc/bond_utils.h
+++ b/cpp/inc/bond/ext/grpc/bond_utils.h
@@ -81,8 +81,7 @@ namespace grpc {
 
             char* dest = buff.get();
 
-            grpc_slice s;
-            while (grpc_byte_buffer_reader_next(&reader, &s) != 0)
+            for (grpc_slice s; grpc_byte_buffer_reader_next(&reader, &s) != 0;)
             {
                 std::memcpy(dest, GRPC_SLICE_START_PTR(s), GRPC_SLICE_LENGTH(s));
                 dest += GRPC_SLICE_LENGTH(s);

--- a/cpp/inc/bond/ext/grpc/bond_utils.h
+++ b/cpp/inc/bond/ext/grpc/bond_utils.h
@@ -86,11 +86,11 @@ namespace grpc {
             {
                 std::memcpy(dest, GRPC_SLICE_START_PTR(s), GRPC_SLICE_LENGTH(s));
                 dest += GRPC_SLICE_LENGTH(s);
+                grpc_slice_unref(s);
             }
 
             BOOST_ASSERT(dest == buff.get() + bufferSize);
 
-            grpc_slice_unref(s);
             grpc_byte_buffer_reader_destroy(&reader);
             grpc_byte_buffer_destroy(buffer);
 

--- a/cpp/inc/bond/ext/grpc/bond_utils.h
+++ b/cpp/inc/bond/ext/grpc/bond_utils.h
@@ -9,6 +9,7 @@
 #include <grpc++/impl/codegen/serialization_traits.h>
 #include <grpc++/impl/codegen/status.h>
 #include <grpc++/impl/codegen/status_code_enum.h>
+#include <grpc++/support/slice.h>
 #include <grpc/impl/codegen/byte_buffer_reader.h>
 #include <grpc/impl/codegen/slice.h>
 
@@ -71,7 +72,7 @@ namespace grpc {
 
             boost::shared_ptr<char[]> buff = boost::make_shared_noinit<char[]>(bufferSize);
 
-            // TODO: exception safety of reader, s, buffer
+            // TODO: exception safety of reader, buffer
             grpc_byte_buffer_reader reader;
             if (!grpc_byte_buffer_reader_init(&reader, buffer))
             {
@@ -81,11 +82,11 @@ namespace grpc {
 
             char* dest = buff.get();
 
-            for (grpc_slice s; grpc_byte_buffer_reader_next(&reader, &s) != 0;)
+            for (grpc_slice grpc_s; grpc_byte_buffer_reader_next(&reader, &grpc_s) != 0;)
             {
-                std::memcpy(dest, GRPC_SLICE_START_PTR(s), GRPC_SLICE_LENGTH(s));
-                dest += GRPC_SLICE_LENGTH(s);
-                grpc_slice_unref(s);
+                grpc::Slice s{ grpc_s, grpc::Slice::STEAL_REF };
+                std::memcpy(dest, s.begin(), s.size());
+                dest += s.size();
             }
 
             BOOST_ASSERT(dest == buff.get() + bufferSize);


### PR DESCRIPTION
The caller of grpc_byte_buffer_reader_next is responsible for calling
grpc_slice_unref on the slice. However, SerializationTraits::Deserialize
was only calling grpc_slice_unref on the last slice. Now, it is called
on each slice.

Also fixes a potential bug that would call grpc_slice_unref on an
uninitialized slice.