### PR TITLE
[c++ grpc] Remove disabled memory leak detection

### DIFF
--- a/cpp/test/grpc/io_manager.cpp
+++ b/cpp/test/grpc/io_manager.cpp
@@ -175,14 +175,6 @@ public:
 
 bool init_unit_test()
 {
-    // grpc allocates a bunch of stuff on-demand caused the leak tracker to
-    // report leaks. Disable it for this test.
-    boost::debug::detect_memory_leaks(false);
-
-    // Initialize the gRPC++ library
-    grpc::internal::GrpcLibraryInitializer initializer;
-    initializer.summon();
-
     io_managerTests::Initialize();
     return true;
 }


### PR DESCRIPTION
The global memory leak [has been fixed](https://github.com/grpc/grpc/commit/1a956bcd3274fb9135d63101b803c00015f3f2af) in grpc 1.12.0.