### PR TITLE
Suppress MSVC warning '<': expression always false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ different versioning scheme, following the Haskell community's
 * Fixed ambiguous call to `maybe::operator==` that breaks GCC 9
   build. ([Pull request
   #975](https://github.com/microsoft/bond/pull/975))
+* Fixed MSVC warning C4296: "'<': expression is always false" in protocol.h.
+  ([Issue
+  #981](https://github.com/microsoft/bond/issues/981))
 
 ## 8.1.0: 2019-03-27 ##
 

--- a/cpp/inc/bond/core/protocol.h
+++ b/cpp/inc/bond/core/protocol.h
@@ -194,10 +194,19 @@ namespace detail
 {
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4296) // C4296: '<' : expression is always false
+#endif // _MSC_VER
+
     // Avoid std::max due to a bug in Visual C++ 2017.
     template <std::size_t V0, std::size_t V1>
     struct max_of
         : std::integral_constant<std::size_t, (V0 < V1 ? V1 : V0)> {};
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif // _MSC_VER
 
     template <typename List> struct
     max_size;


### PR DESCRIPTION
Adds a spot suppression for MSVC warning C4296: '<' : expression is
always false. MSVC's "always constant" warnings tend to trigger on
tempalted code based on the specific instantiation's values,
disregarding that the template itself it not always constant.

Fixes https://github.com/microsoft/bond/issues/981