### PR TITLE
[gbc] Add debug/release Haskell configurations

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -12,9 +12,29 @@ function (add_stack_build target)
     set (flagArgs ENABLE_TESTS)
     set (multiValueArgs SOURCES DEPENDS)
     cmake_parse_arguments (arg "${flagArgs}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
     if (${arg_ENABLE_TESTS})
         set (options "--test")
     endif()
+
+    list (APPEND options $<$<CONFIG:Debug>:--fast>)
+    list (APPEND options $<$<CONFIG:Debug>:--no-executable-stripping>)
+    list (APPEND options $<$<CONFIG:Debug>:--no-library-stripping>)
+    list (APPEND options $<$<CONFIG:Debug>:--no-strip>)
+
+    list (APPEND options $<$<CONFIG:MinSizeRel>:--executable-stripping>)
+    list (APPEND options $<$<CONFIG:MinSizeRel>:--library-stripping>)
+    list (APPEND options $<$<CONFIG:MinSizeRel>:--split-objs>)
+
+    list (APPEND options $<$<CONFIG:Release>:--executable-stripping>)
+    list (APPEND options $<$<CONFIG:Release>:--library-stripping>)
+
+    list (APPEND options $<$<CONFIG:RelWithDebInfo>:--no-executable-stripping>)
+    list (APPEND options $<$<CONFIG:RelWithDebInfo>:--no-library-stripping>)
+    list (APPEND options $<$<CONFIG:RelWithDebInfo>:--no-strip>)
+
+    list (APPEND options $<$<NOT:$<CONFIG:Debug>>:--ghc-options=-O2>)
+
     add_custom_command (
         DEPENDS ${arg_SOURCES}
         COMMAND ${CMAKE_COMMAND}
@@ -22,7 +42,7 @@ function (add_stack_build target)
             -N
             -Dbuild_dir=${CMAKE_CURRENT_BINARY_DIR}
             -Dtarget=${target}
-            -Dstack_options=${options}
+            "-Dstack_options=${options}"
             -P stack_build.cmake
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/build/${target}/${target}${CMAKE_EXECUTABLE_SUFFIX})

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -17,23 +17,27 @@ function (add_stack_build target)
         set (options "--test")
     endif()
 
+    # If unspecified, turn off optimizations
+    list (APPEND options $<$<CONFIG:>:--fast>)
+
     list (APPEND options $<$<CONFIG:Debug>:--fast>)
     list (APPEND options $<$<CONFIG:Debug>:--no-executable-stripping>)
     list (APPEND options $<$<CONFIG:Debug>:--no-library-stripping>)
     list (APPEND options $<$<CONFIG:Debug>:--no-strip>)
 
     list (APPEND options $<$<CONFIG:MinSizeRel>:--executable-stripping>)
+    list (APPEND options $<$<CONFIG:MinSizeRel>:--ghc-options=-O2>)
     list (APPEND options $<$<CONFIG:MinSizeRel>:--library-stripping>)
     list (APPEND options $<$<CONFIG:MinSizeRel>:--split-objs>)
 
     list (APPEND options $<$<CONFIG:Release>:--executable-stripping>)
+    list (APPEND options $<$<CONFIG:Release>:--ghc-options=-O2>)
     list (APPEND options $<$<CONFIG:Release>:--library-stripping>)
 
+    list (APPEND options $<$<CONFIG:RelWithDebInfo>:--ghc-options=-O2>)
     list (APPEND options $<$<CONFIG:RelWithDebInfo>:--no-executable-stripping>)
     list (APPEND options $<$<CONFIG:RelWithDebInfo>:--no-library-stripping>)
     list (APPEND options $<$<CONFIG:RelWithDebInfo>:--no-strip>)
-
-    list (APPEND options $<$<NOT:$<CONFIG:Debug>>:--ghc-options=-O2>)
 
     add_custom_command (
         DEPENDS ${arg_SOURCES}
@@ -42,7 +46,7 @@ function (add_stack_build target)
             -N
             -Dbuild_dir=${CMAKE_CURRENT_BINARY_DIR}
             -Dtarget=${target}
-            "-Dstack_options=${options}"
+            "\"-Dstack_options=${options}\""
             -P stack_build.cmake
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/build/${target}/${target}${CMAKE_EXECUTABLE_SUFFIX})

--- a/compiler/stack_build.cmake
+++ b/compiler/stack_build.cmake
@@ -21,10 +21,8 @@ if (error)
     message (FATAL_ERROR ${setup_output})
 endif()
 
-set (buildGhcOptions "-O2")
-
 execute_process (
-    COMMAND ${STACK_EXECUTABLE} ${BOND_STACK_OPTIONS} build :${target} --no-run-tests ${stack_options} --ghc-options=${buildGhcOptions}
+    COMMAND ${STACK_EXECUTABLE} ${BOND_STACK_OPTIONS} build :${target} --no-run-tests ${stack_options}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     RESULT_VARIABLE error)
 

--- a/cs/Compiler.csproj
+++ b/cs/Compiler.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="$(MSBuildExtensionsPath32)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath32)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -9,6 +9,24 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Compiler</RootNamespace>
     <AssemblyName>Compiler</AssemblyName>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Set the CMake build type to use when building gbc. Options are Debug,
+         MinSizeRel, Release, and RelWithDebInfo.
+
+         The default mapping is:
+         * MSBuild Debug -> CMake Debug
+         * MSbuild Release -> CMake RelWithDebInfo
+
+         WARNING: the CMake MinSizeRel build will likely increase your build
+         time by over an hour and only works if you also delete you Stack
+         snapshots first.
+    -->
+    <BondCompilerCMakeBuildType
+        Condition=" ('$(BondCompilerCMakeBuildType)' == '') And ('$(Configuration)' == 'Release') ">RelWithDebInfo</BondCompilerCMakeBuildType>
+    <BondCompilerCMakeBuildType
+        Condition=" ('$(BondCompilerCMakeBuildType)' == '') And ('$(Configuration)' != 'Release') ">Debug</BondCompilerCMakeBuildType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -66,8 +84,8 @@
     <MakeDir Directories="$(IntermediateOutputPath)" />
 
     <Exec Command="cmake $(ProjectDir)\..\compiler -Wno-dev" WorkingDirectory="$(IntermediateOutputPath)" />
-    <Exec Command="cmake --build . --target gbc" WorkingDirectory="$(IntermediateOutputPath)" />
-    
+    <Exec Command="cmake --build . --config $(BondCompilerCMakeBuildType) --target gbc" WorkingDirectory="$(IntermediateOutputPath)" />
+
     <Copy SourceFiles="$(IntermediateOutputPath)\build\gbc\gbc.exe" DestinationFolder="$(ProjectDir)\tools\" />
   </Target>
 


### PR DESCRIPTION
We were always building gbc with GHC optimizations turned on. We can get
faster build times for things like CI if we don't build with optimizations.

To do that, we now pass different stack & gbc options for the various
CMake build types. The MSBuild Compiler.csproj project translates
MSBuild configurations into CMake configurations.