### PR TITLE
[c++ travis] Split C++ build into its own scripts

### DIFF
--- a/tools/ci-scripts/linux/build.zsh
+++ b/tools/ci-scripts/linux/build.zsh
@@ -7,8 +7,8 @@ FLAVOR=$2
 BOOST=${3:-}
 COMPILER=${4:-clang}
 
-export BOND_ROOT=/root/bond
-export BUILD_ROOT=/root/build
+BOND_ROOT=/root/bond
+BUILD_ROOT=/root/build
 BUILD_SCRIPTS=$BOND_ROOT/tools/ci-scripts/linux
 
 # We set our cflags in non-standard variables because Stack chokes on some
@@ -17,21 +17,21 @@ case "$COMPILER" in
     clang)
         export CXX=clang++
         export CC=clang
-        export BOND_CXX_FLAGS="-Qunused-arguments --system-header-prefix=boost/"
-        export BOND_CC_FLAGS="-Qunused-arguments --system-header-prefix=boost/"
+        BOND_CXX_FLAGS="-Qunused-arguments --system-header-prefix=boost/"
+        BOND_CC_FLAGS="-Qunused-arguments --system-header-prefix=boost/"
         ;;
 
     gcc)
         export CXX=g++
         export CC=gcc
-        export BOND_CXX_FLAGS=
-        export BOND_CC_FLAGS=
+        BOND_CXX_FLAGS=
+        BOND_CC_FLAGS=
         ;;
 
     *) echo "Unknown compiler $COMPILER"; exit 1;;
 esac
 
-export BOND_CMAKE_FLAGS="-DBOND_USE_CCACHE=TRUE"
+BOND_CMAKE_FLAGS="-DBOND_USE_CCACHE=TRUE"
 # Default boost root. C++ requires a specific boost and will override this.
 export BOOST_ROOT=/opt/boosts/boost_1_63_0
 
@@ -41,31 +41,10 @@ ln -s /root/.stack $SYMLINKED_HOME/.stack
 
 cd $BUILD_ROOT
 
-case "$FLAVOR" in
-    cpp-*)
-        case "$FLAVOR" in
-            cpp-core) BOND_CMAKE_FLAGS="$BOND_CMAKE_FLAGS -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_ENABLE_GRPC=FALSE";;
-            cpp-grpc) BOND_CMAKE_FLAGS="$BOND_CMAKE_FLAGS -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DgRPC_ZLIB_PROVIDER=package";;
-            *) echo "Unknown FLAVOR=$FLAVOR"; exit 1;;
-        esac
-
-        if [ ! $BOOST ]; then echo "BOOST not specified"; exit 1; fi
-
-        export BOOST_ROOT=/opt/boosts/boost_`echo $BOOST | tr . _`
-
-        cmake -DBOND_STACK_OPTIONS="--allow-different-user" -DCMAKE_CXX_FLAGS="$BOND_CXX_FLAGS" -DCMAKE_C_FLAGS="$BOND_CC_FLAGS" ${=BOND_CMAKE_FLAGS} /root/bond
-
-        make --jobs 2 check
-        ;;
-
-    *)
-        # Flavors that have separate scripts.
-        local SCRIPT_PATH="$BUILD_SCRIPTS/build_$FLAVOR.zsh"
-        if [[ -e "$SCRIPT_PATH" ]]; then
-            zsh "$SCRIPT_PATH"
-        else
-            echo "Unknown FLAVOR $FLAVOR"
-            exit 1
-        fi
-        ;;
-esac
+local SCRIPT_PATH="$BUILD_SCRIPTS/build_$FLAVOR.zsh"
+if [[ -e "$SCRIPT_PATH" ]]; then
+    source "$SCRIPT_PATH"
+else
+    echo "Unknown FLAVOR $FLAVOR"
+    exit 1
+fi

--- a/tools/ci-scripts/linux/build.zsh
+++ b/tools/ci-scripts/linux/build.zsh
@@ -4,7 +4,7 @@ set -eux
 
 SYMLINKED_HOME=$1
 FLAVOR=$2
-BOOST=${3:-}
+BOOST=${3:-1.63.0}
 COMPILER=${4:-clang}
 
 BOND_ROOT=/root/bond
@@ -32,8 +32,9 @@ case "$COMPILER" in
 esac
 
 BOND_CMAKE_FLAGS="-DBOND_USE_CCACHE=TRUE"
-# Default boost root. C++ requires a specific boost and will override this.
-export BOOST_ROOT=/opt/boosts/boost_1_63_0
+# All of the CMake-based builds need BOOST_ROOT set, even if they don't
+# build any C++ code
+export BOOST_ROOT=/opt/boosts/boost_`echo $BOOST | tr . _`
 
 mkdir -p $SYMLINKED_HOME $BUILD_ROOT
 ln -s /root/.ccache $SYMLINKED_HOME/.ccache

--- a/tools/ci-scripts/linux/build_cpp-common.zsh
+++ b/tools/ci-scripts/linux/build_cpp-common.zsh
@@ -1,0 +1,15 @@
+#!/bin/zsh
+
+set -eux
+
+if [ ! $BOOST ]; then echo "BOOST not specified"; exit 1; fi
+
+export BOOST_ROOT=/opt/boosts/boost_`echo $BOOST | tr . _`
+
+cmake -DBOND_STACK_OPTIONS="--allow-different-user" \
+      -DCMAKE_CXX_FLAGS="$BOND_CXX_FLAGS" \
+      -DCMAKE_C_FLAGS="$BOND_CC_FLAGS" \
+      ${=BOND_CMAKE_FLAGS} \
+      /root/bond
+
+make --jobs 2 check

--- a/tools/ci-scripts/linux/build_cpp-common.zsh
+++ b/tools/ci-scripts/linux/build_cpp-common.zsh
@@ -2,10 +2,6 @@
 
 set -eux
 
-if [ ! $BOOST ]; then echo "BOOST not specified"; exit 1; fi
-
-export BOOST_ROOT=/opt/boosts/boost_`echo $BOOST | tr . _`
-
 cmake -DBOND_STACK_OPTIONS="--allow-different-user" \
       -DCMAKE_CXX_FLAGS="$BOND_CXX_FLAGS" \
       -DCMAKE_C_FLAGS="$BOND_CC_FLAGS" \

--- a/tools/ci-scripts/linux/build_cpp-core.zsh
+++ b/tools/ci-scripts/linux/build_cpp-core.zsh
@@ -1,0 +1,5 @@
+#!/bin/zsh
+
+set -eux
+BOND_CMAKE_FLAGS="$BOND_CMAKE_FLAGS -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_ENABLE_GRPC=FALSE"
+source "$BUILD_SCRIPTS/build_cpp-common.zsh"

--- a/tools/ci-scripts/linux/build_cpp-grpc.zsh
+++ b/tools/ci-scripts/linux/build_cpp-grpc.zsh
@@ -1,0 +1,5 @@
+#!/bin/zsh
+
+set -eux
+BOND_CMAKE_FLAGS="$BOND_CMAKE_FLAGS -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DgRPC_ZLIB_PROVIDER=package"
+source "$BUILD_SCRIPTS/build_cpp-common.zsh"


### PR DESCRIPTION
Splits the C++ build into its own set of scripts, like the other
flavors. This is in preperation for adding another C++ flavor: one that
builds with the gRPC master code instead of the current submodule
version.