### PR TITLE
[travis] Add garbage CI image clean up script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,13 @@ env:
     - FLAVOR="java"
 
 before_install:
-    - CI_BUILD_CONTAINER=bondciimages.azurecr.io/ubuntu-1604:build-8695914
+    - CI_BUILD_IMAGE=bondciimages.azurecr.io/ubuntu-1604:build-8695914
     - if [ "$TRAVIS_OS_NAME" == "linux" ]; then echo "Hardware:"; grep model\ name /proc/cpuinfo | uniq -c; free -m; fi
     - travis_retry docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" bondciimages.azurecr.io
-    - time travis_retry docker pull $CI_BUILD_CONTAINER
+    - time travis_retry docker pull $CI_BUILD_IMAGE
     - docker images # Dump the image ID
 
 script:
-    - docker run -v $HOME/.ccache:/root/.ccache -v $HOME/.stack:/root/.stack -v `pwd`:/root/bond $CI_BUILD_CONTAINER $HOME $FLAVOR $BOOST $COMPILER
+    - docker run -v $HOME/.ccache:/root/.ccache -v $HOME/.stack:/root/.stack -v `pwd`:/root/bond $CI_BUILD_IMAGE $HOME $FLAVOR $BOOST $COMPILER
     # docker runs as root and may leave files in the following directories that are not readable by the travis user
     - sudo chown -R travis:travis $HOME/.ccache $HOME/.stack `pwd`

--- a/tools/ci-scripts/linux/image-cleanup/.gitignore
+++ b/tools/ci-scripts/linux/image-cleanup/.gitignore
@@ -1,0 +1,3 @@
+# Python pre-compiled stuff
+__pycache__/
+*.pyc

--- a/tools/ci-scripts/linux/image-cleanup/.gitignore
+++ b/tools/ci-scripts/linux/image-cleanup/.gitignore
@@ -1,3 +1,4 @@
 # Python pre-compiled stuff
+.mypy_cache/
 __pycache__/
 *.pyc

--- a/tools/ci-scripts/linux/image-cleanup/.pylintrc
+++ b/tools/ci-scripts/linux/image-cleanup/.pylintrc
@@ -1,0 +1,2 @@
+[BASIC]
+good-names=logger

--- a/tools/ci-scripts/linux/image-cleanup/.pylintrc
+++ b/tools/ci-scripts/linux/image-cleanup/.pylintrc
@@ -1,2 +1,1 @@
 [BASIC]
-good-names=logger

--- a/tools/ci-scripts/linux/image-cleanup/collect_images.py
+++ b/tools/ci-scripts/linux/image-cleanup/collect_images.py
@@ -2,15 +2,15 @@
 
 """Main entry point for garbage image cleanup."""
 
-from datetime import timedelta
+import argparse
 import logging
 import subprocess
 import sys
+
+from datetime import timedelta
 from typing import Iterable
 
-from collector.acr import (
-    delete_image_by_manifest,
-    get_image_manifests)
+from collector.acr import (delete_image_by_manifest, get_image_manifests)
 from collector.garbage_manifests import find_garbage_manifests
 from collector.live_images import live_tags
 
@@ -25,7 +25,6 @@ def semi_list(semi_str: str) -> Iterable[str]:
 
 def main() -> None:
     """Program main entry point."""
