### PR TITLE
Remove std::result_of_t deprecated in C++17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ There are no changes to code generation or the language projections.
 * Fixed Cabal packaging issues that prevented the publication of
   [0.12.0.0](#820-2019-11-18).
 
+### C++ ###
+* Fixed MSVC warning for deprecation of `std::result_of_t` in `/std:c++17`.
+
 ## 8.2.0: 2019-11-18  ##
 * IDL core version: 3.0
 * C++ version: 8.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ tag versions. The Bond compiler (`gbc`) and
 different versioning scheme, following the Haskell community's
 [package versioning policy](https://wiki.haskell.org/Package_versioning_policy).
 
+## Unreleased ##
+
+### C++ ###
+* Fixed MSVC warning for deprecation of `std::result_of_t` in `/std:c++17`.
+  ([Issue #1007](https://github.com/microsoft/bond/issues/1007))
+
 ## gbc & compiler library 0.12.0.1: 2019-11-21 ##
 * IDL core version: 3.0
 * C++ version: 8.2.0
@@ -23,9 +29,6 @@ There are no changes to code generation or the language projections.
 
 * Fixed Cabal packaging issues that prevented the publication of
   [0.12.0.0](#820-2019-11-18).
-
-### C++ ###
-* Fixed MSVC warning for deprecation of `std::result_of_t` in `/std:c++17`.
 
 ## 8.2.0: 2019-11-18  ##
 * IDL core version: 3.0

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -226,7 +226,3 @@ set (BOND_STACK_OPTIONS
 if (BOND_ENABLE_GRPC AND ((CXX_STANDARD LESS 11) OR (MSVC_VERSION LESS 1800)))
     message(FATAL_ERROR "BOND_ENABLE_GRPC is TRUE but compiler specified does not support C++11 standard")
 endif()
-
-if(CMAKE_CXX_STANDARD GREATER_EQUAL 17)
-    add_definitions(-DBOND_CXX_17)
-endif()

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -227,6 +227,6 @@ if (BOND_ENABLE_GRPC AND ((CXX_STANDARD LESS 11) OR (MSVC_VERSION LESS 1800)))
     message(FATAL_ERROR "BOND_ENABLE_GRPC is TRUE but compiler specified does not support C++11 standard")
 endif()
 
-if(("${CMAKE_CXX_STANDARD}" EQUAL 17) OR ("${CMAKE_CXX_STANDARD}" EQUAL 20))
+if(CMAKE_CXX_STANDARD GREATER_EQUAL 17)
     add_definitions(-DBOND_CXX_17)
 endif()

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -227,6 +227,6 @@ if (BOND_ENABLE_GRPC AND ((CXX_STANDARD LESS 11) OR (MSVC_VERSION LESS 1800)))
     message(FATAL_ERROR "BOND_ENABLE_GRPC is TRUE but compiler specified does not support C++11 standard")
 endif()
 
-if(CMAKE_CXX_STANDARD GREATER_EQUAL 17)
+if(("${CMAKE_CXX_STANDARD}" EQUAL 17) OR ("${CMAKE_CXX_STANDARD}" EQUAL 20))
     add_definitions(-DBOND_CXX_17)
 endif()

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -226,3 +226,7 @@ set (BOND_STACK_OPTIONS
 if (BOND_ENABLE_GRPC AND ((CXX_STANDARD LESS 11) OR (MSVC_VERSION LESS 1800)))
     message(FATAL_ERROR "BOND_ENABLE_GRPC is TRUE but compiler specified does not support C++11 standard")
 endif()
+
+if(CMAKE_CXX_STANDARD GREATER_EQUAL 17)
+    add_definitions(-DBOND_CXX_17)
+endif()

--- a/cpp/inc/bond/core/config.h
+++ b/cpp/inc/bond/core/config.h
@@ -27,6 +27,15 @@
 #define BOND_NO_SFINAE_EXPR
 #endif
 
+// MSVC doesn't set __cplusplus to the C++ standard level unless the extra
+// /Zc:__cplusplus switch is passed (to prevent breaking existing code that
+// assumes it is always equal to 199711L). We don't want to require users of
+// Bond to have to pass this, so we also check _MSVC_LANG, which is always
+// set to the C++ standard level since MSVC 2015.
+#if (__cplusplus >= 201703L || (defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L)))
+    #define BOND_CXX_17
+#endif
+
 #if defined(BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION)
 #define BOND_NO_CXX14_RETURN_TYPE_DEDUCTION
 #endif

--- a/cpp/inc/bond/core/detail/visit_any.h
+++ b/cpp/inc/bond/core/detail/visit_any.h
@@ -19,8 +19,16 @@ namespace detail
 
 #if !defined(BOND_NO_CXX14_RETURN_TYPE_DEDUCTION) && !defined(BOND_NO_CXX14_GENERIC_LAMBDAS)
 
+#if defined(BOND_CXX_17)
+    template<typename Visitor, typename T>
+    using invoke_result_of_t = std::invoke_result_t<Visitor, T&>;
+#else
+    template<typename Visitor, typename T>
+    using invoke_result_of_t = std::result_of_t<Visitor(T&)>;
+#endif
+
 template <typename T, typename Visitor, typename Any>
-inline typename boost::disable_if<std::is_void<std::result_of_t<Visitor(T&)> >, boost::optional<std::result_of_t<Visitor(T&)> > >::type
+inline typename boost::disable_if<std::is_void<invoke_result_of_t<Visitor, T> >, boost::optional<invoke_result_of_t<Visitor, T> > >::type
 try_visit_any(Visitor&& visitor, Any& x)
 {
     if (auto value = any_cast<T>(&x))
@@ -32,7 +40,7 @@ try_visit_any(Visitor&& visitor, Any& x)
 }
 
 template <typename T, typename Visitor, typename Any>
-inline typename boost::enable_if<std::is_void<std::result_of_t<Visitor(T&)> >, bool>::type
+inline typename boost::enable_if<std::is_void<invoke_result_of_t<Visitor, T> >, bool>::type
 try_visit_any(Visitor&& visitor, Any& x)
 {
     if (auto value = any_cast<T>(&x))


### PR DESCRIPTION
`try_visit_any` uses `std::result_of_t` which is deprecated in C++17. This PR replaces `std::result_of_t` by `std::invoke_result_t` so we can compile in C++ 17 mode without disabling any warnings.

Fixes #1007 