### PR TITLE
[appveyor] Use Boost from NuGet packages if needed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,7 +66,7 @@
             - BOND_BUILD: Python
               APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
               BOND_ARCH: 32
-              BOND_BOOST: "1.61.0"
+              BOND_BOOST: "1.62.0"
               BOND_CMAKE_FLAGS: "-DBOND_ENABLE_GRPC=FALSE"
             - BOND_BUILD: Python
               APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,17 +40,19 @@
         matrix:
               # C++ Core build and tests (Visual C++ 2013)
             - BOND_BUILD: C++
-              BOND_VS: "Visual Studio 12 2013"
-              BOND_VS_NUM: 12
+              BOND_VS_VERSION: Visual Studio 2013
+              # We need to use the Visual Studio 2015 image for the 2013 build
+              # as the C# compatibility tests need a C# 6 compiler, which is
+              # available starting with the 2015 image.
+              APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
               BOND_ARCH: 32
-              BOND_BOOST: 58
+              BOND_BOOST: "1.61.0"
               BOND_CMAKE_FLAGS: "-DBOND_ENABLE_GRPC=FALSE;-DBOND_SKIP_GBC_TESTS=TRUE"
               # C++ Core build and tests
             - BOND_BUILD: C++
-              BOND_VS: "Visual Studio 14 2015"
-              BOND_VS_NUM: 14
+              APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
               BOND_ARCH: 64
-              BOND_BOOST: 60
+              BOND_BOOST: "1.61.0"
               BOND_CMAKE_FLAGS: "-DBOND_ENABLE_GRPC=FALSE"
             - BOND_BUILD: C#
               BOND_OUTPUT: Properties
@@ -62,26 +64,33 @@
               BOND_OUTPUT: Fields
               BOND_CONFIG: Fields
             - BOND_BUILD: Python
-              BOND_VS: "Visual Studio 14 2015"
-              BOND_VS_NUM: 14
+              APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
               BOND_ARCH: 32
-              BOND_BOOST: 60
+              BOND_BOOST: "1.61.0"
               BOND_CMAKE_FLAGS: "-DBOND_ENABLE_GRPC=FALSE"
             - BOND_BUILD: Python
-              BOND_VS: "Visual Studio 14 2015"
-              BOND_VS_NUM: 14
+              APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
               BOND_ARCH: 64
-              BOND_BOOST: 63
+              BOND_BOOST: "1.63.0"
               BOND_CMAKE_FLAGS: "-DBOND_ENABLE_GRPC=FALSE"
               # C++ gRPC build and tests
             - BOND_BUILD: C++
-              BOND_VS: "Visual Studio 14 2015"
-              BOND_VS_NUM: 14
+              APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
               BOND_ARCH: 64
-              BOND_BOOST: 63
+              BOND_BOOST: "1.63.0"
               BOND_CMAKE_FLAGS: "-DBOND_SKIP_CORE_TESTS=TRUE;-DBOND_SKIP_GBC_TESTS=TRUE"
     install:
         - ps: >-
+            if (-not $env:BOND_VS_VERSION)
+            {
+                $env:BOND_VS_VERSION = $env:APPVEYOR_BUILD_WORKER_IMAGE
+            }
+
+            if (-not $env:BOND_VS_VERSION)
+            {
+                $env:BOND_VS_VERSION = 'Visual Studio 2015'
+            }
+
             if (($env:BOND_BUILD -eq 'C++') -or ($env:BOND_BUILD -eq 'Python')) {
 
                 git submodule update --init thirdparty\rapidjson
@@ -92,17 +101,38 @@
                     git submodule update --init --recursive thirdparty\grpc
                 }
 
-            }
+                $boostComponents = (
+                    'boost_chrono',
+                    'boost_date_time',
+                    'boost_thread',
+                    'boost_system',
+                    'boost_unit_test_framework')
 
