### PR TITLE
[c++ grpc] Move bond/ext/detail to test/grpc

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -65,16 +65,6 @@ list (APPEND headers
     ${protocol_detail_headers}
     ${stream_headers})
 
-# ext headers (currently, only used by gRPC stuff, but in its own block
-# because it doesn't depend on gRPC stuff)
-if (BOND_ENABLE_GRPC)
-    file (GLOB ext_detail_headers "inc/bond/ext/detail/*.h")
-    source_group ("ext\\detail" FILES ${ext_detail_headers})
-
-    list (APPEND headers
-        ${ext_detail_headers})
-endif()
-
 # gRPC-specific headers
 if (BOND_ENABLE_GRPC)
     file (GLOB ext_grpc_headers "inc/bond/ext/grpc/*.h")
@@ -84,7 +74,6 @@ if (BOND_ENABLE_GRPC)
     source_group ("ext\\grpc\\detail" FILES ${ext_grpc_detail_headers})
 
     list (APPEND headers
-        ${ext_detail_headers}
         ${ext_grpc_headers}
         ${ext_grpc_detail_headers})
 endif()

--- a/cpp/test/grpc/barrier.h
+++ b/cpp/test/grpc/barrier.h
@@ -12,7 +12,7 @@
 #include <atomic>
 #include <chrono>
 
-namespace bond { namespace ext { namespace detail {
+namespace unit_test {
 
 /// @brief A synchronization primitive that is signaled when a certain
 /// number of threads are waiting on it at the same time.
@@ -90,4 +90,4 @@ private:
     barrier& operator=(barrier&&) = delete;
 };
 
-} } } // namespace bond::ext::detail
+} // namespace unit_test

--- a/cpp/test/grpc/countdown_event.h
+++ b/cpp/test/grpc/countdown_event.h
@@ -12,7 +12,7 @@
 #include <atomic>
 #include <chrono>
 
-namespace bond { namespace ext { namespace detail {
+namespace unit_test {
 
 /// @ A synchronization primitive that is signaled when its count reaches
 /// zero.
@@ -77,4 +77,4 @@ private:
     countdown_event& operator=(countdown_event&&) = delete;
 };
 
-} } } // namespace bond::ext::detail
+} // namespace unit_test

--- a/cpp/test/grpc/event.h
+++ b/cpp/test/grpc/event.h
@@ -11,7 +11,7 @@
 #include <condition_variable>
 #include <mutex>
 
