### PR TITLE
Improve OutputBuffer Grow method for large buffers

### DIFF
--- a/cs/src/core/io/safe/OutputBuffer.cs
+++ b/cs/src/core/io/safe/OutputBuffer.cs
@@ -220,9 +220,14 @@ namespace Bond.IO.Safe
         // Grow the buffer so that there is enough space to write 'count' bytes
         internal virtual void Grow(int count)
         {
-            var minLength = position + count;
+            int minLength = position + count;
             length += length >> 1;
-            if (length < minLength) length = minLength;
+
+            const int ArrayIndexMaxValue = 0x7FFFFFC7;
+            if ((uint)length > ArrayIndexMaxValue)
+                length = ArrayIndexMaxValue;
+            if (length < minLength)
+                length = minLength;
 
             Array.Resize(ref buffer, length);
         }

--- a/cs/src/core/io/safe/OutputBuffer.cs
+++ b/cs/src/core/io/safe/OutputBuffer.cs
@@ -232,9 +232,6 @@ namespace Bond.IO.Safe
             {
                 length = minLength;
             }
-                length = ArrayIndexMaxValue;
-            if (length < minLength)
-                length = minLength;
 
             Array.Resize(ref buffer, length);
         }

--- a/cs/src/core/io/safe/OutputBuffer.cs
+++ b/cs/src/core/io/safe/OutputBuffer.cs
@@ -225,6 +225,13 @@ namespace Bond.IO.Safe
 
             const int ArrayIndexMaxValue = 0x7FFFFFC7;
             if ((uint)length > ArrayIndexMaxValue)
+            {
+                length = ArrayIndexMaxValue;
+            }
+            else if (length < minLength)
+            {
+                length = minLength;
+            }
                 length = ArrayIndexMaxValue;
             if (length < minLength)
                 length = minLength;


### PR DESCRIPTION
Current Grow implementation works inefficiently for
buffer sizes larger than 2/3 of int.MaxValue. After that size,
each grow will result in small incremental resize to the next
required count, copying huge amounts of data each time.