### PR TITLE
[gbc c++] Use init. list for populating attr. map

### DIFF
--- a/compiler/src/Language/Bond/Codegen/Cpp/Util.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Util.hs
@@ -20,6 +20,7 @@ module Language.Bond.Codegen.Cpp.Util
 
 import Data.Monoid
 import Prelude
+import Data.List
 import Data.Text.Lazy (Text, unpack)
 import Data.Text.Lazy.Builder (toLazyText)
 import Text.Shakespeare.Text
@@ -63,10 +64,14 @@ template d = if null $ declParams d then mempty else [lt|template <typename #{pa
 -- attribute initializer
 attributeInit :: [Attribute] -> Text
 attributeInit [] = "::bond::reflection::Attributes()"
-attributeInit xs = [lt|boost::assign::map_list_of<std::string, std::string>#{newlineBeginSep 5 attrNameValue xs}|]
+attributeInit xs = [lt|{
+                    #{commaLineSep 5 attrNameValueText sortedAttributes}
+                }|]
   where
-    idl = MappingContext idlTypeMapping [] [] []  
-    attrNameValue Attribute {..} = [lt|("#{getQualifiedName idl attrName}", "#{attrValue}")|]
+    idl = MappingContext idlTypeMapping [] [] []
+    attrNameValue Attribute {..} = (getQualifiedName idl attrName, attrValue)
+    sortedAttributes = sortOn fst $ map attrNameValue xs
+    attrNameValueText (name, value) = [lt|{ "#{name}", "#{value}" }|]
 
 
 -- modifier tag type for a field

--- a/compiler/tests/generated/alloc_ctors/attributes_reflection.h
+++ b/compiler/tests/generated/alloc_ctors/attributes_reflection.h
@@ -39,9 +39,10 @@ namespace tests
         static ::bond::Metadata GetMetadata()
         {
             return ::bond::reflection::MetadataInit("Foo", "tests.Foo",
-                boost::assign::map_list_of<std::string, std::string>
-                    ("StructAttribute1", "one")
-                    ("StructAttribute2", "two")
+                {
+                    { "StructAttribute1", "one" },
+                    { "StructAttribute2", "two" }
+                }
             );
         }
     };

--- a/compiler/tests/generated/alloc_ctors/attributes_types.cpp
+++ b/compiler/tests/generated/alloc_ctors/attributes_types.cpp
@@ -68,9 +68,10 @@ namespace tests
     
     const ::bond::Metadata Foo::Schema::s_f_metadata
         = ::bond::reflection::MetadataInit("f", ::bond::reflection::optional_field_modifier::value,
-                boost::assign::map_list_of<std::string, std::string>
-                    ("FieldAttribute1", "one")
-                    ("FieldAttribute2", "two"));
+                {
+                    { "FieldAttribute1", "one" },
+                    { "FieldAttribute2", "two" }
+                });
 
     
 } // namespace tests

--- a/compiler/tests/generated/allocator/attributes_reflection.h
+++ b/compiler/tests/generated/allocator/attributes_reflection.h
@@ -39,9 +39,10 @@ namespace tests
         static ::bond::Metadata GetMetadata()
         {
             return ::bond::reflection::MetadataInit("Foo", "tests.Foo",
-                boost::assign::map_list_of<std::string, std::string>
-                    ("StructAttribute1", "one")
-                    ("StructAttribute2", "two")
+                {
+                    { "StructAttribute1", "one" },
+                    { "StructAttribute2", "two" }
+                }
             );
         }
     };

--- a/compiler/tests/generated/allocator/attributes_types.cpp
+++ b/compiler/tests/generated/allocator/attributes_types.cpp
@@ -68,9 +68,10 @@ namespace tests
     
     const ::bond::Metadata Foo::Schema::s_f_metadata
         = ::bond::reflection::MetadataInit("f", ::bond::reflection::optional_field_modifier::value,
-                boost::assign::map_list_of<std::string, std::string>
-                    ("FieldAttribute1", "one")
-                    ("FieldAttribute2", "two"));
+                {
+                    { "FieldAttribute1", "one" },
+                    { "FieldAttribute2", "two" }
+                });
 
     
 } // namespace tests

--- a/compiler/tests/generated/attributes_reflection.h
+++ b/compiler/tests/generated/attributes_reflection.h
@@ -39,9 +39,10 @@ namespace tests
         static ::bond::Metadata GetMetadata()
         {
             return ::bond::reflection::MetadataInit("Foo", "tests.Foo",
-                boost::assign::map_list_of<std::string, std::string>
-                    ("StructAttribute1", "one")
-                    ("StructAttribute2", "two")
+                {
+                    { "StructAttribute1", "one" },
+                    { "StructAttribute2", "two" }
+                }
             );
         }
     };

--- a/compiler/tests/generated/attributes_types.cpp
+++ b/compiler/tests/generated/attributes_types.cpp
@@ -68,9 +68,10 @@ namespace tests
     
     const ::bond::Metadata Foo::Schema::s_f_metadata
         = ::bond::reflection::MetadataInit("f", ::bond::reflection::optional_field_modifier::value,
-                boost::assign::map_list_of<std::string, std::string>
-                    ("FieldAttribute1", "one")
-                    ("FieldAttribute2", "two"));
+                {
+                    { "FieldAttribute1", "one" },
+                    { "FieldAttribute2", "two" }
+                });
 
     
 } // namespace tests

