### PR TITLE
Switch to microsoft/bond casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ different versioning scheme, following the Haskell community's
 * gRPC v1.17.1 is now required to use Bond-over-gRPC.
 * Fixed an ambigious `HexDigit` overload compilation error when
   compiling with some versions of GCC. ([Pull request
-  #954](https://github.com/Microsoft/bond/pull/954))
+  #954](https://github.com/microsoft/bond/pull/954))
 
 ## 8.1.0: 2019-03-27 ##
 
@@ -37,7 +37,7 @@ different versioning scheme, following the Haskell community's
   gRPC clients to support client-side interceptors. For more details about
   C# interceptors, see the [proposal in the gRPC
   project](https://github.com/grpc/proposal/blob/master/L12-csharp-interceptors.md).
-  [Issue #950](https://github.com/Microsoft/bond/issues/950)
+  [Issue #950](https://github.com/microsoft/bond/issues/950)
 
 ## 8.0.1: 2018-06-29 ##
 * `gbc` & compiler library: 0.11.0.3
@@ -57,7 +57,7 @@ different versioning scheme, following the Haskell community's
 
 ### C# ###
 * Fixed alias conversion issue for generic fields [Issue
-  #928](https://github.com/Microsoft/bond/issues/928).
+  #928](https://github.com/microsoft/bond/issues/928).
 
 ## 8.0.0: 2018-05-30 ##
 * `gbc` & compiler library: 0.11.0.0
@@ -70,7 +70,7 @@ different versioning scheme, following the Haskell community's
 * **Breaking change** The deprecated Bond Comm functionality has been removed.
   This includes all gbc options related to Comm and the Comm codegen templates
   in the Haskell library. [Issue
-  #824](https://github.com/Microsoft/bond/issues/824)
+  #824](https://github.com/microsoft/bond/issues/824)
 * C++ codegen now properly generates move assignment operators. Previously,
   this was broken for some cases.
 * C++ codegen no longer generates checks for C++11, except for MSVC 2013
@@ -100,19 +100,19 @@ different versioning scheme, following the Haskell community's
 * `import` statements can now end with an optional semicolon.
 * File and directory paths on the command line, in response files, or in
   `import` statements can now use a mix of forward and backslashes. [Issue
-  #869](https://github.com/Microsoft/bond/issues/869)
+  #869](https://github.com/microsoft/bond/issues/869)
 * gbc is now Authenticode dual-signed with both SHA1 and SHA2.
 
 ### C++ ###
 
 * **Breaking change** The deprecated Bond Comm functionality has been removed.
   This includes all gbc options related to Comm and all Comm APIs and header
-  files. [Issue #824](https://github.com/Microsoft/bond/issues/824)
+  files. [Issue #824](https://github.com/microsoft/bond/issues/824)
 * **Breaking change** Only versions of Boost released in the past two years
   (1.61 and newer) are supported. Bond will *likely* continue to work with
   older versions, but it is no longer tested with anything older than 1.61.
   Test coverage for Boost versions 1.61&ndash;1.66 has been improved. [Issue
-  #771](https://github.com/Microsoft/bond/issues/771)
+  #771](https://github.com/microsoft/bond/issues/771)
 * **Breaking change** Constructors accepting a `Comparer` have been removed
   from the `bond::maybe` and `bond::nullable` types.
 * **Breaking change** The `bond::is_blob` and `bond::is_nullable` traits have
@@ -130,7 +130,7 @@ different versioning scheme, following the Haskell community's
   moved to the `bond::ext` namespace and the "bond/ext" include directory.
 * **Breaking changes** in Bond-over-gRPC (based on real-world use and
   feedback). Check the updated
-  [examples](https://github.com/Microsoft/bond/tree/master/examples/cpp/grpc)
+  [examples](https://github.com/microsoft/bond/tree/master/examples/cpp/grpc)
   to see how to use the changed APIs.
   - The generated `ClientCore` and `ServiceCore` class templates and the
     `Client` and `Service` convenience typedefs have all been replaced with
@@ -179,16 +179,16 @@ different versioning scheme, following the Haskell community's
 * gRPC v1.12.0 is now required to use Bond-over-gRPC.
     * This version include a number of memory leak fixes that users of
       Bond-over-gRPC were encountering. [Issue
-      #810](https://github.com/Microsoft/bond/issues/810)
+      #810](https://github.com/microsoft/bond/issues/810)
     * This version include some Windows-specific performance
       improvements for loopback connections.
 * The `bond::ext::gRPC::wait_callback` has been deprecated in favor of
   additionally generated client functions that return `std::future`.
 * Fixed includes for gRPC services with events or parameterless methods.
-  [Issue #735](https://github.com/Microsoft/bond/issues/735)
+  [Issue #735](https://github.com/microsoft/bond/issues/735)
 * Fixed a bug which would read an unrelated struct's field(s) when
   deserializing a base struct. [Issue
-  #742](https://github.com/Microsoft/bond/issues/742)
+  #742](https://github.com/microsoft/bond/issues/742)
 * Fixed a bug in `bond::MapTo<T>::Field` that failed to pass the `Protocols`
   type parameter to `bond::Apply`.
 * Fixed a race condition when `bond::ext::gRPC::io_manager::shutdown` and
@@ -213,13 +213,13 @@ different versioning scheme, following the Haskell community's
 * Fixed an issue with the `ToString`, `FromString`, `ToEnum` and `FromEnum`
   functions that were previously not exported from a DLL when the
   `--export-attribute` option was passed to `gbc`. [Issue
-  #861](https://github.com/Microsoft/bond/issues/861)
+  #861](https://github.com/microsoft/bond/issues/861)
 * Fixed a bug in `bond::nullable<T, Alloc>` where it was not propagating an
   allocator to `T` when `allocator_type` was not explicitly defined.
 * Fixed a bug in `bond::make_box` where `const T&` was not handled correctly.
 * The use of `bond::check_method` has been replaced with less restricting
   expression SFINAE checks on supported compilers. [Issue
-  #896](https://github.com/Microsoft/bond/issues/896)
+  #896](https://github.com/microsoft/bond/issues/896)
 * Fixed a bug where `bond::ext::gRPC::io_manager` could cause a thread to join
   itself.
 * The preferred namespace for Bond-over-gRPC is now `bond::ext::grpc`. The
@@ -232,7 +232,7 @@ different versioning scheme, following the Haskell community's
 * **Breaking change** The deprecated Bond Comm functionality has been removed.
   This includes all gbc options related to Comm and all Comm APIs, assemblies,
   and NuGet packages. [Issue
-  #824](https://github.com/Microsoft/bond/issues/824)
+  #824](https://github.com/microsoft/bond/issues/824)
 * **Breaking change** The Bond.CSharp and Bond.Compiler.CSharp NuGet packages
   perform implicit codegen when the simplified .NET Core `.csproj` format is
   used. This breaking change *does not* affect projects using the classic
@@ -242,17 +242,17 @@ different versioning scheme, following the Haskell community's
   all implicit inclusion](https://aka.ms/sdkimplicititems). To set per-item
   metadata, use the [item update
   syntax](https://docs.microsoft.com/en-us/visualstudio/msbuild/item-element-msbuild#examples).
-  [Issue #636](https://github.com/Microsoft/bond/issues/636)
+  [Issue #636](https://github.com/microsoft/bond/issues/636)
 * The C# attribute `Bond.Attribute` can now be applied to methods. This fixes
   broken codegen when attributes are used on service methods. [Issue
-  #617](https://github.com/Microsoft/bond/issues/617)
+  #617](https://github.com/microsoft/bond/issues/617)
 * Bond Attributes on service methods are now present on all the client
   overloads for the methods. Previously, just the "friendly" method had the
   attributes.
 * Grpc.Core v1.12.0 is now required to use Bond-over-gRPC.
     * This version include a number of memory leak fixes that users of
       Bond-over-gRPC were encountering. [Issue
-      #810](https://github.com/Microsoft/bond/issues/810)
+      #810](https://github.com/microsoft/bond/issues/810)
     * This version include some Windows-specific performance improvements for
       loopback connections.
 * `BondCodegen` items will now appear in the Visual Studio 2017+ UI in .NET
@@ -266,7 +266,7 @@ different versioning scheme, following the Haskell community's
 * *Preview*: Added preliminary support for generating types with constructors
   with parameters for each field. This functionality will change in the future
   and may be removed. [Pull request
-  #857](https://github.com/Microsoft/bond/pull/857)
+  #857](https://github.com/microsoft/bond/pull/857)
 
 ## 7.0.2: 2017-10-30 ##
 * `gbc` & compiler library: 0.10.1.0
@@ -325,7 +325,7 @@ different versioning scheme, following the Haskell community's
   bond::CoreException is now thrown.
 * Errors from some versions of G++ like "non-template type `Deserialize`
   used as a template" have been fixed.
-  [Issue #538](https://github.com/Microsoft/bond/issues/538)
+  [Issue #538](https://github.com/microsoft/bond/issues/538)
 * Guard against overflows in OutputMemoryStream, blob, and SimpleArray.
 * Use RapidJSON's iterative parser to handle deeply nested JSON data without
   causing a stack overflow.
@@ -354,15 +354,15 @@ different versioning scheme, following the Haskell community's
   Mono's xbuild: only MSBuild is supported. Mono has
   [deprecated xbuild in favor of MSBuild](http://www.mono-project.com/docs/about-mono/releases/5.0.0/#msbuild)
   now that
-  [MSBuild is open source and cross-platform](https://github.com/Microsoft/msbuild).
+  [MSBuild is open source and cross-platform](https://github.com/microsoft/msbuild).
 * **Breaking change** The code generation MSBuild targets now automatically
   compile the generated `_grpc.cs` files if `--grpc` is passed to `gbc`.
   Explicit `<Compile Include="$(IntermediateOutputPath)foo_grpc.cs" />`
   lines in MSBuild projects will need to be removed to fix error MSB3105
   about duplicate items. See commit
-  [a120cd99](https://github.com/Microsoft/bond/commit/a120cd9995d74e11b75766c5195ea4587c304dd7#diff-3b0b4bed9029ae89dbfb824ce7eff5e8R54)
+  [a120cd99](https://github.com/microsoft/bond/commit/a120cd9995d74e11b75766c5195ea4587c304dd7#diff-3b0b4bed9029ae89dbfb824ce7eff5e8R54)
   for an example of how to fix this.
-  [Issue #448](https://github.com/Microsoft/bond/issues/448)
+  [Issue #448](https://github.com/microsoft/bond/issues/448)
 * **Breaking change** The low-level API `IParser.ContainerHandler` now has an
   `arraySegment` parameter for the converted blob.
 * The code generation MSBuild targets will now skip compiling the
@@ -375,17 +375,17 @@ different versioning scheme, following the Haskell community's
 * `Bond.IO.Unsafe.InputStream` can now be used with streams that do not
   implement [`Stream.Seek`][msdn-stream-seek], like
   [`System.IO.Compression.GzipStream`][msdn-gzipstream].
-  [Issue #498](https://github.com/Microsoft/bond/issues/498)
+  [Issue #498](https://github.com/microsoft/bond/issues/498)
     * Such streams are detected by inspecting
       [`Stream.CanSeek`][msdn-stream-canseek].
 * Fix a bug in CompactBinaryWriter when using v2 that repeated first pass
   when a bonded field was serailized, resulting in extra work and extra
   state left in the CompactBinaryWriter.
 * Apply IDL annotations to services and methods for gRPC.
-  [Issue #617](https://github.com/Microsoft/bond/issues/617)
+  [Issue #617](https://github.com/microsoft/bond/issues/617)
 * Fixed a bug that produced C# code that couldn't be compiled when using
   Bond-over-gRPC with a generic type instantiated with a collection.
-  [Issue #623](https://github.com/Microsoft/bond/issues/623)
+  [Issue #623](https://github.com/microsoft/bond/issues/623)
 * When targeting .NET 4.5, avoid resolving external entities when using
   `SimpleXmlReader`.
 * Remove redundant conversions during serialization of aliased blobs.
@@ -442,16 +442,16 @@ This version was not used.
       typedef as a return type of corresponding `GetBufferRange` inside
       their custom input buffer implementation.
     * Please see
-      [InputBuffer](https://github.com/Microsoft/bond/commit/11beaf5319639e4bdee96a25f95154e4fed93a75#diff-9260b18a00d12a6102a69b9fffd7e33f),
-      [OutputBuffer](https://github.com/Microsoft/bond/commit/11beaf5319639e4bdee96a25f95154e4fed93a75#diff-1f15d4c92f87d4bd41f705b20cce80ad),
+      [InputBuffer](https://github.com/microsoft/bond/commit/11beaf5319639e4bdee96a25f95154e4fed93a75#diff-9260b18a00d12a6102a69b9fffd7e33f),
+      [OutputBuffer](https://github.com/microsoft/bond/commit/11beaf5319639e4bdee96a25f95154e4fed93a75#diff-1f15d4c92f87d4bd41f705b20cce80ad),
       and
-      [the bf example](https://github.com/Microsoft/bond/commit/11beaf5319639e4bdee96a25f95154e4fed93a75#diff-bdda0f39d99280d4858b4453906eea17)
+      [the bf example](https://github.com/microsoft/bond/commit/11beaf5319639e4bdee96a25f95154e4fed93a75#diff-bdda0f39d99280d4858b4453906eea17)
       for more details.
 * **Breaking change** The `bond::customize<protocols>` has been removed. All the
   public APIs that require a protocol list (e.g. `bond::Marshal`) now accept
   an extra template argument `Protocols` which defaults to `bond::BuiltInProtocols`.
   Custom input streams now require `bond::type_id<>` to be specialized with a
-  unique magic number. For more details please see [the bf example](https://github.com/Microsoft/bond/tree/master/examples/cpp/core/bf).
+  unique magic number. For more details please see [the bf example](https://github.com/microsoft/bond/tree/master/examples/cpp/core/bf).
 * Initial support for sending
   [Bond objects over gRPC](https://microsoft.github.io/bond/manual/bond_over_grpc.html)
   has been added.
@@ -480,25 +480,25 @@ This version was not used.
 * **Breaking change** Bond assemblies are now
   [strong-name signed](https://msdn.microsoft.com/en-us/library/wd40t7ad(v=vs.110).aspx)
   with the
-  [bond.snk](https://github.com/Microsoft/bond/blob/82c97e12621eeb906d1bd46e3abba9da14289c61/cs/build/internal/bond.snk)
+  [bond.snk](https://github.com/microsoft/bond/blob/82c97e12621eeb906d1bd46e3abba9da14289c61/cs/build/internal/bond.snk)
   key in the repository instead of with a Microsoft key. This allows anyone
   to produce compatible assemblies, not just Microsoft. Official
   distribution of Bond will continue to be
   [Authenticode signed](https://msdn.microsoft.com/en-us/library/ms537361(v=vs.85).aspx)
   with a Microsoft certificate.
-  [Issue #414](https://github.com/Microsoft/bond/issues/414)
+  [Issue #414](https://github.com/microsoft/bond/issues/414)
     * The new public key for assemblies is now
       `00240000048000009400000006020000002400005253413100040000010001000d504ac18b4b149d2f7b0059b482f9b6d44d39059e6a96ff0a2a52678b5cfd8567cc67254132cd2debb5b95f6a1206a15c6f8ddac137c6c3ef4995f28c359acaa683a90995c8f08df7ce0aaa8836d331a344a514c443f112f80bf2ebed40ccb32d7df63c09b0d7bef80aecdc23ec200a458d4f8bafbcdeb9bf5ba111fbbd4787`
 * **Breaking change** Bond assemblies now have assembly and file versions
   that correspond to their NuGet package version. Strong name identities
   will now change release-over-release in line with the NuGet package
-  versions. [Issue #325](https://github.com/Microsoft/bond/issues/325)
+  versions. [Issue #325](https://github.com/microsoft/bond/issues/325)
 * The codegen MSBuild targets will now re-run codegen if gbc itself has been
   changed.
 * Fixed a bug where JSON and XML protocols would permit the serialization of
   non-nullable string fields that were set to null instead of throwing a
   NullReferenceException.
-  [Issue #417](https://github.com/Microsoft/bond/issues/417)
+  [Issue #417](https://github.com/microsoft/bond/issues/417)
 
 ## 5.3.1: 2017-04-25 ##
 
@@ -528,7 +528,7 @@ This version was not used.
 * When generating C++ apply files, there are now explicit `bond::Apply<>`
   instantiations for `CompactBinaryWriter<OutputCounter>` and
   `SimpleBinaryWriter<Null>` writers.
-  [Pull request #373](https://github.com/Microsoft/bond/pull/373)
+  [Pull request #373](https://github.com/microsoft/bond/pull/373)
     * **Breaking change (Haskell library only):**
       `Language.Bond.Codegen.Cpp.ApplyOverloads.Protocol` is now a union of
       `ProtocolReader` and `ProtocolWriter` to permit mixing and matching of
@@ -537,7 +537,7 @@ This version was not used.
 * Add gbc flags to pick which C# files to generate (structs, gRPC, and
   comm). Only structs are generated by default.
 * gbc ensures that method names are unique within a service.
-  [Issue #381](https://github.com/Microsoft/bond/issues/381)
+  [Issue #381](https://github.com/microsoft/bond/issues/381)
 
 ### C++ ###
 
@@ -552,16 +552,16 @@ This version was not used.
   itself. warning.h is still in place on MSVC12; furthermore, we don't alter
   warning.h for now as it may be depended upon by application code.
 * Avoid unaligned memory access on non-x86/x64 platforms.
-  [Issue #305](https://github.com/Microsoft/bond/issues/305)
+  [Issue #305](https://github.com/microsoft/bond/issues/305)
 * Improve compliance with strict-aliasing rules.
     * Bond now builds on Clang/GCC with `-fstrict-aliasing`.
 * When generating C++ apply files, there are now explicit `bond::Apply<>`
   instantiations for `CompactBinaryWriter<OutputCounter>` and
   `SimpleBinaryWriter<Null>` writers.
-  [Pull request #373](https://github.com/Microsoft/bond/pull/373)
+  [Pull request #373](https://github.com/microsoft/bond/pull/373)
 * Improve C++ allocator support
-  [Issue #379](https://github.com/Microsoft/bond/issues/379)
-  [Pull request #380](https://github.com/Microsoft/bond/pull/380)
+  [Issue #379](https://github.com/microsoft/bond/issues/379)
+  [Pull request #380](https://github.com/microsoft/bond/pull/380)
     * Support C++11 and above allocator model for rebind
     * Simplify detection of the default allocator
 * Remove per-field instantiation of DynamicParser<>::UnknownFieldOrTypeMismatch method.
@@ -573,13 +573,13 @@ This version was not used.
 * Added controls to cap incremental allocation between reads in
   `Bond.IO.Unsafe.InputStream`.
 * Extended fix for bug parsing JSON when a string value is a date.
-  [Pull request #358](https://github.com/Microsoft/bond/pull/358)
+  [Pull request #358](https://github.com/microsoft/bond/pull/358)
 * Bond C# 5.1.0 accidentally broke backward compability by renaming
   `Bond.Reflection` to `Bond.BondReflection`. This has been fixed:
   `Bond.BondReflection` was unrenamed back to `Bond.Reflection`, and a shim
   `Bond.BondReflection` type now redirects all calls to their original names
   to minimize further breakage.
-  [Issue #369](https://github.com/Microsoft/bond/issues/369)
+  [Issue #369](https://github.com/microsoft/bond/issues/369)
     * Code that started using `Bond.BondReflection` by name will encounter
       warning CS0618 indicating use of an obselete method/type. To fix this,
       use the original name `Bond.Reflection`. This warning can be
@@ -591,7 +591,7 @@ This version was not used.
 
 * **Breaking change** To generate C# Comm files, be sure to pass the
   `--comm` flag to gbc.
-  [See how the pingpong example was updated](https://github.com/Microsoft/bond/blob/581d88632e0ad8b2fc87f5674273f613e78af752/examples/cs/comm/pingpong/pingpong.csproj#L39).
+  [See how the pingpong example was updated](https://github.com/microsoft/bond/blob/581d88632e0ad8b2fc87f5674273f613e78af752/examples/cs/comm/pingpong/pingpong.csproj#L39).
 * C# Comm is now deprecated. We recommend that you use Bond-over-gRPC. See
   the
   [Bond-over-gRPC manual](https://microsoft.github.io/bond/manual/bond_over_grpc.html).
@@ -616,20 +616,20 @@ This version was not used.
 * Add export-attribute option for C++ and make apply-attribute a
   deprecated synonym for export-attribute
 * Fix C++ Comm build problems when services are shared via DLL.
-  [Issue #314](https://github.com/Microsoft/bond/issues/314)
+  [Issue #314](https://github.com/microsoft/bond/issues/314)
 
 ### C++ ###
 
 * Fixed compatibility with RapidJSON v1.1.0.
-  [Issue #271](https://github.com/Microsoft/bond/issues/271)
+  [Issue #271](https://github.com/microsoft/bond/issues/271)
 * The minimum supported version of Boost is now 1.58
 * The `bf` utility now supports multiple payloads.
-  [Pull request #288](https://github.com/Microsoft/bond/pull/288)
+  [Pull request #288](https://github.com/microsoft/bond/pull/288)
 * Fixed an issue with aliased enums.
-  [Pull request #288](https://github.com/Microsoft/bond/pull/298)
+  [Pull request #288](https://github.com/microsoft/bond/pull/298)
 * Fixed an issue with template parameter deduction in `bond::is_nullable`
   that occurs with Microsoft Visual C++ 2015 Update 3.
-  [Issue #306](https://github.com/Microsoft/bond/issues/306)
+  [Issue #306](https://github.com/microsoft/bond/issues/306)
 
 ### C++ Comm ###
 * Fixed a multiply-defined symbol linker error for
@@ -640,7 +640,7 @@ This version was not used.
 * Added controls to cap pre-allocation during deserialization of containers
   and blobs.
 * Fixed computation of default value for aliased bool and wstring fields.
-  [Issue #300](https://github.com/Microsoft/bond/issue/300)
+  [Issue #300](https://github.com/microsoft/bond/issue/300)
 
 ### C# Comm ###
 
@@ -673,7 +673,7 @@ This version was not used.
 * Bond C# now supports
   [.NET Standard 1.0, 1.3, and 1.6](https://blogs.msdn.microsoft.com/dotnet/2016/09/26/introducing-net-standard/),
   so you can use Bond in .NET Core applications.
-  [Pull request #243](https://github.com/Microsoft/bond/pull/243)
+  [Pull request #243](https://github.com/microsoft/bond/pull/243)
     * Not all assemblies work with all versions of the .NET Standard or on
       all platforms. The
       [manual](https://microsoft.github.io/bond/manual/bond_cs.html#frameworks-targeted)
@@ -721,7 +721,7 @@ This version was not used.
 * **Breaking change:** `bond.TypeDef.list_sub_type` field removed, as it was
   breaking some consumers of serialized SchemaDef. We plan to restore this
   field in the future.
-  [Issue #161 re-opened](https://github.com/Microsoft/bond/issues/161)
+  [Issue #161 re-opened](https://github.com/microsoft/bond/issues/161)
 
 ### IDL comm ###
 * Update IDL to conform to naming conventions.
@@ -731,7 +731,7 @@ This version was not used.
 * **Breaking change:** Runtime SchemaDef `list_sub_type` field removed, as
   it was breaking some consumers of serialized SchemaDef. We plan to restore
   this field in the future.
-  [Issue #161 re-opened](https://github.com/Microsoft/bond/issues/161)
+  [Issue #161 re-opened](https://github.com/microsoft/bond/issues/161)
 * Generated enum types now have a `FromEnum` method that can be used to
   convert from an enum value to a string. Now generated enum types have all
   four of `ToEnum`, `FromEnum`, `ToString`, and `FromString`. (The `...Enum`
@@ -741,10 +741,10 @@ This version was not used.
 * **Breaking change:** Runtime SchemaDef `list_sub_type` field removed, as
   it was breaking some consumers of serialized SchemaDef. We plan to restore
   this field in the future.
-  [Issue #161 re-opened](https://github.com/Microsoft/bond/issues/161)
+  [Issue #161 re-opened](https://github.com/microsoft/bond/issues/161)
 * The Bond.Runtime NuGet package no longer artificially limits
   Newtonsoft.Json to versions before 10.
-  [Issue #212](https://github.com/Microsoft/bond/issues/212)
+  [Issue #212](https://github.com/microsoft/bond/issues/212)
 
 ### C# Comm ###
 * `EpoxyListeners` can now be configured to require clients to authenticate
@@ -767,46 +767,46 @@ This version was not used.
 
 * **Breaking change:** Runtime SchemaDef now includes information about
   whether BT_LIST fields are nullable or blobs.
-  [Issue #161](https://github.com/Microsoft/bond/issues/161)
+  [Issue #161](https://github.com/microsoft/bond/issues/161)
 * User-defined `TypeMapping`s can now be created. This makes is easier to
   implement code generation for new languages. [Pull request
-  #172](https://github.com/Microsoft/bond/pull/172)
+  #172](https://github.com/microsoft/bond/pull/172)
 * Validate default value type mistmatches.
-  [Issue #72](https://github.com/Microsoft/bond/issues/72)
-  [Issue #128](https://github.com/Microsoft/bond/issues/128)
+  [Issue #72](https://github.com/microsoft/bond/issues/72)
+  [Issue #128](https://github.com/microsoft/bond/issues/128)
 * Validate default value out-of-range values.
-  [Issue #73](https://github.com/Microsoft/bond/issues/73)
+  [Issue #73](https://github.com/microsoft/bond/issues/73)
 * Fail when struct field has default value of `nothing`.
-  [Issue #164](https://github.com/Microsoft/bond/issues/164)
+  [Issue #164](https://github.com/microsoft/bond/issues/164)
 * Fail when enum field doesn't have default value.
-  [Issue #177](https://github.com/Microsoft/bond/issues/177)
+  [Issue #177](https://github.com/microsoft/bond/issues/177)
 * Validate default value of type aliases
 * Generated types will used `= default` move constructors if possible. This
   results in many generated types having `noexcept` move constructors.
 * Fix a bug where, if a Bond namespace contained a struct and an enum value with
   the same name, generated C++ would contain ambiguous references.
-  [Issue #202](https://github.com/Microsoft/bond/issues/202)
+  [Issue #202](https://github.com/microsoft/bond/issues/202)
 
 ### IDL core ###
 
 * Set up a separate IDL directory so that IDL is independent of language
-  bindings. [Pull request #219](https://github.com/Microsoft/bond/pull/219)
+  bindings. [Pull request #219](https://github.com/microsoft/bond/pull/219)
 
 ### IDL comm ###
 
 * Set up a separate IDL directory so that IDL is independent of language
   bindings. Convert comm IDL files to use C++-style naming convention. [Pull
-  request #219](https://github.com/Microsoft/bond/pull/219)
+  request #219](https://github.com/microsoft/bond/pull/219)
 
 ### C++ ###
 
-* Improvements in the `nullable` implementation. [Pull request #174](https://github.com/Microsoft/bond/pull/174)
+* Improvements in the `nullable` implementation. [Pull request #174](https://github.com/microsoft/bond/pull/174)
     * Correctly use allocator model.
     * Reduce size of `nullable` in the normal case.
     * And others
 * Runtime SchemaDef now includes information about whether BT_LIST fields
   are nullable or blobs.
-  [Issue #161](https://github.com/Microsoft/bond/issues/161)
+  [Issue #161](https://github.com/microsoft/bond/issues/161)
 * The following Bond types have (possibly conditional) `noexcept` move
   constructors: `blob`, `bonded`, `maybe`, `nullable`, `RuntimeSchema`,
   `value`.
@@ -816,7 +816,7 @@ This version was not used.
 * Bond can now be used with Newtonsoft.Json >= 7.0.1 and < 10
 * Runtime SchemaDef now includes information about whether BT_LIST fields
   are nullable or blobs.
-  [Issue #161](https://github.com/Microsoft/bond/issues/161)
+  [Issue #161](https://github.com/microsoft/bond/issues/161)
 
 ### C# Comm ###
 
@@ -841,7 +841,7 @@ This version was not used.
     * TLS configuration is set via
       `EpoxyTransportBuilder.SetClientTlsConfig`/`EpoxyTransportBuilder.SetServerTlsConfig`.
     * See the
-      [TLS example](https://github.com/Microsoft/bond/tree/master/examples/cs/comm/tls/)
+      [TLS example](https://github.com/microsoft/bond/tree/master/examples/cs/comm/tls/)
       for even more details.
 
 ## 4.2.1: 2016-06-02 ##
@@ -861,12 +861,12 @@ This version was not used.
       [methods](https://microsoft.github.io/bond/manual/compiler.html#methods)
       have been added to the compiler AST.
 * MSBuild-compatible error messages.
-  [Issue #136](https://github.com/Microsoft/bond/issues/136)
+  [Issue #136](https://github.com/microsoft/bond/issues/136)
 
 ### C# ###
 
 * Added
-  [`Deserializer.TryDeserialize()`](https://github.com/Microsoft/bond/blob/db315adaf4b812adc5ca484b1bcffafe1df6d351/cs/src/core/Deserializer.cs#L231-239).
+  [`Deserializer.TryDeserialize()`](https://github.com/microsoft/bond/blob/db315adaf4b812adc5ca484b1bcffafe1df6d351/cs/src/core/Deserializer.cs#L231-239).
 * Added two new
   [NuGet packages](https://microsoft.github.io/bond/manual/bond_cs.html#nuget-packages)
   to make it easier to consume Bond piecemeal.
@@ -889,7 +889,7 @@ This version was not used.
 ### C# ###
 
 * Add support for Compact Binary v2 writing.
-  [Issue #70](https://github.com/Microsoft/bond/issues/70)
+  [Issue #70](https://github.com/microsoft/bond/issues/70)
 
 ## 4.1.0: 2016-04-22
 
@@ -899,13 +899,13 @@ This version was not used.
 ### `gbc` ###
 
 * Field ordinals larger than 65535 are now rejected.
-  [Issue #111](https://github.com/Microsoft/bond/issues/111)
+  [Issue #111](https://github.com/microsoft/bond/issues/111)
 * Fields that duplicate the name of an existing field are now rejected.
-  [Issue #123](https://github.com/Microsoft/bond/issues/123)
+  [Issue #123](https://github.com/microsoft/bond/issues/123)
 * The generated C# code now compiles with no errors or warnings at
-  `/warn:4`. [Issue #82](https://github.com/Microsoft/bond/issues/82)
+  `/warn:4`. [Issue #82](https://github.com/microsoft/bond/issues/82)
 * Added
-  [Visual Studio Code highlighting rules for `.bond` files](https://github.com/Microsoft/bond/tree/b2b9cd7256286fd484444dfaf7645d380a3ee936/tools/syntax/VsCode).
+  [Visual Studio Code highlighting rules for `.bond` files](https://github.com/microsoft/bond/tree/b2b9cd7256286fd484444dfaf7645d380a3ee936/tools/syntax/VsCode).
 
 ### C++ ###
 
@@ -916,16 +916,16 @@ This version was not used.
 ### C# ###
 
 * The generated C# code now compiles with no errors or warnings at
-  `/warn:4`. [Issue #82](https://github.com/Microsoft/bond/issues/82)
+  `/warn:4`. [Issue #82](https://github.com/microsoft/bond/issues/82)
 * Bond-generated enums constants are now cast to 32-bit integers to avoid
   some compiler warnings.
-* [Implicit conversion between `bond.GUID` and `System.Guid`](https://github.com/Microsoft/bond/blob/bc4c56a3ca0858f4bd93916e80ceff9bbeada606/cs/test/core/GuidConversionTests.cs#L14)
+* [Implicit conversion between `bond.GUID` and `System.Guid`](https://github.com/microsoft/bond/blob/bc4c56a3ca0858f4bd93916e80ceff9bbeada606/cs/test/core/GuidConversionTests.cs#L14)
   has been added.
-  [Pull request #145](https://github.com/Microsoft/bond/pull/145)
+  [Pull request #145](https://github.com/microsoft/bond/pull/145)
 * The ability to
   [customize the implementation of `IBonded<T>` used](https://microsoft.github.io/bond/manual/bond_cs.html#understanding-bondedt)
   has been added.
-  [Pull request #153](https://github.com/Microsoft/bond/pull/153)
+  [Pull request #153](https://github.com/microsoft/bond/pull/153)
 
 ## 4.0.2: 2015-12-14
 
@@ -935,17 +935,17 @@ This version was not used.
 ### Bond compiler library ###
 
 * Added a
-  [custom codegen example](https://github.com/Microsoft/bond/tree/master/examples/codegen/read-only).
+  [custom codegen example](https://github.com/microsoft/bond/tree/master/examples/codegen/read-only).
 
 ### C# ###
 
 * Added support to
-  [not inline nested structs in `Serializers`](https://github.com/Microsoft/bond/blob/cb95fdb3e1e10c3e4cae2f2d55e2b116041010a8/cs/src/core/Serializer.cs#L69).
+  [not inline nested structs in `Serializers`](https://github.com/microsoft/bond/blob/cb95fdb3e1e10c3e4cae2f2d55e2b116041010a8/cs/src/core/Serializer.cs#L69).
   This can be used to speed up the time to create the serializer for very
   complex schemas.
 * Fix for rare buffer corruption in InputStream.
-  [Issue #114](https://github.com/Microsoft/bond/issues/114).
-* Fix for SimpleXmlParser not handling XML declarations. [Issue #112](https://github.com/Microsoft/bond/issues/82)
+  [Issue #114](https://github.com/microsoft/bond/issues/114).
+* Fix for SimpleXmlParser not handling XML declarations. [Issue #112](https://github.com/microsoft/bond/issues/82)
 
 ## Breaking changes between 3.x and 4.x ##
 
@@ -966,4 +966,4 @@ Bond C# had the following breaking changes introduced in 4.x compared to the
 ## Earlier release ##
 
 These sections need to be written. In the meantime, consult the
-[repository's history](https://github.com/Microsoft/bond/commits/master).
+[repository's history](https://github.com/microsoft/bond/commits/master).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ potential pitfalls before too much time is spent.
 * Fork the repository on GitHub.
 * Start on a new topic branch off of master.
 * Instructions for getting Bond building and running the tests are in the
-  [README](https://github.com/Microsoft/bond/blob/master/README.md).
+  [README](https://github.com/microsoft/bond/blob/master/README.md).
 * Aim for each pull request to have one commit. If the commit starts to get
   too large, consider splitting it into multiple, independent pull requests.
     * Some changes are more naturally authored in multiple commits. This is
@@ -34,9 +34,9 @@ potential pitfalls before too much time is spent.
 * Make sure that all the tests continue to pass.
     * The CMake `check` target will run the C++ tests for you.
     * The C# unit tests can be run from
-      [the command line](https://github.com/Microsoft/bond/blob/56b5914a5bb41178521e01f6ce078d429e3e6b71/appveyor.yml#L214)
+      [the command line](https://github.com/microsoft/bond/blob/56b5914a5bb41178521e01f6ce078d429e3e6b71/appveyor.yml#L214)
       or from within Visual Studio.
-* Update the [changelog](https://github.com/Microsoft/bond/blob/master/CHANGELOG.md).
+* Update the [changelog](https://github.com/microsoft/bond/blob/master/CHANGELOG.md).
 
 ### Squash commits
 
@@ -77,9 +77,9 @@ commit --amend` or `git rebase --interactive` with *reword* command.
 ### Pull request
 
 Start a GitHub pull request to merge your topic branch into the
-[main repository's master branch](https://github.com/Microsoft/bond/tree/master).
+[main repository's master branch](https://github.com/microsoft/bond/tree/master).
 (If you are a Microsoft employee and are not a member of the
-[Microsoft organization on GitHub](https://github.com/Microsoft) yet, please
+[Microsoft organization on GitHub](https://github.com/microsoft) yet, please
 contact the Bond Development team via e-mail for instructions before
 starting your pull request. There's some process stuff you'll need to do
 ahead of time.)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-![The Bond logo: a stylized glue gun](https://raw.githubusercontent.com/Microsoft/bond/master/doc/src/logos/bond-logo-64x64-white.png)
+![The Bond logo: a stylized glue gun](https://raw.githubusercontent.com/microsoft/bond/master/doc/src/logos/bond-logo-64x64-white.png)
 <hr />
 
-[![Build Status](https://travis-ci.org/Microsoft/bond.svg?branch=master)](https://travis-ci.org/Microsoft/bond)
-[![Bond.CSharp NuGet package](https://img.shields.io/nuget/v/Bond.CSharp.svg?style=flat)](https://Microsoft.github.io/bond/manual/bond_cs.html#nuget-packages)
+[![Build Status](https://travis-ci.org/microsoft/bond.svg?branch=master)](https://travis-ci.org/microsoft/bond)
+[![Bond.CSharp NuGet package](https://img.shields.io/nuget/v/Bond.CSharp.svg?style=flat)](https://microsoft.github.io/bond/manual/bond_cs.html#nuget-packages)
 
 # Bond
 
@@ -11,21 +11,21 @@ data. It supports cross-language serialization/deserialization and powerful
 generic mechanisms for efficiently manipulating data. Bond is broadly used at
 Microsoft in high scale services.
 
-Bond is published on GitHub at [https://github.com/Microsoft/bond/](https://github.com/Microsoft/bond/).
+Bond is published on GitHub at [https://github.com/microsoft/bond/](https://github.com/microsoft/bond/).
 
 For details, see the User's Manuals:
 
-* [C++](https://Microsoft.github.io/bond/manual/bond_cpp.html)
-* [C#](https://Microsoft.github.io/bond/manual/bond_cs.html)
-* [Java](https://Microsoft.github.io/bond/manual/bond_java.html)
-* [Python](https://Microsoft.github.io/bond/manual/bond_py.html)
-* [Bond-over-gRPC](https://Microsoft.github.io/bond/manual/bond_over_grpc.html)
+* [C++](https://microsoft.github.io/bond/manual/bond_cpp.html)
+* [C#](https://microsoft.github.io/bond/manual/bond_cs.html)
+* [Java](https://microsoft.github.io/bond/manual/bond_java.html)
+* [Python](https://microsoft.github.io/bond/manual/bond_py.html)
+* [Bond-over-gRPC](https://microsoft.github.io/bond/manual/bond_over_grpc.html)
 * [`gbc`, the Bond compiler/codegen tool](https://microsoft.github.io/bond/manual/compiler.html)
     * See also
       [the compiler library](https://hackage.haskell.org/package/bond) that
       powers `gbc`.
 
-For a discussion how Bond compares to similar frameworks see [Why Bond](https://Microsoft.github.io/bond/why_bond.html).
+For a discussion how Bond compares to similar frameworks see [Why Bond](https://microsoft.github.io/bond/why_bond.html).
 
 ## Dependencies
 
@@ -38,7 +38,7 @@ to build Bond you will need CMake (3.1+),
 Additionally, Bond requires RapidJSON and optionally requires gRPC. The Bond repository primarily uses Git submodules for these two dependencies. It should be cloned with the `--recursive` flag:
 
 ```bash
-git clone --recursive https://github.com/Microsoft/bond.git
+git clone --recursive https://github.com/microsoft/bond.git
 ```
 
 If you already have RapidJSON and would like to build against it, add argument `-DBOND_FIND_RAPIDJSON=TRUE` to the CMake invocation. It will use find_package(RapidJSON). If you do not provide a RapidJSON library, Bond will also install RapidJSON.
@@ -275,5 +275,5 @@ cmake -DBOND_ENABLE_GRPC=TRUE -G "Visual Studio 14 2015 Win64" ..
 ## Contributing
 
 Interested in contributing to Bond? Take a look at our
-[contribution guidelines](https://github.com/Microsoft/bond/blob/master/CONTRIBUTING.md)
+[contribution guidelines](https://github.com/microsoft/bond/blob/master/CONTRIBUTING.md)
 to get started.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -279,7 +279,7 @@
 
                     git config --global user.name "Appveyor"
 
-                    git clone -b gh-pages "https://${env:BOND_TOKEN}@github.com/Microsoft/bond.git" gh-pages 2>&1 | out-null
+                    git clone -b gh-pages "https://${env:BOND_TOKEN}@github.com/microsoft/bond.git" gh-pages 2>&1 | out-null
 
                     cd gh-pages
 

--- a/compiler/bond.cabal
+++ b/compiler/bond.cabal
@@ -21,12 +21,12 @@ description:        Bond is a cross-platform framework for handling schematized
                     tool, named gbc, which is primarily used to generate code
                     for C++ and C# programs using Bond.
 
-homepage:           https://github.com/Microsoft/bond
+homepage:           https://github.com/microsoft/bond
 license:            MIT
 license-file:       LICENSE
 author:             Adam Sapek <adamsap@microsoft.com>
 maintainer:         Bond Development Team <bond-dev@microsoft.com>
-bug-reports:        https://github.com/Microsoft/bond/issues
+bug-reports:        https://github.com/microsoft/bond/issues
 copyright:          Copyright (c) Microsoft. All rights reserved.
 category:           Language, Compiler, Code Generation
 build-type:         Simple
@@ -37,7 +37,7 @@ flag warningsAsErrors
 
 source-repository head
   type:             git
-  location:         git@github.com:Microsoft/bond.git
+  location:         git@github.com:microsoft/bond.git
 
 library
   hs-source-dirs:   src

--- a/cs/build/nuget/cps/README.md
+++ b/cs/build/nuget/cps/README.md
@@ -56,10 +56,10 @@ three-step process:
 * GitHub issue about [adding a custom item with automatic globbing][add-custom-item-query]
 
 [add-custom-item-query]: https://github.com/dotnet/project-system/issues/2875
-[add-xaml-rules]: https://github.com/Microsoft/VSProjectSystem/blob/master/doc/extensibility/adding_xaml_rules.md
-[build-action]: https://github.com/Microsoft/VSProjectSystem/issues/244#issuecomment-327268174
-[cps]: https://github.com/Microsoft/VSProjectSystem
-[custom-item-types]: https://github.com/Microsoft/VSProjectSystem/blob/master/doc/extensibility/custom_item_types.md
+[add-xaml-rules]: https://github.com/microsoft/VSProjectSystem/blob/master/doc/extensibility/adding_xaml_rules.md
+[build-action]: https://github.com/microsoft/VSProjectSystem/issues/244#issuecomment-327268174
+[cps]: https://github.com/microsoft/VSProjectSystem
+[custom-item-types]: https://github.com/microsoft/VSProjectSystem/blob/master/doc/extensibility/custom_item_types.md
 [implicit-items]: https://aka.ms/sdkimplicititems
 [msbuild-item-update]: https://docs.microsoft.com/en-us/visualstudio/msbuild/item-element-msbuild#attributes-and-elements
-[none-xaml]: https://github.com/Microsoft/VSProjectSystem/blob/1c0a47aba5a22d3eb071dc097b73851bdeaf68db/samples/WindowsScript/WindowsScript/WindowsScript.ProjectType/BuildSystem/Rules/none.xaml
+[none-xaml]: https://github.com/microsoft/VSProjectSystem/blob/1c0a47aba5a22d3eb071dc097b73851bdeaf68db/samples/WindowsScript/WindowsScript/WindowsScript.ProjectType/BuildSystem/Rules/none.xaml

--- a/cs/nuget/bond.compiler.csharp.nuspec
+++ b/cs/nuget/bond.compiler.csharp.nuspec
@@ -6,17 +6,17 @@
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
-    <projectUrl>https://github.com/Microsoft/bond/</projectUrl>
-    <licenseUrl>https://github.com/Microsoft/bond/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/microsoft/bond/</projectUrl>
+    <licenseUrl>https://github.com/microsoft/bond/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>https://raw.githubusercontent.com/Microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
     <summary>The Bond project's code generation C# MSBuild targets</summary>
     <description>
       Includes the Bond compiler (gbc) and C# MSBuild targets for easy integration into project builds.
 
       Bond is an open source, cross-platform framework for working with schematized data. It supports cross-language serialization/deserialization and powerful generic mechanisms for efficiently manipulating data.
 
-      Bond is published on GitHub at https://github.com/Microsoft/bond/
+      Bond is published on GitHub at https://github.com/microsoft/bond/
     </description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>Bond .NET C# serialization</tags>

--- a/cs/nuget/bond.compiler.nuspec
+++ b/cs/nuget/bond.compiler.nuspec
@@ -6,17 +6,17 @@
         <version>$version$</version>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
-        <projectUrl>https://github.com/Microsoft/bond/</projectUrl>
-        <licenseUrl>https://github.com/Microsoft/bond/blob/master/LICENSE</licenseUrl>
+        <projectUrl>https://github.com/microsoft/bond/</projectUrl>
+        <licenseUrl>https://github.com/microsoft/bond/blob/master/LICENSE</licenseUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <iconUrl>https://raw.githubusercontent.com/Microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
+        <iconUrl>https://raw.githubusercontent.com/microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
         <summary>The Bond project's code generator</summary>
         <description>
             Includes the GBC Compiler in charge of code generation from Bond IDL files. This is a tools-only package. For MSBuild targets to integrate automatically into your C# build, use the Bond.Compiler.CSharp package.
 
             Bond is an open source, cross-platform framework for working with schematized data. It supports cross-language serialization/deserialization and powerful generic mechanisms for efficiently manipulating data.
 
-            Bond is published on GitHub at https://github.com/Microsoft/bond/
+            Bond is published on GitHub at https://github.com/microsoft/bond/
 
             The Compiler documentation is available at https://microsoft.github.io/bond/manual/compiler.html
         </description>

--- a/cs/nuget/bond.core.csharp.nuspec
+++ b/cs/nuget/bond.core.csharp.nuspec
@@ -6,15 +6,15 @@
         <version>$version$</version>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
-        <projectUrl>https://github.com/Microsoft/bond/</projectUrl>
-        <licenseUrl>https://github.com/Microsoft/bond/blob/master/LICENSE</licenseUrl>
+        <projectUrl>https://github.com/microsoft/bond/</projectUrl>
+        <licenseUrl>https://github.com/microsoft/bond/blob/master/LICENSE</licenseUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <iconUrl>https://raw.githubusercontent.com/Microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
+        <iconUrl>https://raw.githubusercontent.com/microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
         <summary>Bond is an open source, cross-platform, cross-language framework for working with schematized data.</summary>
         <description>
             Bond is an open source, cross-platform framework for working with schematized data. It supports cross-language serialization/deserialization and powerful generic mechanisms for efficiently manipulating data.
 
-            Bond is published on GitHub at https://github.com/Microsoft/bond/
+            Bond is published on GitHub at https://github.com/microsoft/bond/
 
             The C# documentation is available at https://microsoft.github.io/bond/manual/bond_cs.html
 

--- a/cs/nuget/bond.csharp.nuspec
+++ b/cs/nuget/bond.csharp.nuspec
@@ -6,15 +6,15 @@
         <version>$version$</version>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
-        <projectUrl>https://github.com/Microsoft/bond/</projectUrl>
-        <licenseUrl>https://github.com/Microsoft/bond/blob/master/LICENSE</licenseUrl>
+        <projectUrl>https://github.com/microsoft/bond/</projectUrl>
+        <licenseUrl>https://github.com/microsoft/bond/blob/master/LICENSE</licenseUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <iconUrl>https://raw.githubusercontent.com/Microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
+        <iconUrl>https://raw.githubusercontent.com/microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
         <summary>Bond is an open source, cross-platform, cross-language framework for working with schematized data.</summary>
         <description>
             Bond is an open source, cross-platform framework for working with schematized data. It supports cross-language serialization/deserialization and powerful generic mechanisms for efficiently manipulating data.
 
-            Bond is published on GitHub at https://github.com/Microsoft/bond/
+            Bond is published on GitHub at https://github.com/microsoft/bond/
 
             The C# documentation is available at https://microsoft.github.io/bond/manual/bond_cs.html
 

--- a/cs/nuget/bond.grpc.csharp.nuspec
+++ b/cs/nuget/bond.grpc.csharp.nuspec
@@ -6,17 +6,17 @@
         <version>$version$</version>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
-        <projectUrl>https://github.com/Microsoft/bond/</projectUrl>
-        <licenseUrl>https://github.com/Microsoft/bond/blob/master/LICENSE</licenseUrl>
+        <projectUrl>https://github.com/microsoft/bond/</projectUrl>
+        <licenseUrl>https://github.com/microsoft/bond/blob/master/LICENSE</licenseUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <iconUrl>https://raw.githubusercontent.com/Microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
+        <iconUrl>https://raw.githubusercontent.com/microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
         <summary>Bindings for using Microsoft Bond with gRPC</summary>
         <description>
           This package contains bindings for using Bond with gRPC. The Bond-generated gRPC code depends on types in this assembly.
 
           Bond is an open source, cross-platform framework for working with schematized data. It supports cross-language serialization/deserialization and powerful generic mechanisms for efficiently manipulating data.
 
-          Bond is published on GitHub at https://github.com/Microsoft/bond/
+          Bond is published on GitHub at https://github.com/microsoft/bond/
 
           The C# documentation is available at https://microsoft.github.io/bond/manual/bond_cs.html
         </description>

--- a/cs/nuget/bond.runtime.csharp.nuspec
+++ b/cs/nuget/bond.runtime.csharp.nuspec
@@ -6,15 +6,15 @@
         <version>$version$</version>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
-        <projectUrl>https://github.com/Microsoft/bond/</projectUrl>
-        <licenseUrl>https://github.com/Microsoft/bond/blob/master/LICENSE</licenseUrl>
+        <projectUrl>https://github.com/microsoft/bond/</projectUrl>
+        <licenseUrl>https://github.com/microsoft/bond/blob/master/LICENSE</licenseUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <iconUrl>https://raw.githubusercontent.com/Microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
+        <iconUrl>https://raw.githubusercontent.com/microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
         <summary>Bond is an open source, cross-platform, cross-language framework for working with schematized data.</summary>
         <description>
             Bond is an open source, cross-platform framework for working with schematized data. It supports cross-language serialization/deserialization and powerful generic mechanisms for efficiently manipulating data.
 
-            Bond is published on GitHub at https://github.com/Microsoft/bond/
+            Bond is published on GitHub at https://github.com/microsoft/bond/
 
             The C# documentation is available at https://microsoft.github.io/bond/manual/bond_cs.html
 

--- a/cs/nuget/readme.txt
+++ b/cs/nuget/readme.txt
@@ -4,11 +4,11 @@ About
 Bond is an open source, cross-platform, cross-language framework for working 
 with schematized data.
 
-Bond is published on GitHub at https://github.com/Microsoft/bond/
+Bond is published on GitHub at https://github.com/microsoft/bond/
 
 The C# documentation is available at http://microsoft.github.io/bond/manual/bond_cs.html
 
-The C# examples are at https://github.com/Microsoft/bond/tree/master/examples/cs/core
+The C# examples are at https://github.com/microsoft/bond/tree/master/examples/cs/core
 
 Bond codegen
 ============

--- a/doc/src/bond_cpp.md
+++ b/doc/src/bond_cpp.md
@@ -17,7 +17,7 @@ By design Bond is language and platform independent and is currently supported
 for C++, C#, Java, and Python on Linux, macOS, and Windows.
 
 Bond is published on GitHub at
-[https://github.com/Microsoft/bond/](https://github.com/Microsoft/bond).
+[https://github.com/microsoft/bond/](https://github.com/microsoft/bond).
 
 Basic example
 =============
@@ -1839,12 +1839,12 @@ To consume Bond, you will need to integrate it into your build somehow. If
 you are using one of these C++ package managers, Bond is available as a
 package that you can consume:
 
-* [Vcpkg](https://github.com/Microsoft/vcpkg)'s `bond` package
+* [Vcpkg](https://github.com/microsoft/vcpkg)'s `bond` package
 
 What follows are build-system agnostic instructions for consuming C++ Bond.
 
 These instructions assume that you have used
-[Bond's CMake-based build](https://github.com/Microsoft/bond/README.md) to
+[Bond's CMake-based build](https://github.com/microsoft/bond/README.md) to
 compile and *install* (`make install`/`cmake --build . --target INSTALL`)
 Bond into your development environment somewhere. The CMake variable
 `CMAKE_INSTALL_PREFIX` can be used to control where the install target
@@ -1852,7 +1852,7 @@ places the output files.
 
 (The Bond CMake files can't currently be consumed by another CMake project
 via `add_directory`.
-[Contributions encouraged](https://github.com/Microsoft/bond/blob/master/CONTRIBUTING.md)
+[Contributions encouraged](https://github.com/microsoft/bond/blob/master/CONTRIBUTING.md)
 to help improve this situation.)
 
 After you've built and installed Bond, you can use whatever build system you

--- a/doc/src/bond_cs.md
+++ b/doc/src/bond_cs.md
@@ -17,7 +17,7 @@ By design Bond is language and platform independent and is currently supported
 for C++, C#, Java, and Python on Linux, macOS, and Windows.
 
 Bond is published on GitHub at
-[https://github.com/Microsoft/bond/](https://github.com/Microsoft/bond/).
+[https://github.com/microsoft/bond/](https://github.com/microsoft/bond/).
 
 Basic example
 =============
@@ -688,19 +688,19 @@ Input and output streams
 ========================
 
 The input and output for binary protocols is provided by the
-[`IInputStream`](https://github.com/Microsoft/bond/blob/master/cs/src/core/io/IInputStream.cs)
+[`IInputStream`](https://github.com/microsoft/bond/blob/master/cs/src/core/io/IInputStream.cs)
 and
-[`IOutputStream`](https://github.com/Microsoft/bond/blob/master/cs/src/core/io/IOutputStream.cs)
+[`IOutputStream`](https://github.com/microsoft/bond/blob/master/cs/src/core/io/IOutputStream.cs)
 interfaces. Bond comes with standard implementations of these interfaces for
 memory buffers and `System.IO.Stream`. Applications can also provide their
 own custom implementations.
 
 The `OutputBuffer` class implements the `IOutputStream` interface on top of
 a memory buffer. It comes in two variants.
-[`Bond.IO.Safe.OutputBuffer`](https://github.com/Microsoft/bond/blob/master/cs/src/core/io/safe/OutputBuffer.cs)
+[`Bond.IO.Safe.OutputBuffer`](https://github.com/microsoft/bond/blob/master/cs/src/core/io/safe/OutputBuffer.cs)
 uses only safe managed code and is included in the `Bond.dll` assembly which
 is a Portable Class Library.
-[`Bond.IO.Unsafe.OutputBuffer`](https://github.com/Microsoft/bond/blob/master/cs/src/io/unsafe/OutputBuffer.cs)
+[`Bond.IO.Unsafe.OutputBuffer`](https://github.com/microsoft/bond/blob/master/cs/src/io/unsafe/OutputBuffer.cs)
 uses unsafe code to optimize for performance. It is included in the
 `Bond.IO.dll` assembly, which requires a full .NET runtime. Both
 implementations have identical class names and APIs; the only difference is
@@ -718,12 +718,12 @@ ArraySegment<byte> data = output.Data;
 ```
 
 The
-[`InputBuffer`](https://github.com/Microsoft/bond/blob/master/cs/src/core/io/safe/InputBuffer.cs)
+[`InputBuffer`](https://github.com/microsoft/bond/blob/master/cs/src/core/io/safe/InputBuffer.cs)
 class implements the `IInputStream` interface on top of a memory buffer.
 Like `OutputBuffer` it comes in two flavors, the safe and portable
-[`Bond.IO.Safe.InputBuffer`](https://github.com/Microsoft/bond/blob/master/cs/src/core/io/safe/InputBuffer.cs),
+[`Bond.IO.Safe.InputBuffer`](https://github.com/microsoft/bond/blob/master/cs/src/core/io/safe/InputBuffer.cs),
 and the performance optimized via use of unsafe code
-[`Bond.IO.Unsafe.InputBuffer`](https://github.com/Microsoft/bond/blob/master/cs/src/io/unsafe/InputBuffer.cs).
+[`Bond.IO.Unsafe.InputBuffer`](https://github.com/microsoft/bond/blob/master/cs/src/io/unsafe/InputBuffer.cs).
 
 ```csharp
 // Create an input buffer on top of a byte[]
@@ -732,9 +732,9 @@ var reader = new CompactBinaryReader<InputBuffer>(input);
 ```
 
 The
-[`InputStream`](https://github.com/Microsoft/bond/blob/master/cs/src/io/unsafe/InputStream.cs)
+[`InputStream`](https://github.com/microsoft/bond/blob/master/cs/src/io/unsafe/InputStream.cs)
 and
-[`OutputStream`](https://github.com/Microsoft/bond/blob/master/cs/src/io/unsafe/OutputStream.cs)
+[`OutputStream`](https://github.com/microsoft/bond/blob/master/cs/src/io/unsafe/OutputStream.cs)
 classes provide implementations of `IInputStream` and `IOutputStream` on top
 of `System.IO.Stream`. These classes are included in `Bond.IO.dll` and thus
 are only available to applications using a full .NET runtime and allowing
@@ -1641,7 +1641,7 @@ Bond.Compiler.CSharp and Bond.Core.CSharp packages together.
 ## Platform limitations ##
 
 The pre-compiled gbc that is included in these packages is Windows-only. See
-the [README](https://github.com/Microsoft/bond/blob/master/README.md) for
+the [README](https://github.com/microsoft/bond/blob/master/README.md) for
 instructions to build gbc for other platforms.
 
 Bond.IO.dll (which provides the types in the Bond.IO.Unsafe namespace) is

--- a/doc/src/bond_java.md
+++ b/doc/src/bond_java.md
@@ -16,7 +16,7 @@ serialization protocols, data streams, user defined type aliases and more.
 By design Bond is language and platform independent and is currently supported
 for C++, C#, Java, and Python on Linux, macOS, and Windows.
 
-Bond is published on GitHub at [https://github.com/Microsoft/bond/](https://github.com/Microsoft/bond/).
+Bond is published on GitHub at [https://github.com/microsoft/bond/](https://github.com/microsoft/bond/).
 
 Basic example
 =============
@@ -601,7 +601,7 @@ Build instructions
 Bond for Java is currently only available in source form. You will need to clone
 the Bond repository, install the appropriate dependencies for your platform, and
 build and install the Bond compiler. Follow the instructions in the top-level
-[README.md](https://github.com/Microsoft/bond/blob/master/README.md) to do all
+[README.md](https://github.com/microsoft/bond/blob/master/README.md) to do all
 of this.
 
 Java has two additional requirements:
@@ -643,7 +643,7 @@ cd java/core; gradle build install
 ```
 
 To consume either component from your local maven repository, see the
-[`build.gradle`](https://github.com/Microsoft/bond/blob/master/examples/java/core/serialization/build.gradle)
+[`build.gradle`](https://github.com/microsoft/bond/blob/master/examples/java/core/serialization/build.gradle)
 in any of our Java example projects.
 
 Build tooling
@@ -657,7 +657,7 @@ add the generated code as production and test sources, respectively. You can
 specify Bond files outside those directories and pass options to `gbc` by adding
 an explicit `compileBond` or `compileTestBond` container to your build file. You
 can see an example of this in the
-[`build.gradle`](https://github.com/Microsoft/bond/blob/master/java/core/build.gradle)
+[`build.gradle`](https://github.com/microsoft/bond/blob/master/java/core/build.gradle)
 of the Bond Core library itself.
 
 References

--- a/doc/src/bond_over_grpc.md
+++ b/doc/src/bond_over_grpc.md
@@ -126,7 +126,7 @@ by design.
 For more information about gRPC in C#, take a look at the
 [gRPC C# tutorial](http://www.grpc.io/docs/tutorials/basic/csharp.html).
 
-There is a [Bond-over-gRPC standalone example project](https://github.com/Microsoft/bond-grpc-examples).
+There is a [Bond-over-gRPC standalone example project](https://github.com/microsoft/bond-grpc-examples).
 
 See also the following example:
 

--- a/doc/src/bond_py.md
+++ b/doc/src/bond_py.md
@@ -16,7 +16,7 @@ serialization protocols, data streams, user defined type aliases and more.
 By design Bond is language and platform independent and is currently supported 
 for C++, C#, Java, and Python on Linux, macOS, and Windows.
 
-Bond is published on GitHub at [https://github.com/Microsoft/bond/](https://github.com/Microsoft/bond/).
+Bond is published on GitHub at [https://github.com/microsoft/bond/](https://github.com/microsoft/bond/).
 
 Introduction
 ============

--- a/doc/src/why_bond.md
+++ b/doc/src/why_bond.md
@@ -1,6 +1,6 @@
 % Why Bond?
 
-Bond is an [open source framework](https://github.com/Microsoft/bond/) which
+Bond is an [open source framework](https://github.com/microsoft/bond/) which
 addresses similar scenarios to Protocol Buffers, Thrift and Avro. In this 
 document we try to address similarities and differences between Bond and other 
 solutions. We try to keep it objective and uncolored by opinions but inevitably 

--- a/tools/ci-scripts/linux/image-builder/README.md
+++ b/tools/ci-scripts/linux/image-builder/README.md
@@ -14,7 +14,7 @@ The image is based on Ubuntu 16.04 (Xenial Xerus) and contains:
 ![Docker Ubuntu image build status](https://msazure.visualstudio.com/_apis/public/build/definitions/b32aa71e-8ed2-41b2-9d77-5bc261222004/14573/badge)
 
 A new image is automatically built when the master branch of the main Bond
-repository (https://github.com/Microsoft/bond) is changed. These images are
+repository (https://github.com/microsoft/bond) is changed. These images are
 then pushed to the bondciimages.azurecr.io/ubuntu-1604 container repository.
 The Travis CI builds pull a fixed version of the image specified in
 `.travis.yml` and use that.
@@ -22,7 +22,7 @@ The Travis CI builds pull a fixed version of the image specified in
 The image is built on a Microsoft VSTS instance. Its status is shown in the
 image above. Currently, access to the results of this build are limited to
 Microsoft employees. If you need details about a given build, please
-[open an issue](https://github.com/Microsoft/bond/issues/new) and one of the
+[open an issue](https://github.com/microsoft/bond/issues/new) and one of the
 maintainers from Microsoft can get you the details.
 
 ## Cleanup


### PR DESCRIPTION
Microsoft has renamed its GitHub organization from "Microsoft" to
"microsoft". This commit fixes various paths, as not all tools are able
to follow the Microsoft -> microsoft redirects that are in place.

These replacements were made with the following script:

    for f in $(grep -l -r -e 'github.com/Microsoft' -e 'Microsoft/bond' -e 'Microsoft.github.io' *); do
        sed -i -e 's~github.com/Microsoft~github.com/microsoft~g; s~Microsoft/bond~microsoft/bond~g;s~Microsoft.github.io~microsoft.github.io~g' "$f"
    done