### PR TITLE
[c++] Add detail::Field helper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ different versioning scheme, following the Haskell community's
 * Fixed a race condition when `bond::ext::gRPC::io_manager::shutdown` and
   `bond::ext::gRPC::io_manager::wait` are called concurrently.
 * Fixed a race condition during `bond::ext::gRPC::unary_call` destruction.
+* Fixed the broken move constructor of `bond::bonded<T, Reader&>`.
 
 ### C# ###
 

--- a/cpp/inc/bond/core/bonded.h
+++ b/cpp/inc/bond/core/bonded.h
@@ -26,6 +26,8 @@ template <typename Protocols, typename Transform, typename T, typename Reader>
 typename boost::enable_if<need_double_pass<Transform>, bool>::type inline
 ApplyTransform(const Transform& transform, const bonded<T, Reader>& bonded);
 
+
+// Helper function move_data for dealing with [not] moving a Reader& in bonded<T, Reader&>
 template <typename T, typename U>
 typename boost::enable_if<std::is_reference<T>, T>::type
 inline move_data(U& data)

--- a/cpp/inc/bond/core/bonded.h
+++ b/cpp/inc/bond/core/bonded.h
@@ -26,6 +26,22 @@ template <typename Protocols, typename Transform, typename T, typename Reader>
 typename boost::enable_if<need_double_pass<Transform>, bool>::type inline
 ApplyTransform(const Transform& transform, const bonded<T, Reader>& bonded);
 
+template <typename T, typename U>
+typename boost::enable_if<std::is_reference<T>, T>::type
+inline move_data(U& data)
+{
+    BOOST_STATIC_ASSERT(std::is_same<T, U&>::value);
+    return data;
+}
+
+template <typename T, typename U>
+typename boost::disable_if<std::is_reference<T>, T&&>::type
+inline move_data(U& data)
+{
+    BOOST_STATIC_ASSERT(std::is_same<T, U>::value);
+    return std::move(data);
+}
+
 } // namespace detail
 
 
@@ -61,7 +77,7 @@ public:
     bonded(bonded&& bonded) BOND_NOEXCEPT_IF(
         std::is_nothrow_move_constructible<Reader>::value
         && std::is_nothrow_move_constructible<RuntimeSchema>::value)
-        : _data(std::move(bonded._data)),
+        : _data(detail::move_data<Reader>(bonded._data)),
           _schema(std::move(bonded._schema)),
           _skip(std::move(bonded._skip)),
           _base(std::move(bonded._base))

--- a/cpp/inc/bond/core/bonded_void.h
+++ b/cpp/inc/bond/core/bonded_void.h
@@ -52,7 +52,7 @@ public:
     bonded(bonded&& other) BOND_NOEXCEPT_IF(
         std::is_nothrow_move_constructible<Reader>::value
         && std::is_nothrow_move_constructible<RuntimeSchema>::value)
-        : _data(std::move(other._data)),
+        : _data(detail::move_data<Reader>(other._data)),
           _schema(std::move(other._schema)),
           _skip(std::move(other._skip)),
           _base(std::move(other._base))

--- a/cpp/inc/bond/core/detail/parser_utils.h
+++ b/cpp/inc/bond/core/detail/parser_utils.h
@@ -43,5 +43,19 @@ namespace detail
         return transform.Field(T::id, T::metadata, value);
     }
 
+    template <typename Transform, typename Reader>
+    inline bool Field(const FieldDef& field, const RuntimeSchema& schema, const Transform& transform, Reader& input)
+    {
+        if (field.type.id == BT_STRUCT)
+        {
+            return transform.Field(field.id, field.metadata, bonded<void, Input>(input, RuntimeSchema(schema, field)));
+        }
+        else
+        {
+            BOOST_ASSERT(field.type.id == BT_LIST || field.type.id == BT_SET || field.type.id == BT_MAP);
+            return transform.Field(field.id, field.metadata, value<void, Input>(input, RuntimeSchema(schema, field)));
+        }
+    }
+
 } // namespace detail
 } // namespace bond

