### PR TITLE
[travis] Test Boost 1.61+ with clang & g++

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,24 +13,38 @@ services:
     - docker
 env:
     - FLAVOR="cs"
-    - FLAVOR="cpp-core" BOOST="1.66.0" COMPILER="gcc"
     - FLAVOR="cpp-core" BOOST="1.66.0" COMPILER="clang"
-    - FLAVOR="cpp-core" BOOST="1.65.1" COMPILER="clang"
-    - FLAVOR="cpp-core" BOOST="1.64.0" COMPILER="clang"
-    - FLAVOR="cpp-core" BOOST="1.63.0" COMPILER="clang"
-    - FLAVOR="cpp-core" BOOST="1.62.0" COMPILER="clang"
-    - FLAVOR="cpp-core" BOOST="1.61.0" COMPILER="clang"
-    - FLAVOR="cpp-core" BOOST="1.60.0" COMPILER="clang"
-    - FLAVOR="cpp-core" BOOST="1.59.0" COMPILER="clang"
-    - FLAVOR="cpp-core" BOOST="1.58.0" COMPILER="clang"
     - FLAVOR="cpp-grpc" BOOST="1.66.0" COMPILER="gcc"
-    - FLAVOR="cpp-grpc" BOOST="1.65.1" COMPILER="clang"
-    - FLAVOR="cpp-grpc" BOOST="1.64.0" COMPILER="clang"
-    - FLAVOR="cpp-grpc" BOOST="1.63.0" COMPILER="clang"
-    - FLAVOR="cpp-grpc-master" BOOST="1.66.0" COMPILER="clang" CRON_ONLY="true"
     - FLAVOR="hs"
     - FLAVOR="java"
 
+    - FLAVOR="cpp-core" BOOST="1.65.1" COMPILER="clang" CRON_ONLY="true"
+    - FLAVOR="cpp-core" BOOST="1.64.0" COMPILER="clang" CRON_ONLY="true"
+    - FLAVOR="cpp-core" BOOST="1.63.0" COMPILER="clang" CRON_ONLY="true"
+    - FLAVOR="cpp-core" BOOST="1.62.0" COMPILER="clang" CRON_ONLY="true"
+    - FLAVOR="cpp-core" BOOST="1.61.0" COMPILER="clang" CRON_ONLY="true"
+
+    - FLAVOR="cpp-grpc" BOOST="1.65.1" COMPILER="clang" CRON_ONLY="true"
+    - FLAVOR="cpp-grpc" BOOST="1.64.0" COMPILER="clang" CRON_ONLY="true"
+    - FLAVOR="cpp-grpc" BOOST="1.63.0" COMPILER="clang" CRON_ONLY="true"
+    - FLAVOR="cpp-grpc" BOOST="1.62.0" COMPILER="clang" CRON_ONLY="true"
+    - FLAVOR="cpp-grpc" BOOST="1.61.0" COMPILER="clang" CRON_ONLY="true"
+
+    - FLAVOR="cpp-core" BOOST="1.66.0" COMPILER="gcc" CRON_ONLY="true"
+    - FLAVOR="cpp-core" BOOST="1.65.1" COMPILER="gcc" CRON_ONLY="true"
+    - FLAVOR="cpp-core" BOOST="1.64.0" COMPILER="gcc" CRON_ONLY="true"
+    - FLAVOR="cpp-core" BOOST="1.63.0" COMPILER="gcc" CRON_ONLY="true"
+    - FLAVOR="cpp-core" BOOST="1.62.0" COMPILER="gcc" CRON_ONLY="true"
+    - FLAVOR="cpp-core" BOOST="1.61.0" COMPILER="gcc" CRON_ONLY="true"
+
+    - FLAVOR="cpp-grpc" BOOST="1.66.0" COMPILER="gcc" CRON_ONLY="true"
+    - FLAVOR="cpp-grpc" BOOST="1.65.1" COMPILER="gcc" CRON_ONLY="true"
+    - FLAVOR="cpp-grpc" BOOST="1.64.0" COMPILER="gcc" CRON_ONLY="true"
+    - FLAVOR="cpp-grpc" BOOST="1.63.0" COMPILER="gcc" CRON_ONLY="true"
+    - FLAVOR="cpp-grpc" BOOST="1.62.0" COMPILER="gcc" CRON_ONLY="true"
+    - FLAVOR="cpp-grpc" BOOST="1.61.0" COMPILER="gcc" CRON_ONLY="true"
+
+    - FLAVOR="cpp-grpc-master" BOOST="1.66.0" COMPILER="clang" CRON_ONLY="true"
 script:
     - if [ "$CRON_ONLY" = "true" ] && [ "$TRAVIS_EVENT_TYPE" != "cron" ] ; then echo "Skipping cron-only job"; exit 0; fi
     - CI_BUILD_IMAGE=bondciimages.azurecr.io/ubuntu-1604:build-11401554

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ different versioning scheme, following the Haskell community's
   removed. This includes all gbc options related to Comm and all Comm APIs
   and header files. [Issue
   #824](https://github.com/Microsoft/bond/issues/824)
+* **Breaking change** Only versions of Boost released in the past two years
+  (1.61 and newer) are supported. Bond will *likely* continue to work with
+  older versions, but it is no longer tested with anything older than 1.61.
+  Test coverage for Boost versions 1.61&ndash;1.66 has been improved. [Issue
+  #771](https://github.com/Microsoft/bond/issues/771)
 * **Breaking change** Constructors accepting a `Comparer` have been removed from
   `bond::maybe` and `bond::nullable` types.
 * **Breaking change** The `bond::is_blob` and `bond::is_nullable` traits

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Bond C++ library requires some C++11 features (currently limited to those
 supported bv Visual C++ 2013); a C++11 compiler is required. Additionally,
 to build Bond you will need CMake (3.1+),
 [Haskell Stack](https://docs.haskellstack.org/en/stable/README/#how-to-install)
-(1.5.1+) and Boost (1.58+).
+(1.5.1+) and Boost (1.61+).
 
 Following are specific instructions for building on various platforms.
 
@@ -180,7 +180,7 @@ cmake .. \
 
 Install the following tools:
 
-- Visual Studio 2013 or 2015
+- Visual Studio 2013, 2015, or 2017
     - Visual Studio 2015 is required to build C# Bond from source
 - CMake ([http://www.cmake.org/download/](http://www.cmake.org/download/))
 - Haskell Stack ([https://docs.haskellstack.org/en/stable/install_and_upgrade/#windows](https://docs.haskellstack.org/en/stable/install_and_upgrade/#windows))
@@ -206,7 +206,7 @@ switch is used to run the unit tests as well.
 
 The C++ and Python versions of Bond additionally require:
 
-- Boost 1.58+ ([http://www.boost.org/users/download/](http://www.boost.org/users/download/))
+- Boost 1.61+ ([http://www.boost.org/users/download/](http://www.boost.org/users/download/))
 - Python 2.7 ([https://www.python.org/downloads/](https://www.python.org/downloads/))
 
 You may need to set the environment variables `BOOST_ROOT` and `BOOST_LIBRARYDIR`
@@ -214,8 +214,8 @@ to specify where Boost and its pre-built libraries for your environment (MSVC 12
 found, e.g.:
 
 ```bash
-set BOOST_ROOT=D:\boost_1_58_0
-set BOOST_LIBRARYDIR=D:\boost_1_58_0\lib64-msvc-14.0
+set BOOST_ROOT=D:\boost_1_61_0
+set BOOST_LIBRARYDIR=D:\boost_1_61_0\lib64-msvc-14.0
 ```
 
 The core Bond library and most examples only require Boost headers. The

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -123,7 +123,7 @@ if (APPLE)
 endif()
 find_package (PythonLibs 2.7)
 
-find_package (Boost 1.58.0
+find_package (Boost 1.61.0
     OPTIONAL_COMPONENTS
         chrono
         date_time

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -123,7 +123,7 @@ if (APPLE)
 endif()
 find_package (PythonLibs 2.7)
 
-find_package (Boost 1.61.0
+find_package (Boost 1.58.0
     OPTIONAL_COMPONENTS
         chrono
         date_time

--- a/tools/ci-scripts/linux/image-builder/build_boosts.zsh
+++ b/tools/ci-scripts/linux/image-builder/build_boosts.zsh
@@ -2,7 +2,7 @@
 
 set -eux
 
-BOOST_VERSIONS=(1.58.0 1.59.0 1.60.0 1.61.0 1.62.0 1.63.0 1.64.0 1.65.1 1.66.0)
+BOOST_VERSIONS=(1.61.0 1.62.0 1.63.0 1.64.0 1.65.1 1.66.0)
 BOOST_LIBRARIES="chrono,date_time,python,system,test,thread"
 
 BUILD_ROOT=/tmp/boosts


### PR DESCRIPTION
Drops support for versions of Boost older than two years. Boost 1.61+ or
newer is now required. (Bond will likely continue to work with older
versions of Boost, but we'll no longer actively test against them.)

Using cron jobs, add coverage for all supported versions of Boost with
both Clang and G++.

This is the Travis-side fix for:
* https://github.com/Microsoft/bond/issues/666
* https://github.com/Microsoft/bond/issues/771