### PR TITLE
Avoid addressof(*p) when p doesn't alias an object

### DIFF
--- a/cpp/inc/bond/core/nullable.h
+++ b/cpp/inc/bond/core/nullable.h
@@ -44,6 +44,19 @@ use_value
         || is_wstring<T>::value
         || !std::is_class<T>::value> {};
 
+template<class T>
+BOND_CONSTEXPR inline T* to_address(T* ptr) BOND_NOEXCEPT
+{
+    return ptr;
+}
+
+template<class Ptr>
+inline typename std::pointer_traits<Ptr>::element_type*
+to_address(const Ptr& ptr) BOND_NOEXCEPT
+{
+    return bond::detail::to_address(ptr.operator->());
+}
+
 } // namespace detail
 
 
@@ -458,7 +471,7 @@ private:
     void delete_value()
     {
         rebind_alloc alloc(allocator_holder::get());
-        std::allocator_traits<rebind_alloc>::destroy(alloc, std::addressof(*_value));
+        std::allocator_traits<rebind_alloc>::destroy(alloc, bond::detail::to_address(_value));
         alloc.deallocate(_value, 1);
     }
 
@@ -470,7 +483,7 @@ private:
         try
         {
             std::allocator_traits<rebind_alloc>::construct(
-                alloc, std::addressof(*p), std::forward<Args>(args)...);
+                alloc, bond::detail::to_address(p), std::forward<Args>(args)...);
             return p;
         }
         catch (...)


### PR DESCRIPTION
It is fine for `destroy`, but for `construct` is technically UB to use `addressof(*p)` as `p` does not reference an object that was constructed. See [P0653R2](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0653r2.html) and `std::to_address` in C++2a. This is existing practice in libc++ (`__to_raw_pointer`), libstdc++ (`__to_address`), and Boost (`boost::to_address` since Boost 1.67).