--- a/cpp/inc/bond/core/detail/parser_utils.h
+++ b/cpp/inc/bond/core/detail/parser_utils.h
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include <bond/core/config.h>
+
+#include <bond/core/reflection.h>
+
+
+namespace bond
+{
+namespace detail
+{
+    template <typename T, typename Transform>
+    typename boost::enable_if<is_fast_path_field<T, Transform>, bool>::type
+    inline OmittedField(const T& field, const Transform& transform)
+    {
+        return transform.OmittedField(field);
+    }
+
+
+    template <typename T, typename Transform>
+    typename boost::disable_if<is_fast_path_field<T, Transform>, bool>::type
+    inline OmittedField(const T&, const Transform& transform)
+    {
+        return transform.OmittedField(T::id, T::metadata, get_type_id<typename T::field_type>::value);
+    }
+
+
+    template <typename T, typename Transform, typename X>
+    typename boost::enable_if<is_fast_path_field<T, Transform>, bool>::type
+    inline Field(const T& field, const Transform& transform, const X& value)
+    {
+        return transform.Field(field, value);
+    }
+
+
+    template <typename T, typename Transform, typename X>
+    typename boost::disable_if<is_fast_path_field<T, Transform>, bool>::type
+    inline Field(const T&, const Transform& transform, const X& value)
+    {
+        return transform.Field(T::id, T::metadata, value);
+    }
+
+} // namespace detail
+} // namespace bond

--- a/cpp/inc/bond/core/parser.h
+++ b/cpp/inc/bond/core/parser.h
@@ -151,9 +151,9 @@ private:
 
     template <typename T, typename Transform>
     typename boost::disable_if<is_reader<Input, T>, bool>::type
-    NextField(const T& field, const Transform& transform)
+    NextField(const T&, const Transform& transform)
     {
-        return detail::Field(field, transform, T::GetVariable(_input));
+        return transform.Field(T::id, T::metadata, T::GetVariable(_input));
     }
 
 

--- a/cpp/inc/bond/core/parser.h
+++ b/cpp/inc/bond/core/parser.h
@@ -269,7 +269,7 @@ private:
             if (Head::id == id && get_type_id<typename Head::field_type>::value == type)
             {
                 // Exact match
-                detail::Field(Head(), transform, _input)
+                detail::Field(Head(), transform, _input);
             }
             else if (Head::id >= id && type != bond::BT_STOP && type != bond::BT_STOP_BASE)
             {

--- a/cpp/inc/bond/core/parser.h
+++ b/cpp/inc/bond/core/parser.h
@@ -151,23 +151,21 @@ private:
         for (const_enumerator<std::vector<FieldDef> > enumerator(schema.GetStruct().fields); enumerator.more() && !done;)
         {
             const FieldDef& field = enumerator.next();
+            const auto type = field.type.id;
 
             if (detail::ReadFieldOmitted(_input))
             {
-                transform.OmittedField(field.id, field.metadata, field.type.id);
+                transform.OmittedField(field.id, field.metadata, type);
                 continue;
             }
-
-            if (field.type.id == bond::BT_STRUCT
-                || field.type.id == bond::BT_LIST
-                || field.type.id == bond::BT_SET
-                || field.type.id == bond::BT_MAP)
+            
+            if (type == bond::BT_STRUCT || type == bond::BT_LIST || type == bond::BT_SET || type == bond::BT_MAP)
             {
                 done = detail::Field(field, schema, transform, _input);
             }
             else
             {
-                done = detail::BasicTypeField(field.id, field.metadata, field.type.id, transform, _input);
+                done = detail::BasicTypeField(field.id, field.metadata, type, transform, _input);
             }
         }
 
@@ -497,21 +495,19 @@ private:
         for (const_enumerator<std::vector<FieldDef> > enumerator(schema.GetStruct().fields); enumerator.more() && !done;)
         {
             const FieldDef& fieldDef = enumerator.next();
+            const auto type = fieldDef.type.id;
 
-            if (const typename Reader::Field* field = _input.FindField(fieldDef.id, fieldDef.metadata, fieldDef.type.id))
+            if (const typename Reader::Field* field = _input.FindField(fieldDef.id, fieldDef.metadata, type))
             {
                 Reader input(_input, *field);
 
-                if (fieldDef.type.id == BT_STRUCT
-                    || fieldDef.type.id == BT_LIST
-                    || fieldDef.type.id == BT_SET
-                    || fieldDef.type.id == BT_MAP)
+                if (type == bond::BT_STRUCT || type == bond::BT_LIST || type == bond::BT_SET || type == bond::BT_MAP)
                 {
                     done = detail::Field(fieldDef, schema, transform, input);
                 }
                 else
                 {
-                    done = detail::BasicTypeField(fieldDef.id, fieldDef.metadata, fieldDef.type.id, transform, input);
+                    done = detail::BasicTypeField(fieldDef.id, fieldDef.metadata, type, transform, input);
                 }
             }
         }

--- a/cpp/inc/bond/core/parser.h
+++ b/cpp/inc/bond/core/parser.h
@@ -142,18 +142,9 @@ private:
 
 
     template <typename T, typename Transform>
-    typename boost::enable_if<is_reader<Input, T>, bool>::type
-    NextField(const T& field, const Transform& transform)
+    bool NextField(const T& field, const Transform& transform)
     {
         return detail::Field(field, transform, _input);
-    }
-
-
-    template <typename T, typename Transform>
-    typename boost::disable_if<is_reader<Input, T>, bool>::type
-    NextField(const T&, const Transform& transform)
-    {
-        return transform.Field(T::id, T::metadata, T::GetVariable(_input));
     }
 
 

--- a/cpp/inc/bond/core/parser.h
+++ b/cpp/inc/bond/core/parser.h
@@ -121,7 +121,7 @@ private:
         if (detail::ReadFieldOmitted(_input))
             detail::OmittedField(Head(), transform);
         else
-            if (bool done = NextField(Head(), transform))
+            if (bool done = detail::Field(Head(), transform, _input))
                 return done;
 
         return ReadFields(typename boost::mpl::next<Fields>::type(), transform);
@@ -134,17 +134,10 @@ private:
     {
         typedef typename boost::mpl::deref<Fields>::type Head;
 
-        if (bool done = NextField(Head(), transform))
+        if (bool done = detail::Field(Head(), transform, _input))
             return done;
 
         return ReadFields(typename boost::mpl::next<Fields>::type(), transform);
-    }
-
-
-    template <typename T, typename Transform>
-    bool NextField(const T& field, const Transform& transform)
-    {
-        return detail::Field(field, transform, _input);
     }
 
 
@@ -276,7 +269,7 @@ private:
             if (Head::id == id && get_type_id<typename Head::field_type>::value == type)
             {
                 // Exact match
-                NextField(Head(), transform);
+                detail::Field(Head(), transform, _input)
             }
             else if (Head::id >= id && type != bond::BT_STOP && type != bond::BT_STOP_BASE)
             {
@@ -312,13 +305,6 @@ private:
         {
             UnknownField(id, type, transform);
         }
-    }
-
-
-    template <typename T, typename Transform>
-    bool NextField(const T& field, const Transform& transform)
-    {
-        return detail::Field(field, transform, _input);
     }
 
 
@@ -489,7 +475,7 @@ private:
                 std::is_enum<typename Head::field_type>::value))
         {
             Reader input(_input, *field);
-            NextField(Head(), transform, input);
+            detail::Field(Head(), transform, input)
         }
 
         return ReadFields(typename boost::mpl::next<Fields>::type(), transform);
