### PR TITLE
[travis] Add Boost 1.66 to CI image builder script

### DIFF
--- a/tools/ci-scripts/linux/image-builder/build_boosts.zsh
+++ b/tools/ci-scripts/linux/image-builder/build_boosts.zsh
@@ -2,7 +2,7 @@
 
 set -eux
 
-BOOST_VERSIONS=(1.58.0 1.59.0 1.60.0 1.61.0 1.62.0 1.63.0 1.64.0 1.65.1)
+BOOST_VERSIONS=(1.58.0 1.59.0 1.60.0 1.61.0 1.62.0 1.63.0 1.64.0 1.65.1 1.66.0)
 BOOST_LIBRARIES="chrono,date_time,python,system,test,thread"
 
 BUILD_ROOT=/tmp/boosts


### PR DESCRIPTION
This is the first step in enabling Boost 1.66 CI build on Travis. After
an image is produced that contains Boost 1.66, we still need to consume
that image in .travis.yml and add 1.66 to the configuration matrix.

I've locally tested that Bond builds and the basic tests pass with Boost
1.66 using Clang.