### PR TITLE
[travis] Add Boost 1.67.0 to Travis image

### DIFF
--- a/tools/ci-scripts/linux/image-builder/build_boosts.zsh
+++ b/tools/ci-scripts/linux/image-builder/build_boosts.zsh
@@ -2,7 +2,7 @@
 
 set -eux
 
-BOOST_VERSIONS=(1.61.0 1.62.0 1.63.0 1.64.0 1.65.1 1.66.0)
+BOOST_VERSIONS=(1.61.0 1.62.0 1.63.0 1.64.0 1.65.1 1.66.0 1.67.0)
 BOOST_LIBRARIES="chrono,date_time,python,system,test,thread"
 
 BUILD_ROOT=/tmp/boosts


### PR DESCRIPTION
Using this image to test with Boost 1.67 will come in a subsequent commit.