### PR TITLE
[c++] Clean up includes

### DIFF
--- a/cpp/CODING_GUIDELINES_CPP.md
+++ b/cpp/CODING_GUIDELINES_CPP.md
@@ -1,0 +1,86 @@
+# Bond C++ Coding Guidelines
+
+## Background
+
+A consistent coding style benefits authors and readers. Authors have fewer,
+trivial decisions to make, and readers' assumptions about overall structure
+are more likely to be correct.
+
+Here are the Bond C++ coding guidelines to help have a consistent style.
+
+Guidelines are not hard and fast rules.
+
+This is a work in progress.
+
+### History
+
+Bond has been developed by many people of many years. It is *not* internally
+consistent, so you will very easily find places where these guidelines are
+not followed.
+
+### Tooling
+
+Ideally, as many of these would be enforced via tooling to help with
+uniformity and so that they don't get accidentally forgotten. Such tooling
+has not yet been implemented.
+
+### Improving to follow guidelines
+
+Since these guidelines are not yet finished, we ask that you do not submit
+patches that simply make code conform to guidelines.
+
+## Guidelines
+
+### When in Rome, do as the Romans do
+
+Since Bond is not internally consistent, the local style (to a function, a
+file, a module, &c.) should be followed in as much as that makes sense.
+
+### Header file includes
+
+The beginning of each header file is formulaic:
+
+    // Copyright (c) Microsoft. All rights reserved.
+    // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+    
+    #pragma once
+    
+    #include <bond/core/config.h>
+    
+    // #include "current_module_header_a.h"
+    // #include "current_module_header_b.h
+    
+    // #include <bond/some/header_a.h>
+    // #include <bond/some/header_b.h>
+    
+    // #include <boost/some/header_a.h>
+    // #include <boost/some/header_b.h>
+    
+    // #include <standard_library_a.h>
+    // #include <standard_library_b.h>
+
+A file starts with the copyright notice. Then there is a `#pragma once`
+line. Bond does not use include guards. This is followed by `#include
+<bond/core/config.h>`: all Bond headers--except config.h itself--must
+include config.h before anything else.
+
+Then there are a variable number `#include` sections. To help make each
+header stand on its own, the includes are done in reverse order of
+generality: first includes from the current module, then the rest of Bond,
+then other libraries we use, then Boost, then the standard library and OS
+headers.
+
+Within each section the headers are sorted lexicographically.
+
+If this results in errors, then the header likely needs to be fixed to
+include/forward declare what it uses.
+
+NB: headers generated from any of the IDL files that ship with Bond should
+be included via full path (e.g., `<bond/core/bond_types.h>`). Depending on
+how Bond is built, these headers are not guaranteed to be in the same
+directory as the other Bond headers.
+
+Any time this ordering cannot be followed, there should be a comment
+indicating why.
+
+More flexibility is permitted in "detail" headers.

--- a/cpp/CODING_GUIDELINES_CPP.md
+++ b/cpp/CODING_GUIDELINES_CPP.md
@@ -64,13 +64,14 @@ line. Bond does not use include guards. This is followed by `#include
 <bond/core/config.h>`: all Bond headers--except config.h itself--must
 include config.h before anything else.
 
-Then there are a variable number `#include` sections. To help make each
-header stand on its own, the includes are done in reverse order of
-generality: first includes from the current module, then the rest of Bond,
-then other libraries we use, then Boost, then the standard library and OS
-headers.
+Then there are a variable number `#include` sections.
 
-Within each section the headers are sorted lexicographically.
+To help make each header stand on its own, each header should include the
+headers for what it uses. To help avoid implicit dependencies on indirectly
+included headers, the includes are done in reverse order of generality:
+first includes from the current module, then the rest of Bond, then other
+libraries we use, then Boost, then the standard library and OS headers.
+Additionally, within each section the headers are sorted lexicographically.
 
 If this results in errors, then the header likely needs to be fixed to
 include/forward declare what it uses.

--- a/cpp/inc/bond/comm/address.h
+++ b/cpp/inc/bond/comm/address.h
@@ -1,10 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #pragma once
+
+#include <bond/core/config.h>
 
 #include "exception.h"
 
+#include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/find.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/classification.hpp>
 #include <boost/asio/ip/address.hpp>
 
 #if defined (__APPLE__)

--- a/cpp/inc/bond/comm/comm_message.h
+++ b/cpp/inc/bond/comm/comm_message.h
@@ -1,5 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
+
+#include <bond/core/config.h>
 
 #include <bond/comm/comm_types.h>
 #include <exception>
@@ -14,7 +18,7 @@ struct Request
     std::string method_name;
 
     std::vector<blob> layers;
-    
+
     std::vector<blob> payload;
 };
 

--- a/cpp/inc/bond/comm/detail/callbacks.h
+++ b/cpp/inc/bond/comm/detail/callbacks.h
@@ -1,5 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
+
+#include <bond/core/config.h>
 
 #include <bond/comm/services.h>
 
@@ -75,7 +79,7 @@ public:
             response.is_error = true;
             response.error.error_code = ErrorCode::INVALID_INVOCATION;
             response.error.message = "Callback was dropped";
-            
+
             m_callback(response);
         }
     }

--- a/cpp/inc/bond/comm/detail/future.h
+++ b/cpp/inc/bond/comm/detail/future.h
@@ -1,4 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #pragma once
+
+#include <bond/core/config.h>
 
 #include <bond/comm/message.h>
 
@@ -29,7 +34,7 @@ namespace bond { namespace comm
                     _callback(error(ErrorCode::INVALID_INVOCATION, ex.what()));
                 }
             }
-        
+
         private:
             std::function<void (const message<T>&)> _callback;
         };

--- a/cpp/inc/bond/comm/detail/locks.h
+++ b/cpp/inc/bond/comm/detail/locks.h
@@ -1,5 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
+
+#include <bond/core/config.h>
 
 #include <mutex>
 
@@ -19,22 +23,22 @@ public:
     {
         ::InitializeCriticalSection(&m_CS);
     }
-    
+
     ~critical_section()
     {
         ::DeleteCriticalSection(&m_CS);
     }
-    
+
     bool try_lock()
     {
         return ::TryEnterCriticalSection(&m_CS) != 0;
     }
-    
+
     void lock()
     {
         ::EnterCriticalSection(&m_CS);
     }