-            if ($env:BOND_BOOST -eq 56) {
-                # Hard-coded Boost path per https://www.appveyor.com/docs/installed-software#languages-libraries-frameworks
+                if ($env:BOND_BUILD -eq 'Python') {
+                    $boostComponents += 'boost_python'
+                }
 
-                $env:BOOST_ROOT = "C:/Libraries/boost"
-                $env:BOOST_LIBRARYDIR = "C:/Libraries/boost/lib${env:BOND_ARCH}-msvc-${env:BOND_VS_NUM}.0"
-            }
-            else {
-                $env:BOOST_ROOT = "C:/Libraries/boost_1_${env:BOND_BOOST}_0"
-                $env:BOOST_LIBRARYDIR = "C:/Libraries/boost_1_${env:BOND_BOOST}_0/lib${env:BOND_ARCH}-msvc-${env:BOND_VS_NUM}.0"
+                $vsNum = tools\ci-scripts\windows\ConvertTo-MsvcVersion.ps1 -ImageName $env:BOND_VS_VERSION -Format VsNum
+
+                $boostLoc = tools\ci-scripts\windows\Get-BoostLocation.ps1 `
+                    -Version $env:BOND_BOOST `
+                    -VsNum $vsNum
+
+                if (-not $boostLoc)
+                {
+                    $boostLoc = tools\ci-scripts\windows\Install-Boost.ps1 `
+                        -Version $env:BOND_BOOST `
+                        -VsNum $vsNum `
+                        -Components $boostComponents
+                }
+
+                if ((-not $boostLoc) -or (-not $boostLoc['BOOST_LIBRARYDIR'][$env:BOND_ARCH]))
+                {
+                    throw "No Boost libraries found/installed for $env:BOND_BOOST $env:BOND_ARCH"
+                }
+
+                $env:BOOST_ROOT = $boostLoc['BOOST_ROOT']
+                $env:BOOST_LIBRARYDIR = $boostLoc['BOOST_LIBRARYDIR'][$env:BOND_ARCH]
             }
 
             choco install haskell-stack -y
@@ -154,7 +184,15 @@
 
             $env:_IsNativeEnvironment = "true"
 
-            $cmakeGenerator = $env:BOND_VS
+            $vsCmakeGeneratorNum = tools\ci-scripts\windows\ConvertTo-MsvcVersion.ps1 `
+                -ImageName $env:BOND_VS_VERSION `
+                -Format CMakeGeneratorNum
+
+            $vsYear = tools\ci-scripts\windows\ConvertTo-MsvcVersion.ps1 `
+                -ImageName $env:BOND_VS_VERSION `
+                -Format Year
+
+            $cmakeGenerator = "Visual Studio $vsCmakeGeneratorNum $vsYear"
 
             if ($env:BOND_ARCH -eq 64) {
                 $cmakeGenerator += " Win64"
@@ -184,7 +222,7 @@
 
                 cd build
 
-                cmake "-DBoost_ADDITIONAL_VERSIONS=1.${env:BOND_BOOST}.0" $cmakeFlags -G $cmakeGenerator ..
+                cmake "-DBoost_ADDITIONAL_VERSIONS=${env:BOND_BOOST}" $cmakeFlags -G $cmakeGenerator ..
 
             }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -111,17 +111,19 @@
                     $boostComponents += 'boost_python'
                 }
 
-                $vsNum = tools\ci-scripts\windows\ConvertTo-MsvcVersion.ps1 -ImageName $env:BOND_VS_VERSION -Format VsNum
+                $vcToolsetVer = tools\ci-scripts\windows\ConvertTo-MsvcVersion.ps1 `
+                    -ImageName $env:BOND_VS_VERSION `
+                    -Format VcToolSetVer
 
                 $boostLoc = tools\ci-scripts\windows\Get-BoostLocation.ps1 `
                     -Version $env:BOND_BOOST `
-                    -VsNum $vsNum
+                    -VcToolSetVer $vcToolSetVer
 
                 if (-not $boostLoc)
                 {
                     $boostLoc = tools\ci-scripts\windows\Install-Boost.ps1 `
                         -Version $env:BOND_BOOST `
-                        -VsNum $vsNum `
+                        -VcToolSetVer $vcToolSetVer `
                         -Components $boostComponents
                 }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,11 +84,10 @@
             if (-not $env:BOND_VS_VERSION)
             {
                 $env:BOND_VS_VERSION = $env:APPVEYOR_BUILD_WORKER_IMAGE
-            }
-
-            if (-not $env:BOND_VS_VERSION)
-            {
-                $env:BOND_VS_VERSION = 'Visual Studio 2015'
+                if (-not $env:BOND_VS_VERSION)
+                {
+                    $env:BOND_VS_VERSION = 'Visual Studio 2015'
+                }
             }
 
             if (($env:BOND_BUILD -eq 'C++') -or ($env:BOND_BUILD -eq 'Python')) {

--- a/tools/ci-scripts/windows/ConvertTo-MsvcVersion.ps1
+++ b/tools/ci-scripts/windows/ConvertTo-MsvcVersion.ps1
@@ -9,9 +9,9 @@ The AppVeyor build worker image name.
 
 .PARAMETER Format
 
-The output format. One of 'VsNum', 'Year', or 'CMakeGeneratorNum'.
+The output format. One of 'VcToolsetVer', 'Year', or 'CMakeGeneratorNum'.
 
-VsNum will produce something like '12.0' or '14.1'.
+VcToolsetVer will produce something like '12.0' or '14.1'.
 Year will produce something like '2013' or '2017'.
 CMakeGeneratorNum will produce something like '12' or '15'.
 
@@ -22,15 +22,15 @@ param
     [string]
     $ImageName,
 
-    [ValidateSet('VsNum','Year', 'CMakeGeneratorNum')]
+    [ValidateSet('VcToolsetVer','Year', 'CMakeGeneratorNum')]
     [string]
-    $Format = 'VsNum'
+    $Format = 'VcToolsetVer'
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-function ToVsNum([string]$imageName)
+function ToVcToolsetVer([string]$imageName)
 {
     switch ($imageName)
     {
@@ -41,32 +41,32 @@ function ToVsNum([string]$imageName)
     }
 }
 
-function ToYear([string]$vsNum)
+function ToYear([string]$vcToolsetVer)
 {
-    switch ($vsNum)
+    switch ($vcToolsetVer)
     {
         '12.0' { '2013' }
         '14.0' { '2015' }
         '14.1' { '2017' }
-        default { throw "Unknown VsNum '$vsNum'" }
+        default { throw "Unknown VcToolsetVer '$vcToolsetVer'" }
     }
 }
 
-function ToCMakeGeneratorNum([string]$vsNum)
+function ToCMakeGeneratorNum([string]$vcToolsetVer)
 {
-    switch ($vsNum)
+    switch ($vcToolsetVer)
     {
         '12.0' { '12' }
         '14.0' { '14' }
         '14.1' { '15' }
-        default { throw "Unknown VsNum '$vsNum'" }
+        default { throw "Unknown VcToolsetVer '$vcToolsetVer'" }
     }
 }
 
 switch ($Format)
 {
-    'VsNum' { return ToVsNum $ImageName }
-    'Year' { return ToYear (ToVsNum $ImageName) }
-    'CMakeGeneratorNum' { return ToCMakeGeneratorNum (ToVsNum $ImageName) }
+    'VcToolsetVer' { return ToVcToolsetVer $ImageName }
+    'Year' { return ToYear (ToVcToolsetVer $ImageName) }
+    'CMakeGeneratorNum' { return ToCMakeGeneratorNum (ToVcToolsetVer $ImageName) }
     default { throw "Unknown Format '$Format'" }
 }

--- a/tools/ci-scripts/windows/ConvertTo-MsvcVersion.ps1
+++ b/tools/ci-scripts/windows/ConvertTo-MsvcVersion.ps1
@@ -1,0 +1,72 @@
+﻿<#
+.SYNOPSIS
+
+Convert an AppVeyor build worker image string into a MSVC version number.
+
+.PARAMETER ImageName
+
+The AppVeyor build worker image name.
+
+.PARAMETER Format
+
+The output format. One of 'VsNum', 'Year', or 'CMakeGeneratorNum'.
+
+VsNum will produce something like '12.0' or '14.1'.
+Year will produce something like '2013' or '2017'.
+CMakeGeneratorNum will produce something like '12' or '15'.
+
+#>
+[CmdletBinding()]
+param
+(
+    [string]
+    $ImageName,
+
+    [ValidateSet('VsNum','Year', 'CMakeGeneratorNum')]
+    [string]
+    $Format = 'VsNum'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function ToVsNum([string]$imageName)
+{
+    switch ($imageName)
+    {
+        'Visual Studio 2013' { '12.0' }
+        'Visual Studio 2015' { '14.0' }
+        'Visual Studio 2017' { '14.1' }
+        default { throw "Unknown image name '$imageName'" }
+    }
+}
+
+function ToYear([string]$vsNum)
+{
+    switch ($vsNum)
+    {
+        '12.0' { '2013' }
+        '14.0' { '2015' }
+        '14.1' { '2017' }
+        default { throw "Unknown VsNum '$vsNum'" }
+    }
+}
+
+function ToCMakeGeneratorNum([string]$vsNum)
+{
+    switch ($vsNum)
+    {
+        '12.0' { '12' }
+        '14.0' { '14' }
+        '14.1' { '15' }
+        default { throw "Unknown VsNum '$vsNum'" }
+    }
+}
+
+switch ($Format)
+{
+    'VsNum' { return ToVsNum $ImageName }
+    'Year' { return ToYear (ToVsNum $ImageName) }
+    'CMakeGeneratorNum' { return ToCMakeGeneratorNum (ToVsNum $ImageName) }
+    default { throw "Unknown Format '$Format'" }
+}

--- a/tools/ci-scripts/windows/Get-BoostLocation.ps1
+++ b/tools/ci-scripts/windows/Get-BoostLocation.ps1
@@ -1,0 +1,91 @@
+﻿<#
+.SYNOPSIS
+
+Get's the location of Boost that is installed in the AppVeyor-provided images.
+
+Details for these locations can be found at
+https://www.appveyor.com/docs/build-environment/#pre-installed-software
+
+.PARAMETER Version
+
+The Boost version to find.
+
+.PARAMETER VsNum
+
+Which MSVC compiler version to find libraries for, in Visual Studio version
+number format. (E.g., 12.0, 14.1).
+
+#>
+[CmdletBinding()]
+param
+(
+    [string]
+    $Version,
+
+    [ValidateSet('12.0', '14.0', '14.1')]
+    [string]
+    $VsNum
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function FindBoostLibPath([string]$vsNum, [string]$boostRoot, [string]$platform)
+{
+    $boostLibPath = "$boostRoot\lib$platform-msvc-$vsNum"
+
+    Write-Debug "Checking for libs under '$boostLibPath'"
+
+    if (Test-Path -PathType Leaf "$boostLibPath\*.lib")
+    {
+        return $boostLibPath
+    }
+    else
+    {
+        return $null
+    }
+}
+
+function FindBoostLibPaths([string]$vsNum, [string]$boostRoot)
+{
+    $boostLibDirs = @{}
+    $lib32Dir = FindBoostLibPath $vsNum $boostRoot '32'
+    $lib64Dir = FindBoostLibPath $vsNum $boostRoot '64'
+
+    if ((-not $lib32Dir) -and (-not $lib64Dir))
+    {
+        Write-Debug "Could not find any libraries. Assuming Boost installation is broken."
+        return $null
+    }
+
+    if ($lib32Dir)
+    {
+        $boostLibDirs['32'] = $lib32Dir
+    }
+
+    if ($lib64Dir)
+    {
+        $boostLibDirs['64'] = $lib64Dir
+    }
+
+    return $boostLibDirs
+}
+
+$boostRoot = "C:\Libraries\boost_$($Version.Replace('.', '_'))"
+Write-Debug "Computed boostRoot: '$boostRoot'"
+
+$configHpp = "$boostRoot\boost\config.hpp"
+
+if (-not (Test-Path -PathType Leaf $configHpp))
+{
+    Write-Debug "Could not find '$configHpp'. Assuming Boost installation is broken."
+    return $null
+}
+
+$boostLibDirs = FindBoostLibPaths $VsNum $boostRoot
+if (-not $boostLibDirs)
+{
+    return $null
+}
+
+return @{'BOOST_ROOT' = $boostRoot; 'BOOST_LIBRARYDIR' = $boostLibDirs }

--- a/tools/ci-scripts/windows/Get-BoostLocation.ps1
+++ b/tools/ci-scripts/windows/Get-BoostLocation.ps1
@@ -10,10 +10,10 @@ https://www.appveyor.com/docs/build-environment/#pre-installed-software
 
 The Boost version to find.
 
-.PARAMETER VsNum
+.PARAMETER VcToolsetVer
 
-Which MSVC compiler version to find libraries for, in Visual Studio version
-number format. (E.g., 12.0, 14.1).
+Which MSVC toolset version to find libraries for, in Visual Studio toolset
+version number format. (E.g., 12.0, 14.1).
 
 #>
 [CmdletBinding()]
@@ -24,15 +24,15 @@ param
 
     [ValidateSet('12.0', '14.0', '14.1')]
     [string]
-    $VsNum
+    $VcToolsetVer
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-function FindBoostLibPath([string]$vsNum, [string]$boostRoot, [string]$platform)
+function FindBoostLibPath([string]$vcToolsetVer, [string]$boostRoot, [string]$platform)
 {
-    $boostLibPath = "$boostRoot\lib$platform-msvc-$vsNum"
+    $boostLibPath = "$boostRoot\lib$platform-msvc-$vcToolsetVer"
 
     Write-Debug "Checking for libs under '$boostLibPath'"
 
@@ -46,11 +46,11 @@ function FindBoostLibPath([string]$vsNum, [string]$boostRoot, [string]$platform)
     }
 }
 
-function FindBoostLibPaths([string]$vsNum, [string]$boostRoot)
+function FindBoostLibPaths([string]$vcToolsetVer, [string]$boostRoot)
 {
     $boostLibDirs = @{}
-    $lib32Dir = FindBoostLibPath $vsNum $boostRoot '32'
-    $lib64Dir = FindBoostLibPath $vsNum $boostRoot '64'
+    $lib32Dir = FindBoostLibPath $vcToolsetVer $boostRoot '32'
+    $lib64Dir = FindBoostLibPath $vcToolsetVer $boostRoot '64'
 
     if ((-not $lib32Dir) -and (-not $lib64Dir))
     {
@@ -82,7 +82,7 @@ if (-not (Test-Path -PathType Leaf $configHpp))
     return $null
 }
 
-$boostLibDirs = FindBoostLibPaths $VsNum $boostRoot
+$boostLibDirs = FindBoostLibPaths $VcToolsetVer $boostRoot
 if (-not $boostLibDirs)
 {
     return $null

--- a/tools/ci-scripts/windows/Install-Boost.ps1
+++ b/tools/ci-scripts/windows/Install-Boost.ps1
@@ -1,0 +1,172 @@
+﻿<#
+.SYNOPSIS
+
+Downloads Boost via NuGet and returns the BOOST_ROOT and BOOST_LIBRARYDIR
+locations.
+
+.PARAMETER Version
+
+The Boost version to install.
+
+.PARAMETER Components
+
+The Boost binary components to install. The Boost headers are always installed.
+
+.PARAMETER VsNum
+
+Which MSVC compiler version to find libraries for, in Visual Studio version
+number format. (E.g., 12.0, 14.1).
+
+.PARAMETER OutputDirectory
+
+Where to install Boost. If not set, creates a directory in the TEMP folder.
+
+#>
+[CmdletBinding(SupportsShouldProcess=$True)]
+param
+(
+    [string]
+    $Version,
+
+    [ValidateSet('12.0', '14.0', '14.1')]
+    [string]
+    $VsNum,
+    
+    [string[]]
+    $Components = (
+        'boost_chrono',
+        'boost_date_time',
+        'boost_thread',
+        'boost_system',
+        'boost_unit_test_framework'),
+
+    [string]
+    $OutputDirectory = $null
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-TempFolder
+{
+    $base = [System.IO.Path]::GetTempPath()
+    $result = ''
+
+    do
+    {
+        $randomPart = ''
+        while ($randomPart.Length -lt 5)
+        {
+            $asciiBase = 97 # ASCII for 'a'
+
+            $r = Get-Random -Minimum 0 -Maximum 36
+            if ($r -ge 26) # We use [26-35] for numbers
+            {
+                $asciiBase = 48 # ASCII for '0'
+                $r -= 26 # adjust to be in [0-9] from [26-36].
+            }
+
+            $randomPart += [char]($r + $asciiBase)
+        }
+
+        $result = [System.IO.Path]::Combine($base, $randomPart)
+    } while (Test-Path -LiteralPath $result -PathType Container)
+
+    # There's a TOCTTOU race in this check, but it's very unlikely.
+    Write-Debug "Generated temp folder name: '$result'"
+    return $result
+}
+
+function ConvertVsNum-ToBoostPackageFormat([string]$vsNum)
+{
+    return $vsNum.Replace('.', '')
+}
+
+function Install-NuGetPackage([string]$InstallDir, [string]$PackageId, [string]$PackageVersion)
+{
+    $nugetPrereleaseFlag = @()
+    if ($packageVersion.Contains('-')) {
+        $nugetPrereleaseFlag += 'Prerelease'
+    }
+
+    nuget install $packageId `
+        -OutputDirectory $installDir `
+        -Version $packageVersion `
+        -ExcludeVersion `
+        $nugetPrereleaseFlag
+
+    if (-not $?)
+    {
+        throw "NuGet install of '$packageId' '$packageVersion' failed. Exit code $LastExitCode"
+    }
+}
+
+if (-not $OutputDirectory)
+{
+    $OutputDirectory = Get-TempFolder
+}
+
+if (-not (Test-Path -LiteralPath $OutputDirectory -PathType Container))
+{
+    mkdir $OutputDirectory | Out-Null
+}
+
+$workDir = [System.IO.Path]::Combine($OutputDirectory, 'w')
+$destDir = [System.IO.Path]::Combine($OutputDirectory, 'd')
+$lib32Dir = [System.IO.Path]::Combine($destDir, 'lib32')
+$lib64Dir = [System.IO.Path]::Combine($destDir, 'lib64')
+mkdir $workDir | Out-Null
+mkdir $destDir | Out-Null
+mkdir $lib32Dir | Out-Null
+mkdir $lib64Dir | Out-Null
+
+function Install-BoostHeaders
+{
+    Write-Progress -Activity 'Installing Boost' -Status "Installing 'boost' (headers)"
+
+    if ($PSCmdlet.ShouldProcess('boost', 'Install NuGet package'))
+    {
+        Install-NuGetPackage `
+            -PackageId 'boost' `
+            -InstallDir $workDir `
+            -PackageVersion $Version
+
+        Move-Item `
+            -Path ([System.IO.Path]::Combine($workDir, 'boost', 'lib', 'native', 'include', 'boost')) `
+            -Destination $destDir
+    }
+}
+
+function Install-BoostComponent([string]$Component)
+{
+    $packageId = "$Component-vc$(ConvertVsNum-ToBoostPackageFormat $VsNum)"
+
+    Write-Progress -Activity 'Installing Boost' -Status "Installing '$packageId'"
+
+    if ($PSCmdlet.ShouldProcess($packageId, 'Install NuGet package'))
+    {
+        Install-NuGetPackage `
+            -PackageId $packageId `
+            -InstallDir $workDir `
+            -PackageVersion $Version
+
+        Move-Item `
+            -Path ([System.IO.Path]::Combine($workDir, $packageId, 'lib', 'native', 'address-model-32', 'lib', '*')) `
+            -Destination $lib32Dir
+
+        Move-Item `
+            -Path ([System.IO.Path]::Combine($workDir, $packageId, 'lib', 'native', 'address-model-64', 'lib', '*')) `
+            -Destination $lib64Dir
+    }
+}
+
+Install-BoostHeaders | Out-Null
+
+$Components | % `
+{
+    Install-BoostComponent -Component $PSItem | Out-Null
+}
+
+Write-Progress -Activity 'Installing Boost' -Completed
+
+return @{'BOOST_ROOT' = $destDir; 'BOOST_LIBRARYDIR'= @{'32' = $lib32Dir; '64' = $lib64Dir}}

--- a/tools/ci-scripts/windows/Install-Boost.ps1
+++ b/tools/ci-scripts/windows/Install-Boost.ps1
@@ -12,10 +12,10 @@ The Boost version to install.
 
 The Boost binary components to install. The Boost headers are always installed.
 
-.PARAMETER VsNum
+.PARAMETER VcToolsetVer
 
-Which MSVC compiler version to find libraries for, in Visual Studio version
-number format. (E.g., 12.0, 14.1).
+Which MSVC toolset version to install libraries for, in Visual Studio toolset
+version number format. (E.g., 12.0, 14.1).
 
 .PARAMETER OutputDirectory
 
@@ -30,7 +30,7 @@ param
 
     [ValidateSet('12.0', '14.0', '14.1')]
     [string]
-    $VsNum,
+    $VcToolsetVer,
     
     [string[]]
     $Components = (
@@ -47,9 +47,9 @@ param
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-function ConvertVsNum-ToBoostPackageFormat([string]$vsNum)
+function ConvertVcToolsetVer-ToBoostPackageFormat([string]$vcToolsetVer)
 {
-    return $vsNum.Replace('.', '')
+    return $vcToolsetVer.Replace('.', '')
 }
 
 function Install-NuGetPackage([string]$InstallDir, [string]$PackageId, [string]$PackageVersion)
@@ -112,7 +112,7 @@ function Install-BoostHeaders
 
 function Install-BoostComponent([string]$Component)
 {
-    $packageId = "$Component-vc$(ConvertVsNum-ToBoostPackageFormat $VsNum)"
+    $packageId = "$Component-vc$(ConvertVcToolsetVer-ToBoostPackageFormat $VcToolsetVer)"
 
     Write-Progress -Activity 'Installing Boost' -Status "Installing '$packageId'"
 


### PR DESCRIPTION
The AppVeyor builder images contain some versions of Boost, but not all
the versions that Bond supports for all the compilers that it supports.

This commit:

* Switches to a minimum Boost of 1.61, the minimum supported version as
  of this commit.
* Adds a script to easily find the pre-installed Boost library.
* Adds a script to install a given version of Boost from NuGet.org
  packages.
* Updates the AppVeyor build to install missing versions of Boost from
  NuGet.org.
* Refactors the AppVeyor build to base the MSVC compiler off of the
  BOND_VS_VERSION or the APPVEYOR_BUILD_WORKER_IMAGE variable, which
  should set us up to add MSVC 2017 to the build later.

This is the AppVeyor side of https://github.com/Microsoft/bond/issues/771