-    import argparse
     parser = argparse.ArgumentParser(description=PROGRAM_DESCRIPTION)
     parser.add_argument('--repo-path', '-p',
                         required=True,
@@ -41,8 +40,9 @@ def main() -> None:
     parser.add_argument('--min-age', '-m',
                         required=True,
                         type=int,
-                        help="""the minimum length of time, in days, to keep images around, even
-                        if they are not referenced by the source code.""")
+                        help="""the minimum length of time, in days, before images are eligible for
+                        deletion, even if they are not referenced by the
+                        source code.""")
     parser.add_argument('--dry-run', '-n',
                         action='store_true',
                         help="""report which images would be deleted, but do not actually delete

--- a/tools/ci-scripts/linux/image-cleanup/collect_images.py
+++ b/tools/ci-scripts/linux/image-cleanup/collect_images.py
@@ -46,6 +46,10 @@ def main() -> None:
     parser.add_argument('--manifests',
                         help="""path to a JSON file with image manifests to use instead of
                         running an `az` command.""")
+    parser.add_argument('--dry-run', '-n',
+                        action='store_true',
+                        help="""report which images would be deleted, but do not actually delete
+                        them""")
     parser.add_argument('--verbosity', '-v',
                         default='WARNING',
                         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL', 'NOTSET'],
@@ -74,7 +78,11 @@ def main() -> None:
         manifests = get_image_manifests(args.manifests)
 
         for manifest in find_garbage_manifests(min_age_before_gc, active_tags, manifests):
-            delete_image_by_manifest(manifest)
+            if args.dry_run:
+                print('{}: would delete'.format(manifest.digest))
+            else:
+                delete_image_by_manifest(manifest)
+                print('{}: deleted'.format(manifest.digest))
 
     except subprocess.CalledProcessError as cpe:
         print('Subprocess {} failed with exit code {}'.format(

--- a/tools/ci-scripts/linux/image-cleanup/collect_images.py
+++ b/tools/ci-scripts/linux/image-cleanup/collect_images.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 import logging
 import subprocess
 import sys
+from typing import Iterable
 
 from collector.acr import (
     delete_image_by_manifest,
@@ -18,11 +19,11 @@ longer needed. Images are considered needed a) if they are referenced by the
 .travis.yml file in any of the commits included by the provided
 root_filters, or b) if they are younger than the provided min-age."""
 
-def semi_list(semi_str):
+def semi_list(semi_str: str) -> Iterable[str]:
     """Splits a semi-colon delimited string into a list of string."""
     return semi_str.split(';')
 
-def main():
+def main() -> None:
     """Program main entry point."""
     import argparse
     parser = argparse.ArgumentParser(description=PROGRAM_DESCRIPTION)

--- a/tools/ci-scripts/linux/image-cleanup/collect_images.py
+++ b/tools/ci-scripts/linux/image-cleanup/collect_images.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+"""Main entry point for garbage image cleanup."""
+
+from datetime import timedelta
+import logging
+import subprocess
+import sys
+
+from collector.acr import (
+    delete_image_by_manifest,
+    get_image_manifests)
+from collector.garbage_manifests import find_garbage_manifests
+from collector.live_images import live_tags
+
+PROGRAM_DESCRIPTION = """Remove images from an Azure Container Registry repository if they are no
+longer needed. Images are considered needed a) if they are referenced by the
+.travis.yml file in any of the commits included by the provided
+root_filters, or b) if they are younger than the provided min-age."""
+
+def semi_list(semi_str):
+    """Splits a semi-colon delimited string into a list of string."""
+    return semi_str.split(';')
+
+def main():
+    """Program main entry point."""
+    import argparse
+    parser = argparse.ArgumentParser(description=PROGRAM_DESCRIPTION)
+    parser.add_argument('--repo-path', '-p',
+                        required=True,
+                        help='path to the repository to inspect')
+    parser.add_argument('root_filters',
+                        nargs='+',
+                        type=semi_list,
+                        help="""semi-colon seperated list of arguments for one invocation of `git
+                        rev-parse`. The commits in the union of these
+                        rev-parse invocations are used to find containers
+                        that are referenced by source code. Ex:
+                        '--remotes=origin;--since=2~weeks~ago' or '--tags;-n;1'""")
+    parser.add_argument('--min-age', '-m',
+                        required=True,
+                        type=int,
+                        help="""the minimum length of time, in days, to keep containers around, even
+                        if they are not referenced by the source code.""")
+    parser.add_argument('--manifests',
+                        help="""path to a JSON file with container manifests to use instead of
+                        running an `az` command.""")
+    parser.add_argument('--verbosity', '-v',
+                        default='WARNING',
+                        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL', 'NOTSET'],
+                        help='log level to emit to stderr. Defaults to WARNING.')
+    args = parser.parse_args()
+
+    assert args.root_filters
+
+    numeric_level = getattr(logging, args.verbosity.upper(), None)
+    if not isinstance(numeric_level, int):
+        raise ValueError('Invalid --verbosity level: {}'.format(args.verbosity))
+
+    logging.basicConfig(level=numeric_level)
+
+    if args.min_age < 0:
+        raise ValueError('--min-age must be non-negative, but got {}'.format(args.min_age))
+
+    min_age_before_gc = timedelta(days=args.min_age)
+
+    try:
+        active_tags = live_tags(args.repo_path, args.root_filters)
+        if not active_tags:
+            raise ValueError('No active tags. This can delete all images, so aborting.')
+        logging.info('Active tags: {%s}', ','.join(active_tags))
+
+        manifests = get_image_manifests(args.manifests)
+
+        for manifest in find_garbage_manifests(min_age_before_gc, active_tags, manifests):
+            delete_image_by_manifest(manifest)
+
+    except subprocess.CalledProcessError as cpe:
+        print('Subprocess {} failed with exit code {}'.format(
+            cpe.cmd,
+            cpe.returncode,
+            file=sys.stderr))
+        print('STDOUT:\n', str(cpe.stdout, encoding='utf-8'), file=sys.stderr)
+        print('STDERR:\n', str(cpe.stderr, encoding='utf-8'), file=sys.stderr)
+        raise
+
+if __name__ == '__main__':
+    main()

--- a/tools/ci-scripts/linux/image-cleanup/collect_images.py
+++ b/tools/ci-scripts/linux/image-cleanup/collect_images.py
@@ -35,16 +35,16 @@ def main() -> None:
                         type=semi_list,
                         help="""semi-colon seperated list of arguments for one invocation of `git
                         rev-parse`. The commits in the union of these
-                        rev-parse invocations are used to find containers
+                        rev-parse invocations are used to find container images
                         that are referenced by source code. Ex:
                         '--remotes=origin;--since=2~weeks~ago' or '--tags;-n;1'""")
     parser.add_argument('--min-age', '-m',
                         required=True,
                         type=int,
-                        help="""the minimum length of time, in days, to keep containers around, even
+                        help="""the minimum length of time, in days, to keep images around, even
                         if they are not referenced by the source code.""")
     parser.add_argument('--manifests',
-                        help="""path to a JSON file with container manifests to use instead of
+                        help="""path to a JSON file with image manifests to use instead of
                         running an `az` command.""")
     parser.add_argument('--verbosity', '-v',
                         default='WARNING',

--- a/tools/ci-scripts/linux/image-cleanup/collect_images.py
+++ b/tools/ci-scripts/linux/image-cleanup/collect_images.py
@@ -43,9 +43,6 @@ def main() -> None:
                         type=int,
                         help="""the minimum length of time, in days, to keep images around, even
                         if they are not referenced by the source code.""")
