### PR TITLE
[c++] Remove is_blob/is_nullable traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ different versioning scheme, following the Haskell community's
 
 * **Breaking change** Constructors accepting a `Comparer` have been removed from
   `bond::maybe` and `bond::nullable` types.
+* **Breaking change** The `bond::is_blob` and `bond::is_nullable` traits are removed.
 * The CMake build now enforces a minimum Boost version of 1.58. The build
   has required Boost 1.58 or later since version 5.2.0, but this was not
   enforced.

--- a/cpp/inc/bond/core/blob.h
+++ b/cpp/inc/bond/core/blob.h
@@ -398,8 +398,4 @@ inline T blob_cast(const blob& from)
 }
 
 
-template <> struct
-is_blob<blob>
-    : std::true_type {};
-
 } // namespace bond

--- a/cpp/inc/bond/core/container_interface.h
+++ b/cpp/inc/bond/core/container_interface.h
@@ -47,16 +47,6 @@ is_wstring
 
 
 template <typename T> struct
-is_blob
-    : std::false_type {};
-
-
-template <typename T> struct
-is_nullable
-    : std::false_type {};
-
-
-template <typename T> struct
 element_type
 {
     typedef typename T::value_type type;

--- a/cpp/inc/bond/core/nullable.h
+++ b/cpp/inc/bond/core/nullable.h
@@ -678,8 +678,4 @@ is_list_container<nullable<T, Allocator, useValue> >
     : std::true_type {};
 
 
-template <typename T, typename Allocator, bool useValue> struct
-is_nullable<nullable<T, Allocator, useValue> >
-    : std::true_type {};
-
 } // namespace bond

--- a/cpp/inc/bond/core/reflection.h
+++ b/cpp/inc/bond/core/reflection.h
@@ -839,12 +839,12 @@ template <typename T, typename Enable = void> struct
 get_list_sub_type_id
     : std::integral_constant<ListSubType, NO_SUBTYPE> {};
 
-template <typename T> struct
-get_list_sub_type_id<T, typename boost::enable_if<is_nullable<typename std::remove_const<T>::type> >::type>
+template <typename T, typename Allocator, bool useValue> struct
+get_list_sub_type_id<nullable<T, Allocator, useValue> >
     : std::integral_constant<ListSubType, NULLABLE_SUBTYPE> {};
 
-template <typename T> struct
-get_list_sub_type_id<T, typename boost::enable_if<is_blob<typename std::remove_const<T>::type> >::type>
+template <> struct
+get_list_sub_type_id<blob>
     : std::integral_constant<ListSubType, BLOB_SUBTYPE> {};
 
 


### PR DESCRIPTION
The `blob` and `nullable` types are not customizable. Also `is_blob` and `is_nullable` traits are not part of container concept.