### PR TITLE
[c++] Improve bonded<void, Reader>::_Apply

### DIFF
--- a/cpp/inc/bond/core/bonded_void.h
+++ b/cpp/inc/bond/core/bonded_void.h
@@ -166,7 +166,7 @@ private:
         else
         {
             _skip = false;
-            return detail::Parse<Protocols>(transform, _data, _schema, _base);
+            return detail::Parse<void, Protocols>(transform, _data, _schema, nullptr, _base);
         }
     }
 
@@ -175,7 +175,7 @@ private:
     _Apply(const Transform& transform) const
     {
         _skip = false;
-        return detail::Parse<Protocols>(transform, _data, _schema, _base);
+        return detail::Parse<void, Protocols>(transform, _data, _schema, nullptr, _base);
     }
 
 

--- a/cpp/inc/bond/core/bonded_void.h
+++ b/cpp/inc/bond/core/bonded_void.h
@@ -109,16 +109,10 @@ public:
 
     /// @brief Deserialize to a bonded<T>
     template <typename Protocols = BuiltInProtocols, typename T>
-    void Deserialize(bonded<T>& var) const
+    typename boost::enable_if<uses_marshaled_bonded<Reader, T> >::type
+    Deserialize(bonded<T>& var) const
     {
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4127) // C4127: conditional expression is constant
-#endif
-        if (uses_marshaled_bonded<Reader>::value && _schema.GetType().bonded_type)
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+        if (_schema.GetType().bonded_type)
         {
             bonded<T> tmp;
             _SelectProtocolAndApply<Protocols>(boost::ref(tmp));
@@ -128,6 +122,15 @@ public:
         {
             var = bonded<T>(*this);
         }
+    }
+
+
+    /// @brief Deserialize to a bonded<T>
+    template <typename Protocols = BuiltInProtocols, typename T>
+    typename boost::disable_if<uses_marshaled_bonded<Reader, T> >::type
+    Deserialize(bonded<T>& var) const
+    {
+        var = bonded<T>(*this);
     }
 
 
@@ -153,43 +156,37 @@ public:
 private:
     // Apply transform to serialized data
     template <typename Protocols, typename Transform>
-    bool _Apply(const Transform& transform) const
+    typename boost::enable_if<uses_marshaled_bonded<Reader, Transform>, bool>::type
+    _Apply(const Transform& transform) const
     {
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4127) // C4127: conditional expression is constant
-#endif
-        if (uses_marshaled_bonded<Reader>::value && _schema.GetType().bonded_type)
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+        if (_schema.GetType().bonded_type)
         {
             return _SelectProtocolAndApply<Protocols>(transform);
         }
         else
         {
             _skip = false;
-            return detail::Parse<void, Protocols>(transform, _data, _schema, NULL, _base);
+            return detail::Parse<Protocols>(transform, _data, _schema, _base);
         }
     }
 
-
     template <typename Protocols, typename Transform>
-    typename boost::enable_if<uses_marshaled_bonded<Reader, Transform>, bool>::type
-    _SelectProtocolAndApply(const Transform& transform) const
+    typename boost::disable_if<uses_marshaled_bonded<Reader, Transform>, bool>::type
+    _Apply(const Transform& transform) const
     {
         _skip = false;
-        auto input = CreateInputBuffer(_data.GetBuffer(), detail::ReadBlob(_data));
-        return SelectProtocolAndApply<Protocols>(_schema, input, transform).second;
+        return detail::Parse<Protocols>(transform, _data, _schema, _base);
     }
 
 
     template <typename Protocols, typename Transform>
-    typename boost::disable_if<uses_marshaled_bonded<Reader, Transform>, bool>::type
-    _SelectProtocolAndApply(const Transform&) const
+    bool _SelectProtocolAndApply(const Transform& transform) const
     {
-        BOOST_ASSERT(false);
-        return false;
+        BOOST_STATIC_ASSERT(uses_marshaled_bonded<Reader>::value);
+
+        _skip = false;
+        auto input = CreateInputBuffer(_data.GetBuffer(), detail::ReadBlob(_data));
+        return SelectProtocolAndApply<Protocols>(_schema, input, transform).second;
     }
 
 

--- a/cpp/inc/bond/core/detail/protocol_visitors.h
+++ b/cpp/inc/bond/core/detail/protocol_visitors.h
@@ -207,10 +207,10 @@ inline bool Parse(const Transform& transform, Reader& reader, const Schema& sche
     return Parser<T, Schema, Transform>::Apply(transform, reader, schema, base);
 }
 
-template <typename Protocols, typename Transform, typename Reader, typename Schema>
-inline bool Parse(const Transform& transform, Reader& reader, const RuntimeSchema& schema, bool base)
+template <typename T, typename Protocols, typename Transform, typename Reader, typename Schema>
+inline bool Parse(const Transform& transform, Reader& reader, const Schema& schema, std::nullptr_t, bool base)
 {
-    return Parser<void, RuntimeSchema, Transform>::Apply(transform, reader, schema, base);
+    return Parser<T, Schema, Transform>::Apply(transform, reader, schema, base);
 }
 
 template <typename T, typename Protocols, typename Transform, typename Schema>