-    parser.add_argument('--manifests',
-                        help="""path to a JSON file with image manifests to use instead of
-                        running an `az` command.""")
     parser.add_argument('--dry-run', '-n',
                         action='store_true',
                         help="""report which images would be deleted, but do not actually delete
@@ -75,7 +72,7 @@ def main() -> None:
             raise ValueError('No active tags. This can delete all images, so aborting.')
         logging.info('Active tags: {%s}', ','.join(active_tags))
 
-        manifests = get_image_manifests(args.manifests)
+        manifests = get_image_manifests()
 
         for manifest in find_garbage_manifests(min_age_before_gc, active_tags, manifests):
             if args.dry_run:

--- a/tools/ci-scripts/linux/image-cleanup/collect_images.py
+++ b/tools/ci-scripts/linux/image-cleanup/collect_images.py
@@ -10,7 +10,7 @@ import sys
 from datetime import timedelta
 from typing import Iterable
 
-from collector.acr import (delete_image_by_manifest, get_image_manifests)
+from collector.acr import delete_image_by_manifest, get_image_manifests
 from collector.garbage_manifests import find_garbage_manifests
 from collector.live_images import live_tags
 
@@ -41,8 +41,7 @@ def main() -> None:
                         required=True,
                         type=int,
                         help="""the minimum length of time, in days, before images are eligible for
-                        deletion, even if they are not referenced by the
-                        source code.""")
+                        deletion, even if they are not referenced by the source code.""")
     parser.add_argument('--dry-run', '-n',
                         action='store_true',
                         help="""report which images would be deleted, but do not actually delete

--- a/tools/ci-scripts/linux/image-cleanup/collector/acr.py
+++ b/tools/ci-scripts/linux/image-cleanup/collector/acr.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 import logging
 import json
 import subprocess
-from typing import Iterable
+from typing import Mapping, Iterable, Optional
 
 from .config import REGISTRY_NAME, REPOSITORY_NAME
 
@@ -17,14 +17,14 @@ class ManifestParseError(Exception):
     Used to collect the dictionary that was parsed to ease debugging.
     """
 
-    def __init__(self, dct):
+    def __init__(self, dct: Mapping[str, str]) -> None:
         super().__init__()
         self.dct = dct
 
 class ImageManifest: # pylint: disable=too-few-public-methods
     """Represents an ACR image manifest."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: str) -> None:
         """Initalize an ImageManifest from a dictionary.
 
         This is written to handle the JSON representation of one
@@ -53,7 +53,7 @@ class ImageManifest: # pylint: disable=too-few-public-methods
         except:
             raise ManifestParseError(kwargs)
 
-def get_image_manifests(manifest_path: str = None) -> Iterable[ImageManifest]:
+def get_image_manifests(manifest_path: Optional[str] = None) -> Iterable[ImageManifest]:
     """Get the current ACR image manifests.
 
     Invokes the ``az`` CLI tool to discover the current images.
@@ -81,7 +81,7 @@ def get_image_manifests(manifest_path: str = None) -> Iterable[ImageManifest]:
     return map((lambda json_object: ImageManifest(**json_object)),
                manifests)
 
-def delete_image_by_manifest(manifest: ImageManifest):
+def delete_image_by_manifest(manifest: ImageManifest) -> None:
     """Delete a ACR image (and all its tags)."""
     az_delete_cmd_line = ['az', 'acr', 'repository', 'delete',
                           '--name', REGISTRY_NAME,

--- a/tools/ci-scripts/linux/image-cleanup/collector/acr.py
+++ b/tools/ci-scripts/linux/image-cleanup/collector/acr.py
@@ -23,7 +23,7 @@ class ManifestParseError(Exception):
         self.dct = dct
 
     def __str__(self) -> str:
-        return '{}'.format(self.dct)
+        return str(self.dct)
 
 class ImageManifest: # pylint: disable=too-few-public-methods
     """Represents an ACR image manifest."""

--- a/tools/ci-scripts/linux/image-cleanup/collector/acr.py
+++ b/tools/ci-scripts/linux/image-cleanup/collector/acr.py
@@ -74,7 +74,7 @@ def get_image_manifests(manifest_path: Optional[str] = None) -> Iterable[ImageMa
         manifests = json.loads(str(output, encoding='utf-8'))
 
     if not isinstance(manifests, list):
-        msg = 'Expected an array of manifests ("[{{...}},{{...}}]" in but got {}'.format(
+        msg = 'Expected an array of manifests ("[{{...}},{{...}}]" but got {}'.format(
             type(manifests).__name__)
         raise ValueError(msg)
 
@@ -89,6 +89,7 @@ def delete_image_by_manifest(manifest: ImageManifest) -> None:
                           '--manifest', manifest.digest,
                           '--yes']
     logger.debug('Invoking %s', az_delete_cmd_line)
+    # This will eventually be replaced with subprocess.run, like below.
     print('Would run: {}'.format(az_delete_cmd_line))
     # p = subprocess.run(az_delete_cmd_line, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     # p.check_returncode()

--- a/tools/ci-scripts/linux/image-cleanup/collector/acr.py
+++ b/tools/ci-scripts/linux/image-cleanup/collector/acr.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 import logging
 import json
 import subprocess
-from typing import Mapping, Iterable, Optional
+from typing import Mapping, Iterable
 
 from .config import REGISTRY_NAME, REPOSITORY_NAME
 
@@ -53,25 +53,19 @@ class ImageManifest: # pylint: disable=too-few-public-methods
         except:
             raise ManifestParseError(kwargs)
 
-def get_image_manifests(manifest_path: Optional[str] = None) -> Iterable[ImageManifest]:
+def get_image_manifests() -> Iterable[ImageManifest]:
     """Get the current ACR image manifests.
 
     Invokes the ``az`` CLI tool to discover the current images.
     """
-    manifests = None
-
-    if manifest_path:
-        with open(manifest_path, mode='rt', encoding='utf-8') as file:
-            manifests = json.load(file)
-    else:
-        az_show_manifests_cmd_line = ['az', 'acr', 'repository', 'show-manifests',
-                                      '--name', REGISTRY_NAME,
-                                      '--repository', REPOSITORY_NAME,
-                                      '--output', 'json']
-        logger.debug('Invoking %s', az_show_manifests_cmd_line)
-        output = subprocess.check_output(az_show_manifests_cmd_line,
-                                         stderr=subprocess.PIPE)
-        manifests = json.loads(str(output, encoding='utf-8'))
+    az_show_manifests_cmd_line = ['az', 'acr', 'repository', 'show-manifests',
+                                  '--name', REGISTRY_NAME,
+                                  '--repository', REPOSITORY_NAME,
+                                  '--output', 'json']
+    logger.debug('Invoking %s', az_show_manifests_cmd_line)
+    output = subprocess.check_output(az_show_manifests_cmd_line,
+                                     stderr=subprocess.PIPE)
+    manifests = json.loads(str(output, encoding='utf-8'))
 
     if not isinstance(manifests, list):
         msg = 'Expected an array of manifests ("[{{...}},{{...}}]" but got {}'.format(

--- a/tools/ci-scripts/linux/image-cleanup/collector/acr.py
+++ b/tools/ci-scripts/linux/image-cleanup/collector/acr.py
@@ -1,0 +1,94 @@
+"""Functions and types for interacting with Azure Container Registry via the
+``az`` command line tool."""
+
+from datetime import datetime, timezone
+import logging
+import json
+import subprocess
+from typing import Iterable
+
+from .config import REGISTRY_NAME, REPOSITORY_NAME
+
+logger = logging.getLogger(__name__)
+
+class ManifestParseError(Exception):
+    """Represents an error parsing a manifest dictionary.
+
+    Used to collect the dictionary that was parsed to ease debugging.
+    """
+
+    def __init__(self, dct):
+        super().__init__()
+        self.dct = dct
+
+class ImageManifest: # pylint: disable=too-few-public-methods
+    """Represents an ACR image manifest."""
+
+    def __init__(self, **kwargs):
+        """Initalize an ImageManifest from a dictionary.
+
+        This is written to handle the JSON representation of one
+        manifest from the command ``az acr repository list-manifests``
+        (which returns a list).
+
+        Each manifest looks like:::
+            {
+                "digest": "sha256:1884e693b47726118459af31699a816fcd103a3567397d4306e5b435f64dec33",
+                "tags": [
+                    "build-9867746",
+                    "git-da33ddf6b9c24c14bb7d836adff8ac77f523d047"
+                ],
+                "timestamp": "2018-02-09T23:44:14Z"
+            }
+        """
+
+        try:
+            logger.debug('Parsing %s', kwargs)
+
+            self.digest = kwargs['digest']
+            self.tags = frozenset(kwargs['tags'])
+            self.timestamp = datetime.strptime(
+                kwargs['timestamp'],
+                '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone.utc)
+        except:
+            raise ManifestParseError(kwargs)
+
+def get_image_manifests(manifest_path: str = None) -> Iterable[ImageManifest]:
+    """Get the current ACR image manifests.
+
+    Invokes the ``az`` CLI tool to discover the current images.
+    """
+    manifests = None
+
+    if manifest_path:
+        with open(manifest_path, mode='rt', encoding='utf-8') as file:
+            manifests = json.load(file)
+    else:
+        az_show_manifests_cmd_line = ['az', 'acr', 'repository', 'show-manifests',
+                                      '--name', REGISTRY_NAME,
+                                      '--repository', REPOSITORY_NAME,
+                                      '--output', 'json']
+        logger.debug('Invoking %s', az_show_manifests_cmd_line)
+        output = subprocess.check_output(az_show_manifests_cmd_line,
+                                         stderr=subprocess.PIPE)
+        manifests = json.loads(str(output, encoding='utf-8'))
+
+    if not isinstance(manifests, list):
+        msg = 'Expected an array of manifests ("[{{...}},{{...}}]" in but got {}'.format(
+            type(manifests).__name__)
+        raise ValueError(msg)
+
+    return map((lambda json_object: ImageManifest(**json_object)),
+               manifests)
+
+def delete_image_by_manifest(manifest: ImageManifest):
+    """Delete a ACR image (and all its tags)."""
+    az_delete_cmd_line = ['az', 'acr', 'repository', 'delete',
+                          '--name', REGISTRY_NAME,
+                          '--repository', REPOSITORY_NAME,
+                          '--manifest', manifest.digest,
+                          '--yes']
+    logger.debug('Invoking %s', az_delete_cmd_line)
+    print('Would run: {}'.format(az_delete_cmd_line))
+    # p = subprocess.run(az_delete_cmd_line, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    # p.check_returncode()

--- a/tools/ci-scripts/linux/image-cleanup/collector/config.py
+++ b/tools/ci-scripts/linux/image-cleanup/collector/config.py
@@ -1,0 +1,4 @@
+"""Constants for the garbage image collector."""
+
+REGISTRY_NAME = 'bondciimages'
+REPOSITORY_NAME = 'ubuntu-1604'

--- a/tools/ci-scripts/linux/image-cleanup/collector/garbage_manifests.py
+++ b/tools/ci-scripts/linux/image-cleanup/collector/garbage_manifests.py
@@ -1,22 +1,20 @@
 """Functions to determine whether ACR images are garbage."""
 
-from datetime import datetime, timedelta, timezone
 import logging
+
+from datetime import datetime, timedelta, timezone
 from typing import AbstractSet, Iterable
 
 from .acr import ImageManifest
 from .live_images import ImageTag
 
-logger = logging.getLogger(__name__)
-
-"""Time used as "now" for checking image age."""
-CURRENT_TIME = datetime.now(timezone.utc)
+_LOGGER = logging.getLogger(__name__)
 
 def find_garbage_manifests(
         min_age: timedelta,
         active_tags: AbstractSet[ImageTag],
         image_manifests: Iterable[ImageManifest]) -> Iterable[ImageManifest]:
-    """Return an iterable of the manifests that are considered garbage.
+    """Yield a sequence of the manifests that are considered garbage.
 
     Image manifests are considered garbage if they are both:
     * older than `min_age` and
@@ -24,8 +22,8 @@ def find_garbage_manifests(
 
     Typically `active_tags` is computed by calling `live_images.live_tags`.
     """
-
-    keep_newer_than_time = CURRENT_TIME - min_age
+    keep_newer_than_time = datetime.now(timezone.utc) - min_age
+    _LOGGER.debug('Keeping images newer than %s', keep_newer_than_time)
 
     for manifest in image_manifests:
         # It would probably be faster to check timestamps before tags, but
@@ -34,12 +32,12 @@ def find_garbage_manifests(
         # the newness.
         matching_tags = manifest.tags.intersection(active_tags)
         if matching_tags:
-            logger.info('%s: keep - referenced {%s}', manifest.digest, ','.join(matching_tags))
+            _LOGGER.info('%s: keep - referenced {%s}', manifest.digest, ','.join(matching_tags))
             continue
 
         if manifest.timestamp > keep_newer_than_time:
-            logger.info('%s: keep - too new (%s)', manifest.digest, manifest.timestamp)
+            _LOGGER.info('%s: keep - too new (%s)', manifest.digest, manifest.timestamp)
             continue
 
-        logger.info('%s: garbage', manifest.digest)
+        _LOGGER.info('%s: garbage', manifest.digest)
         yield manifest

--- a/tools/ci-scripts/linux/image-cleanup/collector/garbage_manifests.py
+++ b/tools/ci-scripts/linux/image-cleanup/collector/garbage_manifests.py
@@ -1,0 +1,45 @@
+"""Functions to determine whether ACR images are garbage."""
+
+from datetime import datetime, timedelta, timezone
+import logging
+from typing import AbstractSet, Iterable
+
+from .acr import ImageManifest
+from .live_images import ImageTag
+
+logger = logging.getLogger(__name__)
+
+"""Time used as "now" for checking image age."""
+CURRENT_TIME = datetime.now(timezone.utc)
+
+def find_garbage_manifests(
+        min_age: timedelta,
+        active_tags: AbstractSet[ImageTag],
+        image_manifests: Iterable[ImageManifest]) -> Iterable[ImageManifest]:
+    """Return an iterable of the manifests that are considered garbage.
+
+    Image manifests are considered garbage if they are both:
+    * older than `min_age` and
+    * not tagged with a tag in `active_tags`.
+
+    Typically `active_tags` is computed by calling `live_images.live_tags`.
+    """
+
+    keep_newer_than_time = CURRENT_TIME - min_age
+
+    for manifest in image_manifests:
+        # It would probably be faster to check timestamps before tags, but
+        # the tags are more important of a reason to keep an image, so we
+        # check tags first so that the tag reference gets logged instead of
+        # the newness.
+        matching_tags = manifest.tags.intersection(active_tags)
+        if matching_tags:
+            logger.info('%s: keep - referenced {%s}', manifest.digest, ','.join(matching_tags))
+            continue
+
+        if manifest.timestamp > keep_newer_than_time:
+            logger.info('%s: keep - too new (%s)', manifest.digest, manifest.timestamp)
+            continue
+
+        logger.info('%s: garbage', manifest.digest)
+        yield manifest

--- a/tools/ci-scripts/linux/image-cleanup/collector/live_images.py
+++ b/tools/ci-scripts/linux/image-cleanup/collector/live_images.py
@@ -108,7 +108,7 @@ CI build in the given blobs.
                               git_show_output,
                               re.MULTILINE)
         image_names.update(map((lambda match: ImageName(str(match.group(1), 'utf-8'))),
-                                   matches))
+                               matches))
         logger.debug('Image names currently: %s', image_names)
 
     return frozenset(image_names)

