### PR TITLE
Issue #434. Adds ability to specify RapidJSON library and improves dependency documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,9 @@ set (CMAKE_MODULE_PATH
 set (BOND_ENABLE_GRPC
     "TRUE"
     CACHE BOOL "If FALSE, then do not build gRPC integration")
-
+set (BOND_FIND_RAPIDJSON
+    "FALSE"
+    CACHE BOOL "If FALSE, then use and install rapidjson from thirdparty subdirectory")
 # We need to include third-party CMake modules before we configure our own
 # settings so that we don't apply our settings to third-party code.
 add_subdirectory (thirdparty)
@@ -54,13 +56,19 @@ install (DIRECTORY
     cpp/inc/bond
     cpp/generated/bond
     python/inc/bond
-    thirdparty/rapidjson/include/rapidjson
     DESTINATION include
     PATTERN *.cpp EXCLUDE)
 
 install (EXPORT bond
     DESTINATION lib/bond
     EXPORT_LINK_INTERFACE_LIBRARIES)
+
+if (NOT BOND_FIND_RAPIDJSON)
+    install (DIRECTORY
+        thirdparty/rapidjson/include/rapidjson
+        DESTINATION include
+        PATTERN *.cpp EXCLUDE)
+endif()
 
 # if BOND_GBC_PATH is set we must copy over that gbc to the install location
 if (BOND_GBC_PATH)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For a discussion how Bond compares to similar frameworks see [Why Bond](https://
 
 ## Dependencies
 
-The Bond repository uses Git submodules and should be cloned with the
+The Bond repository uses Git submodules for its RapidJSON and gRPC dependencies. It should be cloned with the
 `--recursive` flag:
 
 ```bash
@@ -41,6 +41,8 @@ supported bv Visual C++ 2013); a C++11 compiler is required. Additionally,
 to build Bond you will need CMake (3.1+),
 [Haskell Stack](https://docs.haskellstack.org/en/stable/README/#how-to-install)
 (1.5.1+) and Boost (1.61+).
+
+If you already have RapidJSON and would like to build against it, you may add argument `-DBOND_FIND_RAPIDJSON=TRUE` to cmake. It will use find_package(RapidJSON). Otherwise, Bond will also install RapidJSON.
 
 Following are specific instructions for building on various platforms.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ to build Bond you will need CMake (3.1+),
 [Haskell Stack](https://docs.haskellstack.org/en/stable/README/#how-to-install)
 (1.5.1+) and Boost (1.61+).
 
-If you already have RapidJSON and would like to build against it, you may add argument `-DBOND_FIND_RAPIDJSON=TRUE` to cmake. It will use find_package(RapidJSON). Otherwise, Bond will also install RapidJSON.
+If you already have RapidJSON and would like to build against it, you may add argument `-DBOND_FIND_RAPIDJSON=TRUE` to CMake. It will use find_package(RapidJSON). Otherwise, Bond will also install RapidJSON.
 
 Following are specific instructions for building on various platforms.
 

--- a/README.md
+++ b/README.md
@@ -29,20 +29,21 @@ For a discussion how Bond compares to similar frameworks see [Why Bond](https://
 
 ## Dependencies
 
-The Bond repository uses Git submodules for its RapidJSON and gRPC dependencies. It should be cloned with the
-`--recursive` flag:
-
-```bash
-git clone --recursive https://github.com/Microsoft/bond.git
-```
-
 Bond C++ library requires some C++11 features (currently limited to those
 supported bv Visual C++ 2013); a C++11 compiler is required. Additionally,
 to build Bond you will need CMake (3.1+),
 [Haskell Stack](https://docs.haskellstack.org/en/stable/README/#how-to-install)
 (1.5.1+) and Boost (1.61+).
 
-If you already have RapidJSON and would like to build against it, you may add argument `-DBOND_FIND_RAPIDJSON=TRUE` to CMake. It will use find_package(RapidJSON). Otherwise, Bond will also install RapidJSON.
+Additionally, Bond requires RapidJSON and optionally requires gRPC. The Bond repository primarily uses Git submodules for these two dependencies. It should be cloned with the `--recursive` flag:
+
+```bash
+git clone --recursive https://github.com/Microsoft/bond.git
+```
+
+If you already have RapidJSON and would like to build against it, add argument `-DBOND_FIND_RAPIDJSON=TRUE` to the CMake invocation. It will use find_package(RapidJSON). If you do not provide a RapidJSON library, Bond will also install RapidJSON.
+
+If you do not wish to build the gRPC component, add argument `-DBOND_ENABLE_GRPC=FALSE` to the CMake invocation.
 
 Following are specific instructions for building on various platforms.
 

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -180,8 +180,17 @@ cxx_add_compile_options(GNU
 include_directories (
     ${BOND_INCLUDE}
     ${BOND_GENERATED}
-    ${Boost_INCLUDE_DIRS}
-    ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/rapidjson/include)
+    ${Boost_INCLUDE_DIRS})
+
+if (BOND_FIND_RAPIDJSON)
+    find_package(RapidJSON)
+    include_directories (
+        ${RapidJSON_INCLUDE_DIRS})
+      
+else()
+    include_directories (
+        ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/rapidjson/include)
+endif()
 
 set (BOND_LIBRARIES_ONLY
     "FALSE"

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -183,7 +183,7 @@ include_directories (
     ${Boost_INCLUDE_DIRS})
 
 if (BOND_FIND_RAPIDJSON)
-    find_package(RapidJSON)
+    find_package(RapidJSON REQUIRED)
     include_directories (
         ${RapidJSON_INCLUDE_DIRS})
       


### PR DESCRIPTION
-Creates cmake cache variable `BOND_FIND_RAPIDJSON`, defaults to False.
-If `BOND_FIND_RAPIDJSON` is set to true, it will require that RapidJSON package be found. Moreover, it will not install RapidJSON.
-if `BOND_FIND_RAPIDJSON` is set to false, the current behavior is kept where it compiles against the submodule and install the RapidJSON include directory. 
-Improves the documentation of dependencies and their management in README.md.

Tested the following cases in both Linux and macOS:
1. No `BOND_FIND_RAPIDJSON` variable is set. Verified it compiles against the submodule and installs the RapidJSON include directory. Verified I could link against Bond.
2. `BOND_FIND_RAPIDJSON` variable is set to true and no RapidJSON package is found. CMake throws an error and doesn't complete configuration.
3. `BOND_FIND_RAPIDJSON` variable is set to true and RapidJSON package is found. Verified it compiles against the found library and doesn't install the RapidJSON include directory. Verified I could link against Bond.

On a final note, if an user provides a RapidJSON library and doesn't want to build against gRPC, Bond doesn't have to checked out recursively.