### PR TITLE
Install happy in Travis CI image

### DIFF
--- a/tools/ci-scripts/linux/image-builder/Dockerfile
+++ b/tools/ci-scripts/linux/image-builder/Dockerfile
@@ -10,6 +10,10 @@ RUN apt-get update && \
     apt-get -y install \
     software-properties-common
 
+# Components for gbc
+RUN apt-get -y install \
+    happy
+
 # Components for Boost
 RUN apt-get -y install \
     build-essential \


### PR DESCRIPTION
Current versions of stack appear to need happy installed ahead of time
to use the happy package.