--- a/tools/ci-scripts/linux/image-cleanup/collector/live_images.py
+++ b/tools/ci-scripts/linux/image-cleanup/collector/live_images.py
@@ -1,0 +1,153 @@
+"""Find referenced containers from Git commits."""
+
+import logging
+import re
+import subprocess
+from typing import AbstractSet, Iterable, NewType, Sequence
+
+from .config import REGISTRY_NAME, REPOSITORY_NAME
+
+logger = logging.getLogger(__name__)
+
+_RevListRoots = NewType('RevListRoots', Sequence[Sequence[str]]) # pylint: disable=invalid-name
+_BlobId = NewType('BlobId', str) # pylint: disable=invalid-name
+
+"""A type for the full name of an image. E.g.,
+"bondciimages.azurecr.io/ubuntu-1604:build-12345".
+"""
+ImageName = NewType('ImageName', str) # pylint: disable=invalid-name
+
+"""A type for the an image tag. E.g., "build-12345"."""
+ImageTag = NewType('ImageTag', str) # pylint: disable=invalid-name
+
+def _blobs_from_roots(
+        repo_path: str,
+        roots: _RevListRoots) -> AbstractSet[_BlobId]:
+    """Return the blob IDs of the revisions of .travis.yml for all the commits
+specified by the given `roots`.
+
+    :param repo_path: Path to the repository to inspect.
+
+    :param roots: A collection of argument lists to pass to ``git
+    rev-list`` to limit the matched commits.
+
+    :return The blob IDs of the .travis.yml revisions.
+    """
+
+    commit_ids = set()
+    for root_args in roots:
+        git_rev_list_cmd_line = ['git', '-C', repo_path, 'rev-list']
+        git_rev_list_cmd_line.extend(root_args)
+
+        logger.debug('Invoking %s', git_rev_list_cmd_line)
+
+        rev_list_output = subprocess.check_output(git_rev_list_cmd_line, stderr=subprocess.PIPE)
+        commit_ids.update(str(rev_list_output, 'utf-8').splitlines())
+        logger.debug('Commit IDs currently: %s', commit_ids)
+
+    blob_ids = set()
+    for commit in commit_ids:
+        git_ls_tree_cmd_line = ['git',
+                                '-C', repo_path,
+                                'ls-tree', commit,
+                                '--', ':/.travis.yml']
+        logger.debug('Invoking %s', git_ls_tree_cmd_line)
+        ls_tree_output = subprocess.check_output(git_ls_tree_cmd_line, stderr=subprocess.PIPE)
+
+        for line in str(ls_tree_output, 'utf-8').splitlines():
+            logger.debug('Parsing ls-tree output: "%s"', line)
+
+            # Expecing output like:
+            #
+            # 100644 blob cbe47c031fb164dca034aac640de08cf35170a68	.travis.yml
+            parts = line.split()
+
+            # The length of parts may not be exactly 4 if the name
+            # contains a space. (Though, this shouldn't happen in this
+            # particular case.) Instead of parsing exactly, we check
+            # that we have at least the first three parts and call it
+            # good enough.
+            if len(parts) < 3:
+                raise ValueError('Cannot parse ls-tree output: "{}"'.format(line))
+
+            obj_type = parts[1]
+            blob_id = parts[2]
+            if obj_type == 'blob':
+                blob_ids.add(blob_id)
+
+    logger.debug('Blobs: %s', blob_ids)
+    return frozenset(blob_ids)
+
+def _images_from_blobs(
+        repo_path: str,
+        commits: Iterable[_BlobId]) -> AbstractSet[ImageName]:
+    """Get the full names (including tags) of the images used for the
+CI build in the given blobs.
+
+    :param repo_path: Path to the repository to inspect.
+
+    :param commits: The Git blob IDs of files in which to look for
+    containers. It's assumed that these are blob IDs of .travis.yml or
+    similar files.
+
+    :return The full container names used by the specificed blobs.
+
+    Containers are found by looking for a line like
+
+    CI_BUILD_CONTAINER=...
+    """
+
+    container_names = set()
+
+    for commit in commits:
+        git_show_cmd_line = ['git', '-C', repo_path, 'show', commit]
+        logger.debug('Invoking %s', git_show_cmd_line)
+        git_show_output = subprocess.check_output(git_show_cmd_line, stderr=subprocess.PIPE)
+
+        matches = re.finditer(b'^.+CI_BUILD_CONTAINER=(.+)\\s*$',
+                              git_show_output,
+                              re.MULTILINE)
+        container_names.update(map((lambda match: str(match.group(1), 'utf-8')),
+                                   matches))
+        logger.debug('Container names currently: %s', container_names)
+
+    return frozenset(container_names)
+
+def live_images(
+        repo_path: str,
+        roots: _RevListRoots) -> AbstractSet[ImageName]:
+    """Return the image names used by all of the commits specified by the
+given `roots`.
+
+    :param repo_path: Path to the repository to inspect.
+
+    :param roots: A collection of argument lists to pass to ``git
+    rev-list`` to limit the matched commits.
+    """
+    return _images_from_blobs(repo_path,
+                              _blobs_from_roots(repo_path, roots))
+
+def live_tags(repo_path: str,
+              roots: _RevListRoots) -> AbstractSet[ImageTag]:
+    """Return the image tags that are referenced by .travis.yml files in
+the commits specified by the given `roots`.
+
+    :param repo_path: Path to the repository to inspect.
+
+    :param roots: A collection of argument lists to pass to ``git rev-list``
+    to limit the matched commits.
+    """
+    expected_prefix = '{}.azurecr.io/{}'.format(REGISTRY_NAME, REPOSITORY_NAME)
+    def matches_expected_prefix(image_name: str) -> bool:
+        """Check (and log) whether an image name is from the expected repository."""
+        if image_name.startswith(expected_prefix):
+            return True
+
+        logger.info(
+            'Discarding image "%s" that does not match expected prefix "%s"',
+            image_name,
+            expected_prefix)
+        return False
+
+    return frozenset(map((lambda image_name: image_name.split(':')[1]),
+                         filter(matches_expected_prefix, live_images(repo_path, roots))))

