### PR TITLE
[c++] Use a "variant" for SimpleJsonReader state

### DIFF
--- a/cpp/inc/bond/protocol/detail/rapidjson_helper.h
+++ b/cpp/inc/bond/protocol/detail/rapidjson_helper.h
@@ -62,73 +62,72 @@ class RapidJsonInputStream
 public:
     typedef char Ch;
 
-    explicit RapidJsonInputStream(const Buffer& buf)
-        : input(buf),
-          current(0),
-          count(0)
+    explicit RapidJsonInputStream(const Buffer& input)
+        : _input(input),
+          _current(0),
+          _count(0)
     {
-        input.Read(current);
+        _input.Read(_current);
     }
 
+    #if defined(_MSC_VER) && _MSC_VER < 1900
+    // since we explicitly implement a move ctor, we need to explicitly
+    // default these
     RapidJsonInputStream(const RapidJsonInputStream&) = default;
     RapidJsonInputStream& operator=(const RapidJsonInputStream&) = default;
 
-    #if defined(_MSC_VER) && _MSC_VER < 1900
     // MSVC cannot = default rvalue ctor or move-assign operators
     RapidJsonInputStream(RapidJsonInputStream&& other)
-        : input(std::move(other.input)),
-          current(std::move(other.current)),
-          count(std::move(other.count))
+        : _input(std::move(other._input)),
+          _current(std::move(other._current)),
+          _count(std::move(other._count))
     { }
 
     RapidJsonInputStream& operator=(RapidJsonInputStream&& other)
     {
-        input = std::move(other.input);
-        current = std::move(other.current);
-        count = std::move(other.count);
+        _input = std::move(other._input);
+        _current = std::move(other._current);
+        _count = std::move(other._count);
         return *this;
     }
-    #else
-    RapidJsonInputStream(RapidJsonInputStream&&) = default;
-    RapidJsonInputStream& operator=(RapidJsonInputStream&&) = default;
     #endif
 
     const Buffer& GetBuffer() const
     {
-        return input;
+        return _input;
     }
 
     Buffer& GetBuffer()
     {
-        return input;
+        return _input;
     }
 
     char Peek()
     {
-        if (!current)
+        if (!_current)
         {
-            input.Read(current);
+            _input.Read(_current);
         }
 
-        return current;
+        return _current;
     }
 
     size_t Tell() const
     {
-        return count;
+        return _count;
     }
 
     char Take()
     {
-        char c = current;
-        current = '\0';
+        char c = _current;
+        _current = '\0';
 
         if (!c)
         {
-            input.Read(c);
+            _input.Read(c);
         }
 
-        ++count;
+        ++_count;
         return c;
     }
 
@@ -138,9 +137,9 @@ public:
     size_t PutEnd(char*) { BOOST_ASSERT(false); return 0; }
 
 private:
-    Buffer input;
-    uint8_t current;
-    size_t count;
+    Buffer _input;
+    uint8_t _current;
+    size_t _count;
 };
 
 
@@ -149,8 +148,8 @@ template <typename Buffer>
 class RapidJsonOutputStream
 {
 public:
-    RapidJsonOutputStream(Buffer& output)
-        : output(output)
+    explicit RapidJsonOutputStream(Buffer& output)
+        : _output(output)
     {
     }
 
@@ -165,7 +164,7 @@ public:
 
     void Put(char c)
     {
-        output.Write(c);
+        _output.Write(c);
     }
 
     void Flush()
@@ -173,7 +172,7 @@ public:
     }
 
 private:
-    Buffer& output;
+    Buffer& _output;
 };
 
 
