### PR TITLE
avoid undefined behaviour of std::memcpy() on initial write to buffer

### DIFF
--- a/cpp/inc/bond/stream/output_buffer.h
+++ b/cpp/inc/bond/stream/output_buffer.h
@@ -221,15 +221,19 @@ public:
         }
 
         //
-        // copy to the tail of current range
-        std::memcpy(_rangePtr + _rangeSize,
-                    buffer,
-                    sizePart);
+        // Copy to the tail of current range. Note that _rangePtr may still be
+        // null here on initial write to an empty buffer. The behaviour of
+        // std::memcpy() is undefined in that situation, even if size == 0.    
+        //
+        if (sizePart > 0)
+        {
+            std::memcpy(_rangePtr + _rangeSize,
+                        buffer,
+                        sizePart);
 
-        //
-        // increase current range size
-        //
-        _rangeSize += sizePart;
+            // increase current range size
+            _rangeSize += sizePart;
+        }
 
         //
         // if there is more bytes to copy, allocate a new buffer


### PR DESCRIPTION
Closes #1018

On the first call to Write, std::memcpy() is called with a nullptr destination and a size of zero. While this should be safe in practice, it is undefined behaviour: https://en.cppreference.com/w/cpp/string/byte/memcpy