### PR TITLE
java gradle: Update README to use a pom.

### DIFF
--- a/java/gradle-plugin/README.md
+++ b/java/gradle-plugin/README.md
@@ -1,7 +1,7 @@
 To build with a development version of this plugin, enter the directory
 containing this README and repeat as follows:
-* make changes
-* gradle build
-* mvn install:install-file -Dfile=build/libs/bond-gradle-1.0.jar -DgroupId=org.bondlib -DartifactId=gradle -Dversion=1.0 -Dpackaging=jar
+* write some code
+* gradle build install
+* mvn install:install-file -Dfile=build/libs/bond-gradle-1.0.jar -DpomFile=build/poms/pom-default.xml
 This will install the plugin to your local maven repository, which the other
 Java projects' build.gradles will use in preference to maven central.

--- a/java/gradle-plugin/README.md
+++ b/java/gradle-plugin/README.md
@@ -1,7 +1,7 @@
 To build with a development version of this plugin, enter the directory
 containing this README and repeat as follows:
 * write some code
-* gradle build install
-* mvn install:install-file -Dfile=build/libs/bond-gradle-1.0.jar -DpomFile=build/poms/pom-default.xml
+* `gradle build install`
+* `mvn install:install-file -Dfile=build/libs/bond-gradle-1.0.jar -DpomFile=build/poms/pom-default.xml`
 This will install the plugin to your local maven repository, which the other
 Java projects' build.gradles will use in preference to maven central.

--- a/java/gradle-plugin/README.md
+++ b/java/gradle-plugin/README.md
@@ -1,7 +1,9 @@
 To build with a development version of this plugin, enter the directory
 containing this README and repeat as follows:
+
 * write some code
 * `gradle build install`
 * `mvn install:install-file -Dfile=build/libs/bond-gradle-1.0.jar -DpomFile=build/poms/pom-default.xml`
+
 This will install the plugin to your local maven repository, which the other
 Java projects' build.gradles will use in preference to maven central.


### PR DESCRIPTION
Previously merged as #683, but appears to have fallen between the cracks during the jvm merge into master. Please squash.