### PR TITLE
[gbc] Fix -Wall -Werror packaging warning

### DIFF
--- a/compiler/bond.cabal
+++ b/compiler/bond.cabal
@@ -31,6 +31,10 @@ copyright:          Copyright (c) Microsoft. All rights reserved.
 category:           Language, Compiler, Code Generation
 build-type:         Simple
 
+flag warningsAsErrors
+  default: False
+  manual: True
+
 source-repository head
   type:             git
   location:         git@github.com:Microsoft/bond.git
@@ -47,7 +51,8 @@ library
                     shakespeare >= 2.0,
                     text >= 0.11,
                     unordered-containers >= 0.2.3.0
-  ghc-options:      -Wall -Werror
+  if flag(warningsAsErrors)
+    ghc-options:      -Wall -Werror
   exposed-modules:  Language.Bond.Parser
                     Language.Bond.Util
                     Language.Bond.Syntax.Types
@@ -88,7 +93,10 @@ test-suite gbc-tests
                     Tests.Codegen.Util
                     Tests.Syntax
                     Tests.Syntax.JSON
-  ghc-options:      -threaded -Wall -Werror
+
+  ghc-options:      -threaded
+  if flag(warningsAsErrors)
+    ghc-options:    -threaded -Wall -Werror
 
   if os(windows) && arch(i386)
     ld-options:     -Wl,--dynamicbase -Wl,--nxcompat -Wl,--large-address-aware
@@ -121,7 +129,10 @@ executable gbc
   main-is:          Main.hs
   other-modules:    IO
                     Options
-  ghc-options:      -threaded -Wall -Werror
+
+  ghc-options:      -threaded
+  if flag(warningsAsErrors)
+    ghc-options:    -threaded -Wall -Werror
 
   if os(windows) && arch(i386)
     ld-options:     -Wl,--dynamicbase -Wl,--nxcompat -Wl,--large-address-aware

--- a/compiler/stack.yaml
+++ b/compiler/stack.yaml
@@ -28,6 +28,10 @@ resolver: lts-7.24
 packages:
 - .
 
+flags:
+  bond:
+    warningsAsErrors: true
+
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps:


### PR DESCRIPTION
Cabal now checks that pacakges do not have -Wall -Werror enabled when
creating sdist tarballs for uploading to Hackage:

> Package check reported the following errors:
> 'ghc-options: -Wall -Werror' makes the package very easy to break with
> future GHC versions because new GHC versions often add new warnings.
> Use just 'ghc-options: -Wall' instead. Alternatively, if you want to
> use this, make it conditional based on a Cabal configuration
> flag (with 'manual: True' and 'default: False') and enable that flag
> during development.

This places those options behind a flag.