### PR TITLE
[travis java] Switch to openjdk-8-jdk-headless

### DIFF
--- a/tools/ci-scripts/linux/image-builder/Dockerfile
+++ b/tools/ci-scripts/linux/image-builder/Dockerfile
@@ -47,7 +47,7 @@ RUN add-apt-repository ppa:cwchien/gradle && \
     apt-get update && \
     apt-get -y install \
     gradle \
-    openjdk-8-jdk
+    openjdk-8-jdk-headless
 
 # Build script
 ENTRYPOINT ["zsh", "/root/bond/tools/ci-scripts/linux/build.zsh"]


### PR DESCRIPTION
Use the "headless" JDK in the Travis CI image to avoid installing a
bunch of X11 (and related) packages that we don't need. This also
reduces the size of the image.

After getting this commit into master, the next step is to wait for a
new image to be built and then consume that image in .travis.yml.

Here's a Travis CI run with the Java leg passing using the headless JDK: https://travis-ci.org/Microsoft/bond/jobs/339709515

I'll update this PR with the size reduction when I build a full image with the headless JDK. For testing, I ripped out a bunch of C# and C++ parts, so I don't have comparable numbers yet.

[skip ci]