### PR TITLE
[c++] Remove Boost min version from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,6 @@ different versioning scheme, following the Haskell community's
   have been removed. The `blob` and `nullable` types are not customizable,
   so these where never needed or used. The related functionality provided by
   `bond::get_list_sub_type_id` remains.
-* The CMake build now enforces a minimum Boost version of 1.58. The build
-  has required Boost 1.58 or later since version 5.2.0, but this was not
-  enforced.
 * gRPC v1.10.0 is now required to use Bond-over-gRPC.
     * This version include a number of memory leak fixes that users of Bond-over-gRPC were encountering. [Issue #810](https://github.com/Microsoft/bond/issues/810)
 * Fixed includes for gRPC services with events or parameterless methods.


### PR DESCRIPTION
This change has not yet been made, as it breaks the current AppVeyor
build.

Issue https://github.com/Microsoft/bond/issues/845 has been opened to
remind us to bump the minimum version later.

[skip ci]