### PR TITLE
[appveyor] Skip AppVeyor builds for boring files

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,18 @@
     version: 1.0.{build}
     clone_depth: 15
 
+    skip_commits:
+      files:
+        # These files are high-churn, but don't affect the build.
+        #
+        # NB: README.md is NOT in this list; the documentation build
+        # consumes it.
+        - CHANGELOG.md
+        # These files are only used by the Travis CI builds and don't affect
+        # the Windows builds.
+        - .travis.yml
+        - tools/image-builder/**
+    
     environment:
         global:
             STACK_ROOT: "c:\\sr"


### PR DESCRIPTION
This list is not exhaustive (e.g., CONTRIBUTING.md is not included). To
keep it maintainable, it only contains high-churn files that don't
affect the build.

* CHANGELOG.md doesn't affect the build but get changes almost daily.
* Travis CI-specific files don't affect the Windows builds.