### PR TITLE
Remove non-functional --split-obj from gbc build

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -32,7 +32,6 @@ function (add_stack_build target)
     list (APPEND options $<$<CONFIG:MinSizeRel>:--executable-stripping>)
     list (APPEND options $<$<CONFIG:MinSizeRel>:--ghc-options=-O2>)
     list (APPEND options $<$<CONFIG:MinSizeRel>:--library-stripping>)
-    list (APPEND options $<$<CONFIG:MinSizeRel>:--split-objs>)
 
     list (APPEND options $<$<CONFIG:Release>:--executable-stripping>)
     list (APPEND options $<$<CONFIG:Release>:--ghc-options=-O2>)


### PR DESCRIPTION
The stack `--split-obj` option is currently not working on Windows. When
it is enabled, builds fail with errors like:

    .stack-work\dist\e626a42b\build\Data\Orphans_o_split: getDirectoryContents:findFirstFile: does not exist (The system cannot find the path specified.)

`--split-obj` is a preview feature, so this isn't unexpected.

For now, removing this flag from the MinSizeRel configuration.