### PR TITLE
[c++ grpc] Fix race in io_manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ different versioning scheme, following the Haskell community's
   base struct. [Issue #742](https://github.com/Microsoft/bond/issues/742)
 * Fixed a bug in `bond::MapTo<T>::Field` where `Protocols` type parameter was
   not passed to `bond::Apply`.
+* Fixed a race condition when `bond::ext::gRPC::io_manager::shutdown` and
+  `bond::ext::gRPC::io_manager::wait` are called concurrently.
 
 ### C# ###
 

--- a/cpp/inc/bond/ext/grpc/io_manager.h
+++ b/cpp/inc/bond/ext/grpc/io_manager.h
@@ -191,7 +191,6 @@ namespace bond { namespace ext { namespace gRPC {
 
                 _threads.clear();
 
-                _cq.reset();
                 _shutdownCompleted.set();
             }
             else


### PR DESCRIPTION
Fixes a race condition when `bond::ext::gRPC::io_manager::shutdown` and `bond::ext::gRPC::io_manager::wait` are called concurrently. The functions are not mutually exclusive and the latter destroys the `grpc::CompletionQueue` which is not necessary.

Fixes #744