### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,18 +272,18 @@ in the `build` directory from above and then following the other `cmake` command
 cmake -DBOND_ENABLE_GRPC=TRUE -G "Visual Studio 14 2015 Win64" ..
 ```
 
-Alternatively, you can build and install bond using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+Alternatively, you can build and install Bond using the [vcpkg](https://github.com/microsoft/vcpkg/) dependency manager:
 
 ```bash
-git clone https://github.com/Microsoft/vcpkg.git
+git clone https://github.com/microsoft/vcpkg.git
 cd vcpkg
 ./bootstrap-vcpkg.sh
 ./vcpkg integrate install
 ./vcpkg install bond
 ```
 
-The bond port in vcpkg is kept up to date by Microsoft team members and community contributors.
-If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+The Bond port in vcpkg is kept up to date by Microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request in the vcpkg repository](https://github.com/microsoft/vcpkg/issues/new/choose).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -274,10 +274,10 @@ cmake -DBOND_ENABLE_GRPC=TRUE -G "Visual Studio 14 2015 Win64" ..
 
 Alternatively, you can build and install Bond using the [vcpkg](https://github.com/microsoft/vcpkg/) dependency manager:
 
-```bash
+```batch
 git clone https://github.com/microsoft/vcpkg.git
 cd vcpkg
-./bootstrap-vcpkg.sh
+./bootstrap-vcpkg.bat
 ./vcpkg integrate install
 ./vcpkg install bond
 ```

--- a/README.md
+++ b/README.md
@@ -272,6 +272,19 @@ in the `build` directory from above and then following the other `cmake` command
 cmake -DBOND_ENABLE_GRPC=TRUE -G "Visual Studio 14 2015 Win64" ..
 ```
 
+Alternatively, you can build and install bond using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+```bash
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install bond
+```
+
+The bond port in vcpkg is kept up to date by Microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Contributing
 
 Interested in contributing to Bond? Take a look at our


### PR DESCRIPTION
Bond is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build Bond, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for Bond and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.