### PR TITLE
[c++ grpc] Use plain unary_call_result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ different versioning scheme, following the Haskell community's
 * **Breaking change** When using Bond-over-gRPC, the generated `ClientCore::Async*`
   functions now accept `std::shared_ptr<grpc::ClientContext>`
   as the last parameter instead of as the first.
+* **Breaking change** When using Bond-over-gRPC, the client callback now directly accepts
+  `bond::ext::gRPC::unary_call_result<Response>` (drops the `std::shared_ptr`).
 * gRPC v1.10.0 is now required to use Bond-over-gRPC.
     * This version include a number of memory leak fixes that users of Bond-over-gRPC were encountering. [Issue #810](https://github.com/Microsoft/bond/issues/810)
 * Fixed includes for gRPC services with events or parameterless methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ different versioning scheme, following the Haskell community's
   as the last parameter instead of as the first.
 * **Breaking change** When using Bond-over-gRPC, the client callback now directly accepts
   `bond::ext::gRPC::unary_call_result<Response>` (drops the `std::shared_ptr`).
+  Also the `unary_call_result` now exposes read-only getters rather than fields.
 * gRPC v1.10.0 is now required to use Bond-over-gRPC.
     * This version include a number of memory leak fixes that users of Bond-over-gRPC were encountering. [Issue #810](https://github.com/Microsoft/bond/issues/810)
 * Fixed includes for gRPC services with events or parameterless methods.

--- a/compiler/src/Language/Bond/Codegen/Cpp/Grpc_h.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Grpc_h.hs
@@ -226,9 +226,9 @@ inline #{className}::#{proxyName}<TThreadPool>::#{proxyName}(
         serviceMethodsWithIndex :: [(Integer,Method)]
         serviceMethodsWithIndex = zip [0..] serviceMethods
 
-        publicProxyMethodDecl Function{methodInput = Void, ..} = [lt|void Async#{methodName}(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< #{payload (methodTypeToMaybe methodResult)}>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});|]
-        publicProxyMethodDecl Function{..} = [lt|void Async#{methodName}(const #{bonded (methodTypeToMaybe methodInput)}& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< #{payload (methodTypeToMaybe methodResult)}>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
-        void Async#{methodName}(const #{payload (methodTypeToMaybe methodInput)}& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< #{payload (methodTypeToMaybe methodResult)}>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
+        publicProxyMethodDecl Function{methodInput = Void, ..} = [lt|void Async#{methodName}(const ::std::function<void(::bond::ext::gRPC::unary_call_result< #{payload (methodTypeToMaybe methodResult)}>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});|]
+        publicProxyMethodDecl Function{..} = [lt|void Async#{methodName}(const #{bonded (methodTypeToMaybe methodInput)}& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< #{payload (methodTypeToMaybe methodResult)}>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Async#{methodName}(const #{payload (methodTypeToMaybe methodInput)}& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< #{payload (methodTypeToMaybe methodResult)}>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
         {
             Async#{methodName}(#{bonded (methodTypeToMaybe methodInput)}{request}, cb, ::std::move(context));
         }|]
@@ -248,7 +248,7 @@ inline #{className}::#{proxyName}<TThreadPool>::#{proxyName}(
         methodDecl Function{..} = [lt|#{template}template <typename TThreadPool>
 inline void #{className}::#{proxyName}<TThreadPool>::Async#{methodName}(
     #{voidParam (methodTypeToMaybe methodInput)}
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< #{payload (methodTypeToMaybe methodResult)}>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< #{payload (methodTypeToMaybe methodResult)}>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     #{voidRequest (methodTypeToMaybe methodInput)}

--- a/compiler/tests/generated/generic_service_grpc.h
+++ b/compiler/tests/generated/generic_service_grpc.h
@@ -53,28 +53,28 @@ public:
             std::shared_ptr< ::bond::ext::gRPC::io_manager> ioManager,
             std::shared_ptr<TThreadPool> threadPool);
 
-        void Asyncfoo31(const ::bond::bonded<Payload>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
-        void Asyncfoo31(const Payload& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
+        void Asyncfoo31(const ::bond::bonded<Payload>& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Asyncfoo31(const Payload& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
         {
             Asyncfoo31(::bond::bonded<Payload>{request}, cb, ::std::move(context));
         }
 
-        void Asyncfoo32(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< Payload>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Asyncfoo32(const ::std::function<void(::bond::ext::gRPC::unary_call_result< Payload>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
 
-        void Asyncfoo33(const ::bond::bonded<Payload>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< Payload>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
-        void Asyncfoo33(const Payload& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< Payload>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
+        void Asyncfoo33(const ::bond::bonded<Payload>& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< Payload>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Asyncfoo33(const Payload& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< Payload>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
         {
             Asyncfoo33(::bond::bonded<Payload>{request}, cb, ::std::move(context));
         }
 
-        void AsyncConsumesGeneric1(const ::bond::bonded< ::tests::SomeBox<int32_t>>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
-        void AsyncConsumesGeneric1(const ::tests::SomeBox<int32_t>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
+        void AsyncConsumesGeneric1(const ::bond::bonded< ::tests::SomeBox<int32_t>>& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void AsyncConsumesGeneric1(const ::tests::SomeBox<int32_t>& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
         {
             AsyncConsumesGeneric1(::bond::bonded< ::tests::SomeBox<int32_t>>{request}, cb, ::std::move(context));
         }
 
-        void AsyncConsumesGeneric2(const ::bond::bonded< ::tests::SomeBox<std::vector<int32_t> >>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
-        void AsyncConsumesGeneric2(const ::tests::SomeBox<std::vector<int32_t> >& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
+        void AsyncConsumesGeneric2(const ::bond::bonded< ::tests::SomeBox<std::vector<int32_t> >>& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void AsyncConsumesGeneric2(const ::tests::SomeBox<std::vector<int32_t> >& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
         {
             AsyncConsumesGeneric2(::bond::bonded< ::tests::SomeBox<std::vector<int32_t> >>{request}, cb, ::std::move(context));
         }
@@ -188,7 +188,7 @@ template <typename Payload>
     template <typename TThreadPool>
 inline void Foo<Payload>::ClientCore<TThreadPool>::Asyncfoo31(
     const ::bond::bonded<Payload>& request,
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     
@@ -205,7 +205,7 @@ template <typename Payload>
     template <typename TThreadPool>
 inline void Foo<Payload>::ClientCore<TThreadPool>::Asyncfoo32(
     
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< Payload>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< Payload>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
@@ -222,7 +222,7 @@ template <typename Payload>
     template <typename TThreadPool>
 inline void Foo<Payload>::ClientCore<TThreadPool>::Asyncfoo33(
     const ::bond::bonded<Payload>& request,
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< Payload>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< Payload>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     
@@ -239,7 +239,7 @@ template <typename Payload>
     template <typename TThreadPool>
 inline void Foo<Payload>::ClientCore<TThreadPool>::AsyncConsumesGeneric1(
     const ::bond::bonded< ::tests::SomeBox<int32_t>>& request,
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     
@@ -256,7 +256,7 @@ template <typename Payload>
     template <typename TThreadPool>
 inline void Foo<Payload>::ClientCore<TThreadPool>::AsyncConsumesGeneric2(
     const ::bond::bonded< ::tests::SomeBox<std::vector<int32_t> >>& request,
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     

--- a/compiler/tests/generated/service_attributes_grpc.h
+++ b/compiler/tests/generated/service_attributes_grpc.h
@@ -52,8 +52,8 @@ public:
             std::shared_ptr< ::bond::ext::gRPC::io_manager> ioManager,
             std::shared_ptr<TThreadPool> threadPool);
 
-        void Asyncfoo(const ::bond::bonded< ::tests::Param>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::Result>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
-        void Asyncfoo(const ::tests::Param& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::Result>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
+        void Asyncfoo(const ::bond::bonded< ::tests::Param>& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::Result>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Asyncfoo(const ::tests::Param& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::Result>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
         {
             Asyncfoo(::bond::bonded< ::tests::Param>{request}, cb, ::std::move(context));
         }
@@ -121,7 +121,7 @@ inline Foo::ClientCore<TThreadPool>::ClientCore(
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo(
     const ::bond::bonded< ::tests::Param>& request,
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::Result>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::Result>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     

--- a/compiler/tests/generated/service_grpc.h
+++ b/compiler/tests/generated/service_grpc.h
@@ -77,61 +77,61 @@ public:
             Asyncfoo15(::bond::bonded< ::tests2::OtherBasicTypes>{request}, ::std::move(context));
         }
 
-        void Asyncfoo21(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Asyncfoo21(const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
 
-        void Asyncfoo22(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Asyncfoo22(const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
 
-        void Asyncfoo23(const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
-        void Asyncfoo23(const ::tests::BasicTypes& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
+        void Asyncfoo23(const ::bond::bonded< ::tests::BasicTypes>& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Asyncfoo23(const ::tests::BasicTypes& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
         {
             Asyncfoo23(::bond::bonded< ::tests::BasicTypes>{request}, cb, ::std::move(context));
         }
 
-        void Asyncfoo24(const ::bond::bonded< ::tests::dummy>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
-        void Asyncfoo24(const ::tests::dummy& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
+        void Asyncfoo24(const ::bond::bonded< ::tests::dummy>& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Asyncfoo24(const ::tests::dummy& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
         {
             Asyncfoo24(::bond::bonded< ::tests::dummy>{request}, cb, ::std::move(context));
         }
 
-        void Asyncfoo31(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Asyncfoo31(const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
 
-        void Asyncfoo32(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Asyncfoo32(const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
 
-        void Asyncfoo33(const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
-        void Asyncfoo33(const ::tests::BasicTypes& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
+        void Asyncfoo33(const ::bond::bonded< ::tests::BasicTypes>& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Asyncfoo33(const ::tests::BasicTypes& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
         {
             Asyncfoo33(::bond::bonded< ::tests::BasicTypes>{request}, cb, ::std::move(context));
         }
 
-        void Async_rd_foo33(const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
-        void Async_rd_foo33(const ::tests::BasicTypes& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
+        void Async_rd_foo33(const ::bond::bonded< ::tests::BasicTypes>& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Async_rd_foo33(const ::tests::BasicTypes& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
         {
             Async_rd_foo33(::bond::bonded< ::tests::BasicTypes>{request}, cb, ::std::move(context));
         }
 
-        void Asyncfoo34(const ::bond::bonded< ::tests::dummy>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
-        void Asyncfoo34(const ::tests::dummy& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
+        void Asyncfoo34(const ::bond::bonded< ::tests::dummy>& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Asyncfoo34(const ::tests::dummy& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
         {
             Asyncfoo34(::bond::bonded< ::tests::dummy>{request}, cb, ::std::move(context));
         }
 
-        void Asyncfoo41(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Asyncfoo41(const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::dummy>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
 
-        void Asyncfoo42(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Asyncfoo42(const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::dummy>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
 
-        void Asyncfoo43(const ::bond::bonded< ::tests::BasicTypes>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
-        void Asyncfoo43(const ::tests::BasicTypes& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
+        void Asyncfoo43(const ::bond::bonded< ::tests::BasicTypes>& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::dummy>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Asyncfoo43(const ::tests::BasicTypes& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::dummy>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
         {
             Asyncfoo43(::bond::bonded< ::tests::BasicTypes>{request}, cb, ::std::move(context));
         }
 
-        void Asyncfoo44(const ::bond::bonded< ::tests::dummy>& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
-        void Asyncfoo44(const ::tests::dummy& request, const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
+        void Asyncfoo44(const ::bond::bonded< ::tests::dummy>& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::dummy>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Asyncfoo44(const ::tests::dummy& request, const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::dummy>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {})
         {
             Asyncfoo44(::bond::bonded< ::tests::dummy>{request}, cb, ::std::move(context));
         }
 
-        void Asynccq(const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
+        void Asynccq(const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>)>& cb, ::std::shared_ptr< ::grpc::ClientContext> context = {});
 
         ClientCore(const ClientCore&) = delete;
         ClientCore& operator=(const ClientCore&) = delete;
@@ -489,7 +489,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo15(
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo21(
     
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
@@ -505,7 +505,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo21(
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo22(
     
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
@@ -521,7 +521,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo22(
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo23(
     const ::bond::bonded< ::tests::BasicTypes>& request,
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     
@@ -537,7 +537,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo23(
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo24(
     const ::bond::bonded< ::tests::dummy>& request,
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::bond::Void>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::bond::Void>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     
@@ -553,7 +553,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo24(
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo31(
     
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
@@ -569,7 +569,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo31(
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo32(
     
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
@@ -585,7 +585,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo32(
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo33(
     const ::bond::bonded< ::tests::BasicTypes>& request,
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     
@@ -601,7 +601,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo33(
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Async_rd_foo33(
     const ::bond::bonded< ::tests::BasicTypes>& request,
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     
@@ -617,7 +617,7 @@ inline void Foo::ClientCore<TThreadPool>::Async_rd_foo33(
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo34(
     const ::bond::bonded< ::tests::dummy>& request,
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     
@@ -633,7 +633,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo34(
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo41(
     
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::dummy>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
@@ -649,7 +649,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo41(
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo42(
     
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::dummy>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};
@@ -665,7 +665,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo42(
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo43(
     const ::bond::bonded< ::tests::BasicTypes>& request,
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::dummy>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     
@@ -681,7 +681,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo43(
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asyncfoo44(
     const ::bond::bonded< ::tests::dummy>& request,
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::dummy>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::dummy>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     
@@ -697,7 +697,7 @@ inline void Foo::ClientCore<TThreadPool>::Asyncfoo44(
 template <typename TThreadPool>
 inline void Foo::ClientCore<TThreadPool>::Asynccq(
     
-    const std::function<void(std::shared_ptr< ::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>>)>& cb,
+    const ::std::function<void(::bond::ext::gRPC::unary_call_result< ::tests::BasicTypes>)>& cb,
     ::std::shared_ptr< ::grpc::ClientContext> context)
 {
     auto request = ::bond::bonded< ::bond::Void>{ ::bond::Void()};

--- a/cpp/inc/bond/ext/grpc/client_callback.h
+++ b/cpp/inc/bond/ext/grpc/client_callback.h
@@ -34,32 +34,32 @@ namespace bond { namespace ext { namespace gRPC {
               _context(std::move(context))
         { }
 
-        const bonded<Response>& response() const BOND_NOEXCEPT
-        {
-            return _response;
-        }
-
-        const grpc::Status& status() const BOND_NOEXCEPT
-        {
-            return _status;
-        }
-
-        const std::shared_ptr<grpc::ClientContext>& context() const BOND_NOEXCEPT
-        {
-            return _context;
-        }
-
-    private:
         /// @brief The response received from the service.
         ///
         /// @note Depending on the implementation of the service, this may or
         /// may not contain an actual response. Consult the documentation for
         /// the service to determine under what conditions it sends back a
         /// response.
-        bonded<Response> _response;
+        const bonded<Response>& response() const BOND_NOEXCEPT
+        {
+            return _response;
+        }
+
         /// @brief The status of the request.
-        grpc::Status _status;
+        const grpc::Status& status() const BOND_NOEXCEPT
+        {
+            return _status;
+        }
+
         /// @brief The client context under which the request was executed.
+        const std::shared_ptr<grpc::ClientContext>& context() const BOND_NOEXCEPT
+        {
+            return _context;
+        }
+
+    private:
+        bonded<Response> _response;
+        grpc::Status _status;
         std::shared_ptr<grpc::ClientContext> _context;
     };
 

--- a/cpp/inc/bond/ext/grpc/client_callback.h
+++ b/cpp/inc/bond/ext/grpc/client_callback.h
@@ -11,50 +11,56 @@
 #include <grpcpp/client_context.h>
 
 #include <memory>
-#include <utility>
+
 
 namespace bond { namespace ext { namespace gRPC {
 
     /// @brief The client-side results of a unary call.
-    template <typename TResponse>
-    struct unary_call_result
+    template <typename Response>
+    class unary_call_result
     {
+    public:
+        /// @brief Create a unary_call_result with the given values.
+        ///
+        /// @param response The response.
+        /// @param status The status.
+        /// @param context the context under which the request is being executed.
+        unary_call_result(
+            bonded<Response> response,
+            const grpc::Status& status,
+            std::shared_ptr<grpc::ClientContext> context)
+            : _response(std::move(response)),
+              _status(status),
+              _context(std::move(context))
+        { }
+
+        const bonded<Response>& response() const BOND_NOEXCEPT
+        {
+            return _response;
+        }
+
+        const grpc::Status& status() const BOND_NOEXCEPT
+        {
+            return _status;
+        }
+
+        const std::shared_ptr<grpc::ClientContext>& context() const BOND_NOEXCEPT
+        {
+            return _context;
+        }
+
+    private:
         /// @brief The response received from the service.
         ///
         /// @note Depending on the implementation of the service, this may or
         /// may not contain an actual response. Consult the documentation for
         /// the service to determine under what conditions it sends back a
         /// response.
-        bond::bonded<TResponse> response;
+        bonded<Response> _response;
         /// @brief The status of the request.
-        grpc::Status status;
-        /// @brief The client context underwhich the request was executed.
-        std::shared_ptr<grpc::ClientContext> context;
-
-        /// @brief Create a unary_call_result with the given context and
-        /// empty \ref response and \ref status members.
-        ///
-        /// @param context the context underwhich the request is being
-        /// executed.
-        explicit unary_call_result(std::shared_ptr<grpc::ClientContext> context)
-            : response(),
-              status(),
-              context(std::move(context))
-        { }
-
-        /// @brief Create a unary_call_result with the given values.
-        ///
-        /// @param response The response.
-        /// @param status The status.
-        /// @param context the context underwhich the request is being executed.
-        unary_call_result(
-            const bond::bonded<TResponse>& response,
-            const grpc::Status& status,
-            std::shared_ptr<grpc::ClientContext> context)
-            : response(response),
-              status(status),
-              context(std::move(context))
-        { }
+        grpc::Status _status;
+        /// @brief The client context under which the request was executed.
+        std::shared_ptr<grpc::ClientContext> _context;
     };
 
 } } } // namespace bond::ext::gRPC

--- a/cpp/inc/bond/ext/grpc/wait_callback.h
+++ b/cpp/inc/bond/ext/grpc/wait_callback.h
@@ -17,7 +17,7 @@
 #include <condition_variable>
 #include <memory>
 #include <mutex>
-#include <tuple>
+
 
 namespace bond { namespace ext { namespace gRPC {
 
@@ -29,41 +29,39 @@ namespace bond { namespace ext { namespace gRPC {
 /// The wait() member function can be used to wait until the callback has
 /// been called. Then, the status() and response() member functions can be
 /// called to inspect the results.
-template <typename TResponse>
+template <typename Response>
 class wait_callback final
 {
 public:
-    wait_callback() : _impl(std::make_shared<impl>()) { }
-
-    typedef unary_call_result<TResponse> arg_type;
+    using arg_type = unary_call_result<Response>;
 
     /// @brief Records the response and status.
     ///
     /// @exception MultipleInvocationException thrown if the callback (or a
     /// copy of the callback) is invoked more than once.
-    void operator()(std::shared_ptr<arg_type> args)
+    void operator()(arg_type result) const
     {
-        std::unique_lock<std::mutex> lock(_impl->_m);
-        if (!_impl->_results)
         {
-            _impl->_results = std::move(args);
+            std::lock_guard<std::mutex> lock(*_state);
 
-            // Drop the lock before notifying so we don't wake someone up to
-            // then have them wait on the lock.
-            lock.unlock();
-            _impl->_cv.notify_all();
+            if (!_state->result)
+            {
+                _state->result = std::move(result);
+            }
+            else
+            {
+                throw MultipleInvocationException();
+            }
         }
-        else
-        {
-            throw MultipleInvocationException();
-        }
+
+        _state->notify_all();
     }
 
     /// @brief Waits for this to have been invoked.
     void wait() const
     {
-        std::unique_lock<std::mutex> lock(_impl->_m);
-        _impl->_cv.wait(lock, [this]() { return static_cast<bool>(_impl->_results); });
+        std::unique_lock<std::mutex> lock(*_state);
+        _state->wait(lock, [this] { return static_cast<bool>(_state->result); });
     }
 
     /// @brief Waits at least \p timeout for this to have been invoked.
@@ -75,17 +73,17 @@ public:
     template <typename Rep, typename Period>
     bool wait_for(const std::chrono::duration<Rep, Period>& timeout) const
     {
-        std::unique_lock<std::mutex> lock(_impl->_m);
-        return _impl->_cv.wait_for(lock, timeout, [this]() { return static_cast<bool>(_impl->_results); });
+        std::unique_lock<std::mutex> lock(*_state);
+        return _state->wait_for(lock, timeout, [this] { return static_cast<bool>(_state->result); });
     }
 
     /// @brief Gets the response.
     ///
     /// @warning Blocks until this has been invoked.
-    const bond::bonded<TResponse>& response() const
+    const bonded<Response>& response() const
     {
         wait();
-        return _impl->_results->response;
+        return _state->result->response();
     }
 
     /// @brief Gets the status.
@@ -94,43 +92,25 @@ public:
     const grpc::Status& status() const
     {
         wait();
-        return _impl->_results->status;
+        return _state->result->status();
     }
 
     /// @brief Gets the context.
     ///
     /// @warning Blocks until this has been invoked.
-    std::shared_ptr<grpc::ClientContext> context() const
+    const std::shared_ptr<grpc::ClientContext>& context() const
     {
         wait();
-        return _impl->_results->context;
+        return _state->result->context();
     }
 
 private:
-    /// The interesting guts of wait_callback. We use an impl class so that
-    /// wait_callback can be copied and all the copies affect the same underlying
-    /// state.
-    struct impl final
+    struct state : std::mutex, std::condition_variable
     {
-        impl() = default;
-        impl(const impl&) = delete;
-        impl(impl&&) = delete;
-        impl& operator=(const impl&) = delete;
-        impl& operator=(impl&&) = delete;
-
-        /// mutex to lock the shared state
-        std::mutex _m;
-        /// condition variable used to signal anyone waiting
-        std::condition_variable _cv;
-        /// The results, but more importantly, doubles as a flag
-        /// indicating whether a callback has been invoked yet. If this is
-        /// nullptr, no callback has been invoked yet. If not nullptr, a
-        /// callback has already been invoked.
-        std::shared_ptr<arg_type> _results;
+        boost::optional<arg_type> result;
     };
 
-    /// shared_ptr to the actual state.
-    std::shared_ptr<impl> _impl;
+    std::shared_ptr<state> _state{ std::make_shared<state>() };
 };
 
 /// @example wait_callback_example.cpp
@@ -138,4 +118,4 @@ private:
 /// This is a brief example showing how wait_callback can be used to
 /// synchronously get the result of invoking an async proxy method.
 
-} } } // bond::extgrpc
+} } } // bond::ext::gRPC

--- a/cpp/test/grpc/wait_callback.cpp
+++ b/cpp/test/grpc/wait_callback.cpp
@@ -6,14 +6,12 @@
 
 #include <bond/core/bond.h>
 #include <bond/core/bond_reflection.h>
-#include <bond/ext/grpc/client_callback.h>
 #include <bond/ext/grpc/wait_callback.h>
 #include <bond/protocol/compact_binary.h>
 #include <bond/stream/output_buffer.h>
 
 #include "event.h"
 
-#include <boost/optional.hpp>
 #include <boost/static_assert.hpp>
 
 #include <atomic>
@@ -49,7 +47,7 @@ namespace wait_callback_tests
         return bond::bonded<bond::Box<int>>(reader);
     }
 
-    static std::shared_ptr<callback_arg> MakeCallbackArg(
+    static callback_arg MakeCallbackArg(
         const bond::bonded<bond::Box<int>>& response,
         const grpc::Status& status)
     {
@@ -59,7 +57,7 @@ namespace wait_callback_tests
         // However, we don't want to deal with making sure that the test
         // globals and the gRPC++ globals are destroyed in the right order.
         // Thus, we test with nullptr.
-        return std::make_shared<callback_arg>(response, status, nullptr);
+        return callback_arg(response, status, nullptr);
     }
 
     static void CallbackCapturesValues()
@@ -103,7 +101,7 @@ namespace wait_callback_tests
     static void CanBeConvertedToStdFunction()
     {
         wait_callbackBox cb;
-        std::function<void(std::shared_ptr<callback_arg>)> f = cb;
+        std::function<void(callback_arg)> f = cb;
 
         f(MakeCallbackArg(anyBondedValue, anyStatus));
 


### PR DESCRIPTION
This change removes the unnecessary `std::shared_ptr` wrapper when passing `unary_call_result<Response>` to a client callback.

Built on top of #882.