### PR TITLE
stack cmake: Print out errors from failed stack steps.

### DIFF
--- a/compiler/stack_build.cmake
+++ b/compiler/stack_build.cmake
@@ -27,11 +27,10 @@ execute_process (
     COMMAND ${STACK_EXECUTABLE} ${BOND_STACK_OPTIONS} build :${target} --no-run-tests ${stack_options} --ghc-options=${buildGhcOptions}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     RESULT_VARIABLE error
-    OUTPUT_VARIABLE build_output
-    ERROR_VARIABLE build_output)
+    ERROR_VARIABLE build_errors)
 
 if (error)
-    message (FATAL_ERROR ${build_output})
+    message (FATAL_ERROR ${build_errors})
 endif()
 
 # Copy results to builddir

--- a/compiler/stack_build.cmake
+++ b/compiler/stack_build.cmake
@@ -14,11 +14,11 @@ execute_process (
     COMMAND ${STACK_EXECUTABLE} ${BOND_STACK_OPTIONS} setup
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     RESULT_VARIABLE error
-    OUTPUT_QUIET
-    ERROR_QUIET)
+    OUTPUT_VARIABLE setup_output
+    ERROR_VARIABLE setup_output)
 
 if (error)
-    message (FATAL_ERROR)
+    message (FATAL_ERROR ${setup_output})
 endif()
 
 set (buildGhcOptions "-O2")
@@ -26,10 +26,12 @@ set (buildGhcOptions "-O2")
 execute_process (
     COMMAND ${STACK_EXECUTABLE} ${BOND_STACK_OPTIONS} build :${target} --no-run-tests ${stack_options} --ghc-options=${buildGhcOptions}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    RESULT_VARIABLE error)
+    RESULT_VARIABLE error
+    OUTPUT_VARIABLE build_output
+    ERROR_VARIABLE build_output)
 
 if (error)
-    message (FATAL_ERROR)
+    message (FATAL_ERROR ${build_output})
 endif()
 
 # Copy results to builddir
@@ -37,10 +39,11 @@ execute_process (
     COMMAND ${STACK_EXECUTABLE} ${BOND_STACK_OPTIONS} path --dist-dir
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     OUTPUT_VARIABLE dist_dir
-    RESULT_VARIABLE error)
+    RESULT_VARIABLE error
+    ERROR_VARIABLE path_errors)
 
 if (error)
-    message (FATAL_ERROR)
+    message (FATAL_ERROR ${path_errors})
 endif()
 
 string (STRIP ${dist_dir} dist_dir)

--- a/compiler/stack_build.cmake
+++ b/compiler/stack_build.cmake
@@ -26,11 +26,10 @@ set (buildGhcOptions "-O2")
 execute_process (
     COMMAND ${STACK_EXECUTABLE} ${BOND_STACK_OPTIONS} build :${target} --no-run-tests ${stack_options} --ghc-options=${buildGhcOptions}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    RESULT_VARIABLE error
-    ERROR_VARIABLE build_errors)
+    RESULT_VARIABLE error)
 
 if (error)
-    message (FATAL_ERROR ${build_errors})
+    message (FATAL_ERROR "build failed - scroll up for its output")
 endif()
 
 # Copy results to builddir


### PR DESCRIPTION
Per [cmake docs](https://cmake.org/cmake/help/v3.0/command/execute_process.html), if you set both `OUTPUT_VARIABLE` and `ERROR_VARIABLE` to the same var, it will contain both streams' lines, merged in the order they were printed.