-    
+
     void unlock()
     {
         ::LeaveCriticalSection(&m_CS);
@@ -70,7 +74,7 @@ public:
         : std::unique_lock<Lock>(std::move(that))
         , m_object(that.m_object)
     {}
-    
+
     lockable_guard(T& _lockable)
         : std::unique_lock<Lock>(_lockable)
         , m_object(_lockable.m_object)

--- a/cpp/inc/bond/comm/detail/logging.h
+++ b/cpp/inc/bond/comm/detail/logging.h
@@ -1,4 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #pragma once
+
+#include <bond/core/config.h>
 
 #include <bond/core/detail/string_stream.h>
 

--- a/cpp/inc/bond/comm/exception.h
+++ b/cpp/inc/bond/comm/exception.h
@@ -1,5 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
+
+#include <bond/core/config.h>
 
 #include <bond/core/exception.h>
 #include <bond/comm/comm_types.h>

--- a/cpp/inc/bond/comm/layers.h
+++ b/cpp/inc/bond/comm/layers.h
@@ -1,5 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
+
+#include <bond/core/config.h>
 
 #include <bond/comm/detail/logging.h>
 #include <bond/comm/services.h>
@@ -54,7 +58,7 @@ class LayerStack<Data, Layer, Layers...>
     , public Layer
 {
 public:
-    
+
     LayerStack()
     {}
 
@@ -90,7 +94,7 @@ public:
 //
 // Layer extension for transports.
 //
-template <typename BaseTransport, 
+template <typename BaseTransport,
           typename LayerProtocol>
 class LayerTransport
     : public BaseTransport
@@ -243,7 +247,7 @@ private:
                        const std::string& service_name,
                        const std::string& method_name,
                        LayerData& data,
-                       std::vector<blob>& buffers) 
+                       std::vector<blob>& buffers)
         {
             _service_name = service_name;
             _method_name = method_name;

--- a/cpp/inc/bond/comm/layers/event_monitor.h
+++ b/cpp/inc/bond/comm/layers/event_monitor.h
@@ -1,5 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
+
+#include <bond/core/config.h>
 
 #include "latency.h"
 

--- a/cpp/inc/bond/comm/layers/latency.h
+++ b/cpp/inc/bond/comm/layers/latency.h
@@ -1,7 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include <bond/comm/layers.h>
+
 #include <boost/assert.hpp>
 
 namespace bond { namespace comm

--- a/cpp/inc/bond/comm/message.h
+++ b/cpp/inc/bond/comm/message.h
@@ -1,5 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
+
+#include <bond/core/config.h>
 
 #include "exception.h"
 
@@ -8,8 +12,8 @@
 #include <bond/core/traits.h>
 #include <bond/stream/output_buffer.h>
 
-#include <boost/variant.hpp>
 #include <boost/mpl/if.hpp>
+#include <boost/variant.hpp>
 
 namespace bond { namespace comm
 {

--- a/cpp/inc/bond/comm/service_table.h
+++ b/cpp/inc/bond/comm/service_table.h
@@ -1,5 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
+
+#include <bond/core/config.h>
 
 #include "services.h"
 
@@ -11,7 +15,7 @@ namespace bond { namespace comm
 //
 class ServiceTable
     : public IService
-{    
+{
     template <typename WireProtocol>
     class Registrar
     {
@@ -64,7 +68,7 @@ public:
     {
         return Registrar<WireProtocol>(*this, wireProtocol);
     }
-    
+
     template <typename Service, typename WireProtocol>
     ServiceTable& Register(const boost::reference_wrapper<Service>& service,
                            const WireProtocol& wireProtocol,

--- a/cpp/inc/bond/comm/services.h
+++ b/cpp/inc/bond/comm/services.h
@@ -1,15 +1,19 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
 
+#include <bond/core/config.h>
+
+#include "detail/future.h"
 #include "message.h"
 #include "wire_protocol.h"
-#include "detail/future.h"
 
 #include <boost/assert.hpp>
 #include <boost/shared_ptr.hpp>
 
-#include <string>
 #include <map>
+#include <string>
 
 namespace bond { namespace comm
 {

--- a/cpp/inc/bond/comm/thread_pool.h
+++ b/cpp/inc/bond/comm/thread_pool.h
@@ -1,4 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #pragma once
+
+#include <bond/core/config.h>
 
 #if defined (__APPLE__)
     // Work-around: 'OSMemoryBarrier' has been explicitly marked deprecated

--- a/cpp/inc/bond/comm/timeout.h
+++ b/cpp/inc/bond/comm/timeout.h
@@ -1,11 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
+
+#include <bond/core/config.h>
 
 #include <bond/comm/message.h>
 #include <bond/comm/thread_pool.h>
 
 #include <boost/asio/steady_timer.hpp>
 #include <boost/atomic/atomic.hpp>
+
 #include <chrono>
 #include <functional>
 #include <memory>

--- a/cpp/inc/bond/comm/transport.h
+++ b/cpp/inc/bond/comm/transport.h
@@ -1,5 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
+
+#include <bond/core/config.h>
 
 #include "service_table.h"
 
@@ -8,7 +12,7 @@ namespace bond { namespace comm
 
 typedef boost::shared_ptr<void> Server;
 
-template <typename Address_, 
+template <typename Address_,
           typename WireProtocol_,
           typename ConnectionContext_ = typename boost::call_traits<Address_>::param_type>
 class Transport

--- a/cpp/inc/bond/comm/transport/detail/epoxy_data_structs.h
+++ b/cpp/inc/bond/comm/transport/detail/epoxy_data_structs.h
@@ -1,10 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #pragma once
+
+#include <bond/core/config.h>
+
+#include <bond/core/blob.h>
 
 #include <stdint.h>
 #include <utility>
 #include <vector>
-
-#include <bond/core/blob.h>
 
 namespace bond { namespace comm
 {

--- a/cpp/inc/bond/comm/transport/detail/epoxy_protocol.h
+++ b/cpp/inc/bond/comm/transport/detail/epoxy_protocol.h
@@ -1,16 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #pragma once
 
-#include <memory>
+#include <bond/core/config.h>
 
-#include <boost/optional.hpp>
+#include "epoxy_data_structs.h"
 
-#include <bond/core/blob.h>
-#include <bond/core/bond.h>
 #include <bond/comm/detail/logging.h>
 #include <bond/comm/epoxy_transport_types.h>
 #include <bond/comm/packet_types.h>
+#include <bond/core/blob.h>
+#include <bond/core/bond.h>
 
-#include "epoxy_data_structs.h"
+#include <boost/optional.hpp>
+
+#include <memory>
 
 namespace bond { namespace comm
 {

--- a/cpp/inc/bond/comm/transport/epoxy.h
+++ b/cpp/inc/bond/comm/transport/epoxy.h
@@ -1,4 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #pragma once
+
+#include <bond/core/config.h>
 
 #if defined(__APPLE__)
     // Work-around: 'OSMemoryBarrier' has been explicitly marked deprecated
@@ -15,19 +20,19 @@
     #include <boost/asio.hpp>
 #endif
 
-#include <bond/comm/layers.h>
 #include <bond/comm/address.h>
 #include <bond/comm/epoxy_transport_apply.h>
 #include <bond/comm/epoxy_transport_reflection.h>
+#include <bond/comm/layers.h>
 #include <bond/comm/transport/detail/epoxy_data_structs.h>
 #include <bond/comm/transport/detail/epoxy_protocol.h>
-#include <bond/comm/transport/thread_service.h>
 #include <bond/comm/transport/packet.h>
+#include <bond/comm/transport/thread_service.h>
 
 #include <boost/atomic/atomic.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/range/adaptor/transformed.hpp>
 
 #include <thread>
 
@@ -832,7 +837,7 @@ private:
         }
 
         //
-        // Trigger connect of client connection 
+        // Trigger connect of client connection
         //
         void Connect()
         {
@@ -1118,7 +1123,7 @@ private:
                 const boost::shared_ptr<INetworkServerSink>& handler)
     override
     {
-        boost::shared_ptr<INetworkServer> server = 
+        boost::shared_ptr<INetworkServer> server =
             boost::make_shared<EpoxyServer>(m_allocator,
                                             address,
                                             handler,

--- a/cpp/inc/bond/comm/transport/null.h
+++ b/cpp/inc/bond/comm/transport/null.h
@@ -1,8 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
 
-#include <bond/comm/address.h>
+#include <bond/core/config.h>
+
 #include "packet.h"
+
+#include <bond/comm/address.h>
 
 namespace bond { namespace comm
 {

--- a/cpp/inc/bond/comm/transport/packet.h
+++ b/cpp/inc/bond/comm/transport/packet.h
@@ -1,25 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
 
-#include <bond/comm/transport.h>
+#include <bond/core/config.h>
+
+#include <bond/comm/detail/callbacks.h>
+#include <bond/comm/detail/locks.h>
+#include <bond/comm/detail/logging.h>
 #include <bond/comm/packet_apply.h>
 #include <bond/comm/packet_reflection.h>
-
+#include <bond/comm/transport.h>
+#include <bond/core/bond.h>
 #include <bond/protocol/compact_binary.h>
 #include <bond/stream/output_buffer.h>
 
-#include <bond/core/bond.h>
-#include <bond/comm/detail/locks.h>
-#include <bond/comm/detail/logging.h>
-#include <bond/comm/detail/callbacks.h>
-
 #include <boost/atomic.hpp>
-#include <boost/foreach.hpp>
 #include <boost/enable_shared_from_this.hpp>
+#include <boost/foreach.hpp>
 #include <boost/weak_ptr.hpp>
 
-#include <unordered_set>
 #include <unordered_map>
+#include <unordered_set>
 
 
 namespace bond { namespace comm

--- a/cpp/inc/bond/comm/transport/thread_service.h
+++ b/cpp/inc/bond/comm/transport/thread_service.h
@@ -1,6 +1,11 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #pragma once
 
-#include <thread>
+#include <bond/core/config.h>
+
+#include <bond/comm/detail/logging.h>
 
 #if defined (__APPLE__)
     // Work-around: 'OSMemoryBarrier' has been explicitly marked deprecated
@@ -20,7 +25,7 @@
 #include <boost/scoped_ptr.hpp>
 #include <boost/thread/thread.hpp>
 
-#include <bond/comm/detail/logging.h>
+#include <thread>
 
 namespace bond { namespace comm {
 

--- a/cpp/inc/bond/comm/wire_protocol.h
+++ b/cpp/inc/bond/comm/wire_protocol.h
@@ -1,5 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
+
+#include <bond/core/config.h>
 
 #include <bond/comm/message.h>
 #include <bond/comm/comm_message.h>

--- a/cpp/inc/bond/core/apply.h
+++ b/cpp/inc/bond/core/apply.h
@@ -3,12 +3,15 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "bonded.h"
 #include "bonded_void.h"
-#include <bond/core/bond_reflection.h>
-#include "parser.h"
-#include "exception.h"
 #include "detail/double_pass.h"
+#include "exception.h"
+#include "parser.h"
+
+#include <bond/core/bond_reflection.h>
 
 namespace bond
 {
@@ -90,4 +93,3 @@ bool Apply(const Transform& transform, const T& value)
 }
 
 } // namespace bond
-

--- a/cpp/inc/bond/core/blob.h
+++ b/cpp/inc/bond/core/blob.h
@@ -4,11 +4,14 @@
 /** @file */
 #pragma once
 
-#include "config.h"
+#include <bond/core/config.h>
+
 #include "container_interface.h"
 #include "detail/checked_add.h"
-#include <boost/shared_array.hpp>
+
 #include <boost/make_shared.hpp>
+#include <boost/shared_array.hpp>
+
 #include <stdint.h>
 #include <cstring>
 

--- a/cpp/inc/bond/core/bond.h
+++ b/cpp/inc/bond/core/bond.h
@@ -4,6 +4,8 @@
 /** @file */
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "apply.h"
 #include "select_protocol.h"
 
@@ -108,7 +110,7 @@ inline T Unmarshal(Buffer input, const RuntimeSchema& schema)
 }
 
 
-/// @brief Initialize a bonded<T> from data stream contained marshaled object 
+/// @brief Initialize a bonded<T> from data stream contained marshaled object
 /// using a runtime schema
 template <typename Protocols = BuiltInProtocols, typename Buffer, typename T>
 inline void Unmarshal(Buffer input, bonded<T>& obj, const RuntimeSchema& schema)
@@ -117,7 +119,7 @@ inline void Unmarshal(Buffer input, bonded<T>& obj, const RuntimeSchema& schema)
 }
 
 
-/// @brief Merge an object with serialize data and write the result using 
+/// @brief Merge an object with serialize data and write the result using
 /// a protocol writer
 template <typename Protocols = BuiltInProtocols, typename T, typename Reader, typename Writer>
 inline void Merge(const T& obj, Reader input, Writer& output)

--- a/cpp/inc/bond/core/bond_fwd.h
+++ b/cpp/inc/bond/core/bond_fwd.h
@@ -3,10 +3,13 @@
 
 #pragma once
 
-#include "config.h"
+#include <bond/core/config.h>
+
 #include "detail/tags.h"
-#include <stdint.h>
+
 #include <boost/utility/enable_if.hpp>
+
+#include <stdint.h>
 
 namespace bond
 {
@@ -23,10 +26,10 @@ class bonded;
 template <typename Reader>
 class bonded<void, Reader>;
 
-template <typename V> struct 
+template <typename V> struct
 remove_bonded;
 
-template <typename V> struct 
+template <typename V> struct
 remove_bonded<bonded<V> >;
 
 template <typename T, typename Reader, typename Enable = void>
@@ -49,16 +52,16 @@ struct BuiltInProtocols;
 template <typename T, typename Protocols = BuiltInProtocols, typename Validator = RequiredFieldValiadator<T> >
 class To;
 
-template <typename T, typename Enable = void> struct 
+template <typename T, typename Enable = void> struct
 schema_for_passthrough;
 
 template<typename T, typename Enable = void> struct
 get_type_id;
 
-template <typename T> struct 
+template <typename T> struct
 may_omit_fields;
 
-template <typename Input> 
+template <typename Input>
 struct base_input;
 
 struct Metadata;
@@ -87,4 +90,3 @@ template <typename Protocols = BuiltInProtocols, typename Writer>
 Serializer<Writer, Protocols> SerializeTo(Writer& output);
 
 } // bond
-

--- a/cpp/inc/bond/core/bond_version.h
+++ b/cpp/inc/bond/core/bond_version.h
@@ -3,7 +3,8 @@
 
 #pragma once
 
-#include "config.h"
+#include <bond/core/config.h>
+
 #include <stdint.h>
 #include <type_traits>
 

--- a/cpp/inc/bond/core/bonded.h
+++ b/cpp/inc/bond/core/bonded.h
@@ -3,15 +3,15 @@
 
 #pragma once
 
-#include "config.h"
+#include <bond/core/config.h>
+
+#include "bond_fwd.h"
+#include "detail/double_pass.h"
+#include "detail/marshaled_bonded.h"
+#include "detail/protocol_visitors.h"
 #include "protocol.h"
 #include "runtime_schema.h"
-#include "bond_fwd.h"
 #include "select_protocol_fwd.h"
-#include "detail/double_pass.h"
-#include "detail/protocol_visitors.h"
-#include "detail/marshaled_bonded.h"
-
 
 namespace bond
 {

--- a/cpp/inc/bond/core/bonded_void.h
+++ b/cpp/inc/bond/core/bonded_void.h
@@ -3,10 +3,12 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "bonded.h"
+#include "detail/nonassignable.h"
 #include "schema.h"
 #include "select_protocol.h"
-#include "detail/nonassignable.h"
 
 namespace bond
 {

--- a/cpp/inc/bond/core/box.h
+++ b/cpp/inc/bond/core/box.h
@@ -3,7 +3,10 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include <bond/core/bond_types.h>
+
 #include <type_traits>
 
 

--- a/cpp/inc/bond/core/capped_allocator.h
+++ b/cpp/inc/bond/core/capped_allocator.h
@@ -3,11 +3,14 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "capped_allocator_fwd.h"
-#include "single_threaded_counter.h"
+#include "detail/value_or_reference.h"
 #include "multi_threaded_counter.h"
 #include "shared_counter.h"
-#include "detail/value_or_reference.h"
+#include "single_threaded_counter.h"
+
 #include <boost/utility/enable_if.hpp>
 
 

--- a/cpp/inc/bond/core/capped_allocator_fwd.h
+++ b/cpp/inc/bond/core/capped_allocator_fwd.h
@@ -3,8 +3,10 @@
 
 #pragma once
 
-#include <memory>
+#include <bond/core/config.h>
+
 #include <cstdint>
+#include <memory>
 
 namespace bond
 {

--- a/cpp/inc/bond/core/cmdargs.h
+++ b/cpp/inc/bond/core/cmdargs.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "bond.h"
 #include "detail/cmdargs.h"
 

--- a/cpp/inc/bond/core/container_interface.h
+++ b/cpp/inc/bond/core/container_interface.h
@@ -3,7 +3,10 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "traits.h"
+
 #include <stdint.h>
 
 namespace bond
@@ -13,18 +16,18 @@ namespace bond
 // container traits - specialize for custom containers
 //
 
-template <typename T> struct 
-is_set_container 
+template <typename T> struct
+is_set_container
     : std::false_type {};
 
 
-template <typename T> struct 
-is_map_container 
+template <typename T> struct
+is_map_container
     : std::false_type {};
 
 
-template <typename T> struct 
-is_list_container 
+template <typename T> struct
+is_list_container
     : std::false_type {};
 
 
@@ -33,13 +36,13 @@ require_modify_element
     : std::false_type {};
 
 
-template <typename T> struct 
-is_string 
+template <typename T> struct
+is_string
     : std::false_type {};
 
 
-template <typename T> struct 
-is_wstring 
+template <typename T> struct
+is_wstring
     : std::false_type {};
 
 
@@ -53,7 +56,7 @@ is_nullable
     : std::false_type {};
 
 
-template <typename T> struct 
+template <typename T> struct
 element_type
 {
     typedef typename T::value_type type;

--- a/cpp/inc/bond/core/containers.h
+++ b/cpp/inc/bond/core/containers.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
-#include "stl_containers.h"
-#include "maybe.h"
+#include <bond/core/config.h>
+
 #include "bond_fwd.h"
+#include "maybe.h"
+#include "stl_containers.h"

--- a/cpp/inc/bond/core/customize.h
+++ b/cpp/inc/bond/core/customize.h
@@ -3,14 +3,16 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "traits.h"
 
 namespace bond
 {
 
 
-template <typename T> struct 
-is_protocol_enabled 
+template <typename T> struct
+is_protocol_enabled
     : std::false_type {};
 
 

--- a/cpp/inc/bond/core/detail/any.h
+++ b/cpp/inc/bond/core/detail/any.h
@@ -10,11 +10,16 @@
 
 #pragma once
 
-#include "mpl.h"
 #include <bond/core/config.h>
+
+#include "mpl.h"
+
+#include <bond/core/config.h>
+
 #include <boost/assert.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/utility/enable_if.hpp>
+
 #include <cstdint>
 #include <type_traits>
 

--- a/cpp/inc/bond/core/detail/checked_add.h
+++ b/cpp/inc/bond/core/detail/checked_add.h
@@ -3,12 +3,15 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
+#include <boost/static_assert.hpp>
+#include <boost/utility/enable_if.hpp>
+
 #include <cstdint>
 #include <limits>
 #include <stdexcept>
 #include <type_traits>
-#include <boost/static_assert.hpp>
-#include <boost/utility/enable_if.hpp>
 
 namespace bond
 {

--- a/cpp/inc/bond/core/detail/cmdargs.h
+++ b/cpp/inc/bond/core/detail/cmdargs.h
@@ -3,10 +3,13 @@
 
 #pragma once
 
-#include <iostream>
+#include <bond/core/config.h>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/tokenizer.hpp>
+
+#include <iostream>
 
 namespace bond
 {
@@ -14,7 +17,7 @@ namespace cmd
 {
 namespace detail
 {
-    
+
 // Enum types already have generated overload for ToString.
 // For other types we use boost::lexical_cast.
 template <typename T>
@@ -220,12 +223,12 @@ public:
             params.push_back(Param(name, value));
         }
     }
-    
+
     // GetFlag
     bool GetFlag(const std::string& flag, const std::string& abbr)
     {
         Params::iterator it = FindParam(flag, abbr);
-            
+
         if (it != params.end())
         {
             if (!it->value.empty())
@@ -247,7 +250,7 @@ public:
     bool GetParam(const std::string& flag, const std::string& abbr, std::string& value)
     {
         Params::iterator it = FindParam(flag, abbr);
-            
+
         if (it != params.end())
         {
             value = it->value;
@@ -309,7 +312,7 @@ private:
                 it->used = true;
                 break;
             }
-                
+
         return it;
     }
 
@@ -330,7 +333,7 @@ public:
     CmdArg(const boost::shared_ptr<Options>& options, bool partial = false)
         : options(options),
           partial(partial)
-    {}    
+    {}
 
     void Begin(const detail::Metadata& /*metadata*/) const
     {}
@@ -342,7 +345,7 @@ public:
             std::string leftovers = options->Leftovers();
 
             if (!leftovers.empty())
-                throw std::runtime_error("Invalid parameter(s):\n" + leftovers); 
+                throw std::runtime_error("Invalid parameter(s):\n" + leftovers);
         }
     }
 
@@ -372,7 +375,7 @@ private:
     // Parse enum
     template <typename T>
     typename boost::enable_if<std::is_enum<T> >::type
-    Parse(const std::string& value, T& var) const 
+    Parse(const std::string& value, T& var) const
     {
         if (!ToEnum(var, value.c_str()))
             throw std::runtime_error("Invalid parameter(s):\n    " + value);
@@ -407,11 +410,11 @@ private:
         typedef boost::tokenizer<boost::escaped_list_separator<char> > tokenizer;
 
         tokenizer tok(value);
-        
+
         for(tokenizer::iterator it = tok.begin(); it != tok.end(); ++it)
         {
             typename bond::element_type<T>::type tmp;
-            
+
             Parse(*it, tmp);
             var.push_back(tmp);
         }
@@ -423,7 +426,7 @@ private:
         Parse(value, var.set_value());
     }
 
-    
+
     // bool param
     bool GetParam(const detail::Metadata& metadata, bool& var) const
     {
@@ -445,17 +448,17 @@ private:
             options->GetParam(value);
         else
             options->GetParam(metadata.Flag(), metadata.Abbr(), value);
-        
+
         if (value.empty())
         {
             if(!metadata.IsOptional())
                 throw std::runtime_error("Required parameter " + metadata.Param() + " missing.");
-            else    
+            else
                 return false;
         }
-        
+
         Parse(value, var);
-        
+
         return true;
     }
 

--- a/cpp/inc/bond/core/detail/counter_base.h
+++ b/cpp/inc/bond/core/detail/counter_base.h
@@ -4,7 +4,9 @@
 #pragma once
 
 #include <bond/core/config.h>
+
 #include <boost/static_assert.hpp>
+
 #include <type_traits>
 
 

--- a/cpp/inc/bond/core/detail/debug.h
+++ b/cpp/inc/bond/core/detail/debug.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "omit_default.h"
 
 namespace bond
@@ -29,7 +31,7 @@ public:
 
     template <typename Field>
     typename boost::enable_if_c<!is_bond_type<typename Field::field_type>::value
-                             && std::is_same<typename Field::field_modifier, 
+                             && std::is_same<typename Field::field_modifier,
                                         reflection::optional_field_modifier>::value>::type
     operator()(const Field&)
     {
@@ -39,7 +41,7 @@ public:
 
     template <typename Field>
     typename boost::disable_if_c<!is_bond_type<typename Field::field_type>::value
-                              && std::is_same<typename Field::field_modifier, 
+                              && std::is_same<typename Field::field_modifier,
                                          reflection::optional_field_modifier>::value>::type
     operator()(const Field&)
     {}
@@ -53,4 +55,3 @@ private:
 } // namespace detail
 
 } // namespace bond
-

--- a/cpp/inc/bond/core/detail/double_pass.h
+++ b/cpp/inc/bond/core/detail/double_pass.h
@@ -3,18 +3,20 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 namespace bond
 {
     namespace detail
     {
-        template <typename Transform, typename Enable = void> struct 
+        template <typename Transform, typename Enable = void> struct
         need_double_pass
             : std::false_type {};
 
-        template <typename Transform> struct 
+        template <typename Transform> struct
         need_double_pass<
-            Transform, 
-            typename boost::enable_if_c<!std::is_same<typename Transform::writer_type, 
+            Transform,
+            typename boost::enable_if_c<!std::is_same<typename Transform::writer_type,
                                                  typename Transform::writer_type::Pass0>::value>::type
         > : std::true_type {};
 

--- a/cpp/inc/bond/core/detail/inheritance.h
+++ b/cpp/inc/bond/core/detail/inheritance.h
@@ -3,11 +3,15 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
+#include "omit_default.h"
+
 namespace bond
 {
 
 
-template <typename Input> 
+template <typename Input>
 struct base_input
 {
     BOOST_STATIC_ASSERT(std::is_reference<Input>::value);
@@ -22,17 +26,17 @@ struct base_input
 namespace detail
 {
 
-template <typename T, typename Enable = void> struct 
+template <typename T, typename Enable = void> struct
 hierarchy_depth
     : std::integral_constant<uint16_t, 1> {};
 
 
-template <typename T> struct 
+template <typename T> struct
 hierarchy_depth<T, typename boost::enable_if<std::is_class<typename schema<typename T::base>::type> >::type>
     : std::integral_constant<uint16_t, 1 + hierarchy_depth<typename schema<typename T::base>::type>::value> {};
 
 
-template <typename T> struct 
+template <typename T> struct
 expected_depth
     : std::integral_constant<uint16_t, 0xffff> {};
 
@@ -75,7 +79,7 @@ protected:
 
         // The hierarchy of the payload schema is deeper than what the transform "expects".
         // We recursively find the matching level to start parsing from.
-        // After we finish parsing the expected parts of the hierarchy, we give 
+        // After we finish parsing the expected parts of the hierarchy, we give
         // the parser a chance to skip the unexpected parts.
         detail::StructBegin(_input, true);
 
@@ -88,7 +92,7 @@ protected:
         return result;
     }
 
-    
+
     template <typename T, typename Transform>
     typename boost::disable_if_c<(hierarchy_depth<T>::value > expected_depth<Transform>::value), bool>::type
     Read(const T&, const Transform& transform)
@@ -153,7 +157,7 @@ protected:
         else
         {
             transform.Begin(schema.GetStruct().metadata);
-            
+
             if (schema.HasBase())
                 transform.Base(bonded<void, Input>(base, schema.GetBaseSchema(), true));
 

--- a/cpp/inc/bond/core/detail/marshaled_bonded.h
+++ b/cpp/inc/bond/core/detail/marshaled_bonded.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
+#include <bond/protocol/compact_binary.h>
 #include <bond/stream/stream_interface.h>
 
 namespace bond

--- a/cpp/inc/bond/core/detail/metadata.h
+++ b/cpp/inc/bond/core/detail/metadata.h
@@ -3,8 +3,12 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "sdl.h"
 #include "tags.h"
+
+#include <bond/core/bond_types.h>
 
 namespace bond
 {

--- a/cpp/inc/bond/core/detail/mpl.h
+++ b/cpp/inc/bond/core/detail/mpl.h
@@ -8,7 +8,10 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include <boost/static_assert.hpp>
+
 #include <initializer_list>
 #include <type_traits>
 #include <utility>

--- a/cpp/inc/bond/core/detail/nonassignable.h
+++ b/cpp/inc/bond/core/detail/nonassignable.h
@@ -3,11 +3,13 @@
 
 #pragma once
 
-namespace bond 
+#include <bond/core/config.h>
+
+namespace bond
 {
 namespace detail
 {
-    class nonassignable 
+    class nonassignable
     {
     protected:
         nonassignable() {}

--- a/cpp/inc/bond/core/detail/odr.h
+++ b/cpp/inc/bond/core/detail/odr.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include <boost/assert.hpp>
 
 namespace bond
@@ -19,7 +21,7 @@ struct counter
         // This assert indicates violation of One Definition Rule for T.
         BOOST_ASSERT(!value++);
     }
-    
+
     static int value;
 };
 

--- a/cpp/inc/bond/core/detail/omit_default.h
+++ b/cpp/inc/bond/core/detail/omit_default.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 namespace bond
 {
 
@@ -23,7 +25,7 @@ bool is_default(const maybe<T>& value, const Metadata& /*metadata*/)
 // compare basic fields with default value from metadata
 template <typename T>
 inline
-typename boost::enable_if_c<is_basic_type<T>::value 
+typename boost::enable_if_c<is_basic_type<T>::value
                         && !is_string_type<T>::value
                         && !is_type_alias<T>::value, bool>::type
 is_default(const T& value, const Metadata& metadata)
@@ -35,7 +37,7 @@ is_default(const T& value, const Metadata& metadata)
 // compare wire value of type alias fields with default value from metadata
 template <typename T>
 inline
-typename boost::enable_if<is_type_alias<T>, bool>::type 
+typename boost::enable_if<is_type_alias<T>, bool>::type
 is_default(const T& value, const Metadata& metadata)
 {
     return (metadata.default_value == get_aliased_value(value));
@@ -70,7 +72,7 @@ typename boost::enable_if<is_container<T>, bool>::type
 is_default(const T& value, const Metadata& /*metadata*/)
 {
     return (container_size(value) == 0);
-} 
+}
 
 
 // structs don't have default value
@@ -80,7 +82,7 @@ typename boost::enable_if<is_bond_type<T>, bool>::type
 is_default(const T& /*value*/, const Metadata& /*metadata*/)
 {
     return false;
-} 
+}
 
 
 // return true if the field may be omitted during serialization
@@ -89,7 +91,7 @@ inline
 typename boost::enable_if<may_omit_fields<Writer>, bool>::type
 omit_field(const Metadata& metadata, const T& value)
 {
-    // Validate that all compilation units in a program use the same 
+    // Validate that all compilation units in a program use the same
     // specialization of may_omit_fields<Writer>
     (void)one_definition<may_omit_fields<Writer>, std::true_type>::value;
 
@@ -104,7 +106,7 @@ inline
 typename boost::disable_if<may_omit_fields<Writer>, bool>::type
 omit_field(const Metadata& /*metadata*/, const T& /*value*/)
 {
-    // Validate that all compilation units in a program use the same 
+    // Validate that all compilation units in a program use the same
     // specialization of may_omit_fields<Writer>
     (void)one_definition<may_omit_fields<Writer>, std::false_type>::value;
 
@@ -123,23 +125,23 @@ bool omit_field(const Metadata& /*metadata*/, const value<T, Reader>& /*value*/)
 
 
 template <typename T, typename Enable = void> struct
-implements_field_omitting 
+implements_field_omitting
     : std::false_type {};
 
 
-// WriteFieldOmitted is an optional protocol writer method which is called for 
+// WriteFieldOmitted is an optional protocol writer method which is called for
 // omitted optional fields. It CAN be implemented by tagged protocols and MUST
 // be implemented by untagged protocols that allow omitting optional fields.
 template <typename Writer> struct
-implements_field_omitting<Writer, 
+implements_field_omitting<Writer,
     typename boost::enable_if<bond::check_method<void (Writer::*)(BondDataType, uint16_t, const Metadata&), &Writer::WriteFieldOmitted> >::type>
     : std::true_type {};
 
 
-// ReadFieldOmitted is an optional protocol reader method which MUST be implemented 
+// ReadFieldOmitted is an optional protocol reader method which MUST be implemented
 // by untagged protocols that allow omitting optional fields.
 template <typename Input> struct
-implements_field_omitting<Input, 
+implements_field_omitting<Input,
     typename boost::enable_if<bond::check_method<bool (Input::*)(), &Input::ReadFieldOmitted> >::type>
     : std::true_type {};
 
@@ -176,9 +178,9 @@ ReadFieldOmitted(Input& /*input*/)
 }
 
 
-// ReadStructBegin and ReadStructEnd are optional methods for protocol 
+// ReadStructBegin and ReadStructEnd are optional methods for protocol
 template <typename T, typename Enable = void> struct
-implements_struct_begin 
+implements_struct_begin
     : std::false_type {};
 
 
@@ -190,13 +192,13 @@ implements_struct_begin_with_base
 
 
 template <typename Input> struct
-implements_struct_begin<Input, 
+implements_struct_begin<Input,
     typename boost::enable_if<bond::check_method<void (Input::*)(), &Input::ReadStructBegin> >::type>
     : std::true_type {};
 
 
 template <typename Input> struct
-implements_struct_begin_with_base<Input, 
+implements_struct_begin_with_base<Input,
     typename boost::enable_if<bond::check_method<void (Input::*)(bool), &Input::ReadStructBegin> >::type>
     : std::true_type {};
 
@@ -252,9 +254,9 @@ StructEnd(Input& /*input*/, bool /*base*/)
 } // namespace detail
 
 
-// It is OK to omit optional fields with default values for all tagged protocols 
+// It is OK to omit optional fields with default values for all tagged protocols
 // and for untagged protocols which implement field omitting support.
-template <typename T> struct 
+template <typename T> struct
 may_omit_fields
     : std::integral_constant<bool,
         !uses_static_parser<typename T::Reader>::value

--- a/cpp/inc/bond/core/detail/once.h
+++ b/cpp/inc/bond/core/detail/once.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #if !defined(BOND_NO_CX11_HDR_MUTEX)
 
 // Use std::call_once when building with a sane compiler.

--- a/cpp/inc/bond/core/detail/pass_through.h
+++ b/cpp/inc/bond/core/detail/pass_through.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include <bond/core/traits.h>
 #include <bond/stream/stream_interface.h>
 

--- a/cpp/inc/bond/core/detail/protocol_visitors.h
+++ b/cpp/inc/bond/core/detail/protocol_visitors.h
@@ -3,12 +3,17 @@
 
 #pragma once
 
-#include "tags.h"
+#include <bond/core/config.h>
+
 #include "pass_through.h"
+#include "tags.h"
+
+#include <bond/core/customize.h>
+#include <bond/core/null.h>
+#include <bond/core/protocol.h>
+#include <bond/core/traits.h>
 #include <bond/stream/input_buffer.h>
 #include <bond/stream/output_buffer.h>
-#include <bond/core/traits.h>
-#include <bond/core/null.h>
 
 
 namespace bond
@@ -34,12 +39,12 @@ public:
           _schema(schema)
     {}
 
-    
+
     template <typename Reader>
     typename boost::enable_if<is_protocol_enabled<typename std::remove_const<Reader>::type>, bool>::type
     operator()(Reader& reader) const
     {
-        // Apply transform to serialized data 
+        // Apply transform to serialized data
         return Apply(_transform, reader, _schema, false);
     }
 
@@ -71,7 +76,7 @@ public:
     Apply(const Serializer<Writer, Protocols>& transform, Reader& reader, const Schema& schema, bool base)
     {
         BOOST_VERIFY(!base);
-        // Triggering the following assert means that bond::enable_protocol_versions trait is 
+        // Triggering the following assert means that bond::enable_protocol_versions trait is
         // defined/specialized inconsistently for the protocol in different compilation units.
         BOOST_ASSERT(is_protocol_version_same(reader, transform._output));
         return FastPassThrough(reader, transform._output, schema);
@@ -109,7 +114,7 @@ protected:
 
 
 template <typename T, typename Schema, typename Transform, typename Enable = void>
-class Parser 
+class Parser
     : public _Parser<T, Schema, Transform>
 {
 public:
@@ -141,9 +146,9 @@ public:
 
     bool operator()(ValueReader& value) const
     {
-        // Serializing bonded<T> containing a non-serialized instance of T 
+        // Serializing bonded<T> containing a non-serialized instance of T
         BOOST_ASSERT(value.pointer);
-        // NOTE TO USER: following assert may indicate that the generated file 
+        // NOTE TO USER: following assert may indicate that the generated file
         // _reflection.h was not included in compilation unit where T is serialized.
         BOOST_ASSERT(has_schema<T>::value);
         return StaticParser<const T&>(*static_cast<const T*>(value.pointer)).Apply(_transform, typename schema_for_passthrough<T>::type());
@@ -208,7 +213,7 @@ inline bool Parse(const Transform& transform, ProtocolReader reader, const Schem
     BOOST_VERIFY(!base);
 
     boost::optional<bool> result;
-    
+
     if (runtime_schema)
     {
         // Use named variable to avoid gcc silently copying objects (which
@@ -252,14 +257,14 @@ public:
           _reader(reader)
     {}
 
-    
+
     template <typename Reader>
     typename boost::enable_if<is_protocol_enabled<typename std::remove_const<Reader>::type> >::type
     operator()(Reader& reader) const
     {
         Buffer merged;
         typename get_protocol_writer<Reader, Buffer>::type writer(merged);
-        
+
         Merge(_var, reader, writer);
 
         _reader = Reader(merged.GetBuffer());
@@ -279,7 +284,7 @@ public:
         // Merge is undefined for non-serialized instance of T
         BOOST_VERIFY(false);
     }
-    
+
 private:
     const T& _var;
     ProtocolReader& _reader;

--- a/cpp/inc/bond/core/detail/sdl.h
+++ b/cpp/inc/bond/core/detail/sdl.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include <boost/assert.hpp>
 #include <boost/core/ignore_unused.hpp>
 #include <iterator>

--- a/cpp/inc/bond/core/detail/string_stream.h
+++ b/cpp/inc/bond/core/detail/string_stream.h
@@ -3,10 +3,12 @@
 
 #pragma once
 
-#include <string>
-#include <vector>
+#include <bond/core/config.h>
+
 #include <stdint.h>
 #include <stdio.h>
+#include <string>
+#include <vector>
 
 namespace bond
 {

--- a/cpp/inc/bond/core/detail/tags.h
+++ b/cpp/inc/bond/core/detail/tags.h
@@ -3,8 +3,12 @@
 
 #pragma once
 
-#include <bond/core/bond_const_enum.h>
+#include <bond/core/config.h>
+
 #include "nonassignable.h"
+
+#include <bond/core/bond_const_enum.h>
+
 #include <type_traits>
 
 namespace bond
@@ -75,17 +79,17 @@ struct ModifyingTransform
 };
 
 
-template <typename T, typename Unused = void> struct 
+template <typename T, typename Unused = void> struct
 is_serializing_transform
     : std::is_base_of<SerializingTransform, T> {};
 
 
-template <typename T, typename Unused = void> struct 
+template <typename T, typename Unused = void> struct
 is_deserializing_transform
     : std::is_base_of<DeserializingTransform, T> {};
 
 
-template <typename T, typename Unused = void> struct 
+template <typename T, typename Unused = void> struct
 is_modifying_transform
     : std::is_base_of<ModifyingTransform, T> {};
 

--- a/cpp/inc/bond/core/detail/tuple_fields.h
+++ b/cpp/inc/bond/core/detail/tuple_fields.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 namespace bond
 {
 namespace detail
@@ -37,7 +39,7 @@ struct tuple_field
     }
 };
 
-using ignore_t = decltype(std::ignore); 
+using ignore_t = decltype(std::ignore);
 
 template <typename Tuple, uint16_t t_id, typename T>
 const Metadata tuple_field<Tuple, t_id, T>::metadata

--- a/cpp/inc/bond/core/detail/typeid_value.h
+++ b/cpp/inc/bond/core/detail/typeid_value.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 namespace bond
 {
 
@@ -41,7 +43,7 @@ inline DeserializeElements(X&, const T& element, uint32_t size);
 template <typename Protocols, typename Transform, typename T>
 inline void DeserializeElements(const Transform& transform, const T& element, uint32_t size);
 
-namespace detail 
+namespace detail
 {
 
 
@@ -76,7 +78,7 @@ bool IsMatching(BondDataType type)
 
         case bond::BT_STRING:
             return is_matching<std::string, T>::value;
-            
+
         case bond::BT_WSTRING:
             return is_matching<std::wstring, T>::value;
 
@@ -118,7 +120,7 @@ inline bool BasicTypeField(uint16_t id, const Metadata& metadata, BondDataType t
 
         case bond::BT_UINT64:
             return transform.Field(id, metadata, value<uint64_t, Reader&>(input));
-            
+
         case bond::BT_FLOAT:
             return transform.Field(id, metadata, value<float, Reader&>(input));
 
@@ -180,7 +182,7 @@ inline void BasicTypeContainer(T& var, BondDataType type, Reader& input, uint32_
 
         case bond::BT_STRING:
             return DeserializeElements<Protocols>(var, value<std::string, Reader&>(input, false), size);
-            
+
         case bond::BT_WSTRING:
             return DeserializeElements<Protocols>(var, value<std::wstring, Reader&>(input, false), size);
 
@@ -262,7 +264,7 @@ inline MatchingTypeContainer(T& var, BondDataType type, Reader& input, uint32_t 
     {
         case bond::BT_STRING:
             return DeserializeElements<Protocols>(var, value<std::string, Reader&>(input, false), size);
-            
+
         default:
             BOOST_ASSERT(!IsMatching<typename element_type<T>::type>(type));
 
@@ -365,7 +367,7 @@ inline MatchingTypeContainer(T& var, BondDataType type, Reader& input, uint32_t 
 }
 
 
-// MatchingMapByKey function are manually expended versions of MapByKey using the type 
+// MatchingMapByKey function are manually expended versions of MapByKey using the type
 // information about destination container. This helps with compilation speed.
 
 template <typename E, typename Reader>
@@ -526,7 +528,7 @@ inline MatchingMapByKey(T& var, BondDataType keyType, const E& element, Reader& 
 
 
 template <typename Protocols, typename T, typename E, typename Reader>
-typename boost::disable_if<is_map_container<T> >::type  
+typename boost::disable_if<is_map_container<T> >::type
 inline MapByKey(T& var, BondDataType keyType, const E& element, Reader& input, uint32_t size)
 {
     switch (keyType)
@@ -554,7 +556,7 @@ inline MapByKey(T& var, BondDataType keyType, const E& element, Reader& input, u
 
         case bond::BT_STRING:
             return DeserializeMapElements<Protocols>(var, value<std::string, Reader&>(input, false), element, size);
-            
+
         case bond::BT_WSTRING:
             return DeserializeMapElements<Protocols>(var, value<std::wstring, Reader&>(input, false), element, size);
 
@@ -578,7 +580,7 @@ inline MapByKey(T& var, BondDataType keyType, const E& element, Reader& input, u
 
 
 template <typename Protocols, typename T, typename E, typename Reader>
-typename boost::enable_if<is_map_element_matching<E, T> >::type  
+typename boost::enable_if<is_map_element_matching<E, T> >::type
 inline MapByKey(T& var, BondDataType keyType, const E& element, Reader& input, uint32_t size)
 {
     return MatchingMapByKey<Protocols>(var, keyType, element, input, size);
@@ -625,7 +627,7 @@ inline void MapByElement(T& var, BondDataType keyType, BondDataType elementType,
 
         case bond::BT_STRING:
             return MapByKey<Protocols>(var, keyType, value<std::string, Reader&>(input, false), input, size);
-            
+
         case bond::BT_WSTRING:
             return MapByKey<Protocols>(var, keyType, value<std::wstring, Reader&>(input, false), input, size);
 
@@ -643,12 +645,12 @@ inline void MapByElement(T& var, BondDataType keyType, BondDataType elementType,
 
         default:
             BOOST_ASSERT(false);
-            break; 
+            break;
     }
 }
 
 
-// MatchingMapByElement function are manually expended versions of MapByElement using 
+// MatchingMapByElement function are manually expended versions of MapByElement using
 // the type information about destination container. This helps with compilation speed.
 
 template <typename Reader>
@@ -704,7 +706,7 @@ inline MatchingMapByElement(T& var, BondDataType keyType, BondDataType elementTy
     {
         case bond::BT_STRING:
             return MapByKey<Protocols>(var, keyType, value<std::string, Reader&>(input, false), input, size);
-            
+
         default:
             BOOST_ASSERT(!IsMatching<typename element_type<T>::type::second_type>(elementType));
 

--- a/cpp/inc/bond/core/detail/validate.h
+++ b/cpp/inc/bond/core/detail/validate.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <bond/core/config.h>
 
 namespace bond
 {
@@ -23,7 +24,7 @@ inline bool ValidateType(BondDataType src, BondDataType dst)
                 case BT_UINT64:
                     return src <= dst;
                 default:
-                    break;  
+                    break;
             }
             break;
 
@@ -37,7 +38,7 @@ inline bool ValidateType(BondDataType src, BondDataType dst)
                 case BT_INT64:
                     return src <= dst;
                 default:
-                    break;  
+                    break;
             }
             break;
 
@@ -67,20 +68,20 @@ inline bool ValidateType(const RuntimeSchema& src,
                          const RuntimeSchema& dst,
                          const struct_list* list,
                          bool& identical)
-{        
+{
     if (dst.GetTypeId() != src.GetTypeId())
     {
         identical = false;
         return ValidateType(src.GetTypeId(), dst.GetTypeId());
     }
-    
+
     if (dst.GetType().bonded_type != src.GetType().bonded_type)
     {
         identical = false;
     }
-    
+
     if (dst.GetTypeId() == BT_STRUCT && !dst.GetType().bonded_type)
-    {        
+    {
         ValidateStruct(src, dst, list, identical);
         return true;
     }
@@ -88,8 +89,8 @@ inline bool ValidateType(const RuntimeSchema& src,
     if (!dst.GetType().element.empty())
     {
         RuntimeSchema r_dst(dst, *dst.GetType().element);
-        RuntimeSchema r_src(src, *src.GetType().element);        
-        
+        RuntimeSchema r_src(src, *src.GetType().element);
+
         if (!ValidateType(r_src, r_dst, list, identical))
         {
             return false;
@@ -100,7 +101,7 @@ inline bool ValidateType(const RuntimeSchema& src,
     {
         RuntimeSchema r_dst(dst, *dst.GetType().key);
         RuntimeSchema r_src(src, *src.GetType().key);
-        
+
         if (!ValidateType(r_src, r_dst, list, identical))
         {
             return false;
@@ -154,8 +155,8 @@ inline void ValidateFields(const RuntimeSchema& src,
             OptionalToRequiredException(s_src, s_dst, *f_src, *f_dst);
         }
 
-        if (!ValidateType(RuntimeSchema(src, *f_src), 
-                          RuntimeSchema(dst, *f_dst), 
+        if (!ValidateType(RuntimeSchema(src, *f_src),
+                          RuntimeSchema(dst, *f_dst),
                           list, identical))
         {
             FieldTypeIncompatibleException(s_src, s_dst, *f_src, *f_dst);
@@ -171,11 +172,11 @@ inline void ValidateStruct(const RuntimeSchema& src,
                            const struct_list* list,
                            bool& identical)
 {
-    struct_list next = { 
-        list, &dst.GetStruct(), &src.GetStruct() 
+    struct_list next = {
+        list, &dst.GetStruct(), &src.GetStruct()
     };
 
-    for (; list; list = list->last) 
+    for (; list; list = list->last)
     {
         if (list->dst == next.dst &&
             list->src == next.src)
@@ -211,7 +212,7 @@ template <typename Protocols>
 class SchemaValidator
     : public DeserializingTransform
 {
-public:    
+public:
     void Begin(const Metadata&) const
     {}
 

--- a/cpp/inc/bond/core/detail/value_or_reference.h
+++ b/cpp/inc/bond/core/detail/value_or_reference.h
@@ -3,12 +3,14 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
+#include <boost/core/ref.hpp>
 #include <boost/optional.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <boost/core/ref.hpp>
+
 #include <functional>
 #include <type_traits>
-
 
 namespace bond
 {

--- a/cpp/inc/bond/core/detail/visit_any.h
+++ b/cpp/inc/bond/core/detail/visit_any.h
@@ -3,10 +3,13 @@
 
 #pragma once
 
-#include "mpl.h"
-#include <boost/optional.hpp>
-#include <type_traits>
+#include <bond/core/config.h>
 
+#include "mpl.h"
+
+#include <boost/optional.hpp>
+
+#include <type_traits>
 
 namespace bond
 {

--- a/cpp/inc/bond/core/exception.h
+++ b/cpp/inc/bond/core/exception.h
@@ -3,8 +3,12 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "detail/string_stream.h"
+
 #include <bond/core/bond_types.h>
+
 #include <boost/locale/encoding_utf.hpp>
 #include <boost/utility/enable_if.hpp>
 

--- a/cpp/inc/bond/core/maybe.h
+++ b/cpp/inc/bond/core/maybe.h
@@ -3,7 +3,10 @@
 
 #pragma once
 
-#include "config.h"
+#include <bond/core/config.h>
+
+#include <type_traits>
+#include <utility>
 
 namespace bond
 {

--- a/cpp/inc/bond/core/merge.h
+++ b/cpp/inc/bond/core/merge.h
@@ -3,11 +3,13 @@
 
 #pragma once
 
-#include "reflection.h"
-#include "exception.h"
-#include "transforms.h"
-#include "detail/tags.h"
+#include <bond/core/config.h>
+
 #include "detail/omit_default.h"
+#include "detail/tags.h"
+#include "exception.h"
+#include "reflection.h"
+#include "transforms.h"
 
 
 namespace bond
@@ -45,7 +47,7 @@ public:
         return Apply<Protocols>(Merger<typename schema<T>::type::base, Writer, Protocols>(_var, _output, true), value);
     }
 
-    
+
     template <typename FieldT, typename X>
     typename boost::enable_if_c<is_struct_field<FieldT>::value
                              || is_struct_container_field<FieldT>::value, bool>::type
@@ -66,7 +68,7 @@ public:
         return this->Field(FieldT::id, FieldT::metadata, FieldT::GetVariable(_var));
     }
 
-    
+
     template <typename FieldT>
     bool OmittedField(const FieldT&) const
     {
@@ -92,7 +94,7 @@ public:
 
     template <typename Key, typename X, typename Reader>
     typename boost::enable_if_c<is_map_element_matching<X, T>::value
-                             && is_map_key_matching<Key, T>::value>::type 
+                             && is_map_key_matching<Key, T>::value>::type
     Container(const value<Key, Reader>& key, const X& value, uint32_t size) const
     {
         Merge(_var, key, value, size);
@@ -110,15 +112,15 @@ private:
         Apply<Protocols>(Merger<U, Writer, Protocols>(var, _output), value);
     }
 
-    
+
     template <typename U, typename X>
     void Merge(const U& var, const X& element, uint32_t size) const
     {
         if (size != container_size(var))
             MergerContainerException(size, container_size(var));
-        
+
         _output.WriteContainerBegin(size, get_type_id<typename element_type<U>::type>::value);
-        
+
         for (const_enumerator<U> items(var); items.more();)
             Merge(items.next(), element);
 
@@ -133,20 +135,20 @@ private:
             MergerContainerException(size, container_size(var));
 
         _output.WriteContainerBegin(size, get_type_id<typename element_type<U>::type>::value);
-        
+
         typename element_type<U>::type::first_type k;
-        
+
         while (size--)
         {
             key.template Deserialize<Protocols>(k);
 
             Write(k);
-            
+
             // Elements of a map migth be serialized out of order, so we must
             // look up the element to merge by key.
             Merge(mapped_at(var, k), value);
         }
-        
+
         _output.WriteContainerEnd();
     }
 

--- a/cpp/inc/bond/core/multi_threaded_counter.h
+++ b/cpp/inc/bond/core/multi_threaded_counter.h
@@ -3,9 +3,13 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "capped_allocator_fwd.h"
 #include "detail/counter_base.h"
+
 #include <boost/assert.hpp>
+
 #include <atomic>
 
 

--- a/cpp/inc/bond/core/null.h
+++ b/cpp/inc/bond/core/null.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "detail/tags.h"
 
 namespace bond

--- a/cpp/inc/bond/core/nullable.h
+++ b/cpp/inc/bond/core/nullable.h
@@ -3,14 +3,17 @@
 
 #pragma once
 
-#include "config.h"
+#include <bond/core/config.h>
+
 #include "container_interface.h"
-#include <stdint.h>
+
 #include <boost/assert.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/noncopyable.hpp>
+#include <boost/static_assert.hpp>
 #include <boost/utility/addressof.hpp>
 #include <boost/utility/enable_if.hpp>
+
+#include <stdint.h>
 
 namespace bond
 {

--- a/cpp/inc/bond/core/parser.h
+++ b/cpp/inc/bond/core/parser.h
@@ -3,13 +3,17 @@
 
 #pragma once
 
-#include "reflection.h"
-#include "detail/typeid_value.h"
-#include "value.h"
-#include "transforms.h"
-#include "merge.h"
-#include "schema.h"
+#include <bond/core/config.h>
+
 #include "detail/inheritance.h"
+#include "detail/omit_default.h"
+#include "detail/typeid_value.h"
+#include "merge.h"
+#include "reflection.h"
+#include "schema.h"
+#include "transforms.h"
+#include "value.h"
+
 #include <bond/protocol/simple_binary_impl.h>
 #include <bond/protocol/simple_json_reader_impl.h>
 
@@ -76,10 +80,10 @@ protected:
 } // namespace detail
 
 //
-// StaticParser iterates serialized data using type schema and calls 
-// specified transform for each data field. 
-// The schema may be provided at compile-time (schema<T>::type::fields) or at runtime 
-// (const RuntimeSchema&). StaticParser is used with protocols which don't 
+// StaticParser iterates serialized data using type schema and calls
+// specified transform for each data field.
+// The schema may be provided at compile-time (schema<T>::type::fields) or at runtime
+// (const RuntimeSchema&). StaticParser is used with protocols which don't
 // tag fields in serialized format with ids or types, e.g. Apache Avro protocol.
 //
 template <typename Input>
@@ -92,11 +96,11 @@ public:
         : detail::ParserInheritance<Input, StaticParser<Input> >(input, base)
     {}
 
-    
+
     template <typename Schema, typename Transform>
     bool
     Apply(const Transform& transform, const Schema& schema)
-    {                                               
+    {
         detail::StructBegin(_input, _base);
         bool result = this->Read(schema, transform);
         detail::StructEnd(_input, _base);
@@ -131,7 +135,7 @@ private:
         else
             if (bool done = NextField(Head(), transform))
                 return done;
-        
+
         return ReadFields(typename boost::mpl::next<Fields>::type(), transform);
     }
 
@@ -218,12 +222,12 @@ private:
 
 //
 // DynamicParser iterates serialized data using field tags included in the
-// data by the protocol and calls specified transform for each data field. 
-// DynamicParser uses schema only for auxiliary metadata, such as field 
-// names or modifiers, and determines what fields are present from the data itself. 
-// The schema may be provided at compile-time (schema<T>::type::fields) or at runtime 
-// (const RuntimeSchema&). 
-// DynamicParser is used with protocols which tag fields in serialized  
+// data by the protocol and calls specified transform for each data field.
+// DynamicParser uses schema only for auxiliary metadata, such as field
+// names or modifiers, and determines what fields are present from the data itself.
+// The schema may be provided at compile-time (schema<T>::type::fields) or at runtime
+// (const RuntimeSchema&).
+// DynamicParser is used with protocols which tag fields in serialized
 // format with ids and types, e.g. Mafia, Thrift or Protocol Buffers.
 //
 template <typename Input>
@@ -236,11 +240,11 @@ public:
         : detail::ParserInheritance<Input, DynamicParser<Input> >(input, base)
     {}
 
-    
+
     template <typename Schema, typename Transform>
     bool
     Apply(const Transform& transform, const Schema& schema)
-    {                                               
+    {
         detail::StructBegin(_input, _base);
         bool result = this->Read(schema, transform);
         detail::StructEnd(_input, _base);
@@ -255,9 +259,9 @@ protected:
     using detail::ParserInheritance<Input, DynamicParser<Input> >::_base;
 
 
-private:      
+private:
     template <typename Fields, typename Transform>
-    bool 
+    bool
     ReadFields(const Fields& fields, const Transform& transform)
     {
         uint16_t     id;
@@ -271,7 +275,7 @@ private:
         {
             // If we are not parsing a base class, and we still didn't get to
             // the end of the struct, it means that:
-            // 
+            //
             // 1) Actual data in the payload had deeper hierarchy than payload schema.
             //
             // or
@@ -280,7 +284,7 @@ private:
             //    the transform "expected".
             //
             // In both cases we emit remaining fields as unknown
-            
+
             for (; type != bond::BT_STOP; _input.ReadFieldEnd(), _input.ReadFieldBegin(type, id))
             {
                 if (type == bond::BT_STOP_BASE)
@@ -295,7 +299,7 @@ private:
         return false;
     }
 
-    
+
     // use compile-time schema
     template <typename Fields, typename Transform>
     void
@@ -314,11 +318,11 @@ private:
             {
                 // Unknown field or non-exact type match
                 UnknownFieldOrTypeMismatch(
-                    Head::id, 
-                    is_basic_type<typename Head::field_type>::value, 
-                    Head::metadata, 
-                    id, 
-                    type, 
+                    Head::id,
+                    is_basic_type<typename Head::field_type>::value,
+                    Head::metadata,
+                    id,
+                    type,
                     transform);
             }
             else
@@ -349,7 +353,7 @@ private:
         }
     }
 
- 
+
     template <typename T, typename Transform>
     typename boost::enable_if_c<is_nested_field<T>::value
                             && !is_fast_path_field<T, Transform>::value, bool>::type
@@ -387,8 +391,8 @@ private:
 
 
     // This function is called only when payload has unknown field id or type is not
-    // matching exactly. This relativly rare so we don't inline the function to help 
-    // the compiler to optimize the common path. 
+    // matching exactly. This relativly rare so we don't inline the function to help
+    // the compiler to optimize the common path.
     template <typename Transform>
     BOND_NO_INLINE
     bool
@@ -434,7 +438,7 @@ private:
             {
                 break;
             }
-            
+
             if (it != end && it->id == id)
             {
                 const FieldDef& field = *it++;
@@ -469,7 +473,7 @@ private:
         {
             // If we are not parsing a base class, and we still didn't get to
             // the end of the struct, it means that:
-            // 
+            //
             // 1) Actual data in the payload had deeper hierarchy than payload schema.
             //
             // or
@@ -478,7 +482,7 @@ private:
             //    the transform "expected".
             //
             // In both cases we emit remaining fields as unknown
-            
+
             for (; type != bond::BT_STOP; _input.ReadFieldEnd(), _input.ReadFieldBegin(type, id))
             {
                 if (type == bond::BT_STOP_BASE)
@@ -521,11 +525,11 @@ private:
 };
 
 
-// DOM parser works with protocol implementations using Document Object Model, 
-// e.g. JSON or XML. The parser assumes that fields in DOM are unordered and 
+// DOM parser works with protocol implementations using Document Object Model,
+// e.g. JSON or XML. The parser assumes that fields in DOM are unordered and
 // are identified by either ordinal or metadata. DOM based protocols may loosly
-// map to Bond meta-schema types thus the parser delegates to the protocol for 
-// field type match checking. 
+// map to Bond meta-schema types thus the parser delegates to the protocol for
+// field type match checking.
 template <typename Input>
 class DOMParser
     : protected detail::ParserInheritance<Input, DOMParser<Input> >
@@ -537,7 +541,7 @@ public:
         : detail::ParserInheritance<Input, DOMParser<Input> >(input, base)
     {}
 
-    
+
     template <typename Schema, typename Transform>
     bool Apply(const Transform& transform, const Schema& schema)
     {
@@ -564,15 +568,15 @@ private:
         typedef typename boost::mpl::deref<Fields>::type Head;
 
         if (const typename Reader::Field* field = _input.FindField(
-                Head::id,  
-                Head::metadata, 
+                Head::id,
+                Head::metadata,
                 get_type_id<typename Head::field_type>::value,
                 std::is_enum<typename Head::field_type>::value))
         {
             Reader input(_input, *field);
             NextField(Head(), transform, input);
         }
-        
+
         return ReadFields(typename boost::mpl::next<Fields>::type(), transform);
     }
 
@@ -628,7 +632,7 @@ private:
         for (const_enumerator<std::vector<FieldDef> > enumerator(schema.GetStruct().fields); enumerator.more() && !done;)
         {
             const FieldDef& fieldDef = enumerator.next();
-            
+
             if (const typename Reader::Field* field = _input.FindField(fieldDef.id, fieldDef.metadata, fieldDef.type.id))
             {
                 Reader input(_input, *field);

--- a/cpp/inc/bond/core/protocol.h
+++ b/cpp/inc/bond/core/protocol.h
@@ -3,17 +3,20 @@
 
 #pragma once
 
-#include "traits.h"
+#include <bond/core/config.h>
+
 #include "customize.h"
 #include "detail/any.h"
 #include "detail/mpl.h"
 #include "detail/odr.h"
 #include "detail/visit_any.h"
-#include <bond/stream/input_buffer.h>
-#include <bond/protocol/simple_binary.h>
+#include "traits.h"
+
 #include <bond/protocol/compact_binary.h>
 #include <bond/protocol/fast_binary.h>
+#include <bond/protocol/simple_binary.h>
 #include <bond/protocol/simple_json_reader.h>
+#include <bond/stream/input_buffer.h>
 
 #include <boost/make_shared.hpp>
 #include <boost/optional.hpp>
@@ -35,28 +38,28 @@ namespace bond
 {
 
 #ifdef BOND_COMPACT_BINARY_PROTOCOL
-template <typename Buffer> struct 
-is_protocol_enabled<CompactBinaryReader<Buffer> > 
+template <typename Buffer> struct
+is_protocol_enabled<CompactBinaryReader<Buffer> >
     : std::true_type {};
-#endif 
+#endif
 
 #ifdef BOND_SIMPLE_BINARY_PROTOCOL
 template <typename Buffer, typename MarshaledBondedProtocols> struct
 is_protocol_enabled<SimpleBinaryReader<Buffer, MarshaledBondedProtocols> >
     : std::true_type {};
-#endif 
+#endif
 
 #ifdef BOND_SIMPLE_JSON_PROTOCOL
-template <typename Buffer> struct 
-is_protocol_enabled<SimpleJsonReader<Buffer> > 
+template <typename Buffer> struct
+is_protocol_enabled<SimpleJsonReader<Buffer> >
     : std::true_type {};
-#endif 
+#endif
 
 #ifdef BOND_FAST_BINARY_PROTOCOL
-template <typename Buffer> struct 
-is_protocol_enabled<FastBinaryReader<Buffer> > 
+template <typename Buffer> struct
+is_protocol_enabled<FastBinaryReader<Buffer> >
     : std::true_type {};
-#endif 
+#endif
 
 // uses_static_parser
 template <typename Reader, typename Enable = void> struct
@@ -101,7 +104,7 @@ uses_dom_parser<Reader&>
     : uses_dom_parser<Reader> {};
 
 
-template <typename Reader, typename Unused> struct 
+template <typename Reader, typename Unused> struct
 uses_marshaled_bonded
     : uses_static_parser<Reader> {};
 
@@ -178,7 +181,7 @@ struct ValueReader
         : instance(boost::static_pointer_cast<const void>(value)),
           pointer(instance.get())
     {}
-    
+
     ValueReader(const ValueReader& value) BOND_NOEXCEPT
         : instance(value.instance),
           pointer(value.pointer)

--- a/cpp/inc/bond/core/reflection.h
+++ b/cpp/inc/bond/core/reflection.h
@@ -3,17 +3,21 @@
 
 #pragma once
 
-#include <boost/static_assert.hpp>
-#include <boost/mpl/transform.hpp>
+#include <bond/core/config.h>
+
+#include "bond_fwd.h"
+#include "detail/metadata.h"
+
+#include <bond/core/bond_types.h>
+
+#include <boost/mpl/copy_if.hpp>
 #include <boost/mpl/find_if.hpp>
 #include <boost/mpl/for_each.hpp>
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/push_front.hpp>
-#include <boost/mpl/copy_if.hpp>
+#include <boost/mpl/transform.hpp>
+#include <boost/static_assert.hpp>
 
-#include <bond/core/bond_types.h>
-#include "bond_fwd.h"
-#include "detail/metadata.h"
 #include <functional>
 
 namespace bond

--- a/cpp/inc/bond/core/runtime_schema.h
+++ b/cpp/inc/bond/core/runtime_schema.h
@@ -3,8 +3,12 @@
 
 #pragma once
 
-#include <bond/core/bond_types.h>
+#include <bond/core/config.h>
+
 #include "detail/nonassignable.h"
+
+#include <bond/core/bond_types.h>
+
 #include <boost/shared_ptr.hpp>
 
 namespace bond

--- a/cpp/inc/bond/core/scalar_interface.h
+++ b/cpp/inc/bond/core/scalar_interface.h
@@ -3,12 +3,14 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 namespace bond
 {
 
 
 // Trait defining what built-it type is aliased by T
-template <typename T> struct 
+template <typename T> struct
 aliased_type
 {
     typedef void type;
@@ -16,7 +18,7 @@ aliased_type
 
 #if 0
 
-// Overloaded function to set variable to an aliased value 
+// Overloaded function to set variable to an aliased value
 template <typename T>
 void set_aliased_value(T& var, typename aliased_type<T>::type value);
 

--- a/cpp/inc/bond/core/schema.h
+++ b/cpp/inc/bond/core/schema.h
@@ -3,12 +3,15 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
+#include "detail/once.h"
+#include "detail/tags.h"
 #include "reflection.h"
 #include "runtime_schema.h"
-#include "detail/tags.h"
-#include "detail/once.h"
-#include <boost/make_shared.hpp>
+
 #include <boost/bind.hpp>
+#include <boost/make_shared.hpp>
 
 namespace bond
 {

--- a/cpp/inc/bond/core/select_protocol.h
+++ b/cpp/inc/bond/core/select_protocol.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "exception.h"
 #include "protocol.h"
 #include "runtime_schema.h"
@@ -207,7 +209,7 @@ inline bool NextProtocol(const RuntimeSchema& schema, Buffer& input, const Trans
 }
 
 
-// Select protocol based on magic number and apply instance of serializing transform 
+// Select protocol based on magic number and apply instance of serializing transform
 template <template <typename Writer, typename ProtocolsT> class Transform, typename Protocols, typename T, typename Buffer>
 inline bool NextProtocol(const T& value, Buffer& output, uint16_t protocol)
 {
@@ -233,7 +235,7 @@ inline bool NextProtocol(const T& value, Buffer& output, uint16_t protocol)
 
 
 //
-// Apply transform to serialized data that was generated using Marshaler 
+// Apply transform to serialized data that was generated using Marshaler
 //
 
 
@@ -256,7 +258,7 @@ inline std::pair<ProtocolType, bool> SelectProtocolAndApply(
 }
 
 
-// Apply deserializing transform with a protocol specified by magic number 
+// Apply deserializing transform with a protocol specified by magic number
 // Use compile-time schema
 template <typename T, typename Protocols = BuiltInProtocols, typename Transform, typename Buffer>
 inline bool Apply(const Transform& transform, Buffer& input, uint16_t protocol)
@@ -282,4 +284,3 @@ inline bool Apply(const T& value, Buffer& output, uint16_t protocol)
 
 
 } // namespace bond
-

--- a/cpp/inc/bond/core/select_protocol_fwd.h
+++ b/cpp/inc/bond/core/select_protocol_fwd.h
@@ -3,8 +3,9 @@
 
 #pragma once
 
-#include "bond_fwd.h"
+#include <bond/core/config.h>
 
+#include "bond_fwd.h"
 
 namespace bond
 {

--- a/cpp/inc/bond/core/shared_counter.h
+++ b/cpp/inc/bond/core/shared_counter.h
@@ -3,12 +3,15 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "capped_allocator_fwd.h"
-#include <boost/intrusive_ptr.hpp>
+
 #include <boost/assert.hpp>
+#include <boost/intrusive_ptr.hpp>
+
 #include <atomic>
 #include <functional>
-
 
 namespace bond
 {
@@ -82,7 +85,7 @@ namespace bond
 
         protected:
             virtual ~internal_counter() = default;
-            
+
             /// @brief Destroys and deallocates current instance.
             virtual void delete_this()
             {

--- a/cpp/inc/bond/core/single_threaded_counter.h
+++ b/cpp/inc/bond/core/single_threaded_counter.h
@@ -3,10 +3,12 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "capped_allocator_fwd.h"
 #include "detail/counter_base.h"
-#include <boost/assert.hpp>
 
+#include <boost/assert.hpp>
 
 namespace bond
 {

--- a/cpp/inc/bond/core/stl_containers.h
+++ b/cpp/inc/bond/core/stl_containers.h
@@ -3,15 +3,19 @@
 
 #pragma once
 
-#include <boost/utility/enable_if.hpp>
-#include <stdint.h>
-#include <string>
-#include <list>
-#include <vector>
-#include <map>
-#include <set>
+#include <bond/core/config.h>
+
 #include "container_interface.h"
 #include "traits.h"
+
+#include <boost/utility/enable_if.hpp>
+
+#include <list>
+#include <map>
+#include <set>
+#include <stdint.h>
+#include <string>
+#include <vector>
 
 // Bond container interface on top of STL container classes
 

--- a/cpp/inc/bond/core/traits.h
+++ b/cpp/inc/bond/core/traits.h
@@ -3,16 +3,18 @@
 
 #pragma once
 
-#include "config.h"
+#include <bond/core/config.h>
+
 #include "bond_fwd.h"
 #include "detail/mpl.h"
 #include "scalar_interface.h"
+
+#include <boost/static_assert.hpp>
 #include <boost/type_traits/has_nothrow_copy.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <boost/static_assert.hpp>
 
-#include <type_traits>
 #include <memory>
+#include <type_traits>
 #include <utility>
 
 namespace bond

--- a/cpp/inc/bond/core/transforms.h
+++ b/cpp/inc/bond/core/transforms.h
@@ -3,16 +3,18 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "bond_fwd.h"
-#include "reflection.h"
-#include "exception.h"
-#include "null.h"
-#include "detail/tags.h"
-#include "detail/odr.h"
-#include "detail/omit_default.h"
 #include "detail/debug.h"
 #include "detail/double_pass.h"
 #include "detail/marshaled_bonded.h"
+#include "detail/odr.h"
+#include "detail/omit_default.h"
+#include "detail/tags.h"
+#include "exception.h"
+#include "null.h"
+#include "reflection.h"
 
 #include <boost/static_assert.hpp>
 
@@ -34,10 +36,10 @@ namespace detail
 
 
 //
-// Serializer writes input using provided protocol writer. 
-// When the input is comming from parsing a struct, applying this transform is  
-// equivalent to serialization using the specfied protocol. 
-// Applying this transform to input from parsing serialized data is equivalent  
+// Serializer writes input using provided protocol writer.
+// When the input is comming from parsing a struct, applying this transform is
+// equivalent to serialization using the specfied protocol.
+// Applying this transform to input from parsing serialized data is equivalent
 // to transcoding from one protocol to another.
 //
 template <typename Writer, typename Protocols>
@@ -54,7 +56,7 @@ public:
           _base(base)
     {}
 
-    
+
     bool NeedPass0() const
     {
         return _output.NeedPass0();
@@ -84,7 +86,7 @@ public:
     template <typename T>
     bool Base(const T& value) const
     {
-        // 'true' means that we are writing a base struct 
+        // 'true' means that we are writing a base struct
         Apply<Protocols>(Serializer(_output, true), value);
         return false;
     }
@@ -114,7 +116,7 @@ public:
         WriteField(id, metadata, value.value());
         return false;
     }
-    
+
     // unknown field
     template <typename T>
     bool UnknownField(uint16_t id, const T& value) const
@@ -133,7 +135,7 @@ public:
         return false;
     }
 
-    
+
     template <typename T>
     void Container(const T& element, uint32_t size) const
     {
@@ -141,7 +143,7 @@ public:
 
         while (size--)
             Write(element);
-    
+
         _output.WriteContainerEnd();
     }
 
@@ -156,7 +158,7 @@ public:
             Write(key);
             Write(value);
         }
-    
+
         _output.WriteContainerEnd();
     }
 
@@ -258,11 +260,11 @@ private:
     Write(const value<T, Reader>& value) const
     {
         T data = T();
-        
+
         value.template Deserialize<Protocols>(data);
         Write(data);
     }
-    
+
     template <typename Reader, typename T>
     typename boost::disable_if<is_basic_type<T> >::type
     Write(const value<T, Reader>& value) const
@@ -270,7 +272,7 @@ private:
         Apply<Protocols>(Serializer(_output), value);
     }
 
-    
+
     template <typename T, typename WriterT, typename ProtocolsT>
     friend class Merger;
 
@@ -307,7 +309,7 @@ public:
     Marshaler(Writer& output)
         : Serializer<Writer, Protocols>(output)
     {}
-    
+
     template <typename T>
     bool Marshal(const T& value) const
     {
@@ -329,7 +331,7 @@ ApplyTransform(const Marshaler<Writer, Protocols>& marshaler, const bonded<T, Re
 
 
 template <typename Protocols, typename Writer, typename T>
-bool inline 
+bool inline
 ApplyTransform(const Marshaler<Writer, Protocols>& marshaler, const T& value)
 {
     return marshaler.Marshal(value);
@@ -354,9 +356,9 @@ protected:
     {
         _required = next_required_field<typename schema<T>::type::fields>::value;
     }
-        
+
     template <typename Head>
-    typename boost::enable_if<std::is_same<typename Head::field_modifier, 
+    typename boost::enable_if<std::is_same<typename Head::field_modifier,
                                            reflection::required_field_modifier> >::type
     Validate() const
     {
@@ -368,7 +370,7 @@ protected:
 
 
     template <typename Schema>
-    typename boost::enable_if_c<next_required_field<typename Schema::fields>::value 
+    typename boost::enable_if_c<next_required_field<typename Schema::fields>::value
                              != invalid_field_id>::type
     Validate() const
     {
@@ -378,21 +380,21 @@ protected:
 
 
     template <typename Head>
-    typename boost::disable_if<std::is_same<typename Head::field_modifier, 
+    typename boost::disable_if<std::is_same<typename Head::field_modifier,
                                             reflection::required_field_modifier> >::type
     Validate() const
     {}
 
 
     template <typename Schema>
-    typename boost::disable_if_c<next_required_field<typename Schema::fields>::value 
+    typename boost::disable_if_c<next_required_field<typename Schema::fields>::value
                               != invalid_field_id>::type
     Validate() const
     {}
 
 private:
     BOND_NORETURN void MissingFieldException() const;
-    
+
     mutable uint16_t _required;
 };
 
@@ -474,7 +476,7 @@ public:
     void Begin(const Metadata& /*metadata*/) const
     {
         // Type T must be a Bond struct (i.e. struct generated by Bond codegen
-        // from a .bond file). If the assert fails for a Bond struct, the likely 
+        // from a .bond file). If the assert fails for a Bond struct, the likely
         // reason is that you didn't include the generated file *_reflection.h.
         BOOST_STATIC_ASSERT(has_schema<T>::value);
 
@@ -526,7 +528,7 @@ public:
 
 
     // Fast path for the common case when parser is using compile-time schema schema<T>::type
-    // and thus already knows schema type for each field.  
+    // and thus already knows schema type for each field.
     typedef T FastPathType;
 
     template <typename FieldT, typename X>
@@ -580,7 +582,7 @@ BOND_STATIC_CONSTEXPR uint16_t mapping_base = invalid_field_id;
 //
 // MapTo<T> maps the input fields onto an instance of a static bond type T,
 // using provided mappings from field path in the source to field path in
-// the type T. Field paths are expressed as a lists of field ids. 
+// the type T. Field paths are expressed as a lists of field ids.
 //
 namespace detail
 {
@@ -604,7 +606,7 @@ public:
     {
         return false;
     }
-    
+
 protected:
     struct PathView
         : boost::noncopyable
@@ -642,8 +644,8 @@ protected:
         else
             return AssignToNested(var, ids, value);
     }
-    
-    
+
+
     template <typename V, typename X>
     bool AssignToNested(V& var, const PathView& ids, const X& value) const
     {
@@ -651,14 +653,14 @@ protected:
     }
 
 
-    template <typename BaseT, typename V, typename X>    
+    template <typename BaseT, typename V, typename X>
     bool AssignToBase(const BaseT*, V& var, const PathView& ids, const X& value) const
     {
         return Assign(static_cast<BaseT&>(var), PathView(ids.path, ids.current + 1), value);
     }
 
-    
-    template <typename V, typename X>    
+
+    template <typename V, typename X>
     bool AssignToBase(const no_base*, V& /*var*/, const PathView& /*ids*/, const X& /*value*/) const
     {
         return false;
@@ -682,8 +684,8 @@ protected:
         return false;
     }
 
-    
-    // Separate AssignToField overloads for bonded<T>, basic types and containers allows us 
+
+    // Separate AssignToField overloads for bonded<T>, basic types and containers allows us
     // to use simpler predicates in boost::mpl::copy_if. This doesn't matter for runtime code
     // but compiles significantly faster.
     template <typename Reader, typename V, typename X>
@@ -692,7 +694,7 @@ protected:
         return AssignToField(typename boost::mpl::begin<typename nested_fields<V>::type>::type(), var, id, value);
     }
 
-    
+
     template <typename Reader, typename V, typename X>
     bool AssignToField(V& var, uint16_t id, const value<X, Reader>& value) const
     {
@@ -706,7 +708,7 @@ protected:
         return AssignToField(typename boost::mpl::begin<typename container_fields<V>::type>::type(), var, id, value);
     }
 
-    
+
     template <typename Fields, typename V, typename X>
     bool AssignToField(const Fields&, V& var, uint16_t id, const X& value) const
     {
@@ -723,7 +725,7 @@ protected:
         }
     }
 
-    
+
     template <typename V, typename X>
     bool AssignToField(const boost::mpl::l_iter<boost::mpl::l_end>&, V& /*var*/, uint16_t /*id*/, const X& /*value*/) const
     {
@@ -737,7 +739,7 @@ protected:
         value.template Deserialize<Protocols>(var);
     }
 
-    
+
     template <typename V, typename X>
     void AssignToVar(maybe<V>& var, const X& value) const
     {
@@ -760,7 +762,7 @@ public:
           _mappings(mappings)
     {}
 
-    
+
     template <typename X>
     bool Base(const X& value) const
     {
@@ -783,11 +785,11 @@ public:
         {
             if (!it->second.fields.empty())
                 return Apply(MapTo(_var, it->second.fields), value);
-            
+
             if (!it->second.path.empty())
                 return this->Assign(_var, it->second.path, value);
         }
-        
+
         return false;
     }
 

--- a/cpp/inc/bond/core/tuple.h
+++ b/cpp/inc/bond/core/tuple.h
@@ -3,9 +3,12 @@
 
 #pragma once
 
-#include <tuple>
+#include <bond/core/config.h>
+
 #include "bond.h"
 #include "detail/tuple_fields.h"
+
+#include <tuple>
 
 namespace bond
 {

--- a/cpp/inc/bond/core/validate.h
+++ b/cpp/inc/bond/core/validate.h
@@ -3,10 +3,12 @@
 
 #pragma once
 
-#include "exception.h"
-#include "schema.h"
+#include <bond/core/config.h>
+
 #include "apply.h"
 #include "detail/validate.h"
+#include "exception.h"
+#include "schema.h"
 
 namespace bond
 {
@@ -74,7 +76,7 @@ inline bool Validate(const RuntimeSchema& src,
 /// @param s1 Schema to compare
 /// @param s2 Schema to compare
 /// @return 'true' if schemas are wire-format equivalent, 'false' if schemas
-/// are different but payload in source can be deserialized as destination, 
+/// are different but payload in source can be deserialized as destination,
 /// and vice versa.
 /// @throw SchemaValidateException if payload in any one schema is incompatible
 /// with the other schema.

--- a/cpp/inc/bond/core/value.h
+++ b/cpp/inc/bond/core/value.h
@@ -3,11 +3,12 @@
 
 #pragma once
 
-#include <boost/static_assert.hpp>
+#include <bond/core/config.h>
 
-#include "config.h"
 #include "protocol.h"
 #include "schema.h"
+
+#include <boost/static_assert.hpp>
 
 namespace bond
 {

--- a/cpp/inc/bond/ext/detail/barrier.h
+++ b/cpp/inc/bond/ext/detail/barrier.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "event.h"
 
 #include <boost/assert.hpp>

--- a/cpp/inc/bond/ext/detail/countdown_event.h
+++ b/cpp/inc/bond/ext/detail/countdown_event.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "event.h"
 
 #include <boost/assert.hpp>

--- a/cpp/inc/bond/ext/detail/event.h
+++ b/cpp/inc/bond/ext/detail/event.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include <boost/assert.hpp>
 
 #include <chrono>

--- a/cpp/inc/bond/ext/grpc/bond_utils.h
+++ b/cpp/inc/bond/ext/grpc/bond_utils.h
@@ -3,6 +3,13 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
+#include <bond/core/bond.h>
+#include <bond/core/bonded.h>
+#include <bond/core/reflection.h>
+#include <bond/stream/output_buffer.h>
+
 #include <grpc++/impl/codegen/config.h>
 #include <grpc++/impl/codegen/core_codegen.h>
 #include <grpc++/impl/codegen/core_codegen_interface.h>
@@ -12,11 +19,6 @@
 #include <grpc++/support/slice.h>
 #include <grpc/impl/codegen/byte_buffer_reader.h>
 #include <grpc/impl/codegen/slice.h>
-
-#include <bond/core/bond.h>
-#include <bond/core/bonded.h>
-#include <bond/core/reflection.h>
-#include <bond/stream/output_buffer.h>
 
 #include <boost/assert.hpp>
 #include <boost/make_shared.hpp>

--- a/cpp/inc/bond/ext/grpc/client_callback.h
+++ b/cpp/inc/bond/ext/grpc/client_callback.h
@@ -3,10 +3,12 @@
 
 #pragma once
 
-#include <grpc++/impl/codegen/status.h>
-#include <grpc++/client_context.h>
+#include <bond/core/config.h>
 
 #include <bond/core/bonded.h>
+
+#include <grpc++/impl/codegen/status.h>
+#include <grpc++/client_context.h>
 
 #include <memory>
 #include <utility>

--- a/cpp/inc/bond/ext/grpc/detail/client_call_data.h
+++ b/cpp/inc/bond/ext/grpc/detail/client_call_data.h
@@ -3,6 +3,14 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
+#include <bond/core/bonded.h>
+#include <bond/ext/grpc/detail/service.h>
+#include <bond/ext/grpc/client_callback.h>
+#include <bond/ext/grpc/io_manager.h>
+#include <bond/ext/grpc/unary_call.h>
+
 #ifdef _MSC_VER
     #pragma warning (push)
     #pragma warning (disable: 4100 4702)
@@ -16,12 +24,6 @@
 #ifdef _MSC_VER
     #pragma warning (pop)
 #endif
-
-#include <bond/core/bonded.h>
-#include <bond/ext/grpc/detail/service.h>
-#include <bond/ext/grpc/client_callback.h>
-#include <bond/ext/grpc/io_manager.h>
-#include <bond/ext/grpc/unary_call.h>
 
 #include <boost/assert.hpp>
 #include <boost/optional.hpp>

--- a/cpp/inc/bond/ext/grpc/detail/io_manager_tag.h
+++ b/cpp/inc/bond/ext/grpc/detail/io_manager_tag.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 namespace bond { namespace ext { namespace gRPC { namespace detail {
 
     /// @brief Interface for completion queue tag types that \ref io_manager

--- a/cpp/inc/bond/ext/grpc/detail/service.h
+++ b/cpp/inc/bond/ext/grpc/detail/service.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #ifdef _MSC_VER
     #pragma warning (push)
     #pragma warning (disable: 4100 4702)

--- a/cpp/inc/bond/ext/grpc/detail/service_call_data.h
+++ b/cpp/inc/bond/ext/grpc/detail/service_call_data.h
@@ -3,6 +3,12 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
+#include <bond/ext/grpc/detail/io_manager_tag.h>
+#include <bond/ext/grpc/detail/service.h>
+#include <bond/ext/grpc/unary_call.h>
+
 #ifdef _MSC_VER
     #pragma warning (push)
     #pragma warning (disable: 4100 4702)
@@ -17,12 +23,9 @@
     #pragma warning (pop)
 #endif
 
-#include <bond/ext/grpc/detail/io_manager_tag.h>
-#include <bond/ext/grpc/detail/service.h>
-#include <bond/ext/grpc/unary_call.h>
-
 #include <boost/assert.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
+
 #include <functional>
 #include <memory>
 #include <thread>

--- a/cpp/inc/bond/ext/grpc/detail/unary_call_impl.h
+++ b/cpp/inc/bond/ext/grpc/detail/unary_call_impl.h
@@ -3,6 +3,11 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
+#include <bond/core/bonded.h>
+#include <bond/ext/grpc/detail/io_manager_tag.h>
+
 #ifdef _MSC_VER
     #pragma warning (push)
     // warning C4100: unreferenced formal parameter
@@ -23,11 +28,9 @@
     #pragma warning (pop)
 #endif
 
-#include <bond/core/bonded.h>
-#include <bond/ext/grpc/detail/io_manager_tag.h>
-
 #include <boost/assert.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
+
 #include <atomic>
 #include <utility>
 

--- a/cpp/inc/bond/ext/grpc/exception.h
+++ b/cpp/inc/bond/ext/grpc/exception.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include <bond/core/exception.h>
 
 namespace bond { namespace ext { namespace gRPC {

--- a/cpp/inc/bond/ext/grpc/io_manager.h
+++ b/cpp/inc/bond/ext/grpc/io_manager.h
@@ -3,6 +3,11 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
+#include <bond/ext/detail/event.h>
+#include <bond/ext/grpc/detail/io_manager_tag.h>
+
 #ifdef _MSC_VER
     #pragma warning (push)
     #pragma warning (disable: 4100 4702)
@@ -14,9 +19,6 @@
 #ifdef _MSC_VER
     #pragma warning (pop)
 #endif
-
-#include <bond/ext/detail/event.h>
-#include <bond/ext/grpc/detail/io_manager_tag.h>
 
 #include <boost/assert.hpp>
 

--- a/cpp/inc/bond/ext/grpc/reflection.h
+++ b/cpp/inc/bond/ext/grpc/reflection.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include <bond/core/reflection.h>
 
 namespace bond { namespace ext { namespace gRPC { namespace reflection {

--- a/cpp/inc/bond/ext/grpc/server.h
+++ b/cpp/inc/bond/ext/grpc/server.h
@@ -36,6 +36,11 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
+#include <bond/ext/grpc/io_manager.h>
+#include <bond/ext/grpc/thread_pool.h>
+
 #ifdef _MSC_VER
     #pragma warning (push)
     #pragma warning (disable: 4100 4702)
@@ -47,11 +52,9 @@
     #pragma warning (pop)
 #endif
 
-#include <bond/ext/grpc/io_manager.h>
-#include <bond/ext/grpc/thread_pool.h>
-
 #include <boost/assert.hpp>
 #include <boost/optional/optional.hpp>
+
 #include <memory>
 #include <thread>
 

--- a/cpp/inc/bond/ext/grpc/server_builder.h
+++ b/cpp/inc/bond/ext/grpc/server_builder.h
@@ -36,6 +36,12 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
+#include <bond/ext/grpc/server.h>
+#include <bond/ext/grpc/thread_pool.h>
+#include <bond/ext/grpc/detail/service.h>
+
 #ifdef _MSC_VER
     #pragma warning (push)
     #pragma warning (disable: 4100 4702)
@@ -47,11 +53,8 @@
     #pragma warning (pop)
 #endif
 
-#include <bond/ext/grpc/server.h>
-#include <bond/ext/grpc/thread_pool.h>
-#include <bond/ext/grpc/detail/service.h>
-
 #include <boost/assert.hpp>
+
 #include <memory>
 #include <set>
 

--- a/cpp/inc/bond/ext/grpc/shared_unary_call.h
+++ b/cpp/inc/bond/ext/grpc/shared_unary_call.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include <bond/ext/grpc/detail/unary_call_impl.h>
 #include <bond/ext/grpc/unary_call.h>
 

--- a/cpp/inc/bond/ext/grpc/thread_pool.h
+++ b/cpp/inc/bond/ext/grpc/thread_pool.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #if defined (__APPLE__)
     // Work-around: 'OSMemoryBarrier' has been explicitly marked deprecated
     #pragma GCC diagnostic push

--- a/cpp/inc/bond/ext/grpc/unary_call.h
+++ b/cpp/inc/bond/ext/grpc/unary_call.h
@@ -3,9 +3,12 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include <bond/ext/grpc/detail/unary_call_impl.h>
 
 #include <boost/smart_ptr/intrusive_ptr.hpp>
+
 #include <utility>
 
 namespace bond { namespace ext { namespace gRPC {

--- a/cpp/inc/bond/ext/grpc/wait_callback.h
+++ b/cpp/inc/bond/ext/grpc/wait_callback.h
@@ -3,9 +3,12 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include <bond/core/bonded.h>
 #include <bond/ext/grpc/exception.h>
 #include <bond/ext/grpc/client_callback.h>
+
 #include <grpc++/impl/codegen/status.h>
 
 #include <boost/optional.hpp>

--- a/cpp/inc/bond/protocol/compact_binary.h
+++ b/cpp/inc/bond/protocol/compact_binary.h
@@ -3,14 +3,19 @@
 
 #pragma once
 
-#include "encoding.h"
+#include <bond/core/config.h>
+
 #include "detail/simple_array.h"
+#include "encoding.h"
+
 #include <bond/core/bond_version.h>
 #include <bond/core/traits.h>
 #include <bond/stream/output_counter.h>
+
 #include <boost/call_traits.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/static_assert.hpp>
+
 #include <cstring>
 
 /*

--- a/cpp/inc/bond/protocol/detail/rapidjson_helper.h
+++ b/cpp/inc/bond/protocol/detail/rapidjson_helper.h
@@ -3,18 +3,20 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
+#include "rapidjson_utils.h"
+
+#include <bond/core/bond_const_enum.h>
+#include <bond/core/bond_types.h>
+#include <bond/core/detail/sdl.h>
+
 #define RAPIDJSON_NO_INT64DEFINE
 #define RAPIDJSON_ASSERT BOOST_ASSERT
 #define RAPIDJSON_PARSE_ERROR(err, offset) bond::RapidJsonException(rapidjson::GetParseError_En(err), offset)
 
-#include <bond/core/bond_const_enum.h>
-#include <bond/core/detail/sdl.h>
-#include <boost/call_traits.hpp>
-#include <boost/noncopyable.hpp>
-
 #include "rapidjson/rapidjson.h"
 #include "rapidjson/error/en.h"
-#include "rapidjson_utils.h"
 
 // rapidjson/document.h v1.1 uses std::min/max in ways that conflict
 // with macros defined in windows. This works around the issue.
@@ -41,6 +43,10 @@
 #endif
 
 #include "rapidjson/writer.h"
+
+#include <boost/call_traits.hpp>
+#include <boost/noncopyable.hpp>
+
 #include <algorithm>
 
 namespace bond

--- a/cpp/inc/bond/protocol/detail/rapidjson_helper.h
+++ b/cpp/inc/bond/protocol/detail/rapidjson_helper.h
@@ -10,6 +10,7 @@
 #include <bond/core/bond_const_enum.h>
 #include <bond/core/bond_types.h>
 #include <bond/core/detail/sdl.h>
+#include <bond/core/exception.h>
 
 #define RAPIDJSON_NO_INT64DEFINE
 #define RAPIDJSON_ASSERT BOOST_ASSERT

--- a/cpp/inc/bond/protocol/detail/rapidjson_utils.h
+++ b/cpp/inc/bond/protocol/detail/rapidjson_utils.h
@@ -3,9 +3,10 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include <string>
 #include <stdint.h>
-
 
 namespace bond
 {

--- a/cpp/inc/bond/protocol/detail/rapidjson_utils_impl.h
+++ b/cpp/inc/bond/protocol/detail/rapidjson_utils_impl.h
@@ -3,10 +3,11 @@
 
 #pragma once
 
+#include <bond/core/config.h>
 #include <bond/core/exception.h>
-#include <boost/locale.hpp>
-#include <boost/lexical_cast.hpp>
 
+#include <boost/lexical_cast.hpp>
+#include <boost/locale.hpp>
 
 namespace bond
 {

--- a/cpp/inc/bond/protocol/detail/simple_array.h
+++ b/cpp/inc/bond/protocol/detail/simple_array.h
@@ -3,9 +3,13 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
+#include <boost/static_assert.hpp>
+
 #include <limits>
 #include <stdexcept>
-#include <boost/static_assert.hpp>
+#include <string.h>
 
 namespace bond
 {
@@ -19,7 +23,7 @@ public:
     SimpleArray()
         : _size(0),
           _capacity(N),
-          _data(_insitu)    
+          _data(_insitu)
     {
         BOOST_STATIC_ASSERT(N != 0);
     }

--- a/cpp/inc/bond/protocol/encoding.h
+++ b/cpp/inc/bond/protocol/encoding.h
@@ -3,9 +3,12 @@
 
 #pragma once
 
-#include <exception>
-#include <bond/core/containers.h>
+#include <bond/core/config.h>
+
 #include <bond/core/blob.h>
+#include <bond/core/containers.h>
+
+#include <exception>
 #include <stdio.h>
 
 namespace bond

--- a/cpp/inc/bond/protocol/fast_binary.h
+++ b/cpp/inc/bond/protocol/fast_binary.h
@@ -3,8 +3,12 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "encoding.h"
+
 #include <bond/core/bond_version.h>
+
 #include <boost/call_traits.hpp>
 #include <boost/noncopyable.hpp>
 

--- a/cpp/inc/bond/protocol/random_protocol.h
+++ b/cpp/inc/bond/protocol/random_protocol.h
@@ -3,10 +3,14 @@
 
 #pragma once
 
-#include <bond/core/containers.h>
+#include <bond/core/config.h>
+
 #include <bond/core/blob.h>
+#include <bond/core/containers.h>
 #include <bond/core/traits.h>
+
 #include <boost/static_assert.hpp>
+
 #include <cstring>
 
 namespace bond

--- a/cpp/inc/bond/protocol/simple_binary.h
+++ b/cpp/inc/bond/protocol/simple_binary.h
@@ -3,9 +3,13 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "encoding.h"
-#include <bond/core/traits.h>
+
 #include <bond/core/bond_version.h>
+#include <bond/core/traits.h>
+
 #include <boost/call_traits.hpp>
 #include <boost/noncopyable.hpp>
 

--- a/cpp/inc/bond/protocol/simple_binary_impl.h
+++ b/cpp/inc/bond/protocol/simple_binary_impl.h
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#pragma once
+
+#include <bond/core/config.h>
+
 #include "simple_binary.h"
 
 namespace bond

--- a/cpp/inc/bond/protocol/simple_json_reader.h
+++ b/cpp/inc/bond/protocol/simple_json_reader.h
@@ -3,10 +3,14 @@
 
 #pragma once
 
-#include "encoding.h"
+#include <bond/core/config.h>
+
 #include "detail/rapidjson_helper.h"
+#include "encoding.h"
+
 #include "rapidjson/document.h"
 #include "rapidjson/reader.h"
+
 #include <boost/call_traits.hpp>
 #include <boost/make_shared.hpp>
 

--- a/cpp/inc/bond/protocol/simple_json_reader_impl.h
+++ b/cpp/inc/bond/protocol/simple_json_reader_impl.h
@@ -3,13 +3,15 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include "simple_json_reader.h"
 
 namespace bond
 {
 
 template <typename BufferT>
-inline const typename SimpleJsonReader<BufferT>::Field* 
+inline const typename SimpleJsonReader<BufferT>::Field*
 SimpleJsonReader<BufferT>::FindField(uint16_t id, const Metadata& metadata, BondDataType type, bool is_enum)
 {
     rapidjson::Value::ConstMemberIterator it = MemberBegin();
@@ -49,7 +51,7 @@ inline void DeserializeContainer(std::vector<bool, A>& var, const T& /*element*/
 {
     rapidjson::Value::ConstValueIterator it = reader.ArrayBegin();
     resize_list(var, reader.ArraySize());
-    
+
     for (enumerator<std::vector<bool, A> > items(var); items.more(); ++it)
     {
         items.next() = it->IsTrue();
@@ -82,7 +84,7 @@ template <typename Protocols, typename X, typename T, typename Buffer>
 inline typename boost::enable_if<is_list_container<X> >::type
 DeserializeContainer(X& var, const T& element, SimpleJsonReader<Buffer>& reader)
 {
-    detail::JsonTypeMatching type(get_type_id<typename element_type<X>::type>::value, 
+    detail::JsonTypeMatching type(get_type_id<typename element_type<X>::type>::value,
                                   GetTypeId(element),
                                   std::is_enum<typename element_type<X>::type>::value);
 
@@ -114,7 +116,7 @@ template <typename Protocols, typename X, typename T, typename Buffer>
 inline typename boost::enable_if<is_set_container<X> >::type
 DeserializeContainer(X& var, const T& element, SimpleJsonReader<Buffer>& reader)
 {
-    detail::JsonTypeMatching type(get_type_id<typename element_type<X>::type>::value, 
+    detail::JsonTypeMatching type(get_type_id<typename element_type<X>::type>::value,
                                   GetTypeId(element),
                                   std::is_enum<typename element_type<X>::type>::value);
     clear_set(var);
@@ -138,12 +140,12 @@ inline typename boost::enable_if<is_map_container<X> >::type
 DeserializeMap(X& var, BondDataType keyType, const T& element, SimpleJsonReader<Buffer>& reader)
 {
     detail::JsonTypeMatching key_type(
-        get_type_id<typename element_type<X>::type::first_type>::value, 
+        get_type_id<typename element_type<X>::type::first_type>::value,
         keyType,
         std::is_enum<typename element_type<X>::type::first_type>::value);
 
     detail::JsonTypeMatching value_type(
-        get_type_id<typename element_type<X>::type::second_type>::value, 
+        get_type_id<typename element_type<X>::type::second_type>::value,
         GetTypeId(element),
         std::is_enum<typename element_type<X>::type::second_type>::value);
 

--- a/cpp/inc/bond/protocol/simple_json_writer.h
+++ b/cpp/inc/bond/protocol/simple_json_writer.h
@@ -3,8 +3,11 @@
 
 #pragma once
 
-#include "encoding.h"
+#include <bond/core/config.h>
+
 #include "detail/rapidjson_helper.h"
+#include "encoding.h"
+
 #include <bond/core/transforms.h>
 
 namespace bond

--- a/cpp/inc/bond/stream/input_buffer.h
+++ b/cpp/inc/bond/stream/input_buffer.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include <bond/core/blob.h>
 #include <bond/core/exception.h>
 #include <bond/core/traits.h>

--- a/cpp/inc/bond/stream/output_buffer.h
+++ b/cpp/inc/bond/stream/output_buffer.h
@@ -4,10 +4,12 @@
 /** @file */
 #pragma once
 
+#include <bond/core/config.h>
+
 #include <bond/core/blob.h>
 #include <bond/core/containers.h>
-#include <bond/core/traits.h>
 #include <bond/core/detail/checked_add.h>
+#include <bond/core/traits.h>
 #include <boost/static_assert.hpp>
 #include <cstring>
 #include <limits>

--- a/cpp/inc/bond/stream/output_counter.h
+++ b/cpp/inc/bond/stream/output_counter.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include <bond/core/blob.h>
 
 namespace bond
@@ -49,7 +51,7 @@ struct VariableUnsigned<uint16_t, 3>
     }
 };
 
-class OutputCounter 
+class OutputCounter
 {
 
     struct Buffer
@@ -79,7 +81,7 @@ public:
     }
 
     void Write(const void*, uint32_t size)
-    {    
+    {
         _count += size;
     }
 

--- a/cpp/inc/bond/stream/stdio_output_stream.h
+++ b/cpp/inc/bond/stream/stdio_output_stream.h
@@ -3,10 +3,14 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
+#include "output_buffer.h"
+
+#include <bond/core/blob.h>
+
 #include <stdio.h>
 #include <stdint.h>
-#include <bond/core/blob.h>
-#include "output_buffer.h"
 
 namespace bond
 {

--- a/cpp/inc/bond/stream/stream_interface.h
+++ b/cpp/inc/bond/stream/stream_interface.h
@@ -3,11 +3,14 @@
 
 #pragma once
 
+#include <bond/core/config.h>
+
 #include <bond/core/blob.h>
 #include <bond/core/detail/mpl.h>
-#include <boost/static_assert.hpp>
-#include <type_traits>
 
+#include <boost/static_assert.hpp>
+
+#include <type_traits>
 
 namespace bond
 {


### PR DESCRIPTION
* Use #pragma once everywhere.
* Every header now include <bond/core/config.h> before anything else.
* Includes are done in sections, from least general to most general.
* Includes within each section are lexicographicaly sorted.
* CODING_GUIDELINES_CPP.md added to capture these guidelines.