### PR TITLE
Use MemoryStream.TryGetBuffer to clone streams on .NET 4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ different versioning scheme, following the Haskell community's
 * `gbc` & compiler library: TBD
 * IDL core version: TBD
 * C++ version: minor bump needed
-* C# NuGet version: TBD
+* C# NuGet version: minor bump needed
 
 ### C++ ###
 
@@ -29,6 +29,12 @@ different versioning scheme, following the Haskell community's
 * Fixed MSVC warning C4296: "'<': expression is always false" in protocol.h.
   ([Issue
   #981](https://github.com/microsoft/bond/issues/981))
+
+### C# ###
+
+* Added .NET 4.6 target framework to Bond.IO.dll so that it can use
+  `MemoryStream.TryGetBuffer()` when cloning streams like is done when
+  targeting .NET Standard 1.3+.
 
 ## 8.1.0: 2019-03-27 ##
 

--- a/cs/nuget/bond.core.csharp.nuspec
+++ b/cs/nuget/bond.core.csharp.nuspec
@@ -37,6 +37,19 @@
         <file target="lib\net45" src="net45\Bond.pdb" />
         <file target="lib\net45" src="net45\Bond.xml" />
 
+        <file target="lib\net46" src="net45\Bond.Attributes.dll" />
+        <file target="lib\net46" src="net45\Bond.Attributes.pdb" />
+        <file target="lib\net46" src="net45\Bond.Attributes.xml" />
+        <file target="lib\net46" src="net46\Bond.IO.dll" />
+        <file target="lib\net46" src="net46\Bond.IO.pdb" />
+        <file target="lib\net46" src="net46\Bond.IO.xml" />
+        <file target="lib\net46" src="net45\Bond.Reflection.dll" />
+        <file target="lib\net46" src="net45\Bond.Reflection.pdb" />
+        <file target="lib\net46" src="net45\Bond.Reflection.xml" />
+        <file target="lib\net46" src="net45\Bond.dll" />
+        <file target="lib\net46" src="net45\Bond.pdb" />
+        <file target="lib\net46" src="net45\Bond.xml" />
+
         <file target="lib\netstandard1.0" src="netstandard1.0\Bond.Attributes.dll" />
         <file target="lib\netstandard1.0" src="netstandard1.0\Bond.Attributes.pdb" />
         <file target="lib\netstandard1.0" src="netstandard1.0\Bond.Attributes.xml" />

--- a/cs/src/io/IO.csproj
+++ b/cs/src/io/IO.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <ProjectGuid>{2E6E238C-9017-445C-9611-66DA780609BE}</ProjectGuid>
-    <TargetFrameworks>net45;netstandard1.3;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net45;net46;netstandard1.3;netstandard1.6</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <RootNamespace>Bond.IO</RootNamespace>
     <AssemblyName>Bond.IO</AssemblyName>

--- a/cs/src/io/unsafe/StreamCloning.cs
+++ b/cs/src/io/unsafe/StreamCloning.cs
@@ -83,7 +83,7 @@ namespace Bond.IO.Unsafe
 
         static class MemoryStreamCloner
         {
-#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
+#if !(NET46 || NETSTANDARD1_3 || NETSTANDARD1_6)
             delegate void GetOriginAndLength(MemoryStream stream, out int origin, out int length);
             static readonly GetOriginAndLength getOriginAndLength;
 
@@ -125,7 +125,7 @@ namespace Bond.IO.Unsafe
                 getOriginAndLength(stream, out origin, out length);
                 return new MemoryStream(stream.GetBuffer(), origin, length - origin, false, true) { Position = stream.Position };
             }
-#else // NETSTANDARD implementation
+#else // NET46 & NETSTANDARD implementation
             internal static MemoryStream CloneMemoryStream(MemoryStream stream)
             {
                 ArraySegment<byte> buffer;

--- a/doc/src/bond_cs.md
+++ b/doc/src/bond_cs.md
@@ -1653,18 +1653,21 @@ namespace).
 
 This table lists which frameworks are targeted by the Bond assemblies.
 
-This table is accurate for Bond NuGet packages 6.0.0 and later.
+This table is accurate for Bond NuGet packages 8.1.0 and later.
 
-| Assembly                 | .NET 4.0 | .NET 4.5 | Profile78 | .NET Standard 1.0 | .NET Standard 1.3 | .NET Standard 1.6 |
-|--------------------------|----------|----------|-----------|-------------------|-------------------|-------------------|
-| Bond.Attributes.dll      | No       | Yes      | Yes       | Yes               | ←                 | Yes               |
-| Bond.Reflection.dll      | No       | Yes      | Yes       | Yes               | ←                 | Yes               |
-| Bond.dll                 | No       | Yes      | Yes       | Yes               | ←                 | Yes               |
-| Bond.JSON.dll            | No       | Yes      | No        | Yes               | ←                 | Yes               |
-| Bond.IO.dll              | No       | Win only | No        | No                | Win only          | Win only          |
+| Assembly                 | .NET 4.0 | .NET 4.5 | .NET 4.6 <sup>1</sup> | .NET Standard 1.0 | .NET Standard 1.3 | .NET Standard 1.6 |
+|--------------------------|----------|----------|-----------------------|-------------------|-------------------|-------------------|
+| Bond.Attributes.dll      | No       | Yes      | ←                     | Yes               | ←                 | Yes               |
+| Bond.Reflection.dll      | No       | Yes      | ←                     | Yes               | ←                 | Yes               |
+| Bond.dll                 | No       | Yes      | ←                     | Yes               | ←                 | Yes               |
+| Bond.JSON.dll            | No       | Yes      | ←                     | Yes               | ←                 | Yes               |
+| Bond.IO.dll              | No       | Win only | Win only              | No                | Win only          | Win only          |
 
 A left arrow (←) indicates that support for that framework is provided by
 the version of the assembly that targets a lower version of the framework.
+
+<sup>1</sup> Targeting .NET Framework 4.6 has been comitted by is not yet
+part of a released package.
 
 References
 ==========


### PR DESCRIPTION
.NET 4.6 implements `MemoryStream.TryGetBuffer()`, so we can use that to
clone streams instead of finding a private method via reflection.

This requires adding .NET 4.6 as one of the target frameworks for
Bond.IO.dll, since NuGet will pick the .NET 4.5 version of Bond.IO.dll
over the .NET Standard 1.3 one when a consuming project itself targets
.NET Framework 4.6+.