### PR TITLE
[c++] Fix short-circuiting in ValidateTwoWay

### DIFF
--- a/cpp/inc/bond/core/validate.h
+++ b/cpp/inc/bond/core/validate.h
@@ -83,7 +83,7 @@ inline bool Validate(const RuntimeSchema& src,
 template <typename Protocols = BuiltInProtocols, typename T1, typename T2>
 inline bool ValidateTwoWay(const T1& s1, const T2& s2)
 {
-    return Validate<Protocols>(s1, s2) & Validate<Protocols>(s2, s1);
+    return Validate<Protocols>(s1, s2) && Validate<Protocols>(s2, s1);
 }
 
 } // namespace bond


### PR DESCRIPTION
Due to a typo in ValidateTwoWay, if Validate<Protocols>(s1, s2) returns
false, Validate<Protocols>(s2, s1) will be called unnecessarily. This
change enables short-circuiting to avoid the unnecessary right hand side
computation.