### PR TITLE
[AppVeyor Fix] Change environment variable _ROOT to _PATH

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,6 +78,8 @@
               BOND_BOOST: "1.63.0"
               BOND_CMAKE_FLAGS: "-DBOND_SKIP_CORE_TESTS=TRUE;-DBOND_SKIP_GBC_TESTS=TRUE"
     install:
+        - sc config wuauserv start= auto
+        - net start wuauserv
         - ps: >-
             if (-not $env:BOND_VS_VERSION)
             {

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -1,5 +1,9 @@
 include (Compiler)
 
+if (POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 set (BOND_GBC_PATH_DESCRIPTION
      "Optional path to the gbc executable to use. If set, this gbc will be used when generating code from .bond files. If not set, then gbc will be built (and the Haskell toolchain will need to be present on the machine) and the gbc tests will be run.")
 

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required (VERSION 2.8.12)
 
+if (POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 set (CMAKE_MODULE_PATH
     ${CMAKE_CURRENT_SOURCE_DIR}/../cmake)
 


### PR DESCRIPTION
The AppVeyor build is broken due to
[changes of CMake 3.1.2](https://cmake.org/cmake/help/latest/policy/CMP0074.html).
and Windows Update Service is not properly restarted.
Seting CMP0074 to NEW and configuring Windows Update Service to auto start fix it.