--- a/tools/ci-scripts/linux/image-cleanup/collector/live_images.py
+++ b/tools/ci-scripts/linux/image-cleanup/collector/live_images.py
@@ -3,7 +3,7 @@
 import logging
 import re
 import subprocess
-from typing import AbstractSet, Iterable, NewType, Sequence, Set
+from typing import AbstractSet, Iterable, NewType, Sequence, Set # pylint: disable=unused-import
 
 from .config import REGISTRY_NAME, REPOSITORY_NAME
 

--- a/tools/ci-scripts/linux/image-cleanup/collector/live_images.py
+++ b/tools/ci-scripts/linux/image-cleanup/collector/live_images.py
@@ -1,4 +1,4 @@
-"""Find referenced containers from Git commits."""
+"""Find referenced images from Git commits."""
 
 import logging
 import re
@@ -87,17 +87,17 @@ CI build in the given blobs.
     :param repo_path: Path to the repository to inspect.
 
     :param commits: The Git blob IDs of files in which to look for
-    containers. It's assumed that these are blob IDs of .travis.yml or
+    image names. It's assumed that these are blob IDs of .travis.yml or
     similar files.
 
-    :return The full container names used by the specificed blobs.
+    :return The full image names used by the specificed blobs.
 
-    Containers are found by looking for a line like
+    Images are found by looking for a line like
 
     CI_BUILD_CONTAINER=...
     """
 
-    container_names = set() # type: Set[ImageName]
+    image_names = set() # type: Set[ImageName]
 
     for commit in commits:
         git_show_cmd_line = ['git', '-C', repo_path, 'show', commit]
@@ -107,11 +107,11 @@ CI build in the given blobs.
         matches = re.finditer(b'^.+CI_BUILD_CONTAINER=(.+)\\s*$',
                               git_show_output,
                               re.MULTILINE)
-        container_names.update(map((lambda match: ImageName(str(match.group(1), 'utf-8'))),
+        image_names.update(map((lambda match: ImageName(str(match.group(1), 'utf-8'))),
                                    matches))
-        logger.debug('Container names currently: %s', container_names)
+        logger.debug('Image names currently: %s', image_names)
 
-    return frozenset(container_names)
+    return frozenset(image_names)
 
 def live_images(
         repo_path: str,

--- a/tools/ci-scripts/linux/image-cleanup/collector/live_images.py
+++ b/tools/ci-scripts/linux/image-cleanup/collector/live_images.py
@@ -110,8 +110,9 @@ CI build in the given blobs.
         matches = re.finditer(b'^.+CI_BUILD_IMAGE=(.+)\\s*$',
                               git_show_output,
                               re.MULTILINE)
-        image_names.update(map((lambda match: ImageName(str(match.group(1), 'utf-8'))),
-                               matches))
+        matched_names = (ImageName(str(match.group(1), 'utf-8'))
+                         for match in matches)
+        image_names.update(matched_names)
         _LOGGER.debug('Image names currently: %s', image_names)
 
     return frozenset(image_names)
@@ -152,5 +153,6 @@ the commits specified by the given `roots`.
             expected_prefix)
         return False
 
-    return frozenset(map((lambda image_name: ImageTag(image_name.split(':')[1])),
-                         filter(matches_expected_prefix, live_images(repo_path, roots))))
+    return frozenset((ImageTag(image_name.split(':')[1])
+                      for image_name in live_images(repo_path, roots)
+                      if matches_expected_prefix(image_name)))

--- a/tools/ci-scripts/linux/image-cleanup/mypy.ini
+++ b/tools/ci-scripts/linux/image-cleanup/mypy.ini
@@ -1,0 +1,17 @@
+[mypy]
+warn_no_return=True
+warn_unused_configs=True
+
+# The same set of flags as enabled by --strict
+check-untyped-defs=True
+disallow-incomplete-defs=True
+disallow-subclassing-any=True
+disallow-untyped-calls=True
+disallow-untyped-decorators=True
+disallow-untyped-defs=True
+no-implicit-optional=True
+strict-optional=True
+warn-redundant-casts=True
+warn-return-any=True
+warn-unused-configs=True
+warn-unused-ignores=True


### PR DESCRIPTION
Every change (well, most every) to the master branch produces a new
Docker image (for our Linux CI builds). However, we don't use each new
image. Instead, occasionally someone updates .travis.yml to point to a
new image. Thus, there's a build up of Docker images in the repository
that aren't being used.

These images are garbage: garbage in the sense that they're not
reachable from any of the .travis.yml roots.

This commit adds a script that can be used to find and remove these
garbage images.

Given a set of filters to find root commits (e.g., we can specify all
tags and all commits in the past two weeks), the script finds all the
referenced Docker images in the various revisions to .travis.yml. It
then compares the referenced images to those present in the repository,
skips images that are too new to be collected, and--for now--prints the
`az` CLI command to remove that image.

The `az` CLI is implemented in Python, so Python is going to be
available wherever `az` is. Since this script was a bit too complicated
for a shell script, Python 3 was chosen as its implementation language.

This script is intended to be run inside a VSTS build using the Azure
CLI task [1]. However, it will work anywhere that `az login` has been
run and given credentials with read/write access to the
bondciimages.azurecr.io repository.

[1]: https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/AzureCLI/Readme.md

TODO:

* [x] Remove --manifests testing argument
* [x] Turn on image deletion after CR: opened #800 for this