### PR TITLE
[c++ grpc] Fix incorrect casts to void*

### DIFF
--- a/cpp/inc/bond/ext/grpc/detail/client_call_data.h
+++ b/cpp/inc/bond/ext/grpc/detail/client_call_data.h
@@ -102,7 +102,7 @@ struct client_unary_call_data
         _responseReader->Finish(
             &_callbackArgs.response,
             &_callbackArgs.status,
-            static_cast<void*>(this));
+            static_cast<void*>(static_cast<io_manager_tag*>(this)));
     }
 
     /// @brief Invoked after the response has been received.

--- a/cpp/inc/bond/ext/grpc/detail/unary_call_impl.h
+++ b/cpp/inc/bond/ext/grpc/detail/unary_call_impl.h
@@ -94,7 +94,7 @@ namespace bond { namespace ext { namespace gRPC { namespace detail {
             bool wasResponseSent = _responseSentFlag.test_and_set();
             if (!wasResponseSent)
             {
-                _responder.Finish(msg, status, static_cast<void*>(this));
+                _responder.Finish(msg, status, static_cast<void*>(static_cast<io_manager_tag*>(this)));
             }
         }
 
@@ -103,7 +103,7 @@ namespace bond { namespace ext { namespace gRPC { namespace detail {
             bool wasResponseSent = _responseSentFlag.test_and_set();
             if (!wasResponseSent)
             {
-                _responder.FinishWithError(status, static_cast<void*>(this));
+                _responder.FinishWithError(status, static_cast<void*>(static_cast<io_manager_tag*>(this)));
             }
         }
 


### PR DESCRIPTION
The `bond::ext::gRPC::io_manager` expects pointers to `bond::ext::gRPC::io_manager_tag` base when it receives `void*` tags. However, we are are directly passing a pointer to derived type instead of explicitly casting to base (which does not cause issues due to current layout of those objects).