### PR TITLE
Move maybe::operator== back from maybe_common to maybe implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ different versioning scheme, following the Haskell community's
 * `gbc` & compiler library: TBD
 * IDL core version: TBD
 * C++ version: minor bump needed
+* Fixed ambiguous call to maybe::operator== that breaks GCC 9 build
 * C# NuGet version: TBD
 
 ### C++ ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ different versioning scheme, following the Haskell community's
 * `gbc` & compiler library: TBD
 * IDL core version: TBD
 * C++ version: minor bump needed
-* Fixed ambiguous call to maybe::operator== that breaks GCC 9 build
 * C# NuGet version: TBD
 
 ### C++ ###
@@ -24,6 +23,9 @@ different versioning scheme, following the Haskell community's
 * Fixed an ambigious `HexDigit` overload compilation error when
   compiling with some versions of GCC. ([Pull request
   #954](https://github.com/Microsoft/bond/pull/954))
+* Fixed ambiguous call to `maybe::operator==` that breaks GCC 9
+  build. ([Pull request
+  #975](https://github.com/microsoft/bond/pull/975))
 
 ## 8.1.0: 2019-03-27 ##
 

--- a/cpp/inc/bond/core/maybe.h
+++ b/cpp/inc/bond/core/maybe.h
@@ -185,29 +185,6 @@ public:
     maybe_common& operator=(maybe_common&&) = default;
     #endif
 
-    /// @brief Compares two maybes for value equality.
-    ///
-    /// @return true if both maybes hold nothing; returns false if one maybe
-    /// holds nothing and the other holds a values; otherwise, calls
-    /// operator== with the two values.
-    ///
-    /// @since 8.0.0 (was a member function prior)
-    friend bool operator==(const maybe_common& lhs, const maybe_common& rhs)
-    {
-        return lhs._value == rhs._value;
-    }
-
-    /// @brief Compares two maybes for value inequality.
-    ///
-    /// See operator==(const maybe_common&,const maybe_common&) for details
-    /// about how maybes holding nothing are handled.
-    ///
-    /// @since 8.0.0 (was a member function prior)
-    friend bool operator!=(const maybe_common& lhs, const maybe_common& rhs)
-    {
-        return !(lhs == rhs);
-    }
-
     /// @brief Compares a maybe and a value for equality.
     ///
     /// @return false if the maybe holds nothing; otherwise, calls
@@ -368,6 +345,27 @@ public:
     {
         this->emplace(std::move(value));
         return *this;
+    }
+
+    /// @brief Compares two maybes for value equality.
+    ///
+    /// @return true if both maybes hold nothing; returns false if one maybe
+    /// holds nothing and the other holds a values; otherwise, calls
+    /// operator== with the two values.
+    ///
+    friend bool operator==(const maybe& lhs, const maybe& rhs)
+    {
+        return lhs._value == rhs._value;
+    }
+
+    /// @brief Compares two maybes for value inequality.
+    ///
+    /// See operator==(const maybe_common&,const maybe_common&) for details
+    /// about how maybes holding nothing are handled.
+    ///
+    friend bool operator!=(const maybe& lhs, const maybe& rhs)
+    {
+        return lhs._value != rhs._value;
     }
 
     /// @brief Set the maybe to hold a value, if needed.
@@ -558,6 +556,27 @@ public:
     // allocator_holder so the friend free functions from maybe_common don't
     // have any competition.
     bool operator==(const alloc_holder&) = delete;
+
+    /// @brief Compares two maybes for value equality.
+    ///
+    /// @return true if both maybes hold nothing; returns false if one maybe
+    /// holds nothing and the other holds a values; otherwise, calls
+    /// operator== with the two values.
+    ///
+    friend bool operator==(const maybe& lhs, const maybe& rhs)
+    {
+        return lhs._value == rhs._value;
+    }
+
+    /// @brief Compares two maybes for value inequality.
+    ///
+    /// See operator==(const maybe_common&,const maybe_common&) for details
+    /// about how maybes holding nothing are handled.
+    ///
+    friend bool operator!=(const maybe& lhs, const maybe& rhs)
+    {
+        return lhs._value != rhs._value;
+    }
 
     /// @brief Set to non-empty, if needed.
     ///


### PR DESCRIPTION
The move of the maybe::operator== from the two variants to the common
base maybe_common causes an ambiguity with the allocator operator==
from libstdc++ in GCC 9.1. Moving them back to the variants fixes this
issue.

More detailed description:

When compiling Bond 8.1 code with gcc 9.1.0 / the current libstdc++, I get an ambiguous overload error for the

    friend bool operator==(const maybe_common& lhs, const maybe_common& rhs)

from maybe.h line 195. The ambiguous other operator being

    operator==(const allocator<_T1>&, const allocator<_T2>&)

from allocator.h:168 (and another similar one from new_allocator.h).

Moving the shared operator== implementation from maybe_common to both of the maybe variants fixes the issue, but I'm not sure if this is the best approach. See the attached patch. I'm also not sure what else would need to be updated.