### PR TITLE
[WiP] Support for xmldoc comments for Struct, Enum and Constant

### DIFF
--- a/compiler/src/Language/Bond/Codegen/Cs/Types_cs.hs
+++ b/compiler/src/Language/Bond/Codegen/Cs/Types_cs.hs
@@ -199,13 +199,13 @@ namespace #{csNamespace}
             def x = if fieldMapping == PublicFields then Nothing else csDefault x
 
     -- C# enum definition for schema enum
-    typeDefinition e@Enum {..} = [lt|#{CS.typeAttributes cs e}public enum #{declName}
+    typeDefinition e@Enum {..} = [lt|#{CS.xmldocComments 1 declXmlDoc}#{CS.typeAttributes cs e}public enum #{declName}
     {
         #{newlineSep 2 constant enumConstants}
     }|]
       where
         -- constant
         constant Constant {..} = let value x = [lt| = unchecked((int)#{x})|] in
-            [lt|#{constantName}#{optional value constantValue},|]
+            [lt|#{CS.xmldocComments 2 constantXmlDoc}#{constantName}#{optional value constantValue},|]
 
     typeDefinition _ = mempty

--- a/compiler/src/Language/Bond/Codegen/Cs/Types_cs.hs
+++ b/compiler/src/Language/Bond/Codegen/Cs/Types_cs.hs
@@ -78,11 +78,13 @@ namespace #{csNamespace}
     propertyAttributes f = case structMapping of
         Class -> CS.propertyAttributes cs f
 
+    xmlDocCommentsField f = CS.xmldocComments 2 (fieldXmlDoc f)
+
     baseClass x = [lt|
         : #{csType x}|]
 
     -- C# type definition for schema struct
-    typeDefinition s@Struct {..} = [lt|#{typeAttributes s}#{struct}#{declName}#{params}#{maybe interface baseClass structBase}#{constraints}
+    typeDefinition s@Struct {..} = [lt|#{CS.xmldocComments 1 declXmlDoc}#{typeAttributes s}#{struct}#{declName}#{params}#{maybe interface baseClass structBase}#{constraints}
     {
         #{doubleLineSep 2 property structFields}#{constructors}
     }|]
@@ -178,7 +180,7 @@ namespace #{csNamespace}
 
         -- property or field
         property f@Field {..} =
-            [lt|#{propertyAttributes f}#{new}#{access}#{csType fieldType} #{fieldName}#{autoPropertyOrField}|]
+            [lt|#{xmlDocCommentsField f}#{propertyAttributes f}#{new}#{access}#{csType fieldType} #{fieldName}#{autoPropertyOrField}|]
           where
             autoPropertyOrField = case fieldMapping of
                 PublicFields        -> [lt|#{optional fieldInitializer $ csDefault f};|]

--- a/compiler/src/Language/Bond/Codegen/Cs/Util.hs
+++ b/compiler/src/Language/Bond/Codegen/Cs/Util.hs
@@ -11,6 +11,7 @@ module Language.Bond.Codegen.Cs.Util
     , defaultValue
     , disableCscWarnings
     , disableReSharperWarnings
+    , xmldocComments
     ) where
 
 import Data.Int (Int64)
@@ -42,6 +43,12 @@ disableReSharperWarnings = [lt|
 // ReSharper disable RedundantUsingDirective
 #endregion
 |]
+
+-- C# xmldoc comments
+xmldocComments :: Int64 -> [String] -> Text
+xmldocComments i = newlineSepEnd i go
+  where
+    go s = [lt|///#{s}|]
 
 -- C# field/property attributes
 propertyAttributes :: MappingContext -> Field -> Text

--- a/compiler/src/Language/Bond/Codegen/Java/Enum_java.hs
+++ b/compiler/src/Language/Bond/Codegen/Java/Enum_java.hs
@@ -118,8 +118,8 @@ public final class #{declName} implements org.bondlib.BondEnum<#{declName}> {
         fixEnumWithInt _ [] result = reverse result
         fixEnumWithInt nextInt (h:r) result = case constantValue h of
           Just n -> let fixedN = (fromInteger (Java.twosComplement 32 (toInteger n))) in
-            fixEnumWithInt (fixedN + 1) r ((Constant (constantName h) (Just fixedN)):result)
-          Nothing -> fixEnumWithInt (nextInt + 1) r ((Constant (constantName h) (Just nextInt)):result)
+            fixEnumWithInt (fixedN + 1) r ((Constant [] (constantName h) (Just fixedN)):result)
+          Nothing -> fixEnumWithInt (nextInt + 1) r ((Constant [] (constantName h) (Just nextInt)):result)
 
         -- Filter a list of constants, leaving a list of constants with distinct values.
         -- If several constants in the input list share a value, the first one that appears will be the one that appears in the output list.

--- a/compiler/src/Language/Bond/Lexer.hs
+++ b/compiler/src/Language/Bond/Lexer.hs
@@ -48,6 +48,7 @@ import Language.Bond.Syntax.Types
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as L
+import qualified Text.Megaparsec.Char as C
 
 -- parser state, mutable and global
 data Symbols =
@@ -76,7 +77,7 @@ type Parser a = StateT Symbols (ParsecT Void String (ReaderT Environment IO)) a
 sc :: Parser ()
 sc = L.space space1 lineCmnt blockCmnt
   where
-    lineCmnt  = L.skipLineComment "//"
+    lineCmnt =  try $ C.string "//" *> notFollowedBy (C.string "/") *> void (takeWhileP (Just "character") (/= '\n'))
     blockCmnt = L.skipBlockComment "/*" "*/"
 
 -- consume whitespace after every lexeme

--- a/compiler/src/Language/Bond/Parser.hs
+++ b/compiler/src/Language/Bond/Parser.hs
@@ -54,6 +54,7 @@ parseBond s c f r = runReaderT (runParserT (evalStateT bond (Symbols [] [])) s c
 bond :: Parser Bond
 bond = do
     whiteSpace
+    _ <- xmldoc -- todo: figure out where to place bond file level xmldoc comments
     imports <- many import_
     namespaces <- some namespace
     local (with namespaces) $ Bond imports namespaces <$> many declaration <* eof

--- a/compiler/src/Language/Bond/Syntax/Types.hs
+++ b/compiler/src/Language/Bond/Syntax/Types.hs
@@ -94,7 +94,8 @@ data Attribute =
 -- | Definition of a 'Struct' field.
 data Field =
     Field
-        { fieldAttributes :: [Attribute]    -- zero or more attributes
+        { fieldXmlDoc :: [String]           -- zero or more xmldoc comments
+        , fieldAttributes :: [Attribute]    -- zero or more attributes
         , fieldOrdinal :: Word16            -- ordinal
         , fieldModifier :: Modifier         -- field modifier
         , fieldType :: Type                 -- type
@@ -106,7 +107,8 @@ data Field =
 -- | Definition of an 'Enum' constant.
 data Constant =
     Constant
-        { constantName :: String            -- enum constant name
+        { constantXmlDoc :: [String]        -- zero or more xmldoc comments
+        , constantName :: String            -- enum constant name
         , constantValue :: Maybe Int        -- optional constant value
         }
     deriving (Eq, Show)
@@ -160,6 +162,7 @@ methodTypeToMaybe (Streaming t) = error ("Unable to handle streaming " ++ (show 
 data Declaration =
     Struct
         { declNamespaces :: [Namespace]     -- namespace(s) in which the struct is declared
+        , declXmlDoc :: [String]            -- zero or more xmldoc comments
         , declAttributes :: [Attribute]     -- zero or more attributes
         , declName :: String                -- struct identifier
         , declParams :: [TypeParam]         -- list of type parameters for generics
@@ -169,6 +172,7 @@ data Declaration =
     |                                       -- ^ <https://microsoft.github.io/bond/manual/compiler.html#struct-definition struct definition>
     Enum
         { declNamespaces :: [Namespace]     -- namespace(s) in which the enum is declared
+        , declXmlDoc :: [String]            -- zero or more xmldoc comments
         , declAttributes :: [Attribute]     -- zero or more attributes
         , declName :: String                -- enum identifier
         , enumConstants :: [Constant]       -- one or more enum constant values
@@ -176,12 +180,14 @@ data Declaration =
     |                                       -- ^ <https://microsoft.github.io/bond/manual/compiler.html#enum-definition enum definition>
     Forward
         { declNamespaces :: [Namespace]     -- namespace(s) in which the struct is declared
+--        , declXmlDoc :: [String]            -- zero or more xmldoc comments
         , declName :: String                -- struct identifier
         , declParams :: [TypeParam]         -- type parameters for generics
         }
     |                                       -- ^ <https://microsoft.github.io/bond/manual/compiler.html#forward-declaration forward declaration>
     Alias
         { declNamespaces :: [Namespace]     -- namespace(s) in which the type alias is declared
+--        , declXmlDoc :: [String]            -- zero or more xmldoc comments
         , declName :: String                -- alias identifier
         , declParams :: [TypeParam]         -- type parameters for generics
         , aliasType :: Type                 -- aliased type
@@ -189,6 +195,7 @@ data Declaration =
     |
     Service
         { declNamespaces :: [Namespace]     -- namespace(s) in which the service is declared
+--        , declXmlDoc :: [String]            -- zero or more xmldoc comments
         , declAttributes :: [Attribute]     -- zero or more attributes
         , declName :: String                -- service name
         , declParams :: [TypeParam]         -- type parameters for generic service

--- a/compiler/src/Language/Bond/Syntax/Util.hs
+++ b/compiler/src/Language/Bond/Syntax/Util.hs
@@ -239,5 +239,5 @@ reifyEnumValues :: [Constant] -> [(String, Int)]
 reifyEnumValues constants = nameValues 0 constants
   where
     nameValues _ [] = []
-    nameValues _ ((Constant name (Just value)):xs) = (name, value) : nameValues (value + 1) xs
-    nameValues next ((Constant name Nothing):xs)   = (name, next) : nameValues (next + 1) xs
+    nameValues _ ((Constant _ name (Just value)):xs) = (name, value) : nameValues (value + 1) xs
+    nameValues next ((Constant _ name Nothing):xs)   = (name, next) : nameValues (next + 1) xs

--- a/compiler/tests/TestMain.hs
+++ b/compiler/tests/TestMain.hs
@@ -162,6 +162,7 @@ tests = testGroup "Compiler tests"
             , verifyCsCodegen "inheritance"
             , verifyCsCodegen "aliases"
             , verifyCsCodegen "complex_inheritance"
+            , verifyCsCodegen "xmldoc"
             , verifyCodegenVariation
                 [ "c#"
                 , "--preview-constructor-parameters"

--- a/compiler/tests/Tests/Syntax/JSON.hs
+++ b/compiler/tests/Tests/Syntax/JSON.hs
@@ -82,11 +82,12 @@ anyType :: Type
 anyType = BT_UserDefined
              (Struct
                { declNamespaces = [Namespace { nsLanguage = Nothing, nsName = ["any"] }]
+               , declXmlDoc = []
                , declAttributes = []
                , declName = "anyTypeName"
                , declParams = []
                , structBase = Nothing
-               , structFields = [Field { fieldAttributes = [], fieldOrdinal = 0, fieldModifier = Optional, fieldType = BT_Int16, fieldName = "anyField", fieldDefault = Nothing }] })
+               , structFields = [Field { fieldXmlDoc = [], fieldAttributes = [], fieldOrdinal = 0, fieldModifier = Optional, fieldType = BT_Int16, fieldName = "anyField", fieldDefault = Nothing }] })
              []
 
 -- | The JSON AST representation of 'anyType'

--- a/compiler/tests/generated/collection-interfaces/xmldoc_types.cs
+++ b/compiler/tests/generated/collection-interfaces/xmldoc_types.cs
@@ -1,0 +1,58 @@
+
+
+// suppress "Missing XML comment for publicly visible type or member"
+#pragma warning disable 1591
+
+
+#region ReSharper warnings
+// ReSharper disable PartialTypeWithSinglePart
+// ReSharper disable RedundantNameQualifier
+// ReSharper disable InconsistentNaming
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedParameter.Local
+// ReSharper disable RedundantUsingDirective
+#endregion
+
+namespace example.some
+{
+    using System.Collections.Generic;
+
+    [System.CodeDom.Compiler.GeneratedCode("gbc", "0.12.0.1")]
+    public enum FooBar
+    {
+        Foo = unchecked((int)1),
+        Bar = unchecked((int)2),
+        Baz = unchecked((int)3),
+    }
+
+    /// This is my struct
+    /// 2nd line
+    [global::Bond.Schema]
+    [System.CodeDom.Compiler.GeneratedCode("gbc", "0.12.0.1")]
+    public partial class SomeStruct
+    {
+        /// some field
+        /// <code>someField = 42</code>
+        /// last line
+        [global::Bond.Id(0)]
+        public int someField { get; set; }
+
+        /// not ignored
+        [global::Bond.Id(1)]
+        public int otherField { get; set; }
+
+        [global::Bond.Id(2)]
+        public int notDocumented { get; set; }
+
+        public SomeStruct()
+            : this("example.some.SomeStruct", "SomeStruct")
+        {}
+
+        protected SomeStruct(string fullName, string name)
+        {
+            someField = 123;
+            otherField = 234;
+            notDocumented = 345;
+        }
+    }
+} // example.some

--- a/compiler/tests/generated/collection-interfaces/xmldoc_types.cs
+++ b/compiler/tests/generated/collection-interfaces/xmldoc_types.cs
@@ -17,10 +17,14 @@ namespace example.some
 {
     using System.Collections.Generic;
 
+    /// foobar
     [System.CodeDom.Compiler.GeneratedCode("gbc", "0.12.0.1")]
     public enum FooBar
     {
+        /// foo
+        /// two lines
         Foo = unchecked((int)1),
+        /// bar
         Bar = unchecked((int)2),
         Baz = unchecked((int)3),
     }

--- a/compiler/tests/generated/xmldoc_types.cs
+++ b/compiler/tests/generated/xmldoc_types.cs
@@ -1,0 +1,58 @@
+
+
+// suppress "Missing XML comment for publicly visible type or member"
+#pragma warning disable 1591
+
+
+#region ReSharper warnings
+// ReSharper disable PartialTypeWithSinglePart
+// ReSharper disable RedundantNameQualifier
+// ReSharper disable InconsistentNaming
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedParameter.Local
+// ReSharper disable RedundantUsingDirective
+#endregion
+
+namespace example.some
+{
+    using System.Collections.Generic;
+
+    [System.CodeDom.Compiler.GeneratedCode("gbc", "0.12.0.1")]
+    public enum FooBar
+    {
+        Foo = unchecked((int)1),
+        Bar = unchecked((int)2),
+        Baz = unchecked((int)3),
+    }
+
+    /// This is my struct
+    /// 2nd line
+    [global::Bond.Schema]
+    [System.CodeDom.Compiler.GeneratedCode("gbc", "0.12.0.1")]
+    public partial class SomeStruct
+    {
+        /// some field
+        /// <code>someField = 42</code>
+        /// last line
+        [global::Bond.Id(0)]
+        public int someField { get; set; }
+
+        /// not ignored
+        [global::Bond.Id(1)]
+        public int otherField { get; set; }
+
+        [global::Bond.Id(2)]
+        public int notDocumented { get; set; }
+
+        public SomeStruct()
+            : this("example.some.SomeStruct", "SomeStruct")
+        {}
+
+        protected SomeStruct(string fullName, string name)
+        {
+            someField = 123;
+            otherField = 234;
+            notDocumented = 345;
+        }
+    }
+} // example.some

--- a/compiler/tests/generated/xmldoc_types.cs
+++ b/compiler/tests/generated/xmldoc_types.cs
@@ -17,10 +17,14 @@ namespace example.some
 {
     using System.Collections.Generic;
 
+    /// foobar
     [System.CodeDom.Compiler.GeneratedCode("gbc", "0.12.0.1")]
     public enum FooBar
     {
+        /// foo
+        /// two lines
         Foo = unchecked((int)1),
+        /// bar
         Bar = unchecked((int)2),
         Baz = unchecked((int)3),
     }

--- a/compiler/tests/schema/xmldoc.bond
+++ b/compiler/tests/schema/xmldoc.bond
@@ -1,0 +1,32 @@
+namespace example.some
+
+/// foobar
+enum FooBar
+{
+    /// foo
+    /// two lines
+    Foo = 1,
+
+    /// bar
+    Bar = 2,
+
+    // not included
+    Baz = 3
+}
+
+/// This is my struct
+/// 2nd line
+struct SomeStruct
+{
+    /// some field
+    /// <code>someField = 42</code>
+    // this is ignored
+    /// last line
+    0: int32 someField = 123;
+    // this is ignored
+
+    /// not ignored
+    1: int32 otherField = 234;
+
+    2: int32 notDocumented = 345;
+}  


### PR DESCRIPTION
[WORK IN PROGRESS]

Support for xmldoc comments:

```
namespace example.some

/// foobar
enum FooBar
{
    /// foo
    /// two lines
    Foo = 1,

    /// bar
    Bar = 2,

    // not included
    Baz = 3
}

/// This is my struct
/// 2nd line
struct SomeStruct
{
    /// some field
    /// <code>someField = 42</code>
    // this is ignored
    /// last line
    0: int32 someField = 123;
    // this is ignored

    /// not ignored
    1: int32 otherField = 234;

    2: int32 notDocumented = 345;
}
```

Gets converted to C# where the xmldoc comments are moved over.