@@ -247,12 +247,11 @@ inline bool Parse(const Transform& transform, ProtocolReader reader, const Schem
     }
 }
 
-
-template <typename Protocols, typename Transform>
-inline bool Parse(const Transform& transform, ProtocolReader reader, const RuntimeSchema& schema, bool base)
+template <typename T, typename Protocols, typename Transform, typename Schema>
+inline bool Parse(const Transform& transform, ProtocolReader reader, const Schema& schema, std::nullptr_t, bool base)
 {
     BOOST_VERIFY(!base);
-    return Parse<void, Protocols>(transform, reader, schema);
+    return Parse<T, Protocols>(transform, reader, schema);
 }
 
 

--- a/cpp/inc/bond/core/detail/protocol_visitors.h
+++ b/cpp/inc/bond/core/detail/protocol_visitors.h
@@ -15,6 +15,8 @@
 #include <bond/stream/input_buffer.h>
 #include <bond/stream/output_buffer.h>
 
+#include <cstddef>
+
 
 namespace bond
 {

--- a/cpp/inc/bond/core/detail/protocol_visitors.h
+++ b/cpp/inc/bond/core/detail/protocol_visitors.h
@@ -207,42 +207,52 @@ inline bool Parse(const Transform& transform, Reader& reader, const Schema& sche
     return Parser<T, Schema, Transform>::Apply(transform, reader, schema, base);
 }
 
-template <typename T, typename Protocols, typename Transform, typename Schema>
-inline bool Parse(const Transform& transform, ProtocolReader reader, const Schema& schema, const RuntimeSchema* runtime_schema, bool base)
+template <typename Protocols, typename Transform, typename Reader, typename Schema>
+inline bool Parse(const Transform& transform, Reader& reader, const RuntimeSchema& schema, bool base)
 {
-    BOOST_VERIFY(!base);
+    return Parser<void, RuntimeSchema, Transform>::Apply(transform, reader, schema, base);
+}
 
-    boost::optional<bool> result;
+template <typename T, typename Protocols, typename Transform, typename Schema>
+inline bool Parse(const Transform& transform, ProtocolReader& reader, const Schema& schema)
+{
+    // Use named variable to avoid gcc silently copying objects (which
+    // causes build break, because Parser<> is non-copyable).
+    Parser<T, Schema, Transform> parser(transform, schema);
 
-    if (runtime_schema)
-    {
-        // Use named variable to avoid gcc silently copying objects (which
-        // causes build break, because Parser<> is non-copyable).
-        Parser<void, RuntimeSchema, Transform> parser(transform, *runtime_schema);
-        result = reader.template Visit<Protocols
+    if (auto&& result = reader.template Visit<Protocols
 #if defined(BOND_NO_CXX14_RETURN_TYPE_DEDUCTION) || defined(BOND_NO_CXX14_GENERIC_LAMBDAS)
-            , bool
+        , bool
 #endif
-            >(parser);
-    }
-    else
-    {
-        // Use named variable to avoid gcc silently copying objects (which
-        // causes build break, because Parser<> is non-copyable).
-        Parser<T, Schema, Transform> parser(transform, schema);
-        result = reader.template Visit<Protocols
-#if defined(BOND_NO_CXX14_RETURN_TYPE_DEDUCTION) || defined(BOND_NO_CXX14_GENERIC_LAMBDAS)
-            , bool
-#endif
-            >(parser);
-    }
-
-    if (result)
+        >(parser))
     {
         return result.get();
     }
 
     UnknownProtocolException();
+}
+
+template <typename T, typename Protocols, typename Transform, typename Schema>
+inline bool Parse(const Transform& transform, ProtocolReader reader, const Schema& schema, const RuntimeSchema* runtime_schema, bool base)
+{
+    BOOST_VERIFY(!base);
+
+    if (runtime_schema)
+    {
+        return Parse<void, Protocols>(transform, reader, *runtime_schema);
+    }
+    else
+    {
+        return Parse<T, Protocols>(transform, reader, schema);
+    }
+}
+
+
+template <typename Protocols, typename Transform>
+inline bool Parse(const Transform& transform, ProtocolReader reader, const RuntimeSchema& schema, bool base)
+{
+    BOOST_VERIFY(!base);
+    return Parse<void, Protocols>(transform, reader, schema);
 }
 
 


### PR DESCRIPTION
Simplifies the `bonded<void, Reader>::_Apply` function when used with protocols that specify `uses_marshaled_bonded<Reader>` to be `false_type` (currently all except `Simple`) by excluding some run-time code paths.