### PR TITLE
[c++] Fix To::UnknownField to do not use ellipses

### DIFF
--- a/cpp/inc/bond/core/transforms.h
+++ b/cpp/inc/bond/core/transforms.h
@@ -454,7 +454,8 @@ public:
     void UnknownEnd() const
     {}
 
-    bool UnknownField(...) const
+    template <typename X>
+    bool UnknownField(uint16_t /*id*/, const X& /*value*/) const
     {
         return false;
     }


### PR DESCRIPTION
The `UnknownField` is expected to accept a non-trivial type `bond::value`, so `...` should not be used.