### PR TITLE
[travis] Include gbc dependencies in CI image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_install:
     - docker images # Dump the image ID
 
 script:
+    # TODO: when switching to consuming an image that has a saved .stack-work, remove the .stack caching and mounting.
     - docker run -v $HOME/.ccache:/root/.ccache -v $HOME/.stack:/root/.stack -v `pwd`:/root/bond $CI_BUILD_CONTAINER $HOME $FLAVOR $BOOST $COMPILER
     # docker runs as root and may leave files in the following directories that are not readable by the travis user
     - sudo chown -R travis:travis $HOME/.ccache $HOME/.stack `pwd`

--- a/tools/ci-scripts/linux/build.zsh
+++ b/tools/ci-scripts/linux/build.zsh
@@ -7,13 +7,13 @@ FLAVOR=$2
 BOOST=${3:-}
 COMPILER=${4:-clang}
 
-export BUILD_ROOT=/root/build
-BUILD_SCRIPTS=$BOND_ROOT/tools/ci-scripts/linux
-
 if [ -z "${BOND_ROOT+set}" ]; then
    # We're not yet running in a container with this value baked in.
    export BOND_ROOT=/root/bond
 fi
+
+export BUILD_ROOT=/root/build
+BUILD_SCRIPTS=$BOND_ROOT/tools/ci-scripts/linux
 
 # We set our cflags in non-standard variables because Stack chokes on some
 # otherwise acceptable configurations.

--- a/tools/ci-scripts/linux/build.zsh
+++ b/tools/ci-scripts/linux/build.zsh
@@ -10,6 +10,11 @@ COMPILER=${4:-clang}
 export BUILD_ROOT=/root/build
 BUILD_SCRIPTS=$BOND_ROOT/tools/ci-scripts/linux
 
+if [ -z "${BOND_ROOT+set}" ]; then
+   # We're not yet running in a container with this value baked in.
+   export BOND_ROOT=/root/bond
+fi
+
 # We set our cflags in non-standard variables because Stack chokes on some
 # otherwise acceptable configurations.
 case "$COMPILER" in

--- a/tools/ci-scripts/linux/build.zsh
+++ b/tools/ci-scripts/linux/build.zsh
@@ -7,7 +7,6 @@ FLAVOR=$2
 BOOST=${3:-}
 COMPILER=${4:-clang}
 
-export BOND_ROOT=/root/bond
 export BUILD_ROOT=/root/build
 BUILD_SCRIPTS=$BOND_ROOT/tools/ci-scripts/linux
 
@@ -37,7 +36,22 @@ export BOOST_ROOT=/opt/boosts/boost_1_63_0
 
 mkdir -p $SYMLINKED_HOME $BUILD_ROOT
 ln -s /root/.ccache $SYMLINKED_HOME/.ccache
-ln -s /root/.stack $SYMLINKED_HOME/.stack
+
+# Point the build's .stack-work at one saved in the image, but only if the
+# image contains a saved stack-work and the source volume wasn't mounted
+# with an existing one.
+SAVED_STACK_WORK=/opt/stack/stack-work
+BUILD_STACK_WORK=$BOND_ROOT/compiler/.stack-work
+if [[ -d $SAVED_STACK_WORK && ! -d $BUILD_STACK_WORK ]]; then
+    ln -s $SAVED_STACK_WORK $BUILD_STACK_WORK
+else
+    # We're building without a saved .stack-work, so symlink .stack to
+    # something that may end up in the Travis cache.
+    #
+    # This branch can be removed after we've switched over to using the
+    # saved .stack-work everywhere.
+    ln -s /root/.stack $SYMLINKED_HOME/.stack
+fi
 
 cd $BUILD_ROOT
 

--- a/tools/ci-scripts/linux/image-builder/Dockerfile
+++ b/tools/ci-scripts/linux/image-builder/Dockerfile
@@ -1,9 +1,16 @@
 FROM ubuntu:16.04
 
 # Cache folders
-VOLUME /root/.ccache /root/.stack
+VOLUME /root/.ccache
 # Source code
 VOLUME /root/bond
+
+# When building the image, this needs to be set to a commit in the
+# https://github.com/Microsoft/bond repository that is used to determine the
+# Stack dependencies to build.
+ARG STACK_DEPS_COMMIT
+
+ENV BOND_ROOT=/root/bond
 
 # Enable PPAs
 RUN apt-get update && \
@@ -29,8 +36,16 @@ RUN apt-get -y install \
     cmake \
     golang
 
