### PR TITLE
travis: Pull down git tags before starting the build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
     - FLAVOR="java"
 
 before_install:
-    - CI_BUILD_IMAGE=bondciimages.azurecr.io/ubuntu-1604:build-10674409
+    - CI_BUILD_IMAGE=bondciimages.azurecr.io/ubuntu-1604:build-11401554
     - if [ "$TRAVIS_OS_NAME" == "linux" ]; then echo "Hardware:"; grep model\ name /proc/cpuinfo | uniq -c; free -m; fi
     - travis_retry docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" bondciimages.azurecr.io
     - time travis_retry docker pull $CI_BUILD_IMAGE

--- a/tools/ci-scripts/linux/build_java.zsh
+++ b/tools/ci-scripts/linux/build_java.zsh
@@ -2,6 +2,13 @@
 
 set -eux
 
+# Java needs git tags to detect the version it's building. If we haven't
+# released in a while, the last tag might be many commits back, so we'll fetch
+# the entire history here.
+pushd $BOND_ROOT
+git fetch --unshallow --tags
+popd
+
 # Install gbc.
 cmake \
     -DBOND_ENABLE_JAVA=TRUE \

--- a/tools/ci-scripts/linux/build_java.zsh
+++ b/tools/ci-scripts/linux/build_java.zsh
@@ -19,12 +19,6 @@ cmake \
     $BOND_ROOT
 make install
 
-# Try to debug failures on travis.
-make gradle-plugin
-find ~/.m2
-cat ~/.m2/repository/org/bondlib/bond-gradle/maven-metadata-local.xml
-cat ~/.m2/repository/org/bondlib/bond-gradle/*/bond-gradle*.pom
-
 # Build and test all Java components.
 make java
 


### PR DESCRIPTION
Without this, Java will automatically configure a version string equal
to the checked-out hash prefix, which has a 6/16 chance of starting with
a letter instead of a number. Gradle doesn't seem to resolve
dependencies properly when this happens.