### PR TITLE
[c++ grpc] Upgrade to gRPC v1.7.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "thirdparty/grpc"]
 	path = thirdparty/grpc
-	url = https://github.com/chwarr/grpc.git
+	url = https://github.com/grpc/grpc.git
 
 [submodule "thirdparty/rapidjson"]
 	path = thirdparty/rapidjson

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,12 @@ different versioning scheme, following the Haskell community's
 
 ### C++ ###
 
+* **Breaking change** Constructors accepting a `Comparer` have been removed from
+  `bond::maybe` and `bond::nullable` types.
 * The CMake build now enforces a minimum Boost version of 1.58. The build
   has required Boost 1.58 or later since version 5.2.0, but this was not
   enforced.
-* **Breaking change** Constructors accepting a `Comparer` have been removed from
-  `bond::maybe` and `bond::nullable` types.
+* gRPC v1.7.1 is now required to use Bond-over-gRPC.
 
 ## 7.0.2: 2017-10-30 ##
 * `gbc` & compiler library: 0.10.1.0

--- a/cpp/inc/bond/ext/grpc/detail/client_call_data.h
+++ b/cpp/inc/bond/ext/grpc/detail/client_call_data.h
@@ -92,7 +92,8 @@ struct client_unary_call_data
                 _ioManager->cq(),
                 method,
                 _callbackArgs.context.get(),
-                request));
+                request,
+                /* start */ true));
 
         _self = this->shared_from_this();
 

--- a/cpp/inc/bond/ext/grpc/detail/unary_call_impl.h
+++ b/cpp/inc/bond/ext/grpc/detail/unary_call_impl.h
@@ -5,7 +5,13 @@
 
 #ifdef _MSC_VER
     #pragma warning (push)
-    #pragma warning (disable: 4100 4702)
+    // warning C4100: unreferenced formal parameter
+    //
+    // warning C4291: no matching operator delete found; memory will not be
+    // freed if initialization throws an exception
+    //
+    // warning C4702: unreachable code
+    #pragma warning (disable: 4100 4291 4702)
 #endif
 
 #include <grpc++/grpc++.h>

--- a/cpp/test/compat/grpc/CMakeLists.txt
+++ b/cpp/test/compat/grpc/CMakeLists.txt
@@ -49,15 +49,6 @@ target_link_libraries (cpp_grpc_compat_client PRIVATE
     grpc++
     ${Boost_CHRONO_LIBRARY})
 
-# TODO: It feels like the grpc++ target should have this as part of its
-# interface... Perhaps a patch for upstream?
-target_include_directories(cpp_grpc_compat_server
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../thirdparty/grpc/include
-)
-target_include_directories(cpp_grpc_compat_client
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../thirdparty/grpc/include
-)
-
 # disable generation of debug symbols to speed up build
 no_pdb()
 

--- a/cpp/test/grpc/CMakeLists.txt
+++ b/cpp/test/grpc/CMakeLists.txt
@@ -33,10 +33,7 @@ add_library (grpc_test_common EXCLUDE_FROM_ALL "main.cpp")
 add_target_to_folder (grpc_test_common)
 target_include_directories (grpc_test_common PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}
-    # TODO: It feels like the grpc++ target should have this as part of its
-    # interface... Perhaps a patch for upstream?
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../thirdparty/grpc/include)
+    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR})
 target_link_libraries (grpc_test_common PUBLIC
     ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
     grpc++)

--- a/examples/cpp/grpc/async-server/CMakeLists.txt
+++ b/examples/cpp/grpc/async-server/CMakeLists.txt
@@ -3,8 +3,3 @@ add_bond_test (grpc-async-server async-server.bond async-server.cpp GRPC)
 cxx_target_compile_definitions (MSVC grpc-async-server PRIVATE -D_WIN32_WINNT=0x0600)
 
 target_link_libraries(grpc-async-server PRIVATE grpc++)
-target_include_directories(grpc-async-server
-  # TODO: It feels like the grpc++ target should have this as part of its
-  # interface... Perhaps a patch for upstream?
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../thirdparty/grpc/include
-)