@@ -499,13 +485,6 @@ private:
     bool ReadFields(const boost::mpl::l_iter<boost::mpl::l_end>&, const Transform&)
     {
         return false;
-    }
-
-
-    template <typename T, typename Transform>
-    bool NextField(const T& field, const Transform& transform, Input input)
-    {
-        return detail::Field(field, transform, input);
     }
 
 

--- a/cpp/inc/bond/core/parser.h
+++ b/cpp/inc/bond/core/parser.h
@@ -475,7 +475,7 @@ private:
                 std::is_enum<typename Head::field_type>::value))
         {
             Reader input(_input, *field);
-            detail::Field(Head(), transform, input)
+            detail::Field(Head(), transform, input);
         }
 
         return ReadFields(typename boost::mpl::next<Fields>::type(), transform);

--- a/cpp/inc/bond/core/parser.h
+++ b/cpp/inc/bond/core/parser.h
@@ -142,26 +142,18 @@ private:
 
 
     template <typename T, typename Transform>
-    typename boost::enable_if_c<is_reader<Input>::value && !is_nested_field<T>::value, bool>::type
+    typename boost::enable_if<is_reader<Input, T>, bool>::type
     NextField(const T& field, const Transform& transform)
     {
-        return detail::Field(field, transform, value<typename T::field_type, Input>(_input));
-    }
-
-
-    template <typename T, typename Transform>
-    typename boost::enable_if_c<is_reader<Input>::value && is_nested_field<T>::value, bool>::type
-    NextField(const T& field, const Transform& transform)
-    {
-        return detail::Field(field, transform, bonded<typename T::field_type, Input>(_input));
+        return detail::Field(field, transform, _input);
     }
 
 
     template <typename T, typename Transform>
     typename boost::disable_if<is_reader<Input, T>, bool>::type
-    NextField(const T&, const Transform& transform)
+    NextField(const T& field, const Transform& transform)
     {
-        return transform.Field(T::id, T::metadata, T::GetVariable(_input));
+        return detail::Field(field, transform, T::GetVariable(_input));
     }
 
 
