### PR TITLE
Update bond.cabal constraints

### DIFF
--- a/compiler/bond.cabal
+++ b/compiler/bond.cabal
@@ -123,7 +123,7 @@ test-suite gbc-tests
                     tasty-hunit,
                     tasty-quickcheck,
                     shakespeare >= 2.0,
-                    megaparsec >= 6.2
+                    megaparsec >= 6.2 && < 7
 
 executable gbc
   main-is:          Main.hs
@@ -145,9 +145,9 @@ executable gbc
                     base >= 4.9 && < 5,
                     bytestring >= 0.10,
                     cmdargs >= 0.10.10,
-                    process < 1.5,
+                    process < 1.7,
                     directory >= 1.1,
                     filepath >= 1.0,
                     monad-loops >= 0.4,
                     text >= 0.11,
-                    megaparsec >= 6.2
+                    megaparsec >= 6.2 && < 7


### PR DESCRIPTION
- Relax dependency on `process` package to support newer version of
 `base`.
- Restrict dependency on `megaparsec` to less than version 7 which has
  incompatible APIs.