### PR TITLE
[c#] Remove unused packages.config files

### DIFF
--- a/cs/test/grpc/packages.config
+++ b/cs/test/grpc/packages.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Grpc.Core" version="1.12.0" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
-  <package id="System.Interactive.Async" version="3.1.1" targetFramework="net45" />
-</packages>

--- a/examples/cs/grpc/shared-types-assembly/client/packages.config
+++ b/examples/cs/grpc/shared-types-assembly/client/packages.config
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Grpc.Core" version="1.12.0" targetFramework="net45" />
-  <package id="System.Interactive.Async" version="3.1.1" targetFramework="net45" />
-</packages>

--- a/examples/cs/grpc/shared-types-assembly/server/packages.config
+++ b/examples/cs/grpc/shared-types-assembly/server/packages.config
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Grpc.Core" version="1.12.0" targetFramework="net45" />
-  <package id="System.Interactive.Async" version="3.1.1" targetFramework="net45" />
-</packages>


### PR DESCRIPTION
When we converted to the SDK-based project format in commit 3c7bdb9738,
we moved our package references inside the .csproj files, so we can
delete the older packages.config files that were left over.