-# Components for Haskell. See https://docs.haskellstack.org/en/stable/install_and_upgrade/#linux
+# Components for Haskell. See
+# https://docs.haskellstack.org/en/stable/install_and_upgrade/#linux
+
+# Move what's normally stored in ~/.stack to something non-user specific.
+ENV STACK_ROOT=/opt/stack/stack-root
+
 RUN wget -qO- https://get.haskellstack.org/ | sh
+
+ADD build_init_stack.zsh /root/
+RUN ["zsh", "-c", "/root/build_init_stack.zsh $STACK_DEPS_COMMIT"]
 
 # Components for C#. See http://www.mono-project.com/download/#download-lin
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \

--- a/tools/ci-scripts/linux/image-builder/build_init_stack.zsh
+++ b/tools/ci-scripts/linux/image-builder/build_init_stack.zsh
@@ -1,0 +1,57 @@
+#!/bin/zsh
+
+set -eux
+
+# This script builds the dependencies used by gbc and gbc-tests into the
+# image so that we build these once.
+#
+# Stack is smart enough to build any missing dependencies, so if the
+# pre-built dependencies in the image no longer match what bond.cabal
+# specifics, we won't get an incorrect build, just a slower one.
+#
+# Stack doesn't have a native way of moving the .stack-work directory
+# outside of the build directory, so we have to play symlink tricks here and
+# also right before we perform the actual build. See also:
+# https://github.com/commercialhaskell/stack/issues/1731
+
+STACK_DEPS_COMMIT=$1
+
+if [[ -z "$STACK_DEPS_COMMIT" ]]; then
+    echo "Required STACK_DEPS_COMMIT not given. Won't be able to download source files. Be sure to set this when building the Docker image." > 2
+    exit 1
+fi
+
+SAVED_STACK_WORK=/opt/stack/stack-work/
+
+# Absolute file paths get embedded in the compiled files, so we need to
+# pre-compile in the same place that the CI builds will also compile gbc.
+# This ends up being done in the source tree, not in CMakes build tree.
+COMPILER_PATH=$BOND_ROOT/compiler
+
+mkdir -p "$SAVED_STACK_WORK"
+mkdir -p "$COMPILER_PATH"
+
+pushd "$COMPILER_PATH"
+
+# Download the minimal files that Stack needs to figure out the dependent
+# packages.
+STACK_FILES=('bond.cabal' 'stack.yaml')
+# This URI is specific to how GitHub exposes files and is tied to the main
+# repository. If we need to support arbitrary repositories later, we'll
+# probably want to shallow clone the repository and sparse checkout just the
+# compiler/ directory.
+DOWNLOAD_URI_FORMAT='https://raw.githubusercontent.com/Microsoft/bond/%s/compiler/%s'
+for FILE in $STACK_FILES; do
+    local FILE_URI=`printf "$DOWNLOAD_URI_FORMAT" "$STACK_DEPS_COMMIT" "$FILE"`
+    wget $FILE_URI
+done
+
+# We can't use --work-dir to move .stack-work outside the current directory,
+# so we use a symlink instead.
+ln -s "$SAVED_STACK_WORK" .stack-work
+
+stack setup
+stack build --only-dependencies bond:gbc bond:gbc-tests
+
+popd
+rm -rf "$COMPILER_PATH"


### PR DESCRIPTION
With this commit, the package dependencies that gbc and gbc-tests use
will be built once with Stack when creating the CI image. Subsequent CI
builds will then just build the gbc and gbc-tests parts and link with
the already built dependencies.

Should a commit modify the dependencies of gbc/gbc-tests, Stack is smart
enough to figure this out, and it will build the missing dependencies,
until a newer CI image is used that contains the updated dependencies.

Stack and cabal don't allow us to just redirect their intermediate
output directories, so the build_init_srack.zsh and build.zsh scripts
now collaborate to symlink .stack-work so that it's shared between image
building and image execution.

This increases the image size by about 2 GiB.

Minor changes:

* Added BUILD_SOURCE_COMMIT Docker build argument. This needs to be set
  to a commit in the https://github.com/Microsoft/bond repository that
  is used to determine the dependencies to build.
* The STACK_ROOT environment variable is defined in the Dockerfile so
  that all invocations of stack--both during image build and during
  image execution--will share the same location.
* Moved the BOND_ROOT environment variable to Dockerfile so it's shared
  across all scripts and across image build and image execution.