--- a/examples/cpp/grpc/grpc_dll/CMakeLists.txt
+++ b/examples/cpp/grpc/grpc_dll/CMakeLists.txt
@@ -18,12 +18,6 @@ target_link_libraries (grpc_dll_example_lib PUBLIC
     grpc++
     bond)
 
-# TODO: It feels like the grpc++ target should have this as part of its
-# interface... Perhaps a patch for upstream?
-target_include_directories(grpc_dll_example_lib
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../thirdparty/grpc/include
-)
-
 cxx_target_compile_definitions (MSVC grpc_dll_example_lib PRIVATE
     -D_WIN32_WINNT=0x0600)
 
@@ -36,12 +30,6 @@ target_include_directories(grpc_dll_example PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries (grpc_dll_example PUBLIC
     grpc_dll_example_lib)
-
-# TODO: It feels like the grpc++ target should have this as part of its
-# interface... Perhaps a patch for upstream?
-target_include_directories(grpc_dll_example
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../thirdparty/grpc/include
-)
 
 cxx_target_compile_definitions (MSVC grpc_dll_example PRIVATE
     -D_WIN32_WINNT=0x0600)

--- a/examples/cpp/grpc/grpc_static_library/CMakeLists.txt
+++ b/examples/cpp/grpc/grpc_static_library/CMakeLists.txt
@@ -26,18 +26,6 @@ add_bond_test (grpc_static_library_client
 target_link_libraries (grpc_static_library_client PRIVATE
     grpc_static_library_lib)
 
-# TODO: It feels like the grpc++ target should have this as part of its
-# interface... Perhaps a patch for upstream?
-target_include_directories(grpc_static_library_lib
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../thirdparty/grpc/include
-)
-target_include_directories(grpc_static_library_server
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../thirdparty/grpc/include
-)
-target_include_directories(grpc_static_library_client
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../thirdparty/grpc/include
-)
-
 cxx_target_compile_definitions (MSVC grpc_static_library_lib PRIVATE
     -D_WIN32_WINNT=0x0600)
 

--- a/examples/cpp/grpc/helloworld/CMakeLists.txt
+++ b/examples/cpp/grpc/helloworld/CMakeLists.txt
@@ -3,8 +3,3 @@ add_bond_test (grpc-helloworld helloworld.bond helloworld.cpp GRPC)
 cxx_target_compile_definitions (MSVC grpc-helloworld PRIVATE -D_WIN32_WINNT=0x0600)
 
 target_link_libraries(grpc-helloworld PRIVATE grpc++)
-target_include_directories(grpc-helloworld
-  # TODO: It feels like the grpc++ target should have this as part of its
-  # interface... Perhaps a patch for upstream?
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../thirdparty/grpc/include
-)

--- a/examples/cpp/grpc/pingpong/CMakeLists.txt
+++ b/examples/cpp/grpc/pingpong/CMakeLists.txt
@@ -3,8 +3,3 @@ add_bond_test (grpc-pingpong pingpong.bond pingpong.cpp GRPC)
 cxx_target_compile_definitions (MSVC grpc-pingpong PRIVATE -D_WIN32_WINNT=0x0600)
 
 target_link_libraries(grpc-pingpong PRIVATE grpc++)
-target_include_directories(grpc-pingpong
-  # TODO: It feels like the grpc++ target should have this as part of its
-  # interface... Perhaps a patch for upstream?
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../thirdparty/grpc/include
-)

--- a/examples/cpp/grpc/scalar/CMakeLists.txt
+++ b/examples/cpp/grpc/scalar/CMakeLists.txt
@@ -3,8 +3,3 @@ add_bond_test (grpc-scalar scalar.bond scalar.cpp GRPC)
 cxx_target_compile_definitions (MSVC grpc-scalar PRIVATE -D_WIN32_WINNT=0x0600)
 
 target_link_libraries(grpc-scalar PRIVATE grpc++)
-target_include_directories(grpc-scalar
-  # TODO: It feels like the grpc++ target should have this as part of its
-  # interface... Perhaps a patch for upstream?
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../thirdparty/grpc/include
-)


### PR DESCRIPTION
Pick up a bug fix in commit gRPC 7269667f (initially implemented for C++
in gRPC commit be9b8142) for channel disconnections we've been
observing.