### PR TITLE
[c++] Faster Serializer::Field

### DIFF
--- a/cpp/inc/bond/core/transforms.h
+++ b/cpp/inc/bond/core/transforms.h
@@ -92,7 +92,8 @@ public:
     }
 
     template <typename T>
-    bool Field(uint16_t id, const Metadata& metadata, const T& value) const
+    typename boost::enable_if_c<may_omit_fields<Writer>::value && !is_bond_type<T>::value, bool>::type
+    Field(uint16_t id, const Metadata& metadata, const T& value) const
     {
         if (detail::omit_field<Writer>(metadata, value))
         {
@@ -105,13 +106,43 @@ public:
     }
 
     template <typename T>
-    bool Field(uint16_t id, const Metadata& metadata, const maybe<T>& value) const
+    typename boost::disable_if_c<may_omit_fields<Writer>::value && !is_bond_type<T>::value, bool>::type
+    Field(uint16_t id, const Metadata& metadata, const T& value) const
+    {
+        BOOST_ASSERT(!detail::omit_field<Writer>(metadata, value));
+
+        WriteField(id, metadata, value);
+        return false;
+    }
+
+    template <typename T, typename Reader>
+    bool Field(uint16_t id, const Metadata& metadata, const value<T, Reader>& value) const
+    {
+        BOOST_ASSERT(!detail::omit_field<Writer>(metadata, value));
+
+        WriteField(id, metadata, value);
+        return false;
+    }
+
+    template <typename T, typename W = Writer>
+    typename boost::enable_if<may_omit_fields<W>, bool>::type
+    Field(uint16_t id, const Metadata& metadata, const maybe<T>& value) const
     {
         if (detail::omit_field<Writer>(metadata, value))
         {
             detail::WriteFieldOmitted(_output, get_type_id<T>::value, id, metadata);
             return false;
         }
+
+        WriteField(id, metadata, value.value());
+        return false;
+    }
+
+    template <typename T, typename W = Writer>
+    typename boost::disable_if<may_omit_fields<W>, bool>::type
+    Field(uint16_t id, const Metadata& metadata, const maybe<T>& value) const
+    {
+        BOOST_ASSERT(!detail::omit_field<Writer>(metadata, value));
 
         WriteField(id, metadata, value.value());
         return false;


### PR DESCRIPTION
The change adds overloads of `Serializer::Field` function that avoids generating calls to `detail::omit_field` in the cases where the result is known at compilation. This makes the compilation a bit faster (it depends on actual types being used, but the expected estimate would be 3-5%) and also likely to generate faster, smaller and more efficient runtime code when compiler fails to optimize away the above calls.