@@ -333,18 +325,9 @@ private:
 
 
     template <typename T, typename Transform>
-    typename boost::enable_if<is_nested_field<T>, bool>::type
-    NextField(const T& field, const Transform& transform)
+    bool NextField(const T& field, const Transform& transform)
     {
-        return detail::Field(field, transform, bonded<typename T::field_type, Input>(_input));
-    }
-
-
-    template <typename T, typename Transform>
-    typename boost::disable_if<is_nested_field<T>, bool>::type
-    NextField(const T& field, const Transform& transform)
-    {
-        return detail::Field(field, transform, value<typename T::field_type, Input>(_input));
+        return detail::Field(field, transform, _input);
     }
 
 
@@ -529,18 +512,9 @@ private:
 
 
     template <typename T, typename Transform>
-    typename boost::enable_if<is_nested_field<T>, bool>::type
-    NextField(const T& field, const Transform& transform, Input input)
+    bool NextField(const T& field, const Transform& transform, Input input)
     {
-        return detail::Field(field, transform, bonded<typename T::field_type, Input>(input));
-    }
-
-
-    template <typename T, typename Transform>
-    typename boost::disable_if<is_nested_field<T>, bool>::type
-    NextField(const T& field, const Transform& transform, Input input)
-    {
-        return detail::Field(field, transform, value<typename T::field_type, Input>(input));
+        return detail::Field(field, transform, input);
     }
 
 

--- a/cpp/inc/bond/core/parser.h
+++ b/cpp/inc/bond/core/parser.h
@@ -182,13 +182,12 @@ private:
                 continue;
             }
 
-            if (field.type.id == bond::BT_STRUCT)
+            if (field.type.id == bond::BT_STRUCT
+                || field.type.id == bond::BT_LIST
+                || field.type.id == bond::BT_SET
+                || field.type.id == bond::BT_MAP)
             {
-                done = transform.Field(field.id, field.metadata, bonded<void, Input>(_input, RuntimeSchema(schema, field)));
-            }
-            else if (field.type.id == bond::BT_LIST || field.type.id == bond::BT_SET || field.type.id == bond::BT_MAP)
-            {
-                done = transform.Field(field.id, field.metadata, value<void, Input>(_input, RuntimeSchema(schema, field)));
+                done = detail::Field(field, schema, transform, _input);
             }
             else
             {
@@ -404,19 +403,11 @@ private:
             {
                 const FieldDef& field = *it++;
 
-                if (type == bond::BT_STRUCT)
+                if (type == bond::BT_STRUCT || type == bond::BT_LIST || type == bond::BT_SET || type == bond::BT_MAP)
                 {
                     if (field.type.id == type)
                     {
-                        transform.Field(id, field.metadata, bonded<void, Input>(_input, RuntimeSchema(schema, field)));
-                        continue;
-                    }
-                }
-                else if (type == bond::BT_LIST || type == bond::BT_SET || type == bond::BT_MAP)
-                {
-                    if (field.type.id == type)
-                    {
-                        transform.Field(id, field.metadata, value<void, Input>(_input, RuntimeSchema(schema, field)));
+                        detail::Field(field, schema, transform, _input);
                         continue;
                     }
                 }
@@ -567,12 +558,17 @@ private:
             {
                 Reader input(_input, *field);
 
-                if (fieldDef.type.id == BT_STRUCT)
-                    done = transform.Field(fieldDef.id, fieldDef.metadata, bonded<void, Input>(input, RuntimeSchema(schema, fieldDef)));
-                else if (fieldDef.type.id == BT_LIST || fieldDef.type.id == BT_SET || fieldDef.type.id == BT_MAP)
-                    done = transform.Field(fieldDef.id, fieldDef.metadata, value<void, Input>(input, RuntimeSchema(schema, fieldDef)));
+                if (fieldDef.type.id == BT_STRUCT
+                    || fieldDef.type.id == BT_LIST
+                    || fieldDef.type.id == BT_SET
+                    || fieldDef.type.id == BT_MAP)
+                {
+                    done = detail::Field(fieldDef, schema, transform, input);
+                }
                 else
+                {
                     done = detail::BasicTypeField(fieldDef.id, fieldDef.metadata, fieldDef.type.id, transform, input);
+                }
             }
         }
 


### PR DESCRIPTION
The change adds a helper `detail::Field` that deals with calling into the correct version of `Field` of the provided Transform.
This also fixes the broken move constructor of `bond::bonded<T, Reader&>`.