### PR TITLE
Implement move assignment for the bond::blob type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ different versioning scheme, following the Haskell community's
 ### C++ ###
 * Fixed a crash in `bond::ext::grpc::server`'s destructor when invoked on
   a moved-from object instance.
+* Added move-assignment operator to `bond::blob`
 
 ## 8.0.0: 2018-05-30 ##
 * `gbc` & compiler library: 0.11.0.0

--- a/cpp/inc/bond/core/blob.h
+++ b/cpp/inc/bond/core/blob.h
@@ -116,6 +116,17 @@ public:
         that._length = 0;
     }
 
+    blob& operator=(blob&& that) BOND_NOEXCEPT_IF(
+        std::is_nothrow_move_assignable<boost::shared_ptr<const char[]> >::value)
+    {
+        _buffer = std::move(that._buffer);
+        _content = std::move(that._content);
+        _length = std::move(that._length);
+        that._content = 0;
+        that._length = 0;
+        return *this;
+    }
+
     blob(const blob& that) = default;
     blob& operator=(const blob& that) = default;
 


### PR DESCRIPTION
Pull request for issue #934. The tests are probably overkill, I can remove them if you want. But they showed that
`
blob& operator=(blob&& that) = default;
`
would copy the internal buffer instead of moving it, so I chose the swap implementation.