### PR TITLE
[WIP] Refresh Linux CI build image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ env:
     - FLAVOR="cpp-grpc-master" BOOST="1.66.0" COMPILER="clang" CRON_ONLY="true"
 script:
     - if [ "$CRON_ONLY" = "true" ] && [ "$TRAVIS_EVENT_TYPE" != "cron" ] ; then echo "Skipping cron-only job"; exit 0; fi
-    - CI_BUILD_IMAGE=bondciimages.azurecr.io/ubuntu-1604:build-22756092
+    - CI_BUILD_IMAGE=bondciimages.azurecr.io/ubuntu-1604:build-24749007
     - if [ "$TRAVIS_OS_NAME" == "linux" ]; then echo "Hardware:"; grep model\ name /proc/cpuinfo | uniq -c; free -m; fi
     - time travis_retry docker pull $CI_BUILD_IMAGE
     - docker images # Dump the image ID


### PR DESCRIPTION
Updates the Linux CI build image to build-24749007 which was built
against commit 3132eb2b90d29d916e703e42ec6482b9b89a86ce.