### PR TITLE
[c#] Generate files under gbc-specific directory

### DIFF
--- a/cs/build/nuget/Common.targets
+++ b/cs/build/nuget/Common.targets
@@ -24,7 +24,7 @@
   <!-- Set sensible defaults. -->
   <PropertyGroup>
     <BondOptions Condition=" '$(BondOptions)' == '' "></BondOptions>
-    <BondOutputDirectory Condition=" '$(BondOutputDirectory)' == '' ">$(IntermediateOutputPath)</BondOutputDirectory>
+    <BondOutputDirectory Condition=" '$(BondOutputDirectory)' == '' ">$(IntermediateOutputPath)\gbc\</BondOutputDirectory>
     <BondCodegenMode Condition="'$(BondCodegenMode)' == ''">c#</BondCodegenMode>
   </PropertyGroup>
 


### PR DESCRIPTION
In order to avoid conflcits with other tools that write files to
$(IntermediateOutputPath) with the same names as gbc, the codegen
targets now generate the files under $(IntermediateOutputPath)\gbc
unless overridden.