### PR TITLE
[c++] Initialize SimpleJsonWriter._count to 0

### DIFF
--- a/cpp/inc/bond/protocol/simple_json_writer.h
+++ b/cpp/inc/bond/protocol/simple_json_writer.h
@@ -37,6 +37,7 @@ public:
         : rapidjson::Writer<detail::RapidJsonOutputStream<BufferT> >(_stream),
           _stream(output),
           _output(output),
+          _count(0),
           _level(0),
           _indent((std::min)(indent, 8)),
           _pretty(pretty),


### PR DESCRIPTION
Avoid any issues with default initialization.