--- a/compiler/tests/generated/scoped_allocator/attributes_reflection.h
+++ b/compiler/tests/generated/scoped_allocator/attributes_reflection.h
@@ -39,9 +39,10 @@ namespace tests
         static ::bond::Metadata GetMetadata()
         {
             return ::bond::reflection::MetadataInit("Foo", "tests.Foo",
-                boost::assign::map_list_of<std::string, std::string>
-                    ("StructAttribute1", "one")
-                    ("StructAttribute2", "two")
+                {
+                    { "StructAttribute1", "one" },
+                    { "StructAttribute2", "two" }
+                }
             );
         }
     };

--- a/compiler/tests/generated/scoped_allocator/attributes_types.cpp
+++ b/compiler/tests/generated/scoped_allocator/attributes_types.cpp
@@ -68,9 +68,10 @@ namespace tests
     
     const ::bond::Metadata Foo::Schema::s_f_metadata
         = ::bond::reflection::MetadataInit("f", ::bond::reflection::optional_field_modifier::value,
-                boost::assign::map_list_of<std::string, std::string>
-                    ("FieldAttribute1", "one")
-                    ("FieldAttribute2", "two"));
+                {
+                    { "FieldAttribute1", "one" },
+                    { "FieldAttribute2", "two" }
+                });
 
     
 } // namespace tests

--- a/compiler/tests/generated/service_attributes_comm.cpp
+++ b/compiler/tests/generated/service_attributes_comm.cpp
@@ -7,14 +7,16 @@ namespace tests
     
     const ::bond::Metadata Foo::Schema::metadata
         = ::bond::reflection::MetadataInit("Foo", "tests.Foo",
-                boost::assign::map_list_of<std::string, std::string>
-                    ("FooAttribute", "Bar"));
+                {
+                    { "FooAttribute", "Bar" }
+                });
     
     const ::bond::Metadata Foo::Schema::s_foo_metadata
         = ::bond::reflection::MetadataInit("foo",
-                boost::assign::map_list_of<std::string, std::string>
-                    ("foo", "method")
-                    ("method", ""));
+                {
+                    { "foo", "method" },
+                    { "method", "" }
+                });
 
     
 } // namespace tests

--- a/compiler/tests/generated/service_attributes_grpc.cpp
+++ b/compiler/tests/generated/service_attributes_grpc.cpp
@@ -7,14 +7,16 @@ namespace tests
     
     const ::bond::Metadata Foo::Schema::metadata
         = ::bond::reflection::MetadataInit("Foo", "tests.Foo",
-                boost::assign::map_list_of<std::string, std::string>
-                    ("FooAttribute", "Bar"));
+                {
+                    { "FooAttribute", "Bar" }
+                });
     
     const ::bond::Metadata Foo::Schema::s_foo_metadata
         = ::bond::reflection::MetadataInit("foo",
-                boost::assign::map_list_of<std::string, std::string>
-                    ("foo", "method")
-                    ("method", ""));
+                {
+                    { "foo", "method" },
+                    { "method", "" }
+                });
 
     
 } // namespace tests

--- a/compiler/tests/generated/type_aliases/attributes_reflection.h
+++ b/compiler/tests/generated/type_aliases/attributes_reflection.h
@@ -39,9 +39,10 @@ namespace tests
         static ::bond::Metadata GetMetadata()
         {
             return ::bond::reflection::MetadataInit("Foo", "tests.Foo",
-                boost::assign::map_list_of<std::string, std::string>
-                    ("StructAttribute1", "one")
-                    ("StructAttribute2", "two")
+                {
+                    { "StructAttribute1", "one" },
+                    { "StructAttribute2", "two" }
+                }
             );
         }
     };

--- a/compiler/tests/generated/type_aliases/attributes_types.cpp
+++ b/compiler/tests/generated/type_aliases/attributes_types.cpp
@@ -68,9 +68,10 @@ namespace tests
     
     const ::bond::Metadata Foo::Schema::s_f_metadata
         = ::bond::reflection::MetadataInit("f", ::bond::reflection::optional_field_modifier::value,
-                boost::assign::map_list_of<std::string, std::string>
-                    ("FieldAttribute1", "one")
-                    ("FieldAttribute2", "two"));
+                {
+                    { "FieldAttribute1", "one" },
+                    { "FieldAttribute2", "two" }
+                });
 
     
 } // namespace tests

--- a/cpp/inc/bond/core/reflection.h
+++ b/cpp/inc/bond/core/reflection.h
@@ -10,8 +10,6 @@
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/push_front.hpp>
 #include <boost/mpl/copy_if.hpp>
-#include <boost/assign.hpp>
-#include <boost/assign/list_of.hpp>
 
 #include <bond/core/bond_types.h>
 #include "bond_fwd.h"

--- a/cpp/inc/bond/core/reflection.h
+++ b/cpp/inc/bond/core/reflection.h
@@ -300,7 +300,7 @@ bond::Metadata MetadataInit(const char* name, const char* qual_name, const Attri
     // boost::mpl::for_each instantiates object of each type in the sequence.
     // We transform the Params to a sequence of type pointers to avoid creating
     // actual complex types that might not even support default ctor.
-    typedef typename boost::mpl::transform<Params, boost::add_pointer<_> >::type ParamsPtr;
+    typedef typename boost::mpl::transform<Params, std::add_pointer<_> >::type ParamsPtr;
 
     boost::mpl::for_each<ParamsPtr>(detail::TypeListBuilder(params));
 


### PR DESCRIPTION
Currently, `boost::assign::map_list_of` is used to initialize C++ metadata attribute maps. This change makes use of [list initialization](http://en.cppreference.com/w/cpp/language/list_initialization) available in `c++11` which is more appropriate and excludes the dependency on boost header.