-namespace bond { namespace ext { namespace detail {
+namespace unit_test {
 
     /// @brief A synchronization primitive that is signaled manually.
     ///
@@ -72,4 +72,4 @@ namespace bond { namespace ext { namespace detail {
         event& operator=(event&&) = delete;
     };
 
-} } } // namespace bond::ext::detail
+} // namespace unit_test

--- a/cpp/test/grpc/io_manager.cpp
+++ b/cpp/test/grpc/io_manager.cpp
@@ -20,12 +20,12 @@
 
 #include <bond/ext/grpc/io_manager.h>
 #include <bond/ext/grpc/detail/io_manager_tag.h>
-#include <bond/ext/detail/countdown_event.h>
-#include <bond/ext/detail/barrier.h>
-#include <bond/ext/detail/event.h>
 
 // TODO: move unit_test_framework.h to cpp/test/inc
 #include "../core/unit_test_framework.h"
+#include "barrier.h"
+#include "countdown_event.h"
+#include "event.h"
 
 #include <boost/chrono.hpp>
 #include <boost/test/debug.hpp>
@@ -33,7 +33,6 @@
 #include <memory>
 #include <utility>
 
-using namespace bond::ext::detail;
 using namespace bond::ext::gRPC::detail;
 using namespace bond::ext::gRPC;
 
@@ -59,7 +58,7 @@ class io_managerTests
     {
         io_manager ioManager;
 
-        alarm_completion_tag<event> act;
+        alarm_completion_tag<unit_test::event> act;
         gpr_timespec deadline = gpr_time_0(GPR_CLOCK_MONOTONIC);
         grpc::Alarm alarm(ioManager.cq(), deadline, static_cast<io_manager_tag*>(&act));
 
@@ -73,7 +72,7 @@ class io_managerTests
 
         const size_t numItems = 1000;
 
-        alarm_completion_tag<countdown_event> act(numItems);
+        alarm_completion_tag<unit_test::countdown_event> act(numItems);
 
         const gpr_timespec deadline = gpr_time_0(GPR_CLOCK_MONOTONIC);
 
@@ -106,8 +105,8 @@ class io_managerTests
             std::unique_ptr<grpc::CompletionQueue>(new grpc::CompletionQueue));
 
         const size_t numConcurrentShutdowns = 5;
-        barrier threadsStarted(numConcurrentShutdowns);
-        barrier threadsObservedShutdown(numConcurrentShutdowns);
+        unit_test::barrier threadsStarted(numConcurrentShutdowns);
+        unit_test::barrier threadsObservedShutdown(numConcurrentShutdowns);
 
         std::vector<std::thread> threads;
         threads.reserve(5);
@@ -144,7 +143,7 @@ class io_managerTests
             io_manager::USE_HARDWARE_CONC,
             io_manager::delay_start_tag{});
 
-        alarm_completion_tag<event> act;
+        alarm_completion_tag<unit_test::event> act;
         gpr_timespec deadline = gpr_time_0(GPR_CLOCK_MONOTONIC);
         grpc::Alarm alarm(ioManager.cq(), deadline, static_cast<io_manager_tag*>(&act));
 

--- a/cpp/test/grpc/thread_pool.cpp
+++ b/cpp/test/grpc/thread_pool.cpp
@@ -6,10 +6,10 @@
 #endif
 
 #include <bond/ext/grpc/thread_pool.h>
-#include <bond/ext/detail/event.h>
 
 // TODO: move unit_test_framework.h to cpp/test/inc
 #include "../core/unit_test_framework.h"
+#include "event.h"
 
 #include <atomic>
 #include <chrono>
@@ -17,11 +17,9 @@
 #include <memory>
 #include <thread>
 
-using namespace bond::ext::detail;
-
 class BasicThreadPoolTests
 {
-    static void addOne(int* i, event* sum_event)
+    static void addOne(int* i, unit_test::event* sum_event)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         (*i)++;
@@ -32,9 +30,9 @@ class BasicThreadPoolTests
     {
         bond::ext::gRPC::thread_pool threads(1);
         int sum = 0;
-        event sum_event;
+        unit_test::event sum_event;
 
-        std::function<void(int*, event*)> f_addOne = addOne;
+        std::function<void(int*, unit_test::event*)> f_addOne = addOne;
 
         threads.schedule(std::bind(f_addOne, &sum, &sum_event));
 
@@ -48,7 +46,7 @@ class BasicThreadPoolTests
     {
         bond::ext::gRPC::thread_pool threads(1);
         int sum = 0;
-        event sum_event;
+        unit_test::event sum_event;
 
         threads.schedule([&sum, &sum_event]()
         {

--- a/cpp/test/grpc/wait_callback.cpp
+++ b/cpp/test/grpc/wait_callback.cpp
@@ -6,11 +6,12 @@
 
 #include <bond/core/bond.h>
 #include <bond/core/bond_reflection.h>
-#include <bond/ext/detail/event.h>
 #include <bond/ext/grpc/client_callback.h>
 #include <bond/ext/grpc/wait_callback.h>
 #include <bond/protocol/compact_binary.h>
 #include <bond/stream/output_buffer.h>
+
+#include "event.h"
 
 #include <boost/optional.hpp>
 
@@ -146,7 +147,7 @@ namespace wait_callback_tests
     static void WaitingThreadGetsNotified()
     {
         wait_callbackBox cb;
-        bond::ext::detail::event threadStarted;
+        unit_test::event threadStarted;
         std::atomic<bool> wasInvoked(false);
 
 


### PR DESCRIPTION
This change moves all utility types located at `bond/ext/detail` to `test/grpc` since they are used only in tests.