### PR TITLE
[c++] Improve UnknownFieldOrTypeMismatch

### DIFF
--- a/cpp/inc/bond/core/parser.h
+++ b/cpp/inc/bond/core/parser.h
@@ -325,9 +325,8 @@ private:
             else if (Head::id >= id && type != bond::BT_STOP && type != bond::BT_STOP_BASE)
             {
                 // Unknown field or non-exact type match
-                UnknownFieldOrTypeMismatch(
+                UnknownFieldOrTypeMismatch<is_basic_type<typename Head::field_type>::value>(
                     Head::id,
-                    is_basic_type<typename Head::field_type>::value,
                     Head::metadata,
                     id,
                     type,
@@ -401,13 +400,12 @@ private:
     // This function is called only when payload has unknown field id or type is not
     // matching exactly. This relativly rare so we don't inline the function to help
     // the compiler to optimize the common path.
-    template <typename Transform>
+    template <bool IsBasicType, typename Transform>
     BOND_NO_INLINE
-    bool
-    UnknownFieldOrTypeMismatch(uint16_t expected_id, bool is_basic_type, const Metadata& metadata, uint16_t id, BondDataType type, const Transform& transform)
+    typename boost::enable_if_c<IsBasicType, bool>::type
+    UnknownFieldOrTypeMismatch(uint16_t expected_id, const Metadata& metadata, uint16_t id, BondDataType type, const Transform& transform)
     {
         if (id == expected_id &&
-            is_basic_type &&
             type != bond::BT_LIST &&
             type != bond::BT_SET &&
             type != bond::BT_MAP &&
@@ -419,6 +417,14 @@ private:
         {
             return UnknownField(id, type, transform);
         }
+    }
+
+    template <bool IsBasicType, typename Transform>
+    BOND_NO_INLINE
+    typename boost::disable_if_c<IsBasicType, bool>::type
+    UnknownFieldOrTypeMismatch(uint16_t /*expected_id*/, const Metadata& /*metadata*/, uint16_t id, BondDataType type, const Transform& transform)
+    {
+        return UnknownField(id, type, transform);
     }
 
 


### PR DESCRIPTION
Simplifies the `DynamicParser<Input>::UnknownFieldOrTypeMismatch` function for basic types by excluding some run-time code paths.