### PR TITLE
Refresh Linux CI build image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ env:
     - FLAVOR="cpp-grpc-master" BOOST="1.66.0" COMPILER="clang" CRON_ONLY="true"
 script:
     - if [ "$CRON_ONLY" = "true" ] && [ "$TRAVIS_EVENT_TYPE" != "cron" ] ; then echo "Skipping cron-only job"; exit 0; fi
-    - CI_BUILD_IMAGE=bondciimages.azurecr.io/ubuntu-1604:build-21070065
+    - CI_BUILD_IMAGE=bondciimages.azurecr.io/ubuntu-1604:build-22756092
     - if [ "$TRAVIS_OS_NAME" == "linux" ]; then echo "Hardware:"; grep model\ name /proc/cpuinfo | uniq -c; free -m; fi
     - time travis_retry docker pull $CI_BUILD_IMAGE
     - docker images # Dump the image ID

--- a/tools/ci-scripts/linux/image-builder/README.md
+++ b/tools/ci-scripts/linux/image-builder/README.md
@@ -31,9 +31,9 @@ maintainers from Microsoft can get you the details.
 
 Not all of the images built automatically are used by CI builds. We have
 another VSTS build that runs a cleanup script to delete unused images. It
-keeps images that are referenced in `.travis.yml` in the past two week's of
-commits in the main GitHub repository or any tags on that repository. It
-also keeps any image younger than seven days.
+keeps images that are referenced in `.travis.yml` in the last 10 commits of
+the master branch, the past two week's of commits, and any tags in the main
+GitHub repository. It also keeps any image younger than seven days.
 
 # Manual Builds
 


### PR DESCRIPTION
Updates the Linux CI build image to build-22756092 which was built
against commit 62da781cb2.

Due to a combination of two bugs in the clean up script, we've lost all
the images except for the one reference by the 8.1.0 tag,
build-13234037.

1. The clean up script was supposed to be configured to retain images
   reference by all tags. However, it was only retaining the image
   reference by the most recent tag. This was fixed by using `git
   rev-list --tags --simplify-by-decoration --dense` instead of `git
   rev-list --tags -n 1`
1. The clean up script was configured to retain images reference by the
   last two weeks of commits. There has been a period without any
   commits in two weeks, so the images reference by the current tip of
   master were collected. This has been fixed by adding the results of
   `git rev-list --reverse -n 10 origin/master` to the set of root
   commits.

Fixes https://github.com/microsoft/bond/issues/979