### PR TITLE
java: Allow maven publication and clean up.

### DIFF
--- a/cmake/FindJavaBuildTools.cmake
+++ b/cmake/FindJavaBuildTools.cmake
@@ -1,5 +1,4 @@
 find_program (GRADLE_EXECUTABLE gradle)
-find_program (MAVEN_EXECUTABLE mvn)
 
 if (GRADLE_EXECUTABLE)
     execute_process (
@@ -9,14 +8,4 @@ if (GRADLE_EXECUTABLE)
     message (STATUS "${gradle_version}")
 else()
     message (FATAL_ERROR "gradle was not found. Java code cannot be built.")
-endif()
-
-if (MAVEN_EXECUTABLE)
-    execute_process (
-        COMMAND ${MAVEN_EXECUTABLE} --version
-        OUTPUT_VARIABLE maven_version)
-    message (STATUS "maven found at ${MAVEN_EXECUTABLE}")
-    message (STATUS "${maven_version}")
-else()
-    message (FATAL_ERROR "maven was not found. Java code cannot be built.")
 endif()

--- a/cmake/Java.cmake
+++ b/cmake/Java.cmake
@@ -30,26 +30,3 @@ function (add_gradle_build target)
     add_target_to_folder("${target}")
     add_dependencies(java "${target}")
 endfunction()
-
-function (add_maven_install target)
-    set (oneValueArgs AFTER_BUILD JAR)
-    cmake_parse_arguments (arg "${flagArgs}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-
-    # The path given to -DpomFile is hard-coded to match the output path of
-    # gradle's maven plugin.
-    add_custom_command (
-        COMMAND
-        ${MAVEN_EXECUTABLE}
-        install:install-file
-        -DpomFile=build/poms/pom-default.xml
-        -Dfile=build/libs/${arg_JAR}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/build/java/${target})
-
-    add_custom_target ("${target}"
-        DEPENDS ${arg_AFTER_BUILD}
-        ${CMAKE_CURRENT_BINARY_DIR}/build/java/${target})
-
-    add_target_to_folder("${target}")
-    add_dependencies(java "${target}")
-endfunction()

--- a/examples/java/core/blob/build.gradle
+++ b/examples/java/core/blob/build.gradle
@@ -20,11 +20,12 @@ mainClassName = 'org.bondlib.examples.BlobExample'
 applicationDefaultJvmArgs = ['-ea']
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    compile files('../../../../java/core/build/libs/bond-5.0.0.jar')
+    compile 'org.bondlib:bond:+'
 }
 
 compileBond {

--- a/examples/java/core/enumerations/build.gradle
+++ b/examples/java/core/enumerations/build.gradle
@@ -20,11 +20,12 @@ mainClassName = 'org.bondlib.examples.Enumerations'
 applicationDefaultJvmArgs = ['-ea']
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    compile files('../../../../java/core/build/libs/bond-5.0.0.jar')
+    compile 'org.bondlib:bond:+'
 }
 
 compileBond {

--- a/examples/java/core/generic_tree/build.gradle
+++ b/examples/java/core/generic_tree/build.gradle
@@ -20,11 +20,12 @@ mainClassName = 'org.bondlib.examples.GenericTree'
 applicationDefaultJvmArgs = ['-ea']
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    compile files('../../../../java/core/build/libs/bond-5.0.0.jar')
+    compile 'org.bondlib:bond:+'
 }
 
 compileBond {

--- a/examples/java/core/generics/build.gradle
+++ b/examples/java/core/generics/build.gradle
@@ -20,11 +20,12 @@ mainClassName = 'org.bondlib.examples.Generics'
 applicationDefaultJvmArgs = ['-ea']
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    compile files('../../../../java/core/build/libs/bond-5.0.0.jar')
+    compile 'org.bondlib:bond:+'
 }
 
 compileBond {

--- a/examples/java/core/imports/build.gradle
+++ b/examples/java/core/imports/build.gradle
@@ -20,11 +20,12 @@ mainClassName = 'org.bondlib.examples.Imports'
 applicationDefaultJvmArgs = ['-ea']
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    compile files('../../../../java/core/build/libs/bond-5.0.0.jar')
+    compile 'org.bondlib:bond:+'
 }
 
 compileBond {

--- a/examples/java/core/inheritance/build.gradle
+++ b/examples/java/core/inheritance/build.gradle
@@ -20,11 +20,12 @@ mainClassName = 'org.bondlib.examples.Inheritance'
 applicationDefaultJvmArgs = ['-ea']
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    compile files('../../../../java/core/build/libs/bond-5.0.0.jar')
+    compile 'org.bondlib:bond:+'
 }
 
 compileBond {

--- a/examples/java/core/nothing_default/build.gradle
+++ b/examples/java/core/nothing_default/build.gradle
@@ -20,11 +20,12 @@ mainClassName = 'org.bondlib.examples.NothingDefault'
 applicationDefaultJvmArgs = ['-ea']
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    compile files('../../../../java/core/build/libs/bond-5.0.0.jar')
+    compile 'org.bondlib:bond:+'
 }
 
 compileBond {

--- a/examples/java/core/polymorphic_container/build.gradle
+++ b/examples/java/core/polymorphic_container/build.gradle
@@ -20,11 +20,12 @@ mainClassName = 'org.bondlib.examples.PolymorphicContainer'
 applicationDefaultJvmArgs = ['-ea']
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    compile files('../../../../java/core/build/libs/bond-5.0.0.jar')
+    compile 'org.bondlib:bond:+'
 }
 
 compileBond {

--- a/examples/java/core/protocol_versions/build.gradle
+++ b/examples/java/core/protocol_versions/build.gradle
@@ -20,11 +20,12 @@ mainClassName = 'org.bondlib.examples.ProtocolVersions'
 applicationDefaultJvmArgs = ['-ea']
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    compile files('../../../../java/core/build/libs/bond-5.0.0.jar')
+    compile 'org.bondlib:bond:+'
 }
 
 compileBond {

--- a/examples/java/core/record_streaming/build.gradle
+++ b/examples/java/core/record_streaming/build.gradle
@@ -20,11 +20,12 @@ mainClassName = 'org.bondlib.examples.RecordStreaming'
 applicationDefaultJvmArgs = ['-ea']
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    compile files('../../../../java/core/build/libs/bond-5.0.0.jar')
+    compile 'org.bondlib:bond:+'
 }
 
 compileBond {

--- a/examples/java/core/runtime_schema/build.gradle
+++ b/examples/java/core/runtime_schema/build.gradle
@@ -20,11 +20,12 @@ mainClassName = 'org.bondlib.examples.RuntimeSchemaExample'
 applicationDefaultJvmArgs = ['-ea']
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    compile files('../../../../java/core/build/libs/bond-5.0.0.jar')
+    compile 'org.bondlib:bond:+'
 }
 
 compileBond {

--- a/examples/java/core/schema_view/build.gradle
+++ b/examples/java/core/schema_view/build.gradle
@@ -20,11 +20,12 @@ mainClassName = 'org.bondlib.examples.SchemaView'
 applicationDefaultJvmArgs = ['-ea']
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    compile files('../../../../java/core/build/libs/bond-5.0.0.jar')
+    compile 'org.bondlib:bond:+'
 }
 
 compileBond {

--- a/examples/java/core/serialization/build.gradle
+++ b/examples/java/core/serialization/build.gradle
@@ -20,11 +20,12 @@ mainClassName = 'org.bondlib.examples.Serialization'
 applicationDefaultJvmArgs = ['-ea']
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    compile files('../../../../java/core/build/libs/bond-5.0.0.jar')
+    compile 'org.bondlib:bond:+'
 }
 
 compileBond {

--- a/examples/java/core/untagged_protocols/build.gradle
+++ b/examples/java/core/untagged_protocols/build.gradle
@@ -20,11 +20,12 @@ mainClassName = 'org.bondlib.examples.UntaggedProtocols'
 applicationDefaultJvmArgs = ['-ea']
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    compile files('../../../../java/core/build/libs/bond-5.0.0.jar')
+    compile 'org.bondlib:bond:+'
 }
 
 compileBond {

--- a/java/compat/CMakeLists.txt
+++ b/java/compat/CMakeLists.txt
@@ -4,4 +4,5 @@ set (CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
 
 include (Java)
 
-add_gradle_build (java-compat DEPENDS java-core)
+add_gradle_build (java-compat
+   DEPENDS java-core)

--- a/java/compat/build.gradle
+++ b/java/compat/build.gradle
@@ -1,5 +1,8 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 group 'org.bondlib'
-version '1.0'
+version '0.0'
 
 buildscript {
     repositories {
@@ -18,11 +21,12 @@ apply plugin: 'org.bondlib.gradle'
 sourceCompatibility = 1.8
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    compile files('../core/build/libs/bond-5.0.0.jar')
+    compile 'org.bondlib:bond:+'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/java/core/CMakeLists.txt
+++ b/java/core/CMakeLists.txt
@@ -4,4 +4,6 @@ set (CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
 
 include (Java)
 
-add_gradle_build (java-core DEPENDS gradle-plugin-install)
+add_gradle_build (java-core
+    GRADLE_TARGET install
+    DEPENDS gradle-plugin)

--- a/java/core/build.gradle
+++ b/java/core/build.gradle
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-group 'org.bondlib'
-version = '5.0.0'
-
 buildscript {
     repositories {
         mavenLocal()
@@ -15,8 +12,17 @@ buildscript {
     }
 }
 
+plugins {
+    id 'com.palantir.git-version' version '0.9.1'
+}
+
 apply plugin: 'java'
+apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'org.bondlib.gradle'
+
+group 'org.bondlib'
+version gitVersion(prefix:'java@')
 
 sourceCompatibility = 1.6
 
@@ -28,6 +34,26 @@ dependencies {
     testCompile 'junit:junit:4.12'
 }
 
+publishing {
+    repositories {
+        maven {
+            url 'https://msazure.pkgs.visualstudio.com/_packaging/Bond/maven/v1'
+                credentials {
+                    username "VSTS"
+                    password project.hasProperty('vstsMavenAccessToken') ? "${vstsMavenAccessToken}" : ''
+                }
+        }
+    }
+
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+}
+
+// Some tests have non-ASCII strings that are UTF-8 encoded. In environments
+// with system encodings other than UTF-8, javac will fail on those tests.
 compileTestJava {
     options.encoding = 'UTF-8'
 }

--- a/java/gradle-plugin/CMakeLists.txt
+++ b/java/gradle-plugin/CMakeLists.txt
@@ -4,7 +4,5 @@ set (CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
 
 include (Java)
 
-add_gradle_build (gradle-plugin GRADLE_TARGET install)
-add_maven_install (gradle-plugin-install
-    AFTER_BUILD gradle-plugin
-    JAR bond-gradle-1.0.jar)
+add_gradle_build (gradle-plugin
+    GRADLE_TARGET install)

--- a/java/gradle-plugin/README.md
+++ b/java/gradle-plugin/README.md
@@ -3,7 +3,6 @@ containing this README and repeat as follows:
 
 * write some code
 * `gradle build install`
-* `mvn install:install-file -Dfile=build/libs/bond-gradle-1.0.jar -DpomFile=build/poms/pom-default.xml`
 
 This will install the plugin to your local maven repository, which the other
 Java projects' build.gradles will use in preference to maven central.

--- a/java/gradle-plugin/build.gradle
+++ b/java/gradle-plugin/build.gradle
@@ -1,13 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+plugins {
+    id 'com.palantir.git-version' version '0.9.1'
+}
+
 apply plugin: 'groovy'
 apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 group 'org.bondlib'
-version '1.0'
+version gitVersion(prefix:'java@')
 
 dependencies {
     compile localGroovy()
     compile gradleApi()
 }
 
-jar {
+publishing {
+    repositories {
+        maven {
+            url 'https://msazure.pkgs.visualstudio.com/_packaging/Bond/maven/v1'
+                credentials {
+                    username "VSTS"
+                    password project.hasProperty('vstsMavenAccessToken') ? "${vstsMavenAccessToken}" : ''
+                }
+        }
+    }
+
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
 }

--- a/java/json/build.gradle
+++ b/java/json/build.gradle
@@ -1,16 +1,44 @@
-group 'org.bondlib'
-version '5.0.0'
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+plugins {
+    id 'com.palantir.git-version' version '0.9.1'
+}
 
 apply plugin: 'java'
+apply plugin: 'maven'
+apply plugin: 'maven-publish'
+
+group 'org.bondlib'
+version gitVersion(prefix:'java@')
 
 sourceCompatibility = 1.6
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    compile files('../core/build/libs/bond-5.0.0.jar')
+    compile 'org.bondlib:bond:+'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.1'
     testCompile group: 'junit', name: 'junit', version: '4.12'
+}
+
+publishing {
+    repositories {
+        maven {
+            url 'https://msazure.pkgs.visualstudio.com/_packaging/Bond/maven/v1'
+                credentials {
+                    username "VSTS"
+                    password project.hasProperty('vstsMavenAccessToken') ? "${vstsMavenAccessToken}" : ''
+                }
+        }
+    }
+
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
 }

--- a/tools/ci-scripts/linux/image-builder/Dockerfile
+++ b/tools/ci-scripts/linux/image-builder/Dockerfile
@@ -47,8 +47,7 @@ RUN add-apt-repository ppa:cwchien/gradle && \
     apt-get update && \
     apt-get -y install \
     gradle \
-    openjdk-8-jdk \
-    maven
+    openjdk-8-jdk
 
 # Build script
 ENTRYPOINT ["zsh", "/root/bond/tools/ci-scripts/linux/build.zsh"]


### PR DESCRIPTION
This commit removes the need for the mvn binary and converts all
Java dependencies within the repo to true dependencies, rather than file
references. It also generates automatic versions for the core and
gradle-plugin projects from git tags.