### PR TITLE
[gbc c++] Fix to not apply attrib. to generics

### DIFF
--- a/compiler/src/Language/Bond/Codegen/Cpp/Reflection_h.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Reflection_h.hs
@@ -72,10 +72,11 @@ reflection_h export_attribute cpp file imports declarations = ("_reflection.h", 
 
         className = CPP.className s
 
-        export_attr = optional (\a -> [lt|#{a}
+        export_attr = onlyNonTemplate $ optional (\a -> [lt|#{a}
         |]) export_attribute
 
         onlyTemplate x = if null declParams then mempty else x
+        onlyNonTemplate x = if null declParams then x else mempty
 
         metadataInitArgs = onlyTemplate [lt|<boost::mpl::list#{classParams} >|]
 

--- a/examples/cpp/core/dll/dll.bond
+++ b/examples/cpp/core/dll/dll.bond
@@ -1,13 +1,13 @@
 namespace examples.dll
 
-struct Item
+struct Item<T>
 {
-    0: string       str = "default string value";
-    1: list<uint32> numbers;
+    0: string  str = "default string value";
+    1: list<T> numbers;
 }
 
 struct MyStruct
 {
-    0: vector<Item> items;
-    1: bonded<Item> item;
+    0: vector<Item<uint32>> items;
+    1: bonded<Item<uint32>> item;
 }

--- a/examples/cpp/core/dll/using_dll.cpp
+++ b/examples/cpp/core/dll/using_dll.cpp
@@ -29,10 +29,10 @@ int main()
     obj.items.resize(1);
     obj.items[0].numbers.push_back(13);
 
-    Item item;
+    Item<uint32_t> item;
 
     item.numbers.push_back(11);
-    obj.item = bond::bonded<Item>(item);
+    obj.item = bond::bonded<Item<uint32_t>>(item);
 
     // Serialize
     bond::OutputBuffer buffer;
@@ -47,7 +47,7 @@ int main()
     bond::CompactBinaryReader<bond::InputBuffer> reader(data);
     bond::Deserialize(reader, obj2);
 
-    Item item2;
+    Item<uint32_t> item2;
     
     obj2.item.Deserialize(item2);
 


### PR DESCRIPTION
Currently, the `--export-attribute` is used to mark all static `bond::Metadata` fields in compile-time `Schema` object, including the cases when the type is a template, which is not correct. This fixes the `gbc` to skip the attribute in such cases.