### PR TITLE
[c++] Fix make_box for const T&

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ different versioning scheme, following the Haskell community's
   passed to `gbc`. [Issue #861](https://github.com/Microsoft/bond/issues/861)
 * Fixed a bug in `bond::nullable<T, Alloc>` where it was not propagating an allocator
   to `T` when `allocator_type` was not explicitly defined.
+* Fixed a bug in `bond::make_box` where `const T&` was not handled correctly.
 
 ### C# ###
 

--- a/cpp/inc/bond/core/box.h
+++ b/cpp/inc/bond/core/box.h
@@ -14,10 +14,10 @@ namespace bond
 {
 
 template <typename T>
-Box<typename std::remove_reference<T>::type> make_box(T&& arg)
+Box<typename std::decay<T>::type> make_box(T&& value)
 {
-    Box<typename std::remove_reference<T>::type> b;
-    b.value = std::forward<T>(arg);
+    Box<typename std::decay<T>::type> b;
+    b.value = std::forward<T>(value);
     return b;
 }
 

--- a/cpp/test/core/basic_tests.cpp
+++ b/cpp/test/core/basic_tests.cpp
@@ -1,5 +1,6 @@
 #include <bond/core/bond_version.h>
 #include <bond/stream/output_counter.h>
+#include <bond/core/box.h>
 
 #include "precompiled.h"
 #include "basic_tests.h"
@@ -389,6 +390,28 @@ TEST_CASE_BEGIN(SimpleBinaryVersion)
 }
 TEST_CASE_END
 
+TEST_CASE_BEGIN(MakeBoxTest)
+{
+    // const T&
+    {
+        const int x = 123;
+        bond::Box<int> b = bond::make_box(x);
+        UT_AssertAreEqual(b.value, x);
+    }
+    // T&
+    {
+        int x = 123;
+        bond::Box<int> b = bond::make_box(x);
+        UT_AssertAreEqual(b.value, x);
+    }
+    // T&&
+    {
+        int x = 123;
+        bond::Box<int> b = bond::make_box(std::move(x));
+        UT_AssertAreEqual(b.value, x);
+    }
+}
+TEST_CASE_END
 
 void BasicTest::Initialize()
 {
@@ -419,6 +442,7 @@ void BasicTest::Initialize()
     AddTestCase<TEST_ID(0xb06), SimpleBinaryVersion>(suite, "Simple Protocol version");
     AddTestCase<TEST_ID(0xb07), CopyMoveTests>(suite, "Copy and Move tests");
     AddTestCase<TEST_ID(0xb08), EnumScopeTest>(suite, "Enum scope tests");
+    AddTestCase<TEST_ID(0xb09), MakeBoxTest>(suite, "make_box tests");
 }
 
 

--- a/cpp/test/core/basic_tests.cpp
+++ b/cpp/test/core/basic_tests.cpp
@@ -1,6 +1,6 @@
 #include <bond/core/bond_version.h>
-#include <bond/stream/output_counter.h>
 #include <bond/core/box.h>
+#include <bond/stream/output_counter.h>
 
 #include "precompiled.h"
 #include "basic_tests.h"


### PR DESCRIPTION
Fixes the bug that makes the following fail to compile:
```cpp
const int x = 1;
bond::Box<int> b = bond::make_box(x);
```