### PR TITLE
[c++ grpc] Fix race in unary_call destruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ different versioning scheme, following the Haskell community's
   base struct. [Issue #742](https://github.com/Microsoft/bond/issues/742)
 * Fixed a bug in `bond::MapTo<T>::Field` where `Protocols` type parameter was
   not passed to `bond::Apply`.
+* Fixed a race condition during `bond::ext::gRPC::unary_call` destruction.
 
 ### C# ###
 

--- a/cpp/inc/bond/ext/grpc/detail/unary_call_impl.h
+++ b/cpp/inc/bond/ext/grpc/detail/unary_call_impl.h
@@ -133,10 +133,7 @@ namespace bond { namespace ext { namespace gRPC { namespace detail {
         {
             if (_refCount.load(std::memory_order::memory_order_acquire) == 2)
             {
-                // There are two possible cases when the current count can be 2.
-                //
-                // Case 2a:
-                // the last user reference has just gone away, but Finish was
+                // The last user reference has just gone away, but Finish was
                 // not called. In this case, we are responsible for sending
                 // an error response and decrementing the final ref
                 // count. FinishWithError will schedule the send of the
@@ -144,14 +141,6 @@ namespace bond { namespace ext { namespace gRPC { namespace detail {
                 // send via invoke() will decrement the final ref count.
                 // Since we hold the ref count ourselves, we will not
                 // get deleted until we're done sending.
-                //
-                // Case 2b:
-                // the user called Finish/FinishWithError and completion of
-                // sending that response has just happened via invoke(),
-                // AND there is still ONE user reference. In this case,
-                // the user reference could go away at any time and
-                // delete us, so we can't touch any part of this object.
-                // But we don't need to send anything anyway.
                 //
                 // Even when multiple threads enter this case, at most one
                 // will succeed in sending error, thanks to _responseSentFlag.


### PR DESCRIPTION
Fixes a race condition in `bond::ext::gRPC::detail::unary_call_impl` when one thread tries to send an error by calling `FinishWithError` when reference count becomes 1 during destruction, and the other thread that tries to perform `delete this` since the reference count becomes 0 due to a prior call to `Finish` by the user.