### PR TITLE
[c#] Restore gRPC golden tests for gbc

### DIFF
--- a/compiler/tests/TestMain.hs
+++ b/compiler/tests/TestMain.hs
@@ -158,6 +158,20 @@ tests = testGroup "Compiler tests"
                 , "--namespace=tests=nsmapped"
                 ]
                 "basic_types_nsmapped"
+            , testGroup "Grpc"
+                [ verifyCsGrpcCodegen
+                    [ "c#"
+                    ]
+                    "service"
+                , verifyCsGrpcCodegen
+                    [ "c#"
+                    ]
+                    "generic_service"
+                , verifyCsGrpcCodegen
+                    [ "c#"
+                    ]
+                    "service_attributes"
+                ]
             ]
         , testGroup "Java"
             [ verifyJavaCodegen "attributes"

--- a/compiler/tests/Tests/Codegen.hs
+++ b/compiler/tests/Tests/Codegen.hs
@@ -11,6 +11,7 @@ module Tests.Codegen
     , verifyApplyCodegen
     , verifyExportsCodegen
     , verifyCsCodegen
+    , verifyCsGrpcCodegen
     , verifyJavaCodegen
     ) where
 
@@ -87,6 +88,20 @@ verifyCppGrpcCodegen args baseName =
         , grpc_cpp
         , types_cpp
         ]
+
+verifyCsGrpcCodegen :: [String] -> FilePath -> TestTree
+verifyCsGrpcCodegen args baseName =
+    testGroup baseName $
+        map (verifyFile (processOptions args) baseName csTypeMapping "")
+            [ grpc_cs
+            , types_cs Class (fieldMapping (processOptions args))
+            ]
+  where
+    fieldMapping Cs {..} = if readonly_properties
+        then ReadOnlyProperties
+        else if fields
+             then PublicFields
+             else Properties
 
 verifyFiles :: Options -> FilePath -> [TestTree]
 verifyFiles options baseName =


### PR DESCRIPTION
In commit 3221200462, the gRPC golden tests for gbc were accidentally
removed, as they were being done in a function called
`verifyCsCommCodegen`. This commit restores them.