### PR TITLE
[c#] Fully strong-name sign .NET Core assemblies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ different versioning scheme, following the Haskell community's
     * This version include a number of memory leak fixes that users of Bond-over-gRPC were encountering. [Issue #810](https://github.com/Microsoft/bond/issues/810)
 * `BondCodegen` items will now appear in the Visual Studio 2017+ UI in .NET
   Core projects.
+* The .NET Standard assemblies are fully strong-name signed. Previously,
+  they were inadvertently only public strong-name signed.
 
 ## 7.0.2: 2017-10-30 ##
 * `gbc` & compiler library: 0.10.1.0

--- a/cs/dnc/src/attributes/project.json
+++ b/cs/dnc/src/attributes/project.json
@@ -20,15 +20,13 @@
         "debug": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": false,
-                "publicSign": true
+                "optimize": false
             }
         },
         "release": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": true,
-                "publicSign": true
+                "optimize": true
             }
         }
     },

--- a/cs/dnc/src/core/project.json
+++ b/cs/dnc/src/core/project.json
@@ -28,15 +28,13 @@
         "debug": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": false,
-                "publicSign": true
+                "optimize": false
             }
         },
         "release": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": true,
-                "publicSign": true
+                "optimize": true
             }
         }
     },

--- a/cs/dnc/src/grpc/project.json
+++ b/cs/dnc/src/grpc/project.json
@@ -20,15 +20,13 @@
         "debug": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": false,
-                "publicSign": true
+                "optimize": false
             }
         },
         "release": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": true,
-                "publicSign": true
+                "optimize": true
             }
         }
     },

--- a/cs/dnc/src/io/project.json
+++ b/cs/dnc/src/io/project.json
@@ -21,15 +21,13 @@
         "debug": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": false,
-                "publicSign": true
+                "optimize": false
             }
         },
         "release": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": true,
-                "publicSign": true
+                "optimize": true
             }
         }
     },

--- a/cs/dnc/src/json/project.json
+++ b/cs/dnc/src/json/project.json
@@ -22,15 +22,13 @@
         "debug": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": false,
-                "publicSign": true
+                "optimize": false
             }
         },
         "release": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": true,
-                "publicSign": true
+                "optimize": true
             }
         }
     },

--- a/cs/dnc/src/reflection/project.json
+++ b/cs/dnc/src/reflection/project.json
@@ -20,15 +20,13 @@
         "debug": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": false,
-                "publicSign": true
+                "optimize": false
             }
         },
         "release": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": true,
-                "publicSign": true
+                "optimize": true
             }
         }
     },

--- a/cs/dnc/test/codegen/no-warnings.tests/project.json
+++ b/cs/dnc/test/codegen/no-warnings.tests/project.json
@@ -18,15 +18,13 @@
         "debug": {
             "buildOptions": {
                 "keyFile": "../../../../build/internal/bond.snk",
-                "optimize": false,
-                "publicSign": true
+                "optimize": false
             }
         },
         "release": {
             "buildOptions": {
                 "keyFile": "../../../../build/internal/bond.snk",
-                "optimize": true,
-                "publicSign": true
+                "optimize": true
             }
         }
     },

--- a/cs/dnc/test/compat/compat.core.tests/project.json
+++ b/cs/dnc/test/compat/compat.core.tests/project.json
@@ -21,15 +21,13 @@
         "debug": {
             "buildOptions": {
                 "keyFile": "../../../../build/internal/bond.snk",
-                "optimize": false,
-                "publicSign": true
+                "optimize": false
             }
         },
         "release": {
             "buildOptions": {
                 "keyFile": "../../../../build/internal/bond.snk",
-                "optimize": true,
-                "publicSign": true
+                "optimize": true
             }
         }
     },

--- a/cs/dnc/test/core.tests/project.json
+++ b/cs/dnc/test/core.tests/project.json
@@ -20,15 +20,13 @@
         "debug": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": false,
-                "publicSign": true
+                "optimize": false
             }
         },
         "release": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": true,
-                "publicSign": true
+                "optimize": true
             }
         }
     },

--- a/cs/dnc/test/expressions.tests/project.json
+++ b/cs/dnc/test/expressions.tests/project.json
@@ -21,15 +21,13 @@
         "debug": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": false,
-                "publicSign": true
+                "optimize": false
             }
         },
         "release": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": true,
-                "publicSign": true
+                "optimize": true
             }
         }
     },

--- a/cs/dnc/test/grpc.tests/project.json
+++ b/cs/dnc/test/grpc.tests/project.json
@@ -19,15 +19,13 @@
         "debug": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": false,
-                "publicSign": true
+                "optimize": false
             }
         },
         "release": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": true,
-                "publicSign": true
+                "optimize": true
             }
         }
     },

--- a/cs/dnc/test/internal.tests/project.json
+++ b/cs/dnc/test/internal.tests/project.json
@@ -20,15 +20,13 @@
         "debug": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": false,
-                "publicSign": true
+                "optimize": false
             }
         },
         "release": {
             "buildOptions": {
                 "keyFile": "../../../build/internal/bond.snk",
-                "optimize": true,
-                "publicSign": true
+                "optimize": true
             }
         }
     },


### PR DESCRIPTION
Previously, we were just [public signing][1] the .NET Core assemblies.
We intended to fully strong-name sign them, so this commit removes the
"publicSign": true entry from the project files.

[1]: https://github.com/dotnet/roslyn/commit/ca61bad288c1d2e216281680fe92ff55d7122e7f