### PR TITLE
[C# Grpc] Support initializing a grpc service client with a CallInvoker instance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,11 @@ different versioning scheme, following the Haskell community's
 ### C# ###
 
 * Updated to gRPC v1.17.1.
-
-### C# ###
-
-* Add a constructor that accepts an `CallInvoker` instance to grpc service client
-  to support client side interceptor. [Issue #950](https://github.com/Microsoft/bond/issues/950).
-  See [L12-csharp-interceptors](https://github.com/grpc/proposal/blob/master/L12-csharp-interceptors.md)
-  and [discussion](https://github.com/grpc/grpc/issues/11646#issuecomment-312799633).
+* Add a constructor that accepts a `CallInvoker` instance to the generated
+  gRPC clients to support client-side interceptors. For more details about
+  C# interceptors, see the [proposal in the gRPC
+  project](https://github.com/grpc/proposal/blob/master/L12-csharp-interceptors.md).
+  [Issue #950](https://github.com/Microsoft/bond/issues/950)
 
 ## 8.0.1: 2018-06-29 ##
 * `gbc` & compiler library: 0.11.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ different versioning scheme, following the Haskell community's
 * C++ version: TBD
 * C# NuGet version: TBD
 
+### C# ###
+
+* Add a constructor that accepts an `CallInvoker` instance to grpc service client
+  to support client side interceptor. [Issue #950](https://github.com/Microsoft/bond/issues/950).
+  See [L12-csharp-interceptors](https://github.com/grpc/proposal/blob/master/L12-csharp-interceptors.md)
+  and [discussion](https://github.com/grpc/grpc/issues/11646#issuecomment-312799633).
+
 ## 8.0.1: 2018-06-29 ##
 * `gbc` & compiler library: 0.11.0.3
 * IDL core version: 3.0

--- a/compiler/src/Language/Bond/Codegen/Cs/Grpc_cs.hs
+++ b/compiler/src/Language/Bond/Codegen/Cs/Grpc_cs.hs
@@ -77,6 +77,10 @@ namespace #{csNamespace}
             {
             }
 
+            public #{declName}Client(global::Grpc.Core.CallInvoker callInvoker) : base(callInvoker)
+            {
+            }
+
             protected #{declName}Client() : base()
             {
             }

--- a/compiler/tests/generated/generic_service_grpc.cs
+++ b/compiler/tests/generated/generic_service_grpc.cs
@@ -77,6 +77,10 @@ namespace tests
             {
             }
 
+            public FooClient(global::Grpc.Core.CallInvoker callInvoker) : base(callInvoker)
+            {
+            }
+
             protected FooClient() : base()
             {
             }

--- a/compiler/tests/generated/service_attributes_grpc.cs
+++ b/compiler/tests/generated/service_attributes_grpc.cs
@@ -44,6 +44,10 @@ namespace tests
             {
             }
 
+            public FooClient(global::Grpc.Core.CallInvoker callInvoker) : base(callInvoker)
+            {
+            }
+
             protected FooClient() : base()
             {
             }

--- a/compiler/tests/generated/service_grpc.cs
+++ b/compiler/tests/generated/service_grpc.cs
@@ -236,6 +236,10 @@ namespace tests
             {
             }
 
+            public FooClient(global::Grpc.Core.CallInvoker callInvoker) : base(callInvoker)
+            {
+            }
+
             protected FooClient() : base()
             {
             }

--- a/compiler/tests/generated/streaming_grpc.cs
+++ b/compiler/tests/generated/streaming_grpc.cs
@@ -95,6 +95,10 @@ namespace tests
             {
             }
 
+            public FooClient(global::Grpc.Core.CallInvoker callInvoker) : base(callInvoker)
+            {
+            }
+
             protected FooClient() : base()
             {
             }
@@ -232,6 +236,10 @@ namespace tests
         public class BarClient : global::Grpc.Core.ClientBase<BarClient>
         {
             public BarClient(global::Grpc.Core.Channel channel) : base(channel)
+            {
+            }
+
+            public BarClient(global::Grpc.Core.CallInvoker callInvoker) : base(callInvoker)
             {
             }
 


### PR DESCRIPTION
New feature of Interceptor was added to grpc, and client side
interceptor relies on CallInvoker to work. 
Protobuf has already added the constructor for C#.

See
[L12-csharp-interceptors](https://github.com/grpc/proposal/blob/master/L12-csharp-interceptors.md)
and
[discussion](https://github.com/grpc/grpc/issues/11646#issuecomment-312799633).

Fix #950 