### PR TITLE
Fixes mpl.h compilation error in Clang raised by -Wreturn-std-move

### DIFF
--- a/cpp/inc/bond/core/detail/mpl.h
+++ b/cpp/inc/bond/core/detail/mpl.h
@@ -114,7 +114,7 @@ inline auto try_apply(F&& f, const list<T, U, R...>&)
 {
     if (auto&& result = f(identity<T>{}))
     {
-        return result;
+        return std::move(result);
     }
 
     return try_apply(std::forward<F>(f), list<U, R...>{});


### PR DESCRIPTION
Addresses issue https://github.com/microsoft/bond/issues/984

All unit tests pass.