### PR TITLE
[c#] Handle gbc from path on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ different versioning scheme, following the Haskell community's
     * This version include a number of memory leak fixes that users of Bond-over-gRPC were encountering. [Issue #810](https://github.com/Microsoft/bond/issues/810)
 * `BondCodegen` items will now appear in the Visual Studio 2017+ UI in .NET
   Core projects.
+* Fixed a bug in the codegen targets when using `gbc` from $PATH on macOS
+  and Linux that prevented the C# compiler from finding the generated C#
+  files.
 
 ## 7.0.2: 2017-10-30 ##
 * `gbc` & compiler library: 0.10.1.0

--- a/cs/build/nuget/Common.targets
+++ b/cs/build/nuget/Common.targets
@@ -72,6 +72,18 @@
     <UpToDateCheckInput Include="$(_PreExistingBondExe)" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <!--Automatic directory separator translation doesn't work on
+         BondOutputDirectory, as sometimes it doesn't exist, so MSBuild
+         doesn't know it's a "path-like" thing. We unconditionally translate
+         to forward slashes, as they work Windows, macOS, and Linux. We also
+         ensure that this always has a trailing slash, which simplifies its
+         use later. -->
+    <_BondOutputDirectoryNormalized>$(BondOutputDirectory)</_BondOutputDirectoryNormalized>
+    <_BondOutputDirectoryNormalized Condition=" !HasTrailingSlash('$(_BondOutputDirectoryNormalized)') ">$(BondOutputDirectory)\</_BondOutputDirectoryNormalized>
+    <_BondOutputDirectoryNormalized>$(_BondOutputDirectoryNormalized.Replace('%5C', '%2F'))</_BondOutputDirectoryNormalized>
+  </PropertyGroup>
+
   <!-- Fail the build if there are duplicate items in @BondCodegen. This is
        unlikely in classic project files, but is likely to be encountered
        when migrating to .NET Core project files. Without a check like this,
@@ -119,14 +131,14 @@
        re-run. -->
   <Target Name="BondCodegenCs"
           Inputs="$(_PreExistingBondExe);@(BondCodegen)"
-          Outputs="$(BondOutputDirectory)\bondcodegen.done"
+          Outputs="$(_BondOutputDirectoryNormalized)bondcodegen.done"
           BeforeTargets="CoreCompile"
           Condition="'@(BondCodegen)' != ''">
 
     <Error Text="Neither Bond.CSharp.props nor Bond.Compiler.CSharp.props was imported. Check that your NuGet package references are working properly."
            Condition="'$(_bond_common_props_imported)' != 'true'" />
 
-    <MakeDir Directories="$(BondOutputDirectory)" />
+    <MakeDir Directories="$(_BondOutputDirectoryNormalized)" />
 
     <!-- just for a simpler commandline read -->
     <PropertyGroup>
@@ -134,7 +146,7 @@
       <_BondExe Condition="Exists('$(BOND_COMPILER_PATH)\gbc.exe')">$(BOND_COMPILER_PATH)\gbc.exe</_BondExe>
       <_BondExe Condition="Exists('$(BOND_COMPILER_PATH)\gbc')">$(BOND_COMPILER_PATH)\gbc</_BondExe>
       <_BondImportDirs>--import-dir="$(BOND_INCLUDE_PATH)" @(BondImportDirectory -> '--import-dir=&quot;%(Identity)\.&quot;',' ')</_BondImportDirs>
-      <_BondCommand>&quot;$(_BondExe)&quot; $(BondCodegenMode) $(_BondImportDirs) --jobs=-2 --namespace=bond=Bond --output-dir="$(BondOutputDirectory)\."</_BondCommand>
+      <_BondCommand>&quot;$(_BondExe)&quot; $(BondCodegenMode) $(_BondImportDirs) --jobs=-2 --namespace=bond=Bond --output-dir="$(_BondOutputDirectoryNormalized)"</_BondCommand>
     </PropertyGroup>
 
     <!-- We'll optimize to generate in a single command where possible -->
@@ -143,11 +155,11 @@
       <_BondCodegenWithDefaultOptions Include="@(BondCodegen)" Condition="'%(BondCodegen.Options)' == ''" />
     </ItemGroup>
 
-    <WriteLinesToFile File="$(BondOutputDirectory)\bonddefaultcodegen.in"
+    <WriteLinesToFile File="$(_BondOutputDirectoryNormalized)bonddefaultcodegen.in"
                       Lines="@(_BondCodegenWithDefaultOptions)"
                       Overwrite="true" />
 
-    <Exec Command="$(_BondCommand) $(BondOptions) @&quot;$(BondOutputDirectory)\bonddefaultcodegen.in&quot;"
+    <Exec Command="$(_BondCommand) $(BondOptions) @&quot;$(_BondOutputDirectoryNormalized)bonddefaultcodegen.in&quot;"
           Condition="'@(_BondCodegenWithDefaultOptions)' != ''" />
 
     <!-- And for any files needing custom options we'll have to generate one by one -->
@@ -155,7 +167,7 @@
           Condition="'%(BondCodegen.Options)' != ''" />
 
     <!-- Record all that we successfully ran codegen on all the files. -->
-    <WriteLinesToFile File="$(BondOutputDirectory)\bondcodegen.done"
+    <WriteLinesToFile File="$(_BondOutputDirectoryNormalized)bondcodegen.done"
                       Lines="#Ran codegen on the following files:;@(BondCodegen)"
                       Overwrite="true" />
   </Target>
@@ -170,7 +182,7 @@
 
     <ItemGroup>
       <_BondGen_Structs_BondOptions
-          Include="@(BondCodegen -> '$(BondOutputDirectory)\%(FileName)_types.cs')"
+          Include="@(BondCodegen -> '$(_BondOutputDirectoryNormalized)%(FileName)_types.cs')"
           Condition="'%(BondCodegen.Options)' == ''
                      AND !$(BondOptions.Contains('--structs=false'))">
         <AutoGen>true</AutoGen>
@@ -178,7 +190,7 @@
       </_BondGen_Structs_BondOptions>
 
       <_BondGen_Structs_Options
-          Include="@(BondCodegen -> '$(BondOutputDirectory)\%(FileName)_types.cs')"
+          Include="@(BondCodegen -> '$(_BondOutputDirectoryNormalized)%(FileName)_types.cs')"
           Condition="'%(BondCodegen.Options)' != ''
                      AND !$([System.String]::new('%(BondCodegen.Options)').Contains('--structs=false'))">
         <AutoGen>true</AutoGen>
@@ -186,7 +198,7 @@
       </_BondGen_Structs_Options>
 
       <_BondGen_Grpc_BondOptions
-          Include="@(_BondCodegenWithDefaultOptions -> '$(BondOutputDirectory)\%(FileName)_grpc.cs')"
+          Include="@(_BondCodegenWithDefaultOptions -> '$(_BondOutputDirectoryNormalized)%(FileName)_grpc.cs')"
           Condition="$(BondOptions.Contains('--grpc'))
                      AND !$(BondOptions.Contains('--grpc=false'))">
         <AutoGen>true</AutoGen>
@@ -194,7 +206,7 @@
       </_BondGen_Grpc_BondOptions>
 
       <_BondGen_Grpc_Options
-          Include="@(BondCodegen -> '$(BondOutputDirectory)\%(FileName)_grpc.cs')"
+          Include="@(BondCodegen -> '$(_BondOutputDirectoryNormalized)%(FileName)_grpc.cs')"
           Condition="$([System.String]::new('%(BondCodegen.Options)').Contains('--grpc'))
                      AND !$([System.String]::new('%(BondCodegen.Options)').Contains('--grpc=false'))">
         <AutoGen>true</AutoGen>
@@ -212,8 +224,8 @@
         * MsBuild wants to keep track of all our outputs, to understand how to clean build.  It seems it
         * needs to know all of them regardless of what we actually produced THIS build, so adding always.
       -->
-      <FileWrites Include="$(BondOutputDirectory)\bondcodegen.done;
-                           $(BondOutputDirectory)\bonddefaultcodegen.in;
+      <FileWrites Include="$(_BondOutputDirectoryNormalized)bondcodegen.done;
+                           $(_BondOutputDirectoryNormalized)bonddefaultcodegen.in;
                            @(_BondGeneratedFileNames)" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
On macOS (and likely Linux), when gbc was not found under
BOND_COMPILER_DIRECTORY--typically when it was found on $PATH--the
output directory for the generated C# files ended up having inconsistent
directory separator translation applied to it.

gbc was invoked with an output directory like
`--output-dir="obj/Debug/net45/\."`, which placed the generated files in
a directory *under* `net45` named `\.`. However, when csc was invoked,
it was given generated file paths like `obj/Debug/net45//foo_types.cs`,
which did not exist, causing compilation to fail.

This inconsistency occurred because when the command line for gbc from
$PATH was constructed, none of the elements look like a path, so MSBuild
didn't translate the trailing `\.` added to the output-dir argument:

    <_BondCommand>&quot;$(_BondExe)&quot; $(BondCodegenMode) $(_BondImportDirs) --jobs=-2 --namespace=bond=Bond --output-dir="$(BondOutputDirectory)\."</_BondCommand>

The `\.` was added to guard against $(BondOutputDirectory) ending with a
slash and then having CMD treat a string like
`--output-dir="obj\Debug\net45\"` as having an escaped double-quote in
it.

When gbc came from BOND_COMPILER_PATH, it looked like a path, so the
added `\.` got translated to `/.`

As a fix, the codegen targets now use $(_BondOutputDirectoryNormalized),
which always has a trailing slash and always uses forward slashes.
Windows, macOS, and Linux can all handle forward slashes for paths.