### PR TITLE
[c++] Improve StaticParser<Input>::ReadFields

### DIFF
--- a/cpp/inc/bond/core/detail/omit_default.h
+++ b/cpp/inc/bond/core/detail/omit_default.h
@@ -129,6 +129,11 @@ implements_field_omitting
     : std::false_type {};
 
 
+template <typename T> struct
+implements_field_omitting<T&>
+    : implements_field_omitting<T> {};
+
+
 // WriteFieldOmitted is an optional protocol writer method which is called for
 // omitted optional fields. It CAN be implemented by tagged protocols and MUST
 // be implemented by untagged protocols that allow omitting optional fields.

--- a/cpp/inc/bond/core/parser.h
+++ b/cpp/inc/bond/core/parser.h
@@ -124,8 +124,8 @@ private:
     }
 
     // use compile-time schema
-    template <typename Fields, typename Transform>
-    bool
+    template <typename Fields, typename Transform, typename I = Input>
+    typename boost::enable_if<detail::implements_field_omitting<I>, bool>::type
     ReadFields(const Fields&, const Transform& transform)
     {
         typedef typename boost::mpl::deref<Fields>::type Head;
@@ -135,6 +135,18 @@ private:
         else
             if (bool done = NextField(Head(), transform))
                 return done;
+
+        return ReadFields(typename boost::mpl::next<Fields>::type(), transform);
+    }
+
+    template <typename Fields, typename Transform, typename I = Input>
+    typename boost::disable_if<detail::implements_field_omitting<I>, bool>::type
+    ReadFields(const Fields&, const Transform& transform)
+    {
+        typedef typename boost::mpl::deref<Fields>::type Head;
+
+        if (bool done = NextField(Head(), transform))
+            return done;
 
         return ReadFields(typename boost::mpl::next<Fields>::type(), transform);
     }

--- a/cpp/inc/bond/core/parser.h
+++ b/cpp/inc/bond/core/parser.h
@@ -124,8 +124,9 @@ private:
     }
 
     // use compile-time schema
-    template <typename Fields, typename Transform, typename I = Input>
-    typename boost::enable_if<detail::implements_field_omitting<I>, bool>::type
+    template <typename Fields, typename Transform, typename I = Input,
+        typename boost::enable_if<detail::implements_field_omitting<I> >::type* = nullptr>
+    bool
     ReadFields(const Fields&, const Transform& transform)
     {
         typedef typename boost::mpl::deref<Fields>::type Head;
@@ -139,8 +140,9 @@ private:
         return ReadFields(typename boost::mpl::next<Fields>::type(), transform);
     }
 
-    template <typename Fields, typename Transform, typename I = Input>
-    typename boost::disable_if<detail::implements_field_omitting<I>, bool>::type
+    template <typename Fields, typename Transform, typename I = Input,
+        typename boost::disable_if<detail::implements_field_omitting<I> >::type* = nullptr>
+    bool
     ReadFields(const Fields&, const Transform& transform)
     {
         typedef typename boost::mpl::deref<Fields>::type Head;


### PR DESCRIPTION
Simplifies the `StaticParser<Input>::ReadFields` function when used with protocols that do not implement field omitting by excluding some run-time code paths.