### PR TITLE
[c++] Cast HexDigit argument to int

### DIFF
--- a/cpp/inc/bond/protocol/simple_json_writer.h
+++ b/cpp/inc/bond/protocol/simple_json_writer.h
@@ -195,10 +195,10 @@ private:
     void WriteUnicode(wchar_t c)
     {
         char u[6] = "\\u";
-        u[2] = detail::HexDigit(c >> 12);
-        u[3] = detail::HexDigit(c >> 8);
-        u[4] = detail::HexDigit(c >> 4);
-        u[5] = detail::HexDigit(c >> 0);
+        u[2] = detail::HexDigit(static_cast<int>(c >> 12));
+        u[3] = detail::HexDigit(static_cast<int>(c >> 8));
+        u[4] = detail::HexDigit(static_cast<int>(c >> 4));
+        u[5] = detail::HexDigit(static_cast<int>(c >> 0));
         _output.Write(u, sizeof(u));
     }
 


### PR DESCRIPTION
Fix implicit conversion error.

bond/cpp/inc/bond/protocol/simple_json_writer.h:201:39: error: call of overloaded ‘HexDigit(unsigned int)’ is ambiguous
         u[5] = detail::HexDigit(c >> 0);
                                       ^
In file included from bond/cpp/inc/bond/protocol/compact_binary.h:9:0,
                 from bond/cpp/inc/bond/core/detail/marshaled_bonded.h:8,
                 from bond/cpp/inc/bond/core/bonded.h:10,
                 from bond/cpp/inc/bond/core/apply.h:8,
                 from bond/cpp/inc/bond/core/bond.h:9,
                 from bond/cpp/inc/bond/core/cmdargs.h:8,
                 from bond/examples/cpp/core/bf/main.cpp:4:
bond/cpp/inc/bond/protocol/encoding.h:155:13: note: candidate: char bond::detail::HexDigit(int)
 inline char HexDigit(int n)
             ^~~~~~~~
bond/cpp/inc/bond/protocol/encoding.h:161:12: note: candidate: int bond::detail::HexDigit(char)
 inline int HexDigit(char c)
            ^~~~~~~~

Signed-off-by: Sinan Kaya <sinan.kaya@microsoft.com>