### PR TITLE
[c++] Use Kind enum in polymorph. cont. visitor

### DIFF
--- a/examples/cpp/core/polymorphic_container_visitor/polymorphic_container_visitor.bond
+++ b/examples/cpp/core/polymorphic_container_visitor/polymorphic_container_visitor.bond
@@ -1,8 +1,15 @@
 namespace examples.polymorphic_containers
 
+enum StructKind
+{
+    StructKind_Unknown;
+    StructKind_Struct1;
+    StructKind_Struct2;
+}
+
 struct Base
 {
-    0: bond_meta::full_name name;
+    0: StructKind kind = StructKind_Unknown;
 }
 
 
@@ -23,5 +30,5 @@ struct Struct2 : Base
 
 struct Polymorphic
 {
-    0: vector<bonded<Base>> items;
+    0: list<bonded<Base>> items;
 }

--- a/examples/cpp/core/polymorphic_container_visitor/polymorphic_container_visitor.cpp
+++ b/examples/cpp/core/polymorphic_container_visitor/polymorphic_container_visitor.cpp
@@ -11,22 +11,25 @@ template <typename T>
 bond::bonded<T> Serialize(const T& obj)
 {
     bond::OutputBuffer buffer;
-    
+
     bond::CompactBinaryWriter<bond::OutputBuffer> writer(buffer);
 
     bond::Serialize(obj, writer);
 
     bond::CompactBinaryReader<bond::InputBuffer> reader(buffer.GetBuffer());
-    
+
     return bond::bonded<T>(reader);
 }
 
 
-struct Extract : private boost::noncopyable
+struct Extract
 {
-    Extract(int& n)
+    explicit Extract(int& n)
         : n(n)
     {}
+
+    Extract(const Extract&) = delete;
+    Extract& operator=(const Extract&) = delete;
 
     template <typename T>
     void operator()(const bond::bonded<T>& bonded) const
@@ -44,15 +47,15 @@ struct Extract : private boost::noncopyable
 int main()
 {
     bond::bonded<Polymorphic> bonded;
-    
+
     {
         Struct1 obj1;
-
+        obj1.kind = StructKind_Struct1;
         obj1.n = 1;
         obj1.str = "1";
 
         Struct2 obj2;
-
+        obj2.kind = StructKind_Struct2;
         obj2.n = 2;
         obj2.str = "2";
 
@@ -66,30 +69,32 @@ int main()
     }
 
     // At this point bonded represents serialized data for a struct which has
-    // a polymorpic list field delcared as vector<bonded<Base>>. Application 
-    // can deserialize the Base part of each element and based of the contained 
+    // a polymorpic list field delcared as vector<bonded<Base>>. Application
+    // can deserialize the Base part of each element and based of the contained
     // type metadata, deserialize the full element to an appropriate struct.
 
     Polymorphic polymorphic;
-
     bonded.Deserialize(polymorphic);
-    
-    for (size_t i = 0; i < polymorphic.items.size(); ++i)
-    {
-        int n;
-        
-        typedef boost::mpl::list<
-            Struct1, 
-            Struct2
-        >::type types;
-        
-        // Apply the Extract visitor after resolving the element to one of the 
-        // listed polymorphic types based on value of the Base::name field. 
-        polymorphic::Apply<types, Base::Schema::var::name>
-            (Extract(n), polymorphic.items[i]);
 
-        BOOST_VERIFY(n - 1 == static_cast<int>(i));
-    }    
-        
-    return 0;    
+    size_t count = 0;
+    for (const auto& item : polymorphic.items)
+    {
+        typedef boost::mpl::map<
+            boost::mpl::pair<std::integral_constant<StructKind, StructKind_Struct1>, Struct1>,
+            boost::mpl::pair<std::integral_constant<StructKind, StructKind_Struct2>, Struct2>
+        > types;
+
+
+        int n;
+        // Apply the Extract visitor after resolving the element to one of the
+        // listed polymorphic types based on value of the Base::kind field.
+        polymorphic::Apply<types, Base::Schema::var::kind>(
+            Extract(n),
+            item);
+
+        BOOST_VERIFY(n - 1 == static_cast<int>(count));
+        ++count;
+    }
+
+    return 0;
 }


### PR DESCRIPTION
Switch the polymorphic_container_visitor example to use a Kind enum
instead of the deprecated bond_meta::full_name.

TODO:
* [x] Build and test with G++ and Clang++
* [x] Wait for MSVC 2013 CI builds and fix and problems found in them.