### PR TITLE
[gbc c++] Use init. list for populating enum maps

### DIFF
--- a/compiler/src/Language/Bond/Codegen/Cpp/Types_cpp.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Types_cpp.hs
@@ -97,7 +97,7 @@ types_cpp cpp file _imports declarations = ("_types.cpp", [lt|
       where
         nameValueConst Constant {..} = [lt|{ "#{constantName}", #{constantName} }|]
         valueNameConst (name, _) = [lt|{ #{name}, "#{name}" }|]
-        enumConstByName = sortBy (\x y -> constantName x `compare` constantName y) enumConstants
-        enumConstByValue = sortBy (\x y -> snd x `compare` snd y) $ constNameValues enumConstants
+        enumConstByName = sortOn constantName enumConstants
+        enumConstByValue = sortOn snd $ reifyEnumValues enumConstants
 
     statics _ = mempty

--- a/compiler/src/Language/Bond/Codegen/Cpp/Types_cpp.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Types_cpp.hs
@@ -41,9 +41,10 @@ types_cpp cpp file _imports declarations = ("_types.cpp", [lt|
     namespace #{declName}
     {
         const
-        std::map<std::string, enum #{declName}> _name_to_value_#{declName} =
-            boost::assign::map_list_of<std::string, enum #{declName}>
-                #{newlineSep 4 constant enumConstants};
+        std::map<std::string, enum #{declName}> _name_to_value_#{declName}
+            {
+                #{commaLineSep 4 constant enumConstants}
+            };
 
         const
         std::map<enum #{declName}, std::string> _value_to_name_#{declName} =
@@ -68,6 +69,6 @@ types_cpp cpp file _imports declarations = ("_types.cpp", [lt|
     } // namespace #{declName}
     } // namespace _bond_enumerators|]
       where
-        constant Constant {..} = [lt|("#{constantName}", #{constantName})|]
+        constant Constant {..} = [lt|{ "#{constantName}", #{constantName} }|]
 
     statics _ = mempty

--- a/compiler/src/Language/Bond/Syntax/SchemaDef.hs
+++ b/compiler/src/Language/Bond/Syntax/SchemaDef.hs
@@ -200,7 +200,7 @@ makeSchemaDef root = SchemaDef $ map structDef structs
         resolve (BT_UserDefined a@Alias{} args) = resolve $ resolveAlias a args
         resolve t = t
     -- resolve value of an enum constant
-    resolveEnum Enum{..} n = fromIntegral . snd . fromJust $ find ((n ==) . fst) $ constNameValues enumConstants
+    resolveEnum Enum{..} n = fromIntegral . snd . fromJust $ find ((n ==) . fst) $ reifyEnumValues enumConstants
     resolveEnum _ _ = error "makeSchemaDef.resolveEnum: not a enum"
 
 $(deriveToJSON defaultOptions {omitNothingFields = True} ''SchemaDef)

--- a/compiler/src/Language/Bond/Syntax/SchemaDef.hs
+++ b/compiler/src/Language/Bond/Syntax/SchemaDef.hs
@@ -200,12 +200,7 @@ makeSchemaDef root = SchemaDef $ map structDef structs
         resolve (BT_UserDefined a@Alias{} args) = resolve $ resolveAlias a args
         resolve t = t
     -- resolve value of an enum constant
-    resolveEnum Enum{..} n = fromIntegral . snd . fromJust $ find ((n ==) . fst) $ nameValues 0 enumConstants
-      where
-        -- fill in values for constants w/o explicitly specified value
-        nameValues _ [] = []
-        nameValues _ ((Constant name (Just value)):xs) = (name, value) : nameValues (value + 1) xs
-        nameValues next ((Constant name Nothing):xs)   = (name, next) : nameValues (next + 1) xs
+    resolveEnum Enum{..} n = fromIntegral . snd . fromJust $ find ((n ==) . fst) $ constNameValues enumConstants
     resolveEnum _ _ = error "makeSchemaDef.resolveEnum: not a enum"
 
 $(deriveToJSON defaultOptions {omitNothingFields = True} ''SchemaDef)

--- a/compiler/src/Language/Bond/Syntax/Util.hs
+++ b/compiler/src/Language/Bond/Syntax/Util.hs
@@ -36,6 +36,7 @@ module Language.Bond.Syntax.Util
     , foldMapType
       -- * Helper functions
     , resolveAlias
+    , constNameValues
     ) where
 
 import Data.Maybe
@@ -231,3 +232,12 @@ resolveAlias Alias {..} args = fmapType resolveParam aliasType
     paramsArgs = zip declParams args
 resolveAlias _ _ = error "resolveAlias: impossible happened."
 
+
+
+-- | Fill in values for constants w/o explicitly specified value
+constNameValues :: [Constant] -> [(String, Int)]
+constNameValues constants = nameValues 0 constants
+  where
+    nameValues _ [] = []
+    nameValues _ ((Constant name (Just value)):xs) = (name, value) : nameValues (value + 1) xs
+    nameValues next ((Constant name Nothing):xs)   = (name, next) : nameValues (next + 1) xs

--- a/compiler/src/Language/Bond/Syntax/Util.hs
+++ b/compiler/src/Language/Bond/Syntax/Util.hs
@@ -36,7 +36,7 @@ module Language.Bond.Syntax.Util
     , foldMapType
       -- * Helper functions
     , resolveAlias
-    , constNameValues
+    , reifyEnumValues
     ) where
 
 import Data.Maybe
@@ -235,8 +235,8 @@ resolveAlias _ _ = error "resolveAlias: impossible happened."
 
 
 -- | Fill in values for constants w/o explicitly specified value
-constNameValues :: [Constant] -> [(String, Int)]
-constNameValues constants = nameValues 0 constants
+reifyEnumValues :: [Constant] -> [(String, Int)]
+reifyEnumValues constants = nameValues 0 constants
   where
     nameValues _ [] = []
     nameValues _ ((Constant name (Just value)):xs) = (name, value) : nameValues (value + 1) xs

--- a/compiler/tests/generated/aliases_types.cpp
+++ b/compiler/tests/generated/aliases_types.cpp
@@ -10,9 +10,10 @@ namespace tests
     namespace EnumToWrap
     {
         const
-        std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap =
-            boost::assign::map_list_of<std::string, enum EnumToWrap>
-                ("anEnumValue", anEnumValue);
+        std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
+            {
+                { "anEnumValue", anEnumValue }
+            };
 
         const
         std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap =

--- a/compiler/tests/generated/aliases_types.cpp
+++ b/compiler/tests/generated/aliases_types.cpp
@@ -9,21 +9,21 @@ namespace tests
     {
     namespace EnumToWrap
     {
-        const
-        std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
+        const std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
             {
                 { "anEnumValue", anEnumValue }
             };
 
-        const
-        std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap =
-            ::bond::reverse_map(_name_to_value_EnumToWrap);
+        const std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap
+            {
+                { anEnumValue, "anEnumValue" }
+            };
 
         const std::string& ToString(enum EnumToWrap value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_EnumToWrap.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_EnumToWrap.end() == it)
                 ::bond::InvalidEnumValueException(value, "EnumToWrap");
 
             return it->second;
@@ -58,6 +58,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace EnumToWrap
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/alloc_ctors/aliases_types.cpp
+++ b/compiler/tests/generated/alloc_ctors/aliases_types.cpp
@@ -10,9 +10,10 @@ namespace tests
     namespace EnumToWrap
     {
         const
-        std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap =
-            boost::assign::map_list_of<std::string, enum EnumToWrap>
-                ("anEnumValue", anEnumValue);
+        std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
+            {
+                { "anEnumValue", anEnumValue }
+            };
 
         const
         std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap =

--- a/compiler/tests/generated/alloc_ctors/aliases_types.cpp
+++ b/compiler/tests/generated/alloc_ctors/aliases_types.cpp
@@ -9,21 +9,21 @@ namespace tests
     {
     namespace EnumToWrap
     {
-        const
-        std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
+        const std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
             {
                 { "anEnumValue", anEnumValue }
             };
 
-        const
-        std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap =
-            ::bond::reverse_map(_name_to_value_EnumToWrap);
+        const std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap
+            {
+                { anEnumValue, "anEnumValue" }
+            };
 
         const std::string& ToString(enum EnumToWrap value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_EnumToWrap.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_EnumToWrap.end() == it)
                 ::bond::InvalidEnumValueException(value, "EnumToWrap");
 
             return it->second;
@@ -58,6 +58,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace EnumToWrap
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/alloc_ctors/attributes_types.cpp
+++ b/compiler/tests/generated/alloc_ctors/attributes_types.cpp
@@ -9,21 +9,21 @@ namespace tests
     {
     namespace Enum
     {
-        const
-        std::map<std::string, enum Enum> _name_to_value_Enum
+        const std::map<std::string, enum Enum> _name_to_value_Enum
             {
                 { "Value1", Value1 }
             };
 
-        const
-        std::map<enum Enum, std::string> _value_to_name_Enum =
-            ::bond::reverse_map(_name_to_value_Enum);
+        const std::map<enum Enum, std::string> _value_to_name_Enum
+            {
+                { Value1, "Value1" }
+            };
 
         const std::string& ToString(enum Enum value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_Enum.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_Enum.end() == it)
                 ::bond::InvalidEnumValueException(value, "Enum");
 
             return it->second;
@@ -58,6 +58,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace Enum
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/alloc_ctors/attributes_types.cpp
+++ b/compiler/tests/generated/alloc_ctors/attributes_types.cpp
@@ -10,9 +10,10 @@ namespace tests
     namespace Enum
     {
         const
-        std::map<std::string, enum Enum> _name_to_value_Enum =
-            boost::assign::map_list_of<std::string, enum Enum>
-                ("Value1", Value1);
+        std::map<std::string, enum Enum> _name_to_value_Enum
+            {
+                { "Value1", Value1 }
+            };
 
         const
         std::map<enum Enum, std::string> _value_to_name_Enum =

--- a/compiler/tests/generated/alloc_ctors/defaults_types.cpp
+++ b/compiler/tests/generated/alloc_ctors/defaults_types.cpp
@@ -9,33 +9,45 @@ namespace tests
     {
     namespace EnumType1
     {
-        const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
             {
                 { "EnumValue1", EnumValue1 },
                 { "EnumValue2", EnumValue2 },
                 { "EnumValue3", EnumValue3 },
                 { "EnumValue4", EnumValue4 },
-                { "Low", Low },
                 { "EnumValue5", EnumValue5 },
                 { "EnumValue6", EnumValue6 },
-                { "Int32Min", Int32Min },
-                { "Int32Max", Int32Max },
-                { "UInt32Min", UInt32Min },
-                { "UInt32Max", UInt32Max },
                 { "HexNeg", HexNeg },
-                { "OctNeg", OctNeg }
+                { "Int32Max", Int32Max },
+                { "Int32Min", Int32Min },
+                { "Low", Low },
+                { "OctNeg", OctNeg },
+                { "UInt32Max", UInt32Max },
+                { "UInt32Min", UInt32Min }
             };
 
-        const
-        std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =
-            ::bond::reverse_map(_name_to_value_EnumType1);
+        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
+            {
+                { Int32Min, "Int32Min" },
+                { HexNeg, "HexNeg" },
+                { OctNeg, "OctNeg" },
+                { EnumValue3, "EnumValue3" },
+                { EnumValue5, "EnumValue5" },
+                { UInt32Min, "UInt32Min" },
+                { Low, "Low" },
+                { EnumValue1, "EnumValue1" },
+                { EnumValue2, "EnumValue2" },
+                { EnumValue4, "EnumValue4" },
+                { Int32Max, "Int32Max" },
+                { EnumValue6, "EnumValue6" },
+                { UInt32Max, "UInt32Max" }
+            };
 
         const std::string& ToString(enum EnumType1 value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_EnumType1.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_EnumType1.end() == it)
                 ::bond::InvalidEnumValueException(value, "EnumType1");
 
             return it->second;
@@ -70,6 +82,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace EnumType1
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/alloc_ctors/defaults_types.cpp
+++ b/compiler/tests/generated/alloc_ctors/defaults_types.cpp
@@ -10,21 +10,22 @@ namespace tests
     namespace EnumType1
     {
         const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1 =
-            boost::assign::map_list_of<std::string, enum EnumType1>
-                ("EnumValue1", EnumValue1)
-                ("EnumValue2", EnumValue2)
-                ("EnumValue3", EnumValue3)
-                ("EnumValue4", EnumValue4)
-                ("Low", Low)
-                ("EnumValue5", EnumValue5)
-                ("EnumValue6", EnumValue6)
-                ("Int32Min", Int32Min)
-                ("Int32Max", Int32Max)
-                ("UInt32Min", UInt32Min)
-                ("UInt32Max", UInt32Max)
-                ("HexNeg", HexNeg)
-                ("OctNeg", OctNeg);
+        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+            {
+                { "EnumValue1", EnumValue1 },
+                { "EnumValue2", EnumValue2 },
+                { "EnumValue3", EnumValue3 },
+                { "EnumValue4", EnumValue4 },
+                { "Low", Low },
+                { "EnumValue5", EnumValue5 },
+                { "EnumValue6", EnumValue6 },
+                { "Int32Min", Int32Min },
+                { "Int32Max", Int32Max },
+                { "UInt32Min", UInt32Min },
+                { "UInt32Max", UInt32Max },
+                { "HexNeg", HexNeg },
+                { "OctNeg", OctNeg }
+            };
 
         const
         std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =

--- a/compiler/tests/generated/alloc_ctors/with_enum_header_types.cpp
+++ b/compiler/tests/generated/alloc_ctors/with_enum_header_types.cpp
@@ -9,31 +9,41 @@ namespace tests
     {
     namespace EnumType1
     {
-        const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
             {
                 { "EnumValue1", EnumValue1 },
                 { "EnumValue2", EnumValue2 },
                 { "EnumValue3", EnumValue3 },
                 { "EnumValue4", EnumValue4 },
-                { "Low", Low },
                 { "EnumValue5", EnumValue5 },
                 { "EnumValue6", EnumValue6 },
-                { "Int32Min", Int32Min },
                 { "Int32Max", Int32Max },
-                { "UInt32Min", UInt32Min },
-                { "UInt32Max", UInt32Max }
+                { "Int32Min", Int32Min },
+                { "Low", Low },
+                { "UInt32Max", UInt32Max },
+                { "UInt32Min", UInt32Min }
             };
 
-        const
-        std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =
-            ::bond::reverse_map(_name_to_value_EnumType1);
+        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
+            {
+                { Int32Min, "Int32Min" },
+                { EnumValue3, "EnumValue3" },
+                { EnumValue5, "EnumValue5" },
+                { UInt32Min, "UInt32Min" },
+                { Low, "Low" },
+                { EnumValue1, "EnumValue1" },
+                { EnumValue2, "EnumValue2" },
+                { EnumValue4, "EnumValue4" },
+                { Int32Max, "Int32Max" },
+                { EnumValue6, "EnumValue6" },
+                { UInt32Max, "UInt32Max" }
+            };
 
         const std::string& ToString(enum EnumType1 value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_EnumType1.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_EnumType1.end() == it)
                 ::bond::InvalidEnumValueException(value, "EnumType1");
 
             return it->second;
@@ -68,6 +78,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace EnumType1
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/alloc_ctors/with_enum_header_types.cpp
+++ b/compiler/tests/generated/alloc_ctors/with_enum_header_types.cpp
@@ -10,19 +10,20 @@ namespace tests
     namespace EnumType1
     {
         const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1 =
-            boost::assign::map_list_of<std::string, enum EnumType1>
-                ("EnumValue1", EnumValue1)
-                ("EnumValue2", EnumValue2)
-                ("EnumValue3", EnumValue3)
-                ("EnumValue4", EnumValue4)
-                ("Low", Low)
-                ("EnumValue5", EnumValue5)
-                ("EnumValue6", EnumValue6)
-                ("Int32Min", Int32Min)
-                ("Int32Max", Int32Max)
-                ("UInt32Min", UInt32Min)
-                ("UInt32Max", UInt32Max);
+        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+            {
+                { "EnumValue1", EnumValue1 },
+                { "EnumValue2", EnumValue2 },
+                { "EnumValue3", EnumValue3 },
+                { "EnumValue4", EnumValue4 },
+                { "Low", Low },
+                { "EnumValue5", EnumValue5 },
+                { "EnumValue6", EnumValue6 },
+                { "Int32Min", Int32Min },
+                { "Int32Max", Int32Max },
+                { "UInt32Min", UInt32Min },
+                { "UInt32Max", UInt32Max }
+            };
 
         const
         std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =

--- a/compiler/tests/generated/allocator/aliases_types.cpp
+++ b/compiler/tests/generated/allocator/aliases_types.cpp
@@ -10,9 +10,10 @@ namespace tests
     namespace EnumToWrap
     {
         const
-        std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap =
-            boost::assign::map_list_of<std::string, enum EnumToWrap>
-                ("anEnumValue", anEnumValue);
+        std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
+            {
+                { "anEnumValue", anEnumValue }
+            };
 
         const
         std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap =

--- a/compiler/tests/generated/allocator/aliases_types.cpp
+++ b/compiler/tests/generated/allocator/aliases_types.cpp
@@ -9,21 +9,21 @@ namespace tests
     {
     namespace EnumToWrap
     {
-        const
-        std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
+        const std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
             {
                 { "anEnumValue", anEnumValue }
             };
 
-        const
-        std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap =
-            ::bond::reverse_map(_name_to_value_EnumToWrap);
+        const std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap
+            {
+                { anEnumValue, "anEnumValue" }
+            };
 
         const std::string& ToString(enum EnumToWrap value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_EnumToWrap.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_EnumToWrap.end() == it)
                 ::bond::InvalidEnumValueException(value, "EnumToWrap");
 
             return it->second;
@@ -58,6 +58,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace EnumToWrap
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/allocator/attributes_types.cpp
+++ b/compiler/tests/generated/allocator/attributes_types.cpp
@@ -9,21 +9,21 @@ namespace tests
     {
     namespace Enum
     {
-        const
-        std::map<std::string, enum Enum> _name_to_value_Enum
+        const std::map<std::string, enum Enum> _name_to_value_Enum
             {
                 { "Value1", Value1 }
             };
 
-        const
-        std::map<enum Enum, std::string> _value_to_name_Enum =
-            ::bond::reverse_map(_name_to_value_Enum);
+        const std::map<enum Enum, std::string> _value_to_name_Enum
+            {
+                { Value1, "Value1" }
+            };
 
         const std::string& ToString(enum Enum value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_Enum.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_Enum.end() == it)
                 ::bond::InvalidEnumValueException(value, "Enum");
 
             return it->second;
@@ -58,6 +58,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace Enum
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/allocator/attributes_types.cpp
+++ b/compiler/tests/generated/allocator/attributes_types.cpp
@@ -10,9 +10,10 @@ namespace tests
     namespace Enum
     {
         const
-        std::map<std::string, enum Enum> _name_to_value_Enum =
-            boost::assign::map_list_of<std::string, enum Enum>
-                ("Value1", Value1);
+        std::map<std::string, enum Enum> _name_to_value_Enum
+            {
+                { "Value1", Value1 }
+            };
 
         const
         std::map<enum Enum, std::string> _value_to_name_Enum =

--- a/compiler/tests/generated/allocator/defaults_types.cpp
+++ b/compiler/tests/generated/allocator/defaults_types.cpp
@@ -9,33 +9,45 @@ namespace tests
     {
     namespace EnumType1
     {
-        const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
             {
                 { "EnumValue1", EnumValue1 },
                 { "EnumValue2", EnumValue2 },
                 { "EnumValue3", EnumValue3 },
                 { "EnumValue4", EnumValue4 },
-                { "Low", Low },
                 { "EnumValue5", EnumValue5 },
                 { "EnumValue6", EnumValue6 },
-                { "Int32Min", Int32Min },
-                { "Int32Max", Int32Max },
-                { "UInt32Min", UInt32Min },
-                { "UInt32Max", UInt32Max },
                 { "HexNeg", HexNeg },
-                { "OctNeg", OctNeg }
+                { "Int32Max", Int32Max },
+                { "Int32Min", Int32Min },
+                { "Low", Low },
+                { "OctNeg", OctNeg },
+                { "UInt32Max", UInt32Max },
+                { "UInt32Min", UInt32Min }
             };
 
-        const
-        std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =
-            ::bond::reverse_map(_name_to_value_EnumType1);
+        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
+            {
+                { Int32Min, "Int32Min" },
+                { HexNeg, "HexNeg" },
+                { OctNeg, "OctNeg" },
+                { EnumValue3, "EnumValue3" },
+                { EnumValue5, "EnumValue5" },
+                { UInt32Min, "UInt32Min" },
+                { Low, "Low" },
+                { EnumValue1, "EnumValue1" },
+                { EnumValue2, "EnumValue2" },
+                { EnumValue4, "EnumValue4" },
+                { Int32Max, "Int32Max" },
+                { EnumValue6, "EnumValue6" },
+                { UInt32Max, "UInt32Max" }
+            };
 
         const std::string& ToString(enum EnumType1 value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_EnumType1.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_EnumType1.end() == it)
                 ::bond::InvalidEnumValueException(value, "EnumType1");
 
             return it->second;
@@ -70,6 +82,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace EnumType1
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/allocator/defaults_types.cpp
+++ b/compiler/tests/generated/allocator/defaults_types.cpp
@@ -10,21 +10,22 @@ namespace tests
     namespace EnumType1
     {
         const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1 =
-            boost::assign::map_list_of<std::string, enum EnumType1>
-                ("EnumValue1", EnumValue1)
-                ("EnumValue2", EnumValue2)
-                ("EnumValue3", EnumValue3)
-                ("EnumValue4", EnumValue4)
-                ("Low", Low)
-                ("EnumValue5", EnumValue5)
-                ("EnumValue6", EnumValue6)
-                ("Int32Min", Int32Min)
-                ("Int32Max", Int32Max)
-                ("UInt32Min", UInt32Min)
-                ("UInt32Max", UInt32Max)
-                ("HexNeg", HexNeg)
-                ("OctNeg", OctNeg);
+        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+            {
+                { "EnumValue1", EnumValue1 },
+                { "EnumValue2", EnumValue2 },
+                { "EnumValue3", EnumValue3 },
+                { "EnumValue4", EnumValue4 },
+                { "Low", Low },
+                { "EnumValue5", EnumValue5 },
+                { "EnumValue6", EnumValue6 },
+                { "Int32Min", Int32Min },
+                { "Int32Max", Int32Max },
+                { "UInt32Min", UInt32Min },
+                { "UInt32Max", UInt32Max },
+                { "HexNeg", HexNeg },
+                { "OctNeg", OctNeg }
+            };
 
         const
         std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =

--- a/compiler/tests/generated/allocator/with_enum_header_types.cpp
+++ b/compiler/tests/generated/allocator/with_enum_header_types.cpp
@@ -9,31 +9,41 @@ namespace tests
     {
     namespace EnumType1
     {
-        const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
             {
                 { "EnumValue1", EnumValue1 },
                 { "EnumValue2", EnumValue2 },
                 { "EnumValue3", EnumValue3 },
                 { "EnumValue4", EnumValue4 },
-                { "Low", Low },
                 { "EnumValue5", EnumValue5 },
                 { "EnumValue6", EnumValue6 },
-                { "Int32Min", Int32Min },
                 { "Int32Max", Int32Max },
-                { "UInt32Min", UInt32Min },
-                { "UInt32Max", UInt32Max }
+                { "Int32Min", Int32Min },
+                { "Low", Low },
+                { "UInt32Max", UInt32Max },
+                { "UInt32Min", UInt32Min }
             };
 
-        const
-        std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =
-            ::bond::reverse_map(_name_to_value_EnumType1);
+        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
+            {
+                { Int32Min, "Int32Min" },
+                { EnumValue3, "EnumValue3" },
+                { EnumValue5, "EnumValue5" },
+                { UInt32Min, "UInt32Min" },
+                { Low, "Low" },
+                { EnumValue1, "EnumValue1" },
+                { EnumValue2, "EnumValue2" },
+                { EnumValue4, "EnumValue4" },
+                { Int32Max, "Int32Max" },
+                { EnumValue6, "EnumValue6" },
+                { UInt32Max, "UInt32Max" }
+            };
 
         const std::string& ToString(enum EnumType1 value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_EnumType1.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_EnumType1.end() == it)
                 ::bond::InvalidEnumValueException(value, "EnumType1");
 
             return it->second;
@@ -68,6 +78,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace EnumType1
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/allocator/with_enum_header_types.cpp
+++ b/compiler/tests/generated/allocator/with_enum_header_types.cpp
@@ -10,19 +10,20 @@ namespace tests
     namespace EnumType1
     {
         const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1 =
-            boost::assign::map_list_of<std::string, enum EnumType1>
-                ("EnumValue1", EnumValue1)
-                ("EnumValue2", EnumValue2)
-                ("EnumValue3", EnumValue3)
-                ("EnumValue4", EnumValue4)
-                ("Low", Low)
-                ("EnumValue5", EnumValue5)
-                ("EnumValue6", EnumValue6)
-                ("Int32Min", Int32Min)
-                ("Int32Max", Int32Max)
-                ("UInt32Min", UInt32Min)
-                ("UInt32Max", UInt32Max);
+        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+            {
+                { "EnumValue1", EnumValue1 },
+                { "EnumValue2", EnumValue2 },
+                { "EnumValue3", EnumValue3 },
+                { "EnumValue4", EnumValue4 },
+                { "Low", Low },
+                { "EnumValue5", EnumValue5 },
+                { "EnumValue6", EnumValue6 },
+                { "Int32Min", Int32Min },
+                { "Int32Max", Int32Max },
+                { "UInt32Min", UInt32Min },
+                { "UInt32Max", UInt32Max }
+            };
 
         const
         std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =

--- a/compiler/tests/generated/attributes_types.cpp
+++ b/compiler/tests/generated/attributes_types.cpp
@@ -9,21 +9,21 @@ namespace tests
     {
     namespace Enum
     {
-        const
-        std::map<std::string, enum Enum> _name_to_value_Enum
+        const std::map<std::string, enum Enum> _name_to_value_Enum
             {
                 { "Value1", Value1 }
             };
 
-        const
-        std::map<enum Enum, std::string> _value_to_name_Enum =
-            ::bond::reverse_map(_name_to_value_Enum);
+        const std::map<enum Enum, std::string> _value_to_name_Enum
+            {
+                { Value1, "Value1" }
+            };
 
         const std::string& ToString(enum Enum value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_Enum.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_Enum.end() == it)
                 ::bond::InvalidEnumValueException(value, "Enum");
 
             return it->second;
@@ -58,6 +58,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace Enum
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/attributes_types.cpp
+++ b/compiler/tests/generated/attributes_types.cpp
@@ -10,9 +10,10 @@ namespace tests
     namespace Enum
     {
         const
-        std::map<std::string, enum Enum> _name_to_value_Enum =
-            boost::assign::map_list_of<std::string, enum Enum>
-                ("Value1", Value1);
+        std::map<std::string, enum Enum> _name_to_value_Enum
+            {
+                { "Value1", Value1 }
+            };
 
         const
         std::map<enum Enum, std::string> _value_to_name_Enum =

--- a/compiler/tests/generated/defaults_types.cpp
+++ b/compiler/tests/generated/defaults_types.cpp
@@ -9,33 +9,45 @@ namespace tests
     {
     namespace EnumType1
     {
-        const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
             {
                 { "EnumValue1", EnumValue1 },
                 { "EnumValue2", EnumValue2 },
                 { "EnumValue3", EnumValue3 },
                 { "EnumValue4", EnumValue4 },
-                { "Low", Low },
                 { "EnumValue5", EnumValue5 },
                 { "EnumValue6", EnumValue6 },
-                { "Int32Min", Int32Min },
-                { "Int32Max", Int32Max },
-                { "UInt32Min", UInt32Min },
-                { "UInt32Max", UInt32Max },
                 { "HexNeg", HexNeg },
-                { "OctNeg", OctNeg }
+                { "Int32Max", Int32Max },
+                { "Int32Min", Int32Min },
+                { "Low", Low },
+                { "OctNeg", OctNeg },
+                { "UInt32Max", UInt32Max },
+                { "UInt32Min", UInt32Min }
             };
 
-        const
-        std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =
-            ::bond::reverse_map(_name_to_value_EnumType1);
+        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
+            {
+                { Int32Min, "Int32Min" },
+                { HexNeg, "HexNeg" },
+                { OctNeg, "OctNeg" },
+                { EnumValue3, "EnumValue3" },
+                { EnumValue5, "EnumValue5" },
+                { UInt32Min, "UInt32Min" },
+                { Low, "Low" },
+                { EnumValue1, "EnumValue1" },
+                { EnumValue2, "EnumValue2" },
+                { EnumValue4, "EnumValue4" },
+                { Int32Max, "Int32Max" },
+                { EnumValue6, "EnumValue6" },
+                { UInt32Max, "UInt32Max" }
+            };
 
         const std::string& ToString(enum EnumType1 value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_EnumType1.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_EnumType1.end() == it)
                 ::bond::InvalidEnumValueException(value, "EnumType1");
 
             return it->second;
@@ -70,6 +82,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace EnumType1
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/defaults_types.cpp
+++ b/compiler/tests/generated/defaults_types.cpp
@@ -10,21 +10,22 @@ namespace tests
     namespace EnumType1
     {
         const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1 =
-            boost::assign::map_list_of<std::string, enum EnumType1>
-                ("EnumValue1", EnumValue1)
-                ("EnumValue2", EnumValue2)
-                ("EnumValue3", EnumValue3)
-                ("EnumValue4", EnumValue4)
-                ("Low", Low)
-                ("EnumValue5", EnumValue5)
-                ("EnumValue6", EnumValue6)
-                ("Int32Min", Int32Min)
-                ("Int32Max", Int32Max)
-                ("UInt32Min", UInt32Min)
-                ("UInt32Max", UInt32Max)
-                ("HexNeg", HexNeg)
-                ("OctNeg", OctNeg);
+        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+            {
+                { "EnumValue1", EnumValue1 },
+                { "EnumValue2", EnumValue2 },
+                { "EnumValue3", EnumValue3 },
+                { "EnumValue4", EnumValue4 },
+                { "Low", Low },
+                { "EnumValue5", EnumValue5 },
+                { "EnumValue6", EnumValue6 },
+                { "Int32Min", Int32Min },
+                { "Int32Max", Int32Max },
+                { "UInt32Min", UInt32Min },
+                { "UInt32Max", UInt32Max },
+                { "HexNeg", HexNeg },
+                { "OctNeg", OctNeg }
+            };
 
         const
         std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =

--- a/compiler/tests/generated/scoped_allocator/aliases_types.cpp
+++ b/compiler/tests/generated/scoped_allocator/aliases_types.cpp
@@ -10,9 +10,10 @@ namespace tests
     namespace EnumToWrap
     {
         const
-        std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap =
-            boost::assign::map_list_of<std::string, enum EnumToWrap>
-                ("anEnumValue", anEnumValue);
+        std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
+            {
+                { "anEnumValue", anEnumValue }
+            };
 
         const
         std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap =

--- a/compiler/tests/generated/scoped_allocator/aliases_types.cpp
+++ b/compiler/tests/generated/scoped_allocator/aliases_types.cpp
@@ -9,21 +9,21 @@ namespace tests
     {
     namespace EnumToWrap
     {
-        const
-        std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
+        const std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
             {
                 { "anEnumValue", anEnumValue }
             };
 
-        const
-        std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap =
-            ::bond::reverse_map(_name_to_value_EnumToWrap);
+        const std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap
+            {
+                { anEnumValue, "anEnumValue" }
+            };
 
         const std::string& ToString(enum EnumToWrap value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_EnumToWrap.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_EnumToWrap.end() == it)
                 ::bond::InvalidEnumValueException(value, "EnumToWrap");
 
             return it->second;
@@ -58,6 +58,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace EnumToWrap
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/scoped_allocator/attributes_types.cpp
+++ b/compiler/tests/generated/scoped_allocator/attributes_types.cpp
@@ -9,21 +9,21 @@ namespace tests
     {
     namespace Enum
     {
-        const
-        std::map<std::string, enum Enum> _name_to_value_Enum
+        const std::map<std::string, enum Enum> _name_to_value_Enum
             {
                 { "Value1", Value1 }
             };
 
-        const
-        std::map<enum Enum, std::string> _value_to_name_Enum =
-            ::bond::reverse_map(_name_to_value_Enum);
+        const std::map<enum Enum, std::string> _value_to_name_Enum
+            {
+                { Value1, "Value1" }
+            };
 
         const std::string& ToString(enum Enum value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_Enum.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_Enum.end() == it)
                 ::bond::InvalidEnumValueException(value, "Enum");
 
             return it->second;
@@ -58,6 +58,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace Enum
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/scoped_allocator/attributes_types.cpp
+++ b/compiler/tests/generated/scoped_allocator/attributes_types.cpp
@@ -10,9 +10,10 @@ namespace tests
     namespace Enum
     {
         const
-        std::map<std::string, enum Enum> _name_to_value_Enum =
-            boost::assign::map_list_of<std::string, enum Enum>
-                ("Value1", Value1);
+        std::map<std::string, enum Enum> _name_to_value_Enum
+            {
+                { "Value1", Value1 }
+            };
 
         const
         std::map<enum Enum, std::string> _value_to_name_Enum =

--- a/compiler/tests/generated/scoped_allocator/defaults_types.cpp
+++ b/compiler/tests/generated/scoped_allocator/defaults_types.cpp
@@ -9,33 +9,45 @@ namespace tests
     {
     namespace EnumType1
     {
-        const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
             {
                 { "EnumValue1", EnumValue1 },
                 { "EnumValue2", EnumValue2 },
                 { "EnumValue3", EnumValue3 },
                 { "EnumValue4", EnumValue4 },
-                { "Low", Low },
                 { "EnumValue5", EnumValue5 },
                 { "EnumValue6", EnumValue6 },
-                { "Int32Min", Int32Min },
-                { "Int32Max", Int32Max },
-                { "UInt32Min", UInt32Min },
-                { "UInt32Max", UInt32Max },
                 { "HexNeg", HexNeg },
-                { "OctNeg", OctNeg }
+                { "Int32Max", Int32Max },
+                { "Int32Min", Int32Min },
+                { "Low", Low },
+                { "OctNeg", OctNeg },
+                { "UInt32Max", UInt32Max },
+                { "UInt32Min", UInt32Min }
             };
 
-        const
-        std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =
-            ::bond::reverse_map(_name_to_value_EnumType1);
+        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
+            {
+                { Int32Min, "Int32Min" },
+                { HexNeg, "HexNeg" },
+                { OctNeg, "OctNeg" },
+                { EnumValue3, "EnumValue3" },
+                { EnumValue5, "EnumValue5" },
+                { UInt32Min, "UInt32Min" },
+                { Low, "Low" },
+                { EnumValue1, "EnumValue1" },
+                { EnumValue2, "EnumValue2" },
+                { EnumValue4, "EnumValue4" },
+                { Int32Max, "Int32Max" },
+                { EnumValue6, "EnumValue6" },
+                { UInt32Max, "UInt32Max" }
+            };
 
         const std::string& ToString(enum EnumType1 value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_EnumType1.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_EnumType1.end() == it)
                 ::bond::InvalidEnumValueException(value, "EnumType1");
 
             return it->second;
@@ -70,6 +82,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace EnumType1
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/scoped_allocator/defaults_types.cpp
+++ b/compiler/tests/generated/scoped_allocator/defaults_types.cpp
@@ -10,21 +10,22 @@ namespace tests
     namespace EnumType1
     {
         const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1 =
-            boost::assign::map_list_of<std::string, enum EnumType1>
-                ("EnumValue1", EnumValue1)
-                ("EnumValue2", EnumValue2)
-                ("EnumValue3", EnumValue3)
-                ("EnumValue4", EnumValue4)
-                ("Low", Low)
-                ("EnumValue5", EnumValue5)
-                ("EnumValue6", EnumValue6)
-                ("Int32Min", Int32Min)
-                ("Int32Max", Int32Max)
-                ("UInt32Min", UInt32Min)
-                ("UInt32Max", UInt32Max)
-                ("HexNeg", HexNeg)
-                ("OctNeg", OctNeg);
+        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+            {
+                { "EnumValue1", EnumValue1 },
+                { "EnumValue2", EnumValue2 },
+                { "EnumValue3", EnumValue3 },
+                { "EnumValue4", EnumValue4 },
+                { "Low", Low },
+                { "EnumValue5", EnumValue5 },
+                { "EnumValue6", EnumValue6 },
+                { "Int32Min", Int32Min },
+                { "Int32Max", Int32Max },
+                { "UInt32Min", UInt32Min },
+                { "UInt32Max", UInt32Max },
+                { "HexNeg", HexNeg },
+                { "OctNeg", OctNeg }
+            };
 
         const
         std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =

--- a/compiler/tests/generated/scoped_allocator/with_enum_header_types.cpp
+++ b/compiler/tests/generated/scoped_allocator/with_enum_header_types.cpp
@@ -9,31 +9,41 @@ namespace tests
     {
     namespace EnumType1
     {
-        const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
             {
                 { "EnumValue1", EnumValue1 },
                 { "EnumValue2", EnumValue2 },
                 { "EnumValue3", EnumValue3 },
                 { "EnumValue4", EnumValue4 },
-                { "Low", Low },
                 { "EnumValue5", EnumValue5 },
                 { "EnumValue6", EnumValue6 },
-                { "Int32Min", Int32Min },
                 { "Int32Max", Int32Max },
-                { "UInt32Min", UInt32Min },
-                { "UInt32Max", UInt32Max }
+                { "Int32Min", Int32Min },
+                { "Low", Low },
+                { "UInt32Max", UInt32Max },
+                { "UInt32Min", UInt32Min }
             };
 
-        const
-        std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =
-            ::bond::reverse_map(_name_to_value_EnumType1);
+        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
+            {
+                { Int32Min, "Int32Min" },
+                { EnumValue3, "EnumValue3" },
+                { EnumValue5, "EnumValue5" },
+                { UInt32Min, "UInt32Min" },
+                { Low, "Low" },
+                { EnumValue1, "EnumValue1" },
+                { EnumValue2, "EnumValue2" },
+                { EnumValue4, "EnumValue4" },
+                { Int32Max, "Int32Max" },
+                { EnumValue6, "EnumValue6" },
+                { UInt32Max, "UInt32Max" }
+            };
 
         const std::string& ToString(enum EnumType1 value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_EnumType1.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_EnumType1.end() == it)
                 ::bond::InvalidEnumValueException(value, "EnumType1");
 
             return it->second;
@@ -68,6 +78,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace EnumType1
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/scoped_allocator/with_enum_header_types.cpp
+++ b/compiler/tests/generated/scoped_allocator/with_enum_header_types.cpp
@@ -10,19 +10,20 @@ namespace tests
     namespace EnumType1
     {
         const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1 =
-            boost::assign::map_list_of<std::string, enum EnumType1>
-                ("EnumValue1", EnumValue1)
-                ("EnumValue2", EnumValue2)
-                ("EnumValue3", EnumValue3)
-                ("EnumValue4", EnumValue4)
-                ("Low", Low)
-                ("EnumValue5", EnumValue5)
-                ("EnumValue6", EnumValue6)
-                ("Int32Min", Int32Min)
-                ("Int32Max", Int32Max)
-                ("UInt32Min", UInt32Min)
-                ("UInt32Max", UInt32Max);
+        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+            {
+                { "EnumValue1", EnumValue1 },
+                { "EnumValue2", EnumValue2 },
+                { "EnumValue3", EnumValue3 },
+                { "EnumValue4", EnumValue4 },
+                { "Low", Low },
+                { "EnumValue5", EnumValue5 },
+                { "EnumValue6", EnumValue6 },
+                { "Int32Min", Int32Min },
+                { "Int32Max", Int32Max },
+                { "UInt32Min", UInt32Min },
+                { "UInt32Max", UInt32Max }
+            };
 
         const
         std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =

--- a/compiler/tests/generated/type_aliases/aliases_types.cpp
+++ b/compiler/tests/generated/type_aliases/aliases_types.cpp
@@ -10,9 +10,10 @@ namespace tests
     namespace EnumToWrap
     {
         const
-        std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap =
-            boost::assign::map_list_of<std::string, enum EnumToWrap>
-                ("anEnumValue", anEnumValue);
+        std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
+            {
+                { "anEnumValue", anEnumValue }
+            };
 
         const
         std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap =

--- a/compiler/tests/generated/type_aliases/aliases_types.cpp
+++ b/compiler/tests/generated/type_aliases/aliases_types.cpp
@@ -9,21 +9,21 @@ namespace tests
     {
     namespace EnumToWrap
     {
-        const
-        std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
+        const std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
             {
                 { "anEnumValue", anEnumValue }
             };
 
-        const
-        std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap =
-            ::bond::reverse_map(_name_to_value_EnumToWrap);
+        const std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap
+            {
+                { anEnumValue, "anEnumValue" }
+            };
 
         const std::string& ToString(enum EnumToWrap value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_EnumToWrap.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_EnumToWrap.end() == it)
                 ::bond::InvalidEnumValueException(value, "EnumToWrap");
 
             return it->second;
@@ -58,6 +58,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace EnumToWrap
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/type_aliases/attributes_types.cpp
+++ b/compiler/tests/generated/type_aliases/attributes_types.cpp
@@ -9,21 +9,21 @@ namespace tests
     {
     namespace Enum
     {
-        const
-        std::map<std::string, enum Enum> _name_to_value_Enum
+        const std::map<std::string, enum Enum> _name_to_value_Enum
             {
                 { "Value1", Value1 }
             };
 
-        const
-        std::map<enum Enum, std::string> _value_to_name_Enum =
-            ::bond::reverse_map(_name_to_value_Enum);
+        const std::map<enum Enum, std::string> _value_to_name_Enum
+            {
+                { Value1, "Value1" }
+            };
 
         const std::string& ToString(enum Enum value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_Enum.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_Enum.end() == it)
                 ::bond::InvalidEnumValueException(value, "Enum");
 
             return it->second;
@@ -58,6 +58,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace Enum
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/type_aliases/attributes_types.cpp
+++ b/compiler/tests/generated/type_aliases/attributes_types.cpp
@@ -10,9 +10,10 @@ namespace tests
     namespace Enum
     {
         const
-        std::map<std::string, enum Enum> _name_to_value_Enum =
-            boost::assign::map_list_of<std::string, enum Enum>
-                ("Value1", Value1);
+        std::map<std::string, enum Enum> _name_to_value_Enum
+            {
+                { "Value1", Value1 }
+            };
 
         const
         std::map<enum Enum, std::string> _value_to_name_Enum =

--- a/compiler/tests/generated/type_aliases/defaults_types.cpp
+++ b/compiler/tests/generated/type_aliases/defaults_types.cpp
@@ -9,33 +9,45 @@ namespace tests
     {
     namespace EnumType1
     {
-        const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
             {
                 { "EnumValue1", EnumValue1 },
                 { "EnumValue2", EnumValue2 },
                 { "EnumValue3", EnumValue3 },
                 { "EnumValue4", EnumValue4 },
-                { "Low", Low },
                 { "EnumValue5", EnumValue5 },
                 { "EnumValue6", EnumValue6 },
-                { "Int32Min", Int32Min },
-                { "Int32Max", Int32Max },
-                { "UInt32Min", UInt32Min },
-                { "UInt32Max", UInt32Max },
                 { "HexNeg", HexNeg },
-                { "OctNeg", OctNeg }
+                { "Int32Max", Int32Max },
+                { "Int32Min", Int32Min },
+                { "Low", Low },
+                { "OctNeg", OctNeg },
+                { "UInt32Max", UInt32Max },
+                { "UInt32Min", UInt32Min }
             };
 
-        const
-        std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =
-            ::bond::reverse_map(_name_to_value_EnumType1);
+        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
+            {
+                { Int32Min, "Int32Min" },
+                { HexNeg, "HexNeg" },
+                { OctNeg, "OctNeg" },
+                { EnumValue3, "EnumValue3" },
+                { EnumValue5, "EnumValue5" },
+                { UInt32Min, "UInt32Min" },
+                { Low, "Low" },
+                { EnumValue1, "EnumValue1" },
+                { EnumValue2, "EnumValue2" },
+                { EnumValue4, "EnumValue4" },
+                { Int32Max, "Int32Max" },
+                { EnumValue6, "EnumValue6" },
+                { UInt32Max, "UInt32Max" }
+            };
 
         const std::string& ToString(enum EnumType1 value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_EnumType1.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_EnumType1.end() == it)
                 ::bond::InvalidEnumValueException(value, "EnumType1");
 
             return it->second;
@@ -70,6 +82,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace EnumType1
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/type_aliases/defaults_types.cpp
+++ b/compiler/tests/generated/type_aliases/defaults_types.cpp
@@ -10,21 +10,22 @@ namespace tests
     namespace EnumType1
     {
         const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1 =
-            boost::assign::map_list_of<std::string, enum EnumType1>
-                ("EnumValue1", EnumValue1)
-                ("EnumValue2", EnumValue2)
-                ("EnumValue3", EnumValue3)
-                ("EnumValue4", EnumValue4)
-                ("Low", Low)
-                ("EnumValue5", EnumValue5)
-                ("EnumValue6", EnumValue6)
-                ("Int32Min", Int32Min)
-                ("Int32Max", Int32Max)
-                ("UInt32Min", UInt32Min)
-                ("UInt32Max", UInt32Max)
-                ("HexNeg", HexNeg)
-                ("OctNeg", OctNeg);
+        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+            {
+                { "EnumValue1", EnumValue1 },
+                { "EnumValue2", EnumValue2 },
+                { "EnumValue3", EnumValue3 },
+                { "EnumValue4", EnumValue4 },
+                { "Low", Low },
+                { "EnumValue5", EnumValue5 },
+                { "EnumValue6", EnumValue6 },
+                { "Int32Min", Int32Min },
+                { "Int32Max", Int32Max },
+                { "UInt32Min", UInt32Min },
+                { "UInt32Max", UInt32Max },
+                { "HexNeg", HexNeg },
+                { "OctNeg", OctNeg }
+            };
 
         const
         std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =

--- a/compiler/tests/generated/type_aliases/with_enum_header_types.cpp
+++ b/compiler/tests/generated/type_aliases/with_enum_header_types.cpp
@@ -9,31 +9,41 @@ namespace tests
     {
     namespace EnumType1
     {
-        const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
             {
                 { "EnumValue1", EnumValue1 },
                 { "EnumValue2", EnumValue2 },
                 { "EnumValue3", EnumValue3 },
                 { "EnumValue4", EnumValue4 },
-                { "Low", Low },
                 { "EnumValue5", EnumValue5 },
                 { "EnumValue6", EnumValue6 },
-                { "Int32Min", Int32Min },
                 { "Int32Max", Int32Max },
-                { "UInt32Min", UInt32Min },
-                { "UInt32Max", UInt32Max }
+                { "Int32Min", Int32Min },
+                { "Low", Low },
+                { "UInt32Max", UInt32Max },
+                { "UInt32Min", UInt32Min }
             };
 
-        const
-        std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =
-            ::bond::reverse_map(_name_to_value_EnumType1);
+        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
+            {
+                { Int32Min, "Int32Min" },
+                { EnumValue3, "EnumValue3" },
+                { EnumValue5, "EnumValue5" },
+                { UInt32Min, "UInt32Min" },
+                { Low, "Low" },
+                { EnumValue1, "EnumValue1" },
+                { EnumValue2, "EnumValue2" },
+                { EnumValue4, "EnumValue4" },
+                { Int32Max, "Int32Max" },
+                { EnumValue6, "EnumValue6" },
+                { UInt32Max, "UInt32Max" }
+            };
 
         const std::string& ToString(enum EnumType1 value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_EnumType1.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_EnumType1.end() == it)
                 ::bond::InvalidEnumValueException(value, "EnumType1");
 
             return it->second;
@@ -68,6 +78,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace EnumType1
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/type_aliases/with_enum_header_types.cpp
+++ b/compiler/tests/generated/type_aliases/with_enum_header_types.cpp
@@ -10,19 +10,20 @@ namespace tests
     namespace EnumType1
     {
         const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1 =
-            boost::assign::map_list_of<std::string, enum EnumType1>
-                ("EnumValue1", EnumValue1)
-                ("EnumValue2", EnumValue2)
-                ("EnumValue3", EnumValue3)
-                ("EnumValue4", EnumValue4)
-                ("Low", Low)
-                ("EnumValue5", EnumValue5)
-                ("EnumValue6", EnumValue6)
-                ("Int32Min", Int32Min)
-                ("Int32Max", Int32Max)
-                ("UInt32Min", UInt32Min)
-                ("UInt32Max", UInt32Max);
+        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+            {
+                { "EnumValue1", EnumValue1 },
+                { "EnumValue2", EnumValue2 },
+                { "EnumValue3", EnumValue3 },
+                { "EnumValue4", EnumValue4 },
+                { "Low", Low },
+                { "EnumValue5", EnumValue5 },
+                { "EnumValue6", EnumValue6 },
+                { "Int32Min", Int32Min },
+                { "Int32Max", Int32Max },
+                { "UInt32Min", UInt32Min },
+                { "UInt32Max", UInt32Max }
+            };
 
         const
         std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =

--- a/compiler/tests/generated/with_enum_header_types.cpp
+++ b/compiler/tests/generated/with_enum_header_types.cpp
@@ -9,31 +9,41 @@ namespace tests
     {
     namespace EnumType1
     {
-        const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
             {
                 { "EnumValue1", EnumValue1 },
                 { "EnumValue2", EnumValue2 },
                 { "EnumValue3", EnumValue3 },
                 { "EnumValue4", EnumValue4 },
-                { "Low", Low },
                 { "EnumValue5", EnumValue5 },
                 { "EnumValue6", EnumValue6 },
-                { "Int32Min", Int32Min },
                 { "Int32Max", Int32Max },
-                { "UInt32Min", UInt32Min },
-                { "UInt32Max", UInt32Max }
+                { "Int32Min", Int32Min },
+                { "Low", Low },
+                { "UInt32Max", UInt32Max },
+                { "UInt32Min", UInt32Min }
             };
 
-        const
-        std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =
-            ::bond::reverse_map(_name_to_value_EnumType1);
+        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
+            {
+                { Int32Min, "Int32Min" },
+                { EnumValue3, "EnumValue3" },
+                { EnumValue5, "EnumValue5" },
+                { UInt32Min, "UInt32Min" },
+                { Low, "Low" },
+                { EnumValue1, "EnumValue1" },
+                { EnumValue2, "EnumValue2" },
+                { EnumValue4, "EnumValue4" },
+                { Int32Max, "Int32Max" },
+                { EnumValue6, "EnumValue6" },
+                { UInt32Max, "UInt32Max" }
+            };
 
         const std::string& ToString(enum EnumType1 value)
         {
-            auto it = GetValueToNameMap(value).find(value);
+            auto it = _value_to_name_EnumType1.find(value);
 
-            if (GetValueToNameMap(value).end() == it)
+            if (_value_to_name_EnumType1.end() == it)
                 ::bond::InvalidEnumValueException(value, "EnumType1");
 
             return it->second;
@@ -68,6 +78,7 @@ namespace tests
 
             return true;
         }
+
     } // namespace EnumType1
     } // namespace _bond_enumerators
 

--- a/compiler/tests/generated/with_enum_header_types.cpp
+++ b/compiler/tests/generated/with_enum_header_types.cpp
@@ -10,19 +10,20 @@ namespace tests
     namespace EnumType1
     {
         const
-        std::map<std::string, enum EnumType1> _name_to_value_EnumType1 =
-            boost::assign::map_list_of<std::string, enum EnumType1>
-                ("EnumValue1", EnumValue1)
-                ("EnumValue2", EnumValue2)
-                ("EnumValue3", EnumValue3)
-                ("EnumValue4", EnumValue4)
-                ("Low", Low)
-                ("EnumValue5", EnumValue5)
-                ("EnumValue6", EnumValue6)
-                ("Int32Min", Int32Min)
-                ("Int32Max", Int32Max)
-                ("UInt32Min", UInt32Min)
-                ("UInt32Max", UInt32Max);
+        std::map<std::string, enum EnumType1> _name_to_value_EnumType1
+            {
+                { "EnumValue1", EnumValue1 },
+                { "EnumValue2", EnumValue2 },
+                { "EnumValue3", EnumValue3 },
+                { "EnumValue4", EnumValue4 },
+                { "Low", Low },
+                { "EnumValue5", EnumValue5 },
+                { "EnumValue6", EnumValue6 },
+                { "Int32Min", Int32Min },
+                { "Int32Max", Int32Max },
+                { "UInt32Min", UInt32Min },
+                { "UInt32Max", UInt32Max }
+            };
 
         const
         std::map<enum EnumType1, std::string> _value_to_name_EnumType1 =


### PR DESCRIPTION
Currently, `boost::assign::map_list_of` is used to initialize C++ enum maps. This change makes use of [list initialization](http://en.cppreference.com/w/cpp/language/list_initialization) available in `c++11` which is more appropriate and avoids extra dependency on template-heavy boost headers.