### PR TITLE
[gbc] Sync `stack build` and CMake Debug config

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -17,14 +17,8 @@ function (add_stack_build target)
         set (options "--test")
     endif()
 
-    # If unspecified, turn off optimizations
-    list (APPEND options $<$<CONFIG:>:--fast>)
-
-    list (APPEND options $<$<CONFIG:Debug>:--fast>)
-    list (APPEND options $<$<CONFIG:Debug>:--no-executable-stripping>)
-    list (APPEND options $<$<CONFIG:Debug>:--no-library-stripping>)
-    list (APPEND options $<$<CONFIG:Debug>:--no-strip>)
-
+    # These command line arguments override what's in stack.yaml for
+    # specific configurations.
     list (APPEND options $<$<CONFIG:MinSizeRel>:--executable-stripping>)
     list (APPEND options $<$<CONFIG:MinSizeRel>:--ghc-options=-O2>)
     list (APPEND options $<$<CONFIG:MinSizeRel>:--library-stripping>)

--- a/compiler/stack.yaml
+++ b/compiler/stack.yaml
@@ -39,3 +39,18 @@ extra-deps:
 - primitive-0.6.2.0
 - scientific-0.3.5.2
 - vector-0.12.0.1
+
+#
+# The following sections are related to build optimizations and debug
+# settings.
+#
+# These defaults are chosen for a fast build that can be debugged. The
+# CMake-based build will override these via commmand line arguments when
+# needed. See CMakeLists.txt for those details.
+#
+ghc-options:
+  "$locals": -O0
+
+build:
+  executable-stripping: false
+  library-stripping: false


### PR DESCRIPTION
With this commit, bare `stack build` at the command line and the CMake
Debug configuration use the same settings. This minimizes spurious
rebuilds when developing gbc out of the compiler directory and building
Bond via CMake (C++, Java, Python) or MSBuild (C#).