### PR TITLE
[c++] Update changelog: minor bump needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ different versioning scheme, following the Haskell community's
 [package versioning policy](https://wiki.haskell.org/Package_versioning_policy).
 
 ## Unreleased  ##
-* `gbc` & compiler library: TBD
+* `gbc` & compiler library: (minor bump needed)
 * IDL core version: TBD
 * IDL comm version: TBD
-* C++ version: TBD
+* C++ version: (minor bump needed)
 * C# NuGet version: TBD
 * C# Comm NuGet version: TBD
 


### PR DESCRIPTION
A minor version bump is needed due to the new operator= added in commit
0d911ca9.

[skip ci]