### PR TITLE
[c++] Fix base to derived deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,8 @@ different versioning scheme, following the Haskell community's
 * gRPC v1.7.1 is now required to use Bond-over-gRPC.
 * Fixed includes for gRPC services with events or parameterless methods.
   [Issue #735](https://github.com/Microsoft/bond/issues/735)
-* Fixed a bug which would read unrelated struct's field(s) when deserializing base struct
-  [Issue #742](https://github.com/Microsoft/bond/issues/742).
+* Fixed a bug which would read an unrelated struct's field(s) when deserializing a
+  base struct. [Issue #742](https://github.com/Microsoft/bond/issues/742)
 
 ### C# ###
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ different versioning scheme, following the Haskell community's
 * gRPC v1.7.1 is now required to use Bond-over-gRPC.
 * Fixed includes for gRPC services with events or parameterless methods.
   [Issue #735](https://github.com/Microsoft/bond/issues/735)
+* Fixed a bug which would read unrelated struct's field(s) when deserializing base struct
+  [Issue #742](https://github.com/Microsoft/bond/issues/742).
 
 ### C# ###
 

--- a/cpp/inc/bond/core/parser.h
+++ b/cpp/inc/bond/core/parser.h
@@ -271,6 +271,8 @@ private:
 
         ReadFields(fields, id, type, transform);
 
+        bool done;
+
         if (!_base)
         {
             // If we are not parsing a base class, and we still didn't get to
@@ -292,11 +294,17 @@ private:
                 else
                     UnknownField(id, type, transform);
             }
+
+            done = false;
+        }
+        else
+        {
+            done = (type == bond::BT_STOP);
         }
 
         _input.ReadFieldEnd();
 
-        return false;
+        return done;
     }
 
 
@@ -469,6 +477,8 @@ private:
             UnknownField(id, type, transform);
         }
 
+        bool done;
+
         if (!_base)
         {
             // If we are not parsing a base class, and we still didn't get to
@@ -494,11 +504,17 @@ private:
                     UnknownField(id, type, transform);
                 }
             }
+
+            done = false;
+        }
+        else
+        {
+            done = (type == bond::BT_STOP);
         }
 
         _input.ReadFieldEnd();
 
-        return false;
+        return done;
     }
 
 

--- a/cpp/inc/bond/core/transforms.h
+++ b/cpp/inc/bond/core/transforms.h
@@ -388,6 +388,12 @@ protected:
         _required = next_required_field<typename schema<T>::type::fields>::value;
     }
 
+    void Base(bool done) const
+    {
+        if (done)
+            UnexpectedStructStopException();
+    }
+
     template <typename Head>
     typename boost::enable_if<std::is_same<typename Head::field_modifier,
                                            reflection::required_field_modifier> >::type
@@ -426,6 +432,8 @@ protected:
 private:
     BOND_NORETURN void MissingFieldException() const;
 
+    BOND_NORETURN void UnexpectedStructStopException() const;
+
     mutable uint16_t _required;
 };
 
@@ -435,6 +443,14 @@ void RequiredFieldValiadator<T>::MissingFieldException() const
     BOND_THROW(CoreException,
           "De-serialization failed: required field " << _required <<
           " is missing from " << schema<T>::type::metadata.qualified_name);
+}
+
+template <typename T>
+void RequiredFieldValiadator<T>::UnexpectedStructStopException() const
+{
+    BOND_THROW(CoreException,
+        "De-serialization failed: unexpected struct stop is encountered for "
+        << schema<T>::type::metadata.qualified_name);
 }
 
 //
@@ -530,7 +546,9 @@ public:
     template <typename X>
     bool Base(const X& value) const
     {
-        return AssignToBase(_var, value);
+        bool done = AssignToBase(_var, value);
+        Validator::Base(done);
+        return done;
     }
 
 

--- a/cpp/inc/bond/core/transforms.h
+++ b/cpp/inc/bond/core/transforms.h
@@ -533,7 +533,7 @@ public:
     template <typename X>
     bool Base(const X& value) const
     {
-        if (bool done = AssignToBase(_var, value))
+        if (AssignToBase(_var, value))
         {
             UnexpectedStructStopException();
         }

--- a/cpp/inc/bond/core/transforms.h
+++ b/cpp/inc/bond/core/transforms.h
@@ -440,6 +440,8 @@ private:
 template <typename T>
 void RequiredFieldValiadator<T>::MissingFieldException() const
 {
+    (void)typename schema<T>::type();
+
     BOND_THROW(CoreException,
           "De-serialization failed: required field " << _required <<
           " is missing from " << schema<T>::type::metadata.qualified_name);
@@ -448,6 +450,8 @@ void RequiredFieldValiadator<T>::MissingFieldException() const
 template <typename T>
 void RequiredFieldValiadator<T>::UnexpectedStructStopException() const
 {
+    (void)typename schema<T>::type();
+
     BOND_THROW(CoreException,
         "De-serialization failed: unexpected struct stop is encountered for "
         << schema<T>::type::metadata.qualified_name);

--- a/cpp/test/core/unit_test.bond
+++ b/cpp/test/core/unit_test.bond
@@ -97,6 +97,12 @@ struct ListOfBase
 };
 
 
+struct ListOfBondedBase
+{
+    1: list<bonded<SimpleBase>> l;
+}
+
+
 struct NestedStruct1OptionalBondedView
 {
     1: bonded<SimpleStruct> s;

--- a/python/test/core/unit_test.py
+++ b/python/test/core/unit_test.py
@@ -389,11 +389,6 @@ class BondTest(unittest.TestCase):
         src2.n2 = self.randomSimpleWithBase()
         dst2 = test.Bonded()
         Deserialize(Serialize(src), dst2)
-        # downcast bonded<SimpleStruct> to bonded<SimpleWithBase>
-        bonded = test.bonded_unittest_SimpleWithBase_(dst2.n2)
-        obj3 = test.SimpleWithBase()
-        bonded.Deserialize(obj3)
-        self.assertTrue(obj3, src2.n2)
 
     def test_Polymorphism(self):
         src = test.Bonded()


### PR DESCRIPTION
With this change deserialization will now fail by throwing `bond::CoreException` when `BT_STOP` is encountered while deserializing a base struct.

Fixes https://github.com/Microsoft/bond/issues/742