### PR TITLE
Refresh Travis CI build image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ env:
     - FLAVOR="cpp-grpc-master" BOOST="1.66.0" COMPILER="clang" CRON_ONLY="true"
 script:
     - if [ "$CRON_ONLY" = "true" ] && [ "$TRAVIS_EVENT_TYPE" != "cron" ] ; then echo "Skipping cron-only job"; exit 0; fi
-    - CI_BUILD_IMAGE=bondciimages.azurecr.io/ubuntu-1604:build-22756092
+    - CI_BUILD_IMAGE=bondciimages.azurecr.io/ubuntu-1604:build-24950697
     - if [ "$TRAVIS_OS_NAME" == "linux" ]; then echo "Hardware:"; grep model\ name /proc/cpuinfo | uniq -c; free -m; fi
     - time travis_retry docker pull $CI_BUILD_IMAGE
     - docker images # Dump the image ID

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ env:
     - FLAVOR="cpp-grpc-master" BOOST="1.66.0" COMPILER="clang" CRON_ONLY="true"
 script:
     - if [ "$CRON_ONLY" = "true" ] && [ "$TRAVIS_EVENT_TYPE" != "cron" ] ; then echo "Skipping cron-only job"; exit 0; fi
-    - CI_BUILD_IMAGE=bondciimages.azurecr.io/ubuntu-1604:build-24950697
+    - CI_BUILD_IMAGE=bondciimages.azurecr.io/ubuntu-1604:build-24985895
     - if [ "$TRAVIS_OS_NAME" == "linux" ]; then echo "Hardware:"; grep model\ name /proc/cpuinfo | uniq -c; free -m; fi
     - time travis_retry docker pull $CI_BUILD_IMAGE
     - docker images # Dump the image ID


### PR DESCRIPTION
The Travis CI image now includes happy pre-installed, as the Haskell LTS we
use needs happy pre-installed.

This image was built from commit dd105d96b64884c1297286a0023d726db06ec1a2.