### PR TITLE
[c++ grpc] Don't ignore dirty grpc submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,6 @@
 [submodule "thirdparty/grpc"]
     path = thirdparty/grpc
     url = https://github.com/grpc/grpc.git
-    # When using CMake to build, the zlib submodule inside of the grpc
-    # submodule ends up with a generated file that makes Git consider
-    # the submodule dirty.
-    ignore = dirty
 
 [submodule "thirdparty/rapidjson"]
     path = thirdparty/rapidjson


### PR DESCRIPTION
The grpc submodule itself now marks it's zlib submodule as "ignore =
dirty", so we no longer have to do that for grpc just to ignore zlib.