### PR TITLE
[gbc c++ grpc] Fix to not apply attr. to generic

### DIFF
--- a/compiler/src/Language/Bond/Codegen/Cpp/Grpc_h.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Grpc_h.hs
@@ -179,9 +179,10 @@ inline #{className}::#{proxyName}<TThreadPool>::#{proxyName}(
         className = CPP.className s
         template = CPP.template s
         onlyTemplate x = if null declParams then mempty else x
+        onlyNonTemplate x = if null declParams then x else mempty
         typename = onlyTemplate [lt|typename |]
 
-        export_attr = optional (\a -> [lt|#{a}
+        export_attr = onlyNonTemplate $ optional (\a -> [lt|#{a}
         |]) export_attribute
 
         methodMetadataVar m = [lt|s_#{methodName m}_metadata|]

--- a/examples/cpp/grpc/grpc_dll/grpc_dll.bond
+++ b/examples/cpp/grpc/grpc_dll/grpc_dll.bond
@@ -1,18 +1,18 @@
 namespace examples.grpc_dll
 
-struct Item
+struct Item<T>
 {
-    0: string       str = "default string value";
-    1: list<uint32> numbers;
+    0: string  str = "default string value";
+    1: list<T> numbers;
 }
 
 struct MyStruct
 {
-    0: vector<Item> items;
-    1: bonded<Item> item;
+    0: vector<Item<uint32>> items;
+    1: bonded<Item<uint32>> item;
 }
 
-service TestService
+service TestService<T>
 {
-    Item TestMethod(MyStruct);
+    Item<T> TestMethod(MyStruct);
 }

--- a/examples/cpp/grpc/grpc_dll/using_grpc_dll.cpp
+++ b/examples/cpp/grpc/grpc_dll/using_grpc_dll.cpp
@@ -43,15 +43,15 @@ using grpc::ServerContext;
 
 using namespace examples::grpc_dll;
 
-struct TestServiceImpl : TestService::Service
+struct TestServiceImpl : TestService<uint32_t>::Service
 {
     void TestMethod(bond::ext::gRPC::unary_call<
                         bond::bonded<MyStruct>,
-                        Item> call) override
+                        Item<uint32_t>> call) override
     {
         MyStruct request = call.request().Deserialize();
 
-        Item response;
+        Item<uint32_t> response;
         response = request.items[0];
 
         call.Finish(response);
@@ -74,10 +74,10 @@ int main()
         obj.items.resize(1);
         obj.items[0].numbers.push_back(13);
 
-        Item item;
+        Item<uint32_t> item;
 
         item.numbers.push_back(11);
-        obj.item = bond::bonded<Item>(item);
+        obj.item = bond::bonded<Item<uint32_t>>(item);
 
         // Serialize
         bond::OutputBuffer buffer;
@@ -92,7 +92,7 @@ int main()
         bond::CompactBinaryReader<bond::InputBuffer> reader(data);
         bond::Deserialize(reader, obj2);
 
-        Item item2;
+        Item<uint32_t> item2;
 
         obj2.item.Deserialize(item2);
 
@@ -105,9 +105,9 @@ int main()
 
         std::cout << schema.GetSchema().structs[schema.GetSchema().root.struct_def].fields[0].metadata.name << std::endl;
 
-        print_metadata()(TestService::Schema());
+        print_metadata()(TestService<uint32_t>::Schema());
 
-        boost::mpl::for_each<TestService::Schema::methods>(print_metadata());
+        boost::mpl::for_each<TestService<uint32_t>::Schema::methods>(print_metadata());
     }
 
     { // Exercise gRPC facilities
@@ -126,7 +126,7 @@ int main()
         std::unique_ptr<bond::ext::gRPC::server> server(builder.BuildAndStart());
 
         // Create a proxy
-        TestService::Client proxy(
+        TestService<uint32_t>::Client proxy(
             grpc::CreateChannel(server_address, grpc::InsecureChannelCredentials()),
             ioManager,
             threadPool);


### PR DESCRIPTION
Currently, the `--export-attribute` is used to mark all static `bond::Metadata` fields in compile-time `Schema` object, including the cases when the service is a template, which is not correct. This fixes the `gbc` to skip the attribute in such cases.