### PR TITLE
Build gRPC++ using latest gRPC master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,17 +27,17 @@ env:
     - FLAVOR="cpp-grpc" BOOST="1.65.1" COMPILER="clang"
     - FLAVOR="cpp-grpc" BOOST="1.64.0" COMPILER="clang"
     - FLAVOR="cpp-grpc" BOOST="1.63.0" COMPILER="clang"
+    - FLAVOR="cpp-grpc-master" BOOST="1.66.0" COMPILER="clang" CRON_ONLY="true"
     - FLAVOR="hs"
     - FLAVOR="java"
 
-before_install:
+script:
+    - if [ "$CRON_ONLY" = "true" ] && [ "$TRAVIS_EVENT_TYPE" != "cron" ] ; then echo "Skipping cron-only job"; exit 0; fi
     - CI_BUILD_IMAGE=bondciimages.azurecr.io/ubuntu-1604:build-11401554
     - if [ "$TRAVIS_OS_NAME" == "linux" ]; then echo "Hardware:"; grep model\ name /proc/cpuinfo | uniq -c; free -m; fi
     - travis_retry docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" bondciimages.azurecr.io
     - time travis_retry docker pull $CI_BUILD_IMAGE
     - docker images # Dump the image ID
-
-script:
     - docker run -v $HOME/.ccache:/root/.ccache -v $HOME/.stack:/root/.stack -v `pwd`:/root/bond $CI_BUILD_IMAGE $HOME $FLAVOR $BOOST $COMPILER
     # docker runs as root and may leave files in the following directories that are not readable by the travis user
     - sudo chown -R travis:travis $HOME/.ccache $HOME/.stack `pwd`

--- a/tools/ci-scripts/linux/build_cpp-grpc-master.zsh
+++ b/tools/ci-scripts/linux/build_cpp-grpc-master.zsh
@@ -3,13 +3,12 @@
 set -eux
 
 # Get gRPC's current master
-cd "$BOND_ROOT/thirdparty/grpc"
+pushd "$BOND_ROOT/thirdparty/grpc"
 git fetch origin master
 git checkout origin/master
 git submodule sync --recursive
 git submodule update --recursive
-
-cd "$BUILD_ROOT"
+popd
 
 BOND_CMAKE_FLAGS="$BOND_CMAKE_FLAGS -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DgRPC_ZLIB_PROVIDER=package"
 source "$BUILD_SCRIPTS/build_cpp-common.zsh"

--- a/tools/ci-scripts/linux/build_cpp-grpc-master.zsh
+++ b/tools/ci-scripts/linux/build_cpp-grpc-master.zsh
@@ -1,0 +1,15 @@
+#!/bin/zsh
+
+set -eux
+
+# Get gRPC's current master
+cd "$BOND_ROOT/thirdparty/grpc"
+git fetch origin master
+git checkout origin/master
+git submodule sync --recursive
+git submodule update --recursive
+
+cd "$BUILD_ROOT"
+
+BOND_CMAKE_FLAGS="$BOND_CMAKE_FLAGS -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DgRPC_ZLIB_PROVIDER=package"
+source "$BUILD_SCRIPTS/build_cpp-common.zsh"


### PR DESCRIPTION
This build flavor builds Bond with the latest gRPC master branch so we
can detect potential breaks faster than when we upgrade our submodule.

This build flavor isn't needed on every commit or pull request, so it's
only enabled for Travis's cron builds.