@@ -181,7 +180,7 @@ private:
 template <>
 struct RapidJsonInputStream<const rapidjson::UTF8<>::Ch*> : rapidjson::StringStream
 {
-    RapidJsonInputStream(const char* buffer)
+    explicit RapidJsonInputStream(const char* buffer)
         : rapidjson::StringStream(buffer)
     {}
 

--- a/cpp/inc/bond/protocol/simple_json_reader.h
+++ b/cpp/inc/bond/protocol/simple_json_reader.h
@@ -227,7 +227,7 @@ private:
         // MSVC cannot = default rvalue ctor or move-assign operators
         StreamHolder(StreamHolder&& other)
             : _stream(std::move(other._stream)),
-             _parent(std::move(other._parent))
+              _parent(std::move(other._parent))
         { }
 
         StreamHolder& operator=(StreamHolder&& other)

--- a/cpp/inc/bond/protocol/simple_json_reader.h
+++ b/cpp/inc/bond/protocol/simple_json_reader.h
@@ -11,8 +11,9 @@
 #include "rapidjson/document.h"
 #include "rapidjson/reader.h"
 
-#include <boost/call_traits.hpp>
 #include <boost/make_shared.hpp>
+#include <boost/none.hpp>
+#include <boost/optional/optional.hpp>
 
 namespace bond
 {
@@ -35,26 +36,27 @@ public:
     BOND_STATIC_CONSTEXPR uint16_t version = 0x0001;
 
     /// @brief Construct from input buffer/stream containing serialized data.
-    SimpleJsonReader(typename boost::call_traits<Buffer>::param_type input)
-        : _input(input),
-          _stream(_input),
+    SimpleJsonReader(const Buffer& input)
+        : _streamHolder(input),
           _document(boost::make_shared<rapidjson::Document>()),
-          _value(NULL)
-    {}
+          _value(nullptr)
+    { }
 
-    SimpleJsonReader(const SimpleJsonReader& that, const Field& value)
-        : _stream(that._stream),
-          _document(that._document),
+    /// @brief Create a "child" SimpleJsonReader to read \c value, which is
+    /// known to be a member of the document in \c parent.
+    ///
+    /// @warning \c parent must remain alive for the lifetime of this child.
+    SimpleJsonReader(SimpleJsonReader& parent, const Field& value)
+        : _streamHolder(parent),
+          _document(parent._document),
           _value(&value)
-    {}
+    {
+        // Must have an already-parsed parent
+        BOOST_ASSERT(parent._value);
+    }
 
     /// @brief Copy constructor
-    SimpleJsonReader(const SimpleJsonReader& that)
-        : _input(that._input),
-          _stream(that._stream, _input),
-          _document(that._document),
-          _value(that._value)
-    {}
+    SimpleJsonReader(const SimpleJsonReader&) = default;
 
     bool ReadVersion()
     {
@@ -68,7 +70,10 @@ public:
         {
             const unsigned parseFlags = rapidjson::kParseIterativeFlag | rapidjson::kParseStopWhenDoneFlag;
 
-            _document->ParseStream<parseFlags>(_stream);
+            _document->ParseStream<parseFlags>(_streamHolder.GetStream());
+
+            // If there were any parse errors, an exception should have been
+            // thrown, as we define RAPIDJSON_PARSE_ERROR
             BOOST_ASSERT(!_document->HasParseError());
             _value = _document.get();
         }
@@ -90,7 +95,7 @@ public:
     template <typename T>
     void Read(T& var)
     {
-        detail::Read(*_value, var);
+        detail::Read(*GetValue(), var);
     }
 
     template <typename T>
@@ -106,11 +111,11 @@ public:
 
     template <typename T>
     void Skip()
-    {}
+    { }
 
     template <typename T>
     void Skip(const T&)
-    {}
+    { }
 
 
     bool operator==(const SimpleJsonReader& rhs) const
@@ -119,43 +124,47 @@ public:
     }
 
     /// @brief Access to underlying buffer
-    typename boost::call_traits<Buffer>::const_reference
-    GetBuffer() const
+    const Buffer& GetBuffer() const
     {
-        return _input;
+        return _streamHolder.GetStream().GetBuffer();
     }
 
     /// @brief Access to underlying buffer
-    typename boost::call_traits<Buffer>::reference
-    GetBuffer()
+    Buffer& GetBuffer()
     {
-        return _input;
+        return _streamHolder.GetStream().GetBuffer();
     }
 
 private:
     rapidjson::Value::ConstMemberIterator MemberBegin() const
     {
-        return _value->IsObject() ? _value->MemberBegin() : rapidjson::Value::ConstMemberIterator();
+        return GetValue()->IsObject() ? GetValue()->MemberBegin() : rapidjson::Value::ConstMemberIterator();
     }
 
     rapidjson::Value::ConstMemberIterator MemberEnd() const
     {
-        return _value->IsObject() ? _value->MemberEnd() : rapidjson::Value::ConstMemberIterator();
+        return GetValue()->IsObject() ? GetValue()->MemberEnd() : rapidjson::Value::ConstMemberIterator();
     }
 
     rapidjson::Value::ConstValueIterator ArrayBegin() const
     {
-        return _value->IsArray() ? _value->Begin() : rapidjson::Value::ConstValueIterator();
+        return GetValue()->IsArray() ? GetValue()->Begin() : rapidjson::Value::ConstValueIterator();
     }
 
     rapidjson::Value::ConstValueIterator ArrayEnd() const
     {
-        return _value->IsArray() ? _value->End() : rapidjson::Value::ConstValueIterator();
+        return GetValue()->IsArray() ? GetValue()->End() : rapidjson::Value::ConstValueIterator();
     }
 
     uint32_t ArraySize() const
     {
-        return _value->IsArray() ? _value->Size() : 0;
+        return GetValue()->IsArray() ? GetValue()->Size() : 0;
+    }
+
+    const rapidjson::Value* GetValue() const
+    {
+        BOOST_ASSERT(_value);
+        return _value;
     }
 
     template <typename Input>
@@ -179,15 +188,88 @@ private:
     friend typename boost::enable_if<is_map_container<X> >::type
     DeserializeMap(X&, BondDataType, const T&, SimpleJsonReader<Buffer>&);
 
-    SimpleJsonReader(const SimpleJsonReader& that, const char* name)
-        : _stream(that._stream),
-          _document(that._document),
-          _value(&(*that._value)[name])
-    {}
+    /// @brief Holds either an input stream XOR a pointer to some parent
+    /// StreamHolder.
+    class StreamHolder
+    {
+    public:
+        explicit StreamHolder(const Buffer& input)
+            : _stream(),
+              _parent()
+        {
+            // could use boost::in_place to construct this in the
+            // initializer list when the minimum version of Boost is 1.63
+            _stream.emplace(input);
+            BOOST_ASSERT(IsParent());
+        }
 
+        explicit StreamHolder(SimpleJsonReader& parent)
+            : _stream(),
+              // If we're creating a child of a child, use the "root" parent
+              // as our parent instead of having a bunch of intermediate
+              // children as parent.
+              _parent(parent._streamHolder.GetParent())
+        {
+            BOOST_ASSERT(_parent->IsParent());
+            BOOST_ASSERT(!IsParent());
+        }
 
-    Buffer _input;
-    detail::RapidJsonInputStream<Buffer> _stream;
+        // Intentionaly deep copy. Copies of SimpleJsonReader are expected
+        // to be deep copies, even if they're made from children.
+        StreamHolder(const StreamHolder& other)
+            : _stream(other.GetStream()),
+              _parent()
+        {
+            BOOST_ASSERT(IsParent());
+        }
+
+        #if defined(_MSC_VER) && _MSC_VER < 1900
+        // MSVC cannot = default rvalue ctor or move-assign operators
+        StreamHolder(StreamHolder&& other)
+            : _stream(std::move(other._stream)),
+             _parent(std::move(other._parent))
+        { }
+
+        StreamHolder& operator=(StreamHolder&& other)
+        {
+            _stream = std::move(other._stream);
+            _parent = std::move(other._parent);
+            return *this;
+        }
+        #else
+        StreamHolder(StreamHolder&&) = default;
+        StreamHolder& operator=(StreamHolder&&) = default ;
+        #endif
+
+        StreamHolder& operator=(const StreamHolder&) = default;
+
+        const detail::RapidJsonInputStream<Buffer>& GetStream() const
+        {
+            return IsParent() ? _stream.value() : _parent->GetStream();
+        }
+
+        detail::RapidJsonInputStream<Buffer>& GetStream()
+        {
+            return IsParent() ? _stream.value() : _parent->GetStream();
+        }
+
+    private:
+        bool IsParent() const
+        {
+            const bool isParent = _parent == nullptr;
+            BOOST_ASSERT(isParent == static_cast<bool>(_stream)); // parents must have a stream
+            return isParent;
+        }
+
+        StreamHolder* GetParent()
+        {
+            return IsParent() ? this : _parent;
+        }
+
+        boost::optional<detail::RapidJsonInputStream<Buffer>> _stream;
+        StreamHolder* _parent;
+    } _streamHolder;
+
     boost::shared_ptr<rapidjson::Document> _document;
     const rapidjson::Value* _value;
 };


### PR DESCRIPTION
A SimpleJsonReader either has an input buffer and an associated stream
or it is a child of some other SimpleJsonReader that will use its
parent's already parsed document. This logic is now more explicit:

* A SimpleJsonReader now either has an input stream XOR a parent
  pointer. This logic is implemented in the helper StreamHolder class.
* detail::RapidJsonInputStream now owns its input buffer instead of
  having a reference to its input buffer.
    * Before, when child SimpleJsonReader instances had their own
      detail::RapidJsonInputStream instances, we needed to be able to
      make cheap copies of detail::RapidJsonInputStream. But, the
      children didn't actually use their stream except to sometimes make
      a deep copy. Since they now just have a pointer to their parent
      which can be used to make a deep copy,
      detail::RapidJsonInputStream can own its buffer: we only copy
      detail::RapidJsonInputStream instances when we need a deep copy.

Also, minor refactoring like the removal of boost::call_traits in favor
of using rvalue references where appropriate.