### PR TITLE
Clean up compiler of MSVC 2013 conditional code

### DIFF
--- a/compiler/src/Language/Bond/Codegen/Cpp/Enum_h.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Enum_h.hs
@@ -20,7 +20,7 @@ enum_h :: MappingContext -> String -> [Import] -> [Declaration] -> (String, Text
 enum_h cpp _file _imports declarations = ("_enum.h", [lt|
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #{CPP.openNamespace cpp}
 namespace _bond_enumerators

--- a/compiler/src/Language/Bond/Codegen/Cpp/Enum_h.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Enum_h.hs
@@ -20,7 +20,7 @@ enum_h :: MappingContext -> String -> [Import] -> [Declaration] -> (String, Text
 enum_h cpp _file _imports declarations = ("_enum.h", [lt|
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 
 #{CPP.openNamespace cpp}
 namespace _bond_enumerators

--- a/compiler/src/Language/Bond/Codegen/Cpp/Types_cpp.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Types_cpp.hs
@@ -38,22 +38,11 @@ types_cpp cpp file _imports declarations = ("_types.cpp", [lt|
     -- ToString is intentionally not implemented in terms of FromEnum, as
     -- ToString returns a reference to the name stored in the map. FromEnum
     -- copies this name into the output paramater.
-    statics e@Enum {..} = [lt|
+    statics Enum {..} = [lt|
     namespace _bond_enumerators
     {
     namespace #{declName}
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum #{declName}> _name_to_value_#{declName}
-            {
-                #{CPP.enumNameToValueInitList 4 e}
-            };
-
-        const std::map<enum #{declName}, std::string> _value_to_name_#{declName}
-            {
-                #{CPP.enumValueToNameInitList 4 e}
-            };
-#else
         namespace
         {
             struct _hash_#{declName}
@@ -64,14 +53,9 @@ types_cpp cpp file _imports declarations = ("_types.cpp", [lt|
                 }
             };
         }
-#endif
         const std::string& ToString(enum #{declName} value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum #{declName}, std::string, _hash_#{declName}> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -88,11 +72,7 @@ types_cpp cpp file _imports declarations = ("_types.cpp", [lt|
 
         bool ToEnum(enum #{declName}& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum #{declName}> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -105,11 +85,7 @@ types_cpp cpp file _imports declarations = ("_types.cpp", [lt|
 
         bool FromEnum(std::string& name, enum #{declName} value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum #{declName}, std::string, _hash_#{declName}> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/src/Language/Bond/Codegen/Cpp/Types_h.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Types_h.hs
@@ -302,8 +302,6 @@ types_h export_attribute userHeaders enumHeader allocator alloc_ctors_enabled ty
         -- move constructor
         moveCtor = if hasMetaFields then [lt|
         #{explicit}|]
-            -- even if implicit would be okay, fall back to explicit for
-            -- compilers that don't support = default for move constructors
                                     else [lt|
         #{implicit}|]
           where

--- a/compiler/src/Language/Bond/Codegen/Cpp/Util.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Util.hs
@@ -159,8 +159,8 @@ enumDefinition Enum {..} = [lt|enum #{declName}
         };|]
   where
     constant Constant {..} = [lt|#{constantName}#{optional value constantValue}|]
-    value (-2147483648) = [lt| = static_cast<std::int32_t>(-2147483647-1)|]
-    value x = [lt| = static_cast<std::int32_t>(#{x})|]
+    value (-2147483648) = [lt| = static_cast<int32_t>(-2147483647-1)|]
+    value x = [lt| = static_cast<int32_t>(#{x})|]
 enumDefinition _ = error "enumDefinition: impossible happened."
 
 isEnumDeclaration :: Declaration -> Bool

--- a/compiler/src/Language/Bond/Codegen/Cpp/Util.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Util.hs
@@ -159,8 +159,8 @@ enumDefinition Enum {..} = [lt|enum #{declName}
         };|]
   where
     constant Constant {..} = [lt|#{constantName}#{optional value constantValue}|]
-    value (-2147483648) = [lt| = static_cast<int32_t>(-2147483647-1)|]
-    value x = [lt| = static_cast<int32_t>(#{x})|]
+    value (-2147483648) = [lt| = static_cast<std::int32_t>(-2147483647-1)|]
+    value x = [lt| = static_cast<std::int32_t>(#{x})|]
 enumDefinition _ = error "enumDefinition: impossible happened."
 
 isEnumDeclaration :: Declaration -> Bool

--- a/compiler/tests/generated/alias_key_types.h
+++ b/compiler/tests/generated/alias_key_types.h
@@ -32,28 +32,12 @@ namespace test
         // Compiler generated copy ctor OK
         foo(const foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo(foo&& other)
-          : m(std::move(other.m)),
-            s(std::move(other.s))
-        {
-        }
-#else
         foo(foo&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo& operator=(foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         foo& operator=(const foo&) = default;
         foo& operator=(foo&&) = default;
-#endif
 
         bool operator==(const foo& other) const
         {

--- a/compiler/tests/generated/alias_with_allocator_types.h
+++ b/compiler/tests/generated/alias_with_allocator_types.h
@@ -36,9 +36,8 @@ namespace test
         ::bond::maybe<std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > > st1;
         std::set<std::list<std::map<int32_t, std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> >, std::less<int32_t>, typename std::allocator_traits<arena>::template rebind_alloc<std::pair<const int32_t, std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > > > >, typename std::allocator_traits<arena>::template rebind_alloc<std::map<int32_t, std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> >, std::less<int32_t>, typename std::allocator_traits<arena>::template rebind_alloc<std::pair<const int32_t, std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > > > > > >, std::less<std::list<std::map<int32_t, std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> >, std::less<int32_t>, typename std::allocator_traits<arena>::template rebind_alloc<std::pair<const int32_t, std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > > > >, typename std::allocator_traits<arena>::template rebind_alloc<std::map<int32_t, std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> >, std::less<int32_t>, typename std::allocator_traits<arena>::template rebind_alloc<std::pair<const int32_t, std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > > > > > > >, typename std::allocator_traits<arena>::template rebind_alloc<std::list<std::map<int32_t, std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> >, std::less<int32_t>, typename std::allocator_traits<arena>::template rebind_alloc<std::pair<const int32_t, std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > > > >, typename std::allocator_traits<arena>::template rebind_alloc<std::map<int32_t, std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> >, std::less<int32_t>, typename std::allocator_traits<arena>::template rebind_alloc<std::pair<const int32_t, std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > > > > > > > > na;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        foo(_bond_vc12_ctor_workaround_ = {})
+        foo()
           : d("foo")
         {
         }
@@ -47,25 +46,7 @@ namespace test
         // Compiler generated copy ctor OK
         foo(const foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo(foo&& other)
-          : l(std::move(other.l)),
-            v(std::move(other.v)),
-            s(std::move(other.s)),
-            m(std::move(other.m)),
-            st(std::move(other.st)),
-            d(std::move(other.d)),
-            l1(std::move(other.l1)),
-            v1(std::move(other.v1)),
-            s1(std::move(other.s1)),
-            m1(std::move(other.m1)),
-            st1(std::move(other.st1)),
-            na(std::move(other.na))
-        {
-        }
-#else
         foo(foo&&) = default;
-#endif
         
         explicit
         foo(const arena& allocator)
@@ -85,17 +66,9 @@ namespace test
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo& operator=(foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         foo& operator=(const foo&) = default;
         foo& operator=(foo&&) = default;
-#endif
 
         bool operator==(const foo& other) const
         {
@@ -157,9 +130,8 @@ namespace test
         ::test::foo f;
         ::test::foo f1;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        withFoo(_bond_vc12_ctor_workaround_ = {})
+        withFoo()
         {
         }
 
@@ -167,15 +139,7 @@ namespace test
         // Compiler generated copy ctor OK
         withFoo(const withFoo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        withFoo(withFoo&& other)
-          : f(std::move(other.f)),
-            f1(std::move(other.f1))
-        {
-        }
-#else
         withFoo(withFoo&&) = default;
-#endif
         
         explicit
         withFoo(const arena& allocator)
@@ -185,17 +149,9 @@ namespace test
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        withFoo& operator=(withFoo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         withFoo& operator=(const withFoo&) = default;
         withFoo& operator=(withFoo&&) = default;
-#endif
 
         bool operator==(const withFoo& other) const
         {

--- a/compiler/tests/generated/aliases_types.cpp
+++ b/compiler/tests/generated/aliases_types.cpp
@@ -10,17 +10,6 @@ namespace tests
     {
     namespace EnumToWrap
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
-            {
-                { "anEnumValue", anEnumValue }
-            };
-
-        const std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap
-            {
-                { anEnumValue, "anEnumValue" }
-            };
-#else
         namespace
         {
             struct _hash_EnumToWrap
@@ -31,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum EnumToWrap value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumToWrap, std::string, _hash_EnumToWrap> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -55,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum EnumToWrap& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum EnumToWrap> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -72,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum EnumToWrap value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumToWrap, std::string, _hash_EnumToWrap> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/aliases_types.h
+++ b/compiler/tests/generated/aliases_types.h
@@ -32,27 +32,12 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : aa(std::move(other.aa))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {
@@ -105,21 +90,7 @@ namespace tests
             return "tests.EnumToWrap";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap;
 
-        inline const std::map<enum EnumToWrap, std::string>& GetValueToNameMap(enum EnumToWrap)
-        {
-            return _value_to_name_EnumToWrap;
-        }
-
-        extern const std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap;
-
-        inline const std::map<std::string, enum EnumToWrap>& GetNameToValueMap(enum EnumToWrap)
-        {
-            return _name_to_value_EnumToWrap;
-        }
-#else
         template <typename Map = std::map<enum EnumToWrap, std::string> >
         inline const Map& GetValueToNameMap(enum EnumToWrap, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -139,7 +110,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum EnumToWrap value);
 
         void FromString(const std::string& name, enum EnumToWrap& value);
@@ -168,27 +138,12 @@ namespace tests
         // Compiler generated copy ctor OK
         WrappingAnEnum(const WrappingAnEnum&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        WrappingAnEnum(WrappingAnEnum&& other)
-          : aWrappedEnum(std::move(other.aWrappedEnum))
-        {
-        }
-#else
         WrappingAnEnum(WrappingAnEnum&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        WrappingAnEnum& operator=(WrappingAnEnum other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         WrappingAnEnum& operator=(const WrappingAnEnum&) = default;
         WrappingAnEnum& operator=(WrappingAnEnum&&) = default;
-#endif
 
         bool operator==(const WrappingAnEnum& other) const
         {

--- a/compiler/tests/generated/alloc_ctors/alias_key_types.h
+++ b/compiler/tests/generated/alloc_ctors/alias_key_types.h
@@ -26,9 +26,8 @@ namespace test
         std::map<std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> >, int32_t, std::less<std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > >, typename std::allocator_traits<arena>::template rebind_alloc<std::pair<const std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> >, int32_t> > > m;
         std::set<int32_t, std::less<int32_t>, typename std::allocator_traits<arena>::template rebind_alloc<int32_t> > s;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        foo(_bond_vc12_ctor_workaround_ = {})
+        foo()
         {
         }
 
@@ -42,15 +41,7 @@ namespace test
         {
         }
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo(foo&& other)
-          : m(std::move(other.m)),
-            s(std::move(other.s))
-        {
-        }
-#else
         foo(foo&&) = default;
-#endif
 
         foo(foo&& other, const arena& allocator)
           : m(std::move(other.m), allocator),
@@ -66,17 +57,9 @@ namespace test
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo& operator=(foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         foo& operator=(const foo&) = default;
         foo& operator=(foo&&) = default;
-#endif
 
         bool operator==(const foo& other) const
         {

--- a/compiler/tests/generated/alloc_ctors/aliases_types.cpp
+++ b/compiler/tests/generated/alloc_ctors/aliases_types.cpp
@@ -10,17 +10,6 @@ namespace tests
     {
     namespace EnumToWrap
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
-            {
-                { "anEnumValue", anEnumValue }
-            };
-
-        const std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap
-            {
-                { anEnumValue, "anEnumValue" }
-            };
-#else
         namespace
         {
             struct _hash_EnumToWrap
@@ -31,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum EnumToWrap value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumToWrap, std::string, _hash_EnumToWrap> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -55,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum EnumToWrap& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum EnumToWrap> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -72,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum EnumToWrap value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumToWrap, std::string, _hash_EnumToWrap> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/alloc_ctors/aliases_types.h
+++ b/compiler/tests/generated/alloc_ctors/aliases_types.h
@@ -26,9 +26,8 @@ namespace tests
 
         std::vector<std::vector<T, typename std::allocator_traits<arena>::template rebind_alloc<T> >, typename std::allocator_traits<arena>::template rebind_alloc<std::vector<T, typename std::allocator_traits<arena>::template rebind_alloc<T> > > > aa;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
         {
         }
 
@@ -41,14 +40,7 @@ namespace tests
         {
         }
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : aa(std::move(other.aa))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
 
         Foo(Foo&& other, const arena& allocator)
           : aa(std::move(other.aa), allocator)
@@ -62,17 +54,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {
@@ -125,21 +109,7 @@ namespace tests
             return "tests.EnumToWrap";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap;
 
-        inline const std::map<enum EnumToWrap, std::string>& GetValueToNameMap(enum EnumToWrap)
-        {
-            return _value_to_name_EnumToWrap;
-        }
-
-        extern const std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap;
-
-        inline const std::map<std::string, enum EnumToWrap>& GetNameToValueMap(enum EnumToWrap)
-        {
-            return _name_to_value_EnumToWrap;
-        }
-#else
         template <typename Map = std::map<enum EnumToWrap, std::string> >
         inline const Map& GetValueToNameMap(enum EnumToWrap, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -159,7 +129,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum EnumToWrap value);
 
         void FromString(const std::string& name, enum EnumToWrap& value);
@@ -195,14 +164,7 @@ namespace tests
         {
         }
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        WrappingAnEnum(WrappingAnEnum&& other)
-          : aWrappedEnum(std::move(other.aWrappedEnum))
-        {
-        }
-#else
         WrappingAnEnum(WrappingAnEnum&&) = default;
-#endif
 
         WrappingAnEnum(WrappingAnEnum&& other, const arena&)
           : aWrappedEnum(std::move(other.aWrappedEnum))
@@ -216,17 +178,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        WrappingAnEnum& operator=(WrappingAnEnum other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         WrappingAnEnum& operator=(const WrappingAnEnum&) = default;
         WrappingAnEnum& operator=(WrappingAnEnum&&) = default;
-#endif
 
         bool operator==(const WrappingAnEnum& other) const
         {

--- a/compiler/tests/generated/alloc_ctors/attributes_types.cpp
+++ b/compiler/tests/generated/alloc_ctors/attributes_types.cpp
@@ -10,17 +10,6 @@ namespace tests
     {
     namespace Enum
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum Enum> _name_to_value_Enum
-            {
-                { "Value1", Value1 }
-            };
-
-        const std::map<enum Enum, std::string> _value_to_name_Enum
-            {
-                { Value1, "Value1" }
-            };
-#else
         namespace
         {
             struct _hash_Enum
@@ -31,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum Enum value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum Enum, std::string, _hash_Enum> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -55,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum Enum& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum Enum> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -72,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum Enum value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum Enum, std::string, _hash_Enum> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/alloc_ctors/attributes_types.h
+++ b/compiler/tests/generated/alloc_ctors/attributes_types.h
@@ -38,21 +38,7 @@ namespace tests
             return "tests.Enum";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum Enum, std::string> _value_to_name_Enum;
 
-        inline const std::map<enum Enum, std::string>& GetValueToNameMap(enum Enum)
-        {
-            return _value_to_name_Enum;
-        }
-
-        extern const std::map<std::string, enum Enum> _name_to_value_Enum;
-
-        inline const std::map<std::string, enum Enum>& GetNameToValueMap(enum Enum)
-        {
-            return _name_to_value_Enum;
-        }
-#else
         template <typename Map = std::map<enum Enum, std::string> >
         inline const Map& GetValueToNameMap(enum Enum, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -72,7 +58,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum Enum value);
 
         void FromString(const std::string& name, enum Enum& value);
@@ -94,9 +79,8 @@ namespace tests
 
         std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > f;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
         {
         }
 
@@ -109,14 +93,7 @@ namespace tests
         {
         }
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : f(std::move(other.f))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
 
         Foo(Foo&& other, const arena& allocator)
           : f(std::move(other.f), allocator)
@@ -130,17 +107,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/alloc_ctors/basic_types_nsmapped_types.h
+++ b/compiler/tests/generated/alloc_ctors/basic_types_nsmapped_types.h
@@ -38,9 +38,8 @@ namespace nsmapped
         float _float;
         ::bond::blob _blob;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        BasicTypes(_bond_vc12_ctor_workaround_ = {})
+        BasicTypes()
           : _bool(),
             _uint64(),
             _uint16(),
@@ -77,27 +76,7 @@ namespace nsmapped
         {
         }
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes(BasicTypes&& other)
-          : _bool(std::move(other._bool)),
-            _str(std::move(other._str)),
-            _wstr(std::move(other._wstr)),
-            _uint64(std::move(other._uint64)),
-            _uint16(std::move(other._uint16)),
-            _uint32(std::move(other._uint32)),
-            _uint8(std::move(other._uint8)),
-            _int8(std::move(other._int8)),
-            _int16(std::move(other._int16)),
-            _int32(std::move(other._int32)),
-            _int64(std::move(other._int64)),
-            _double(std::move(other._double)),
-            _float(std::move(other._float)),
-            _blob(std::move(other._blob))
-        {
-        }
-#else
         BasicTypes(BasicTypes&&) = default;
-#endif
 
         BasicTypes(BasicTypes&& other, const arena& allocator)
           : _bool(std::move(other._bool)),
@@ -136,17 +115,9 @@ namespace nsmapped
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes& operator=(BasicTypes other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         BasicTypes& operator=(const BasicTypes&) = default;
         BasicTypes& operator=(BasicTypes&&) = default;
-#endif
 
         bool operator==(const BasicTypes& other) const
         {

--- a/compiler/tests/generated/alloc_ctors/basic_types_types.h
+++ b/compiler/tests/generated/alloc_ctors/basic_types_types.h
@@ -38,9 +38,8 @@ namespace tests
         float _float;
         ::bond::blob _blob;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        BasicTypes(_bond_vc12_ctor_workaround_ = {})
+        BasicTypes()
           : _bool(),
             _uint64(),
             _uint16(),
@@ -77,27 +76,7 @@ namespace tests
         {
         }
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes(BasicTypes&& other)
-          : _bool(std::move(other._bool)),
-            _str(std::move(other._str)),
-            _wstr(std::move(other._wstr)),
-            _uint64(std::move(other._uint64)),
-            _uint16(std::move(other._uint16)),
-            _uint32(std::move(other._uint32)),
-            _uint8(std::move(other._uint8)),
-            _int8(std::move(other._int8)),
-            _int16(std::move(other._int16)),
-            _int32(std::move(other._int32)),
-            _int64(std::move(other._int64)),
-            _double(std::move(other._double)),
-            _float(std::move(other._float)),
-            _blob(std::move(other._blob))
-        {
-        }
-#else
         BasicTypes(BasicTypes&&) = default;
-#endif
 
         BasicTypes(BasicTypes&& other, const arena& allocator)
           : _bool(std::move(other._bool)),
@@ -136,17 +115,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes& operator=(BasicTypes other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         BasicTypes& operator=(const BasicTypes&) = default;
         BasicTypes& operator=(BasicTypes&&) = default;
-#endif
 
         bool operator==(const BasicTypes& other) const
         {

--- a/compiler/tests/generated/alloc_ctors/bond_meta_types.h
+++ b/compiler/tests/generated/alloc_ctors/bond_meta_types.h
@@ -28,9 +28,8 @@ namespace bondmeta
         std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > full_name;
         std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > name;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        HasMetaFields(_bond_vc12_ctor_workaround_ = {})
+        HasMetaFields()
         {
             InitMetadata("HasMetaFields", "deprecated.bondmeta.HasMetaFields");
         }

--- a/compiler/tests/generated/alloc_ctors/complex_types_types.h
+++ b/compiler/tests/generated/alloc_ctors/complex_types_types.h
@@ -38,13 +38,7 @@ namespace tests
         {
         }
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&&)
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
 
         Foo(Foo&&, const arena&)
         {
@@ -56,17 +50,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo&) const
         {
@@ -111,9 +97,8 @@ namespace tests
         ::bond::bonded< ::tests::Foo> bfoo;
         std::map<double, std::list<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, typename std::allocator_traits<arena>::template rebind_alloc< ::bond::nullable< ::bond::bonded< ::tests::Bar> > > >, typename std::allocator_traits<arena>::template rebind_alloc<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, typename std::allocator_traits<arena>::template rebind_alloc< ::bond::nullable< ::bond::bonded< ::tests::Bar> > > > > >, std::less<double>, typename std::allocator_traits<arena>::template rebind_alloc<std::pair<const double, std::list<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, typename std::allocator_traits<arena>::template rebind_alloc< ::bond::nullable< ::bond::bonded< ::tests::Bar> > > >, typename std::allocator_traits<arena>::template rebind_alloc<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, typename std::allocator_traits<arena>::template rebind_alloc< ::bond::nullable< ::bond::bonded< ::tests::Bar> > > > > > > > > m;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        ComplexTypes(_bond_vc12_ctor_workaround_ = {})
+        ComplexTypes()
         {
         }
 
@@ -132,20 +117,7 @@ namespace tests
         {
         }
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        ComplexTypes(ComplexTypes&& other)
-          : li8(std::move(other.li8)),
-            sb(std::move(other.sb)),
-            vb(std::move(other.vb)),
-            nf(std::move(other.nf)),
-            msws(std::move(other.msws)),
-            bfoo(std::move(other.bfoo)),
-            m(std::move(other.m))
-        {
-        }
-#else
         ComplexTypes(ComplexTypes&&) = default;
-#endif
 
         ComplexTypes(ComplexTypes&& other, const arena& allocator)
           : li8(std::move(other.li8), allocator),
@@ -170,17 +142,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        ComplexTypes& operator=(ComplexTypes other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         ComplexTypes& operator=(const ComplexTypes&) = default;
         ComplexTypes& operator=(ComplexTypes&&) = default;
-#endif
 
         bool operator==(const ComplexTypes& other) const
         {

--- a/compiler/tests/generated/alloc_ctors/defaults_types.cpp
+++ b/compiler/tests/generated/alloc_ctors/defaults_types.cpp
@@ -10,41 +10,6 @@ namespace tests
     {
     namespace EnumType1
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
-            {
-                { "EnumValue1", EnumValue1 },
-                { "EnumValue2", EnumValue2 },
-                { "EnumValue3", EnumValue3 },
-                { "EnumValue4", EnumValue4 },
-                { "EnumValue5", EnumValue5 },
-                { "EnumValue6", EnumValue6 },
-                { "HexNeg", HexNeg },
-                { "Int32Max", Int32Max },
-                { "Int32Min", Int32Min },
-                { "Low", Low },
-                { "OctNeg", OctNeg },
-                { "UInt32Max", UInt32Max },
-                { "UInt32Min", UInt32Min }
-            };
-
-        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
-            {
-                { Int32Min, "Int32Min" },
-                { HexNeg, "HexNeg" },
-                { OctNeg, "OctNeg" },
-                { EnumValue3, "EnumValue3" },
-                { EnumValue5, "EnumValue5" },
-                { UInt32Min, "UInt32Min" },
-                { Low, "Low" },
-                { EnumValue1, "EnumValue1" },
-                { EnumValue2, "EnumValue2" },
-                { EnumValue4, "EnumValue4" },
-                { Int32Max, "Int32Max" },
-                { EnumValue6, "EnumValue6" },
-                { UInt32Max, "UInt32Max" }
-            };
-#else
         namespace
         {
             struct _hash_EnumType1
@@ -55,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -79,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum EnumType1& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum EnumType1> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -96,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/alloc_ctors/defaults_types.h
+++ b/compiler/tests/generated/alloc_ctors/defaults_types.h
@@ -25,19 +25,19 @@ namespace tests
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<std::int32_t>(5),
-            EnumValue2 = static_cast<std::int32_t>(10),
-            EnumValue3 = static_cast<std::int32_t>(-10),
-            EnumValue4 = static_cast<std::int32_t>(42),
-            Low = static_cast<std::int32_t>(1),
-            EnumValue5 = static_cast<std::int32_t>(-10),
-            EnumValue6 = static_cast<std::int32_t>(4294967286),
-            Int32Min = static_cast<std::int32_t>(-2147483647-1),
-            Int32Max = static_cast<std::int32_t>(2147483647),
-            UInt32Min = static_cast<std::int32_t>(0),
-            UInt32Max = static_cast<std::int32_t>(4294967295),
-            HexNeg = static_cast<std::int32_t>(-255),
-            OctNeg = static_cast<std::int32_t>(-83)
+            EnumValue1 = static_cast<int32_t>(5),
+            EnumValue2 = static_cast<int32_t>(10),
+            EnumValue3 = static_cast<int32_t>(-10),
+            EnumValue4 = static_cast<int32_t>(42),
+            Low = static_cast<int32_t>(1),
+            EnumValue5 = static_cast<int32_t>(-10),
+            EnumValue6 = static_cast<int32_t>(4294967286),
+            Int32Min = static_cast<int32_t>(-2147483647-1),
+            Int32Max = static_cast<int32_t>(2147483647),
+            UInt32Min = static_cast<int32_t>(0),
+            UInt32Max = static_cast<int32_t>(4294967295),
+            HexNeg = static_cast<int32_t>(-255),
+            OctNeg = static_cast<int32_t>(-83)
         };
         
         inline BOND_CONSTEXPR const char* GetTypeName(enum EnumType1)

--- a/compiler/tests/generated/alloc_ctors/defaults_types.h
+++ b/compiler/tests/generated/alloc_ctors/defaults_types.h
@@ -25,19 +25,19 @@ namespace tests
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<int32_t>(5),
-            EnumValue2 = static_cast<int32_t>(10),
-            EnumValue3 = static_cast<int32_t>(-10),
-            EnumValue4 = static_cast<int32_t>(42),
-            Low = static_cast<int32_t>(1),
-            EnumValue5 = static_cast<int32_t>(-10),
-            EnumValue6 = static_cast<int32_t>(4294967286),
-            Int32Min = static_cast<int32_t>(-2147483647-1),
-            Int32Max = static_cast<int32_t>(2147483647),
-            UInt32Min = static_cast<int32_t>(0),
-            UInt32Max = static_cast<int32_t>(4294967295),
-            HexNeg = static_cast<int32_t>(-255),
-            OctNeg = static_cast<int32_t>(-83)
+            EnumValue1 = static_cast<std::int32_t>(5),
+            EnumValue2 = static_cast<std::int32_t>(10),
+            EnumValue3 = static_cast<std::int32_t>(-10),
+            EnumValue4 = static_cast<std::int32_t>(42),
+            Low = static_cast<std::int32_t>(1),
+            EnumValue5 = static_cast<std::int32_t>(-10),
+            EnumValue6 = static_cast<std::int32_t>(4294967286),
+            Int32Min = static_cast<std::int32_t>(-2147483647-1),
+            Int32Max = static_cast<std::int32_t>(2147483647),
+            UInt32Min = static_cast<std::int32_t>(0),
+            UInt32Max = static_cast<std::int32_t>(4294967295),
+            HexNeg = static_cast<std::int32_t>(-255),
+            OctNeg = static_cast<std::int32_t>(-83)
         };
         
         inline BOND_CONSTEXPR const char* GetTypeName(enum EnumType1)
@@ -50,21 +50,7 @@ namespace tests
             return "tests.EnumType1";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum EnumType1, std::string> _value_to_name_EnumType1;
 
-        inline const std::map<enum EnumType1, std::string>& GetValueToNameMap(enum EnumType1)
-        {
-            return _value_to_name_EnumType1;
-        }
-
-        extern const std::map<std::string, enum EnumType1> _name_to_value_EnumType1;
-
-        inline const std::map<std::string, enum EnumType1>& GetNameToValueMap(enum EnumType1)
-        {
-            return _name_to_value_EnumType1;
-        }
-#else
         template <typename Map = std::map<enum EnumType1, std::string> >
         inline const Map& GetValueToNameMap(enum EnumType1, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -108,7 +94,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum EnumType1 value);
 
         void FromString(const std::string& name, enum EnumType1& value);
@@ -167,9 +152,8 @@ namespace tests
         int64_t m_int64_neg_hex;
         int64_t m_int64_neg_oct;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
           : m_bool_1(true),
             m_bool_2(false),
             m_str_1("default string value"),
@@ -243,51 +227,7 @@ namespace tests
         {
         }
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : m_bool_1(std::move(other.m_bool_1)),
-            m_bool_2(std::move(other.m_bool_2)),
-            m_bool_3(std::move(other.m_bool_3)),
-            m_str_1(std::move(other.m_str_1)),
-            m_str_2(std::move(other.m_str_2)),
-            m_int8_4(std::move(other.m_int8_4)),
-            m_int8_5(std::move(other.m_int8_5)),
-            m_int16_4(std::move(other.m_int16_4)),
-            m_int16_5(std::move(other.m_int16_5)),
-            m_int32_4(std::move(other.m_int32_4)),
-            m_int32_max(std::move(other.m_int32_max)),
-            m_int64_4(std::move(other.m_int64_4)),
-            m_int64_max(std::move(other.m_int64_max)),
-            m_uint8_2(std::move(other.m_uint8_2)),
-            m_uint8_3(std::move(other.m_uint8_3)),
-            m_uint16_2(std::move(other.m_uint16_2)),
-            m_uint16_3(std::move(other.m_uint16_3)),
-            m_uint32_3(std::move(other.m_uint32_3)),
-            m_uint32_max(std::move(other.m_uint32_max)),
-            m_uint64_3(std::move(other.m_uint64_3)),
-            m_uint64_max(std::move(other.m_uint64_max)),
-            m_double_3(std::move(other.m_double_3)),
-            m_double_4(std::move(other.m_double_4)),
-            m_double_5(std::move(other.m_double_5)),
-            m_float_3(std::move(other.m_float_3)),
-            m_float_4(std::move(other.m_float_4)),
-            m_float_7(std::move(other.m_float_7)),
-            m_enum1(std::move(other.m_enum1)),
-            m_enum2(std::move(other.m_enum2)),
-            m_enum3(std::move(other.m_enum3)),
-            m_enum_int32min(std::move(other.m_enum_int32min)),
-            m_enum_int32max(std::move(other.m_enum_int32max)),
-            m_enum_uint32_min(std::move(other.m_enum_uint32_min)),
-            m_enum_uint32_max(std::move(other.m_enum_uint32_max)),
-            m_wstr_1(std::move(other.m_wstr_1)),
-            m_wstr_2(std::move(other.m_wstr_2)),
-            m_int64_neg_hex(std::move(other.m_int64_neg_hex)),
-            m_int64_neg_oct(std::move(other.m_int64_neg_oct))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
 
         Foo(Foo&& other, const arena& allocator)
           : m_bool_1(std::move(other.m_bool_1)),
@@ -375,17 +315,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/alloc_ctors/field_modifiers_types.h
+++ b/compiler/tests/generated/alloc_ctors/field_modifiers_types.h
@@ -45,16 +45,7 @@ namespace tests
         {
         }
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : o(std::move(other.o)),
-            r(std::move(other.r)),
-            ro(std::move(other.ro))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
 
         Foo(Foo&& other, const arena&)
           : o(std::move(other.o)),
@@ -72,17 +63,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/alloc_ctors/generics_types.h
+++ b/compiler/tests/generated/alloc_ctors/generics_types.h
@@ -27,9 +27,8 @@ namespace tests
         T2 t2;
         ::bond::nullable< ::tests::Foo<T1, bool> > n;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
           : t2()
         {
         }
@@ -44,15 +43,7 @@ namespace tests
         {
         }
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : t2(std::move(other.t2)),
-            n(std::move(other.n))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
 
         Foo(Foo&& other, const arena& allocator)
           : t2(std::move(other.t2)),
@@ -68,17 +59,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/alloc_ctors/import_types.h
+++ b/compiler/tests/generated/alloc_ctors/import_types.h
@@ -26,9 +26,8 @@ namespace import_test
 
         ::empty::Empty e;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        HasEmpty(_bond_vc12_ctor_workaround_ = {})
+        HasEmpty()
         {
         }
 
@@ -41,14 +40,7 @@ namespace import_test
         {
         }
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        HasEmpty(HasEmpty&& other)
-          : e(std::move(other.e))
-        {
-        }
-#else
         HasEmpty(HasEmpty&&) = default;
-#endif
 
         HasEmpty(HasEmpty&& other, const arena& allocator)
           : e(std::move(other.e), allocator)
@@ -62,17 +54,9 @@ namespace import_test
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        HasEmpty& operator=(HasEmpty other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         HasEmpty& operator=(const HasEmpty&) = default;
         HasEmpty& operator=(HasEmpty&&) = default;
-#endif
 
         bool operator==(const HasEmpty& other) const
         {

--- a/compiler/tests/generated/alloc_ctors/inheritance_types.h
+++ b/compiler/tests/generated/alloc_ctors/inheritance_types.h
@@ -39,14 +39,7 @@ namespace tests
         {
         }
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Base(Base&& other)
-          : x(std::move(other.x))
-        {
-        }
-#else
         Base(Base&&) = default;
-#endif
 
         Base(Base&& other, const arena&)
           : x(std::move(other.x))
@@ -60,17 +53,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Base& operator=(Base other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Base& operator=(const Base&) = default;
         Base& operator=(Base&&) = default;
-#endif
 
         bool operator==(const Base& other) const
         {
@@ -110,9 +95,8 @@ namespace tests
 
         int32_t x;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
           : x()
         {
         }
@@ -127,15 +111,7 @@ namespace tests
         {
         }
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : ::tests::Base(std::move(other)),
-            x(std::move(other.x))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
 
         Foo(Foo&& other, const arena& allocator)
           : ::tests::Base(std::move(other), allocator),
@@ -151,17 +127,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/alloc_ctors/maybe_blob_types.h
+++ b/compiler/tests/generated/alloc_ctors/maybe_blob_types.h
@@ -38,14 +38,7 @@ namespace tests
         {
         }
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : b(std::move(other.b))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
 
         Foo(Foo&& other, const arena&)
           : b(std::move(other.b))
@@ -58,17 +51,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/alloc_ctors/with_enum_header_enum.h
+++ b/compiler/tests/generated/alloc_ctors/with_enum_header_enum.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 
 namespace tests
 {
@@ -12,17 +12,17 @@ namespace _bond_enumerators
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<std::int32_t>(5),
-            EnumValue2 = static_cast<std::int32_t>(10),
-            EnumValue3 = static_cast<std::int32_t>(-10),
-            EnumValue4 = static_cast<std::int32_t>(42),
-            Low = static_cast<std::int32_t>(1),
-            EnumValue5 = static_cast<std::int32_t>(-10),
-            EnumValue6 = static_cast<std::int32_t>(4294967286),
-            Int32Min = static_cast<std::int32_t>(-2147483647-1),
-            Int32Max = static_cast<std::int32_t>(2147483647),
-            UInt32Min = static_cast<std::int32_t>(0),
-            UInt32Max = static_cast<std::int32_t>(4294967295)
+            EnumValue1 = static_cast<int32_t>(5),
+            EnumValue2 = static_cast<int32_t>(10),
+            EnumValue3 = static_cast<int32_t>(-10),
+            EnumValue4 = static_cast<int32_t>(42),
+            Low = static_cast<int32_t>(1),
+            EnumValue5 = static_cast<int32_t>(-10),
+            EnumValue6 = static_cast<int32_t>(4294967286),
+            Int32Min = static_cast<int32_t>(-2147483647-1),
+            Int32Max = static_cast<int32_t>(2147483647),
+            UInt32Min = static_cast<int32_t>(0),
+            UInt32Max = static_cast<int32_t>(4294967295)
         };
     } // namespace EnumType1
 

--- a/compiler/tests/generated/alloc_ctors/with_enum_header_enum.h
+++ b/compiler/tests/generated/alloc_ctors/with_enum_header_enum.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace tests
 {
@@ -12,17 +12,17 @@ namespace _bond_enumerators
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<int32_t>(5),
-            EnumValue2 = static_cast<int32_t>(10),
-            EnumValue3 = static_cast<int32_t>(-10),
-            EnumValue4 = static_cast<int32_t>(42),
-            Low = static_cast<int32_t>(1),
-            EnumValue5 = static_cast<int32_t>(-10),
-            EnumValue6 = static_cast<int32_t>(4294967286),
-            Int32Min = static_cast<int32_t>(-2147483647-1),
-            Int32Max = static_cast<int32_t>(2147483647),
-            UInt32Min = static_cast<int32_t>(0),
-            UInt32Max = static_cast<int32_t>(4294967295)
+            EnumValue1 = static_cast<std::int32_t>(5),
+            EnumValue2 = static_cast<std::int32_t>(10),
+            EnumValue3 = static_cast<std::int32_t>(-10),
+            EnumValue4 = static_cast<std::int32_t>(42),
+            Low = static_cast<std::int32_t>(1),
+            EnumValue5 = static_cast<std::int32_t>(-10),
+            EnumValue6 = static_cast<std::int32_t>(4294967286),
+            Int32Min = static_cast<std::int32_t>(-2147483647-1),
+            Int32Max = static_cast<std::int32_t>(2147483647),
+            UInt32Min = static_cast<std::int32_t>(0),
+            UInt32Max = static_cast<std::int32_t>(4294967295)
         };
     } // namespace EnumType1
 

--- a/compiler/tests/generated/alloc_ctors/with_enum_header_types.cpp
+++ b/compiler/tests/generated/alloc_ctors/with_enum_header_types.cpp
@@ -10,37 +10,6 @@ namespace tests
     {
     namespace EnumType1
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
-            {
-                { "EnumValue1", EnumValue1 },
-                { "EnumValue2", EnumValue2 },
-                { "EnumValue3", EnumValue3 },
-                { "EnumValue4", EnumValue4 },
-                { "EnumValue5", EnumValue5 },
-                { "EnumValue6", EnumValue6 },
-                { "Int32Max", Int32Max },
-                { "Int32Min", Int32Min },
-                { "Low", Low },
-                { "UInt32Max", UInt32Max },
-                { "UInt32Min", UInt32Min }
-            };
-
-        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
-            {
-                { Int32Min, "Int32Min" },
-                { EnumValue3, "EnumValue3" },
-                { EnumValue5, "EnumValue5" },
-                { UInt32Min, "UInt32Min" },
-                { Low, "Low" },
-                { EnumValue1, "EnumValue1" },
-                { EnumValue2, "EnumValue2" },
-                { EnumValue4, "EnumValue4" },
-                { Int32Max, "Int32Max" },
-                { EnumValue6, "EnumValue6" },
-                { UInt32Max, "UInt32Max" }
-            };
-#else
         namespace
         {
             struct _hash_EnumType1
@@ -51,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -75,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum EnumType1& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum EnumType1> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -92,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/alloc_ctors/with_enum_header_types.h
+++ b/compiler/tests/generated/alloc_ctors/with_enum_header_types.h
@@ -34,21 +34,7 @@ namespace tests
             return "tests.EnumType1";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum EnumType1, std::string> _value_to_name_EnumType1;
 
-        inline const std::map<enum EnumType1, std::string>& GetValueToNameMap(enum EnumType1)
-        {
-            return _value_to_name_EnumType1;
-        }
-
-        extern const std::map<std::string, enum EnumType1> _name_to_value_EnumType1;
-
-        inline const std::map<std::string, enum EnumType1>& GetNameToValueMap(enum EnumType1)
-        {
-            return _name_to_value_EnumType1;
-        }
-#else
         template <typename Map = std::map<enum EnumType1, std::string> >
         inline const Map& GetValueToNameMap(enum EnumType1, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -88,7 +74,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum EnumType1 value);
 
         void FromString(const std::string& name, enum EnumType1& value);
@@ -144,9 +129,8 @@ namespace tests
         std::basic_string<wchar_t, std::char_traits<wchar_t>, typename std::allocator_traits<arena>::template rebind_alloc<wchar_t> > m_wstr_1;
         ::bond::maybe<std::basic_string<wchar_t, std::char_traits<wchar_t>, typename std::allocator_traits<arena>::template rebind_alloc<wchar_t> > > m_wstr_2;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
           : m_bool_1(true),
             m_bool_2(false),
             m_str_1("default string value"),
@@ -216,49 +200,7 @@ namespace tests
         {
         }
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : m_bool_1(std::move(other.m_bool_1)),
-            m_bool_2(std::move(other.m_bool_2)),
-            m_bool_3(std::move(other.m_bool_3)),
-            m_str_1(std::move(other.m_str_1)),
-            m_str_2(std::move(other.m_str_2)),
-            m_int8_4(std::move(other.m_int8_4)),
-            m_int8_5(std::move(other.m_int8_5)),
-            m_int16_4(std::move(other.m_int16_4)),
-            m_int16_5(std::move(other.m_int16_5)),
-            m_int32_4(std::move(other.m_int32_4)),
-            m_int32_max(std::move(other.m_int32_max)),
-            m_int64_4(std::move(other.m_int64_4)),
-            m_int64_max(std::move(other.m_int64_max)),
-            m_uint8_2(std::move(other.m_uint8_2)),
-            m_uint8_3(std::move(other.m_uint8_3)),
-            m_uint16_2(std::move(other.m_uint16_2)),
-            m_uint16_3(std::move(other.m_uint16_3)),
-            m_uint32_3(std::move(other.m_uint32_3)),
-            m_uint32_max(std::move(other.m_uint32_max)),
-            m_uint64_3(std::move(other.m_uint64_3)),
-            m_uint64_max(std::move(other.m_uint64_max)),
-            m_double_3(std::move(other.m_double_3)),
-            m_double_4(std::move(other.m_double_4)),
-            m_double_5(std::move(other.m_double_5)),
-            m_float_3(std::move(other.m_float_3)),
-            m_float_4(std::move(other.m_float_4)),
-            m_float_7(std::move(other.m_float_7)),
-            m_enum1(std::move(other.m_enum1)),
-            m_enum2(std::move(other.m_enum2)),
-            m_enum3(std::move(other.m_enum3)),
-            m_enum_int32min(std::move(other.m_enum_int32min)),
-            m_enum_int32max(std::move(other.m_enum_int32max)),
-            m_enum_uint32_min(std::move(other.m_enum_uint32_min)),
-            m_enum_uint32_max(std::move(other.m_enum_uint32_max)),
-            m_wstr_1(std::move(other.m_wstr_1)),
-            m_wstr_2(std::move(other.m_wstr_2))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
 
         Foo(Foo&& other, const arena& allocator)
           : m_bool_1(std::move(other.m_bool_1)),
@@ -342,17 +284,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/allocator/alias_key_types.h
+++ b/compiler/tests/generated/allocator/alias_key_types.h
@@ -26,9 +26,8 @@ namespace test
         std::map<std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> >, int32_t, std::less<std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > >, typename std::allocator_traits<arena>::template rebind_alloc<std::pair<const std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> >, int32_t> > > m;
         std::set<int32_t, std::less<int32_t>, typename std::allocator_traits<arena>::template rebind_alloc<int32_t> > s;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        foo(_bond_vc12_ctor_workaround_ = {})
+        foo()
         {
         }
 
@@ -36,15 +35,7 @@ namespace test
         // Compiler generated copy ctor OK
         foo(const foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo(foo&& other)
-          : m(std::move(other.m)),
-            s(std::move(other.s))
-        {
-        }
-#else
         foo(foo&&) = default;
-#endif
         
         explicit
         foo(const arena& allocator)
@@ -54,17 +45,9 @@ namespace test
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo& operator=(foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         foo& operator=(const foo&) = default;
         foo& operator=(foo&&) = default;
-#endif
 
         bool operator==(const foo& other) const
         {

--- a/compiler/tests/generated/allocator/aliases_types.cpp
+++ b/compiler/tests/generated/allocator/aliases_types.cpp
@@ -10,17 +10,6 @@ namespace tests
     {
     namespace EnumToWrap
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
-            {
-                { "anEnumValue", anEnumValue }
-            };
-
-        const std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap
-            {
-                { anEnumValue, "anEnumValue" }
-            };
-#else
         namespace
         {
             struct _hash_EnumToWrap
@@ -31,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum EnumToWrap value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumToWrap, std::string, _hash_EnumToWrap> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -55,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum EnumToWrap& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum EnumToWrap> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -72,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum EnumToWrap value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumToWrap, std::string, _hash_EnumToWrap> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/allocator/aliases_types.h
+++ b/compiler/tests/generated/allocator/aliases_types.h
@@ -26,9 +26,8 @@ namespace tests
 
         std::vector<std::vector<T, typename std::allocator_traits<arena>::template rebind_alloc<T> >, typename std::allocator_traits<arena>::template rebind_alloc<std::vector<T, typename std::allocator_traits<arena>::template rebind_alloc<T> > > > aa;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
         {
         }
 
@@ -36,14 +35,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : aa(std::move(other.aa))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -52,17 +44,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {
@@ -115,21 +99,7 @@ namespace tests
             return "tests.EnumToWrap";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap;
 
-        inline const std::map<enum EnumToWrap, std::string>& GetValueToNameMap(enum EnumToWrap)
-        {
-            return _value_to_name_EnumToWrap;
-        }
-
-        extern const std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap;
-
-        inline const std::map<std::string, enum EnumToWrap>& GetNameToValueMap(enum EnumToWrap)
-        {
-            return _name_to_value_EnumToWrap;
-        }
-#else
         template <typename Map = std::map<enum EnumToWrap, std::string> >
         inline const Map& GetValueToNameMap(enum EnumToWrap, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -149,7 +119,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum EnumToWrap value);
 
         void FromString(const std::string& name, enum EnumToWrap& value);
@@ -180,14 +149,7 @@ namespace tests
         // Compiler generated copy ctor OK
         WrappingAnEnum(const WrappingAnEnum&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        WrappingAnEnum(WrappingAnEnum&& other)
-          : aWrappedEnum(std::move(other.aWrappedEnum))
-        {
-        }
-#else
         WrappingAnEnum(WrappingAnEnum&&) = default;
-#endif
         
         explicit
         WrappingAnEnum(const arena&)
@@ -196,17 +158,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        WrappingAnEnum& operator=(WrappingAnEnum other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         WrappingAnEnum& operator=(const WrappingAnEnum&) = default;
         WrappingAnEnum& operator=(WrappingAnEnum&&) = default;
-#endif
 
         bool operator==(const WrappingAnEnum& other) const
         {

--- a/compiler/tests/generated/allocator/attributes_types.cpp
+++ b/compiler/tests/generated/allocator/attributes_types.cpp
@@ -10,17 +10,6 @@ namespace tests
     {
     namespace Enum
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum Enum> _name_to_value_Enum
-            {
-                { "Value1", Value1 }
-            };
-
-        const std::map<enum Enum, std::string> _value_to_name_Enum
-            {
-                { Value1, "Value1" }
-            };
-#else
         namespace
         {
             struct _hash_Enum
@@ -31,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum Enum value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum Enum, std::string, _hash_Enum> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -55,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum Enum& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum Enum> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -72,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum Enum value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum Enum, std::string, _hash_Enum> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/allocator/attributes_types.h
+++ b/compiler/tests/generated/allocator/attributes_types.h
@@ -38,21 +38,7 @@ namespace tests
             return "tests.Enum";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum Enum, std::string> _value_to_name_Enum;
 
-        inline const std::map<enum Enum, std::string>& GetValueToNameMap(enum Enum)
-        {
-            return _value_to_name_Enum;
-        }
-
-        extern const std::map<std::string, enum Enum> _name_to_value_Enum;
-
-        inline const std::map<std::string, enum Enum>& GetNameToValueMap(enum Enum)
-        {
-            return _name_to_value_Enum;
-        }
-#else
         template <typename Map = std::map<enum Enum, std::string> >
         inline const Map& GetValueToNameMap(enum Enum, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -72,7 +58,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum Enum value);
 
         void FromString(const std::string& name, enum Enum& value);
@@ -94,9 +79,8 @@ namespace tests
 
         std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > f;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
         {
         }
 
@@ -104,14 +88,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : f(std::move(other.f))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -120,17 +97,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/allocator/basic_types_nsmapped_types.h
+++ b/compiler/tests/generated/allocator/basic_types_nsmapped_types.h
@@ -38,9 +38,8 @@ namespace nsmapped
         float _float;
         ::bond::blob _blob;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        BasicTypes(_bond_vc12_ctor_workaround_ = {})
+        BasicTypes()
           : _bool(),
             _uint64(),
             _uint16(),
@@ -59,27 +58,7 @@ namespace nsmapped
         // Compiler generated copy ctor OK
         BasicTypes(const BasicTypes&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes(BasicTypes&& other)
-          : _bool(std::move(other._bool)),
-            _str(std::move(other._str)),
-            _wstr(std::move(other._wstr)),
-            _uint64(std::move(other._uint64)),
-            _uint16(std::move(other._uint16)),
-            _uint32(std::move(other._uint32)),
-            _uint8(std::move(other._uint8)),
-            _int8(std::move(other._int8)),
-            _int16(std::move(other._int16)),
-            _int32(std::move(other._int32)),
-            _int64(std::move(other._int64)),
-            _double(std::move(other._double)),
-            _float(std::move(other._float)),
-            _blob(std::move(other._blob))
-        {
-        }
-#else
         BasicTypes(BasicTypes&&) = default;
-#endif
         
         explicit
         BasicTypes(const arena& allocator)
@@ -100,17 +79,9 @@ namespace nsmapped
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes& operator=(BasicTypes other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         BasicTypes& operator=(const BasicTypes&) = default;
         BasicTypes& operator=(BasicTypes&&) = default;
-#endif
 
         bool operator==(const BasicTypes& other) const
         {

--- a/compiler/tests/generated/allocator/basic_types_types.h
+++ b/compiler/tests/generated/allocator/basic_types_types.h
@@ -38,9 +38,8 @@ namespace tests
         float _float;
         ::bond::blob _blob;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        BasicTypes(_bond_vc12_ctor_workaround_ = {})
+        BasicTypes()
           : _bool(),
             _uint64(),
             _uint16(),
@@ -59,27 +58,7 @@ namespace tests
         // Compiler generated copy ctor OK
         BasicTypes(const BasicTypes&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes(BasicTypes&& other)
-          : _bool(std::move(other._bool)),
-            _str(std::move(other._str)),
-            _wstr(std::move(other._wstr)),
-            _uint64(std::move(other._uint64)),
-            _uint16(std::move(other._uint16)),
-            _uint32(std::move(other._uint32)),
-            _uint8(std::move(other._uint8)),
-            _int8(std::move(other._int8)),
-            _int16(std::move(other._int16)),
-            _int32(std::move(other._int32)),
-            _int64(std::move(other._int64)),
-            _double(std::move(other._double)),
-            _float(std::move(other._float)),
-            _blob(std::move(other._blob))
-        {
-        }
-#else
         BasicTypes(BasicTypes&&) = default;
-#endif
         
         explicit
         BasicTypes(const arena& allocator)
@@ -100,17 +79,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes& operator=(BasicTypes other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         BasicTypes& operator=(const BasicTypes&) = default;
         BasicTypes& operator=(BasicTypes&&) = default;
-#endif
 
         bool operator==(const BasicTypes& other) const
         {

--- a/compiler/tests/generated/allocator/bond_meta_types.h
+++ b/compiler/tests/generated/allocator/bond_meta_types.h
@@ -28,9 +28,8 @@ namespace bondmeta
         std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > full_name;
         std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > name;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        HasMetaFields(_bond_vc12_ctor_workaround_ = {})
+        HasMetaFields()
         {
             InitMetadata("HasMetaFields", "deprecated.bondmeta.HasMetaFields");
         }

--- a/compiler/tests/generated/allocator/complex_types_types.h
+++ b/compiler/tests/generated/allocator/complex_types_types.h
@@ -34,13 +34,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&&)
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena&)
@@ -48,17 +42,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo&) const
         {
@@ -103,9 +89,8 @@ namespace tests
         ::bond::bonded< ::tests::Foo> bfoo;
         std::map<double, std::list<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, typename std::allocator_traits<arena>::template rebind_alloc< ::bond::nullable< ::bond::bonded< ::tests::Bar> > > >, typename std::allocator_traits<arena>::template rebind_alloc<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, typename std::allocator_traits<arena>::template rebind_alloc< ::bond::nullable< ::bond::bonded< ::tests::Bar> > > > > >, std::less<double>, typename std::allocator_traits<arena>::template rebind_alloc<std::pair<const double, std::list<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, typename std::allocator_traits<arena>::template rebind_alloc< ::bond::nullable< ::bond::bonded< ::tests::Bar> > > >, typename std::allocator_traits<arena>::template rebind_alloc<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, typename std::allocator_traits<arena>::template rebind_alloc< ::bond::nullable< ::bond::bonded< ::tests::Bar> > > > > > > > > m;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        ComplexTypes(_bond_vc12_ctor_workaround_ = {})
+        ComplexTypes()
         {
         }
 
@@ -113,20 +98,7 @@ namespace tests
         // Compiler generated copy ctor OK
         ComplexTypes(const ComplexTypes&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        ComplexTypes(ComplexTypes&& other)
-          : li8(std::move(other.li8)),
-            sb(std::move(other.sb)),
-            vb(std::move(other.vb)),
-            nf(std::move(other.nf)),
-            msws(std::move(other.msws)),
-            bfoo(std::move(other.bfoo)),
-            m(std::move(other.m))
-        {
-        }
-#else
         ComplexTypes(ComplexTypes&&) = default;
-#endif
         
         explicit
         ComplexTypes(const arena& allocator)
@@ -140,17 +112,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        ComplexTypes& operator=(ComplexTypes other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         ComplexTypes& operator=(const ComplexTypes&) = default;
         ComplexTypes& operator=(ComplexTypes&&) = default;
-#endif
 
         bool operator==(const ComplexTypes& other) const
         {

--- a/compiler/tests/generated/allocator/defaults_types.cpp
+++ b/compiler/tests/generated/allocator/defaults_types.cpp
@@ -10,41 +10,6 @@ namespace tests
     {
     namespace EnumType1
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
-            {
-                { "EnumValue1", EnumValue1 },
-                { "EnumValue2", EnumValue2 },
-                { "EnumValue3", EnumValue3 },
-                { "EnumValue4", EnumValue4 },
-                { "EnumValue5", EnumValue5 },
-                { "EnumValue6", EnumValue6 },
-                { "HexNeg", HexNeg },
-                { "Int32Max", Int32Max },
-                { "Int32Min", Int32Min },
-                { "Low", Low },
-                { "OctNeg", OctNeg },
-                { "UInt32Max", UInt32Max },
-                { "UInt32Min", UInt32Min }
-            };
-
-        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
-            {
-                { Int32Min, "Int32Min" },
-                { HexNeg, "HexNeg" },
-                { OctNeg, "OctNeg" },
-                { EnumValue3, "EnumValue3" },
-                { EnumValue5, "EnumValue5" },
-                { UInt32Min, "UInt32Min" },
-                { Low, "Low" },
-                { EnumValue1, "EnumValue1" },
-                { EnumValue2, "EnumValue2" },
-                { EnumValue4, "EnumValue4" },
-                { Int32Max, "Int32Max" },
-                { EnumValue6, "EnumValue6" },
-                { UInt32Max, "UInt32Max" }
-            };
-#else
         namespace
         {
             struct _hash_EnumType1
@@ -55,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -79,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum EnumType1& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum EnumType1> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -96,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/allocator/defaults_types.h
+++ b/compiler/tests/generated/allocator/defaults_types.h
@@ -25,19 +25,19 @@ namespace tests
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<std::int32_t>(5),
-            EnumValue2 = static_cast<std::int32_t>(10),
-            EnumValue3 = static_cast<std::int32_t>(-10),
-            EnumValue4 = static_cast<std::int32_t>(42),
-            Low = static_cast<std::int32_t>(1),
-            EnumValue5 = static_cast<std::int32_t>(-10),
-            EnumValue6 = static_cast<std::int32_t>(4294967286),
-            Int32Min = static_cast<std::int32_t>(-2147483647-1),
-            Int32Max = static_cast<std::int32_t>(2147483647),
-            UInt32Min = static_cast<std::int32_t>(0),
-            UInt32Max = static_cast<std::int32_t>(4294967295),
-            HexNeg = static_cast<std::int32_t>(-255),
-            OctNeg = static_cast<std::int32_t>(-83)
+            EnumValue1 = static_cast<int32_t>(5),
+            EnumValue2 = static_cast<int32_t>(10),
+            EnumValue3 = static_cast<int32_t>(-10),
+            EnumValue4 = static_cast<int32_t>(42),
+            Low = static_cast<int32_t>(1),
+            EnumValue5 = static_cast<int32_t>(-10),
+            EnumValue6 = static_cast<int32_t>(4294967286),
+            Int32Min = static_cast<int32_t>(-2147483647-1),
+            Int32Max = static_cast<int32_t>(2147483647),
+            UInt32Min = static_cast<int32_t>(0),
+            UInt32Max = static_cast<int32_t>(4294967295),
+            HexNeg = static_cast<int32_t>(-255),
+            OctNeg = static_cast<int32_t>(-83)
         };
         
         inline BOND_CONSTEXPR const char* GetTypeName(enum EnumType1)

--- a/compiler/tests/generated/allocator/defaults_types.h
+++ b/compiler/tests/generated/allocator/defaults_types.h
@@ -25,19 +25,19 @@ namespace tests
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<int32_t>(5),
-            EnumValue2 = static_cast<int32_t>(10),
-            EnumValue3 = static_cast<int32_t>(-10),
-            EnumValue4 = static_cast<int32_t>(42),
-            Low = static_cast<int32_t>(1),
-            EnumValue5 = static_cast<int32_t>(-10),
-            EnumValue6 = static_cast<int32_t>(4294967286),
-            Int32Min = static_cast<int32_t>(-2147483647-1),
-            Int32Max = static_cast<int32_t>(2147483647),
-            UInt32Min = static_cast<int32_t>(0),
-            UInt32Max = static_cast<int32_t>(4294967295),
-            HexNeg = static_cast<int32_t>(-255),
-            OctNeg = static_cast<int32_t>(-83)
+            EnumValue1 = static_cast<std::int32_t>(5),
+            EnumValue2 = static_cast<std::int32_t>(10),
+            EnumValue3 = static_cast<std::int32_t>(-10),
+            EnumValue4 = static_cast<std::int32_t>(42),
+            Low = static_cast<std::int32_t>(1),
+            EnumValue5 = static_cast<std::int32_t>(-10),
+            EnumValue6 = static_cast<std::int32_t>(4294967286),
+            Int32Min = static_cast<std::int32_t>(-2147483647-1),
+            Int32Max = static_cast<std::int32_t>(2147483647),
+            UInt32Min = static_cast<std::int32_t>(0),
+            UInt32Max = static_cast<std::int32_t>(4294967295),
+            HexNeg = static_cast<std::int32_t>(-255),
+            OctNeg = static_cast<std::int32_t>(-83)
         };
         
         inline BOND_CONSTEXPR const char* GetTypeName(enum EnumType1)
@@ -50,21 +50,7 @@ namespace tests
             return "tests.EnumType1";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum EnumType1, std::string> _value_to_name_EnumType1;
 
-        inline const std::map<enum EnumType1, std::string>& GetValueToNameMap(enum EnumType1)
-        {
-            return _value_to_name_EnumType1;
-        }
-
-        extern const std::map<std::string, enum EnumType1> _name_to_value_EnumType1;
-
-        inline const std::map<std::string, enum EnumType1>& GetNameToValueMap(enum EnumType1)
-        {
-            return _name_to_value_EnumType1;
-        }
-#else
         template <typename Map = std::map<enum EnumType1, std::string> >
         inline const Map& GetValueToNameMap(enum EnumType1, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -108,7 +94,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum EnumType1 value);
 
         void FromString(const std::string& name, enum EnumType1& value);
@@ -167,9 +152,8 @@ namespace tests
         int64_t m_int64_neg_hex;
         int64_t m_int64_neg_oct;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
           : m_bool_1(true),
             m_bool_2(false),
             m_str_1("default string value"),
@@ -201,51 +185,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : m_bool_1(std::move(other.m_bool_1)),
-            m_bool_2(std::move(other.m_bool_2)),
-            m_bool_3(std::move(other.m_bool_3)),
-            m_str_1(std::move(other.m_str_1)),
-            m_str_2(std::move(other.m_str_2)),
-            m_int8_4(std::move(other.m_int8_4)),
-            m_int8_5(std::move(other.m_int8_5)),
-            m_int16_4(std::move(other.m_int16_4)),
-            m_int16_5(std::move(other.m_int16_5)),
-            m_int32_4(std::move(other.m_int32_4)),
-            m_int32_max(std::move(other.m_int32_max)),
-            m_int64_4(std::move(other.m_int64_4)),
-            m_int64_max(std::move(other.m_int64_max)),
-            m_uint8_2(std::move(other.m_uint8_2)),
-            m_uint8_3(std::move(other.m_uint8_3)),
-            m_uint16_2(std::move(other.m_uint16_2)),
-            m_uint16_3(std::move(other.m_uint16_3)),
-            m_uint32_3(std::move(other.m_uint32_3)),
-            m_uint32_max(std::move(other.m_uint32_max)),
-            m_uint64_3(std::move(other.m_uint64_3)),
-            m_uint64_max(std::move(other.m_uint64_max)),
-            m_double_3(std::move(other.m_double_3)),
-            m_double_4(std::move(other.m_double_4)),
-            m_double_5(std::move(other.m_double_5)),
-            m_float_3(std::move(other.m_float_3)),
-            m_float_4(std::move(other.m_float_4)),
-            m_float_7(std::move(other.m_float_7)),
-            m_enum1(std::move(other.m_enum1)),
-            m_enum2(std::move(other.m_enum2)),
-            m_enum3(std::move(other.m_enum3)),
-            m_enum_int32min(std::move(other.m_enum_int32min)),
-            m_enum_int32max(std::move(other.m_enum_int32max)),
-            m_enum_uint32_min(std::move(other.m_enum_uint32_min)),
-            m_enum_uint32_max(std::move(other.m_enum_uint32_max)),
-            m_wstr_1(std::move(other.m_wstr_1)),
-            m_wstr_2(std::move(other.m_wstr_2)),
-            m_int64_neg_hex(std::move(other.m_int64_neg_hex)),
-            m_int64_neg_oct(std::move(other.m_int64_neg_oct))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -291,17 +231,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/allocator/field_modifiers_types.h
+++ b/compiler/tests/generated/allocator/field_modifiers_types.h
@@ -38,16 +38,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : o(std::move(other.o)),
-            r(std::move(other.r)),
-            ro(std::move(other.ro))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena&)
@@ -58,17 +49,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/allocator/generics_types.h
+++ b/compiler/tests/generated/allocator/generics_types.h
@@ -27,9 +27,8 @@ namespace tests
         T2 t2;
         ::bond::nullable< ::tests::Foo<T1, bool> > n;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
           : t2()
         {
         }
@@ -38,15 +37,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : t2(std::move(other.t2)),
-            n(std::move(other.n))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -56,17 +47,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/allocator/import_types.h
+++ b/compiler/tests/generated/allocator/import_types.h
@@ -26,9 +26,8 @@ namespace import_test
 
         ::empty::Empty e;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        HasEmpty(_bond_vc12_ctor_workaround_ = {})
+        HasEmpty()
         {
         }
 
@@ -36,14 +35,7 @@ namespace import_test
         // Compiler generated copy ctor OK
         HasEmpty(const HasEmpty&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        HasEmpty(HasEmpty&& other)
-          : e(std::move(other.e))
-        {
-        }
-#else
         HasEmpty(HasEmpty&&) = default;
-#endif
         
         explicit
         HasEmpty(const arena& allocator)
@@ -52,17 +44,9 @@ namespace import_test
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        HasEmpty& operator=(HasEmpty other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         HasEmpty& operator=(const HasEmpty&) = default;
         HasEmpty& operator=(HasEmpty&&) = default;
-#endif
 
         bool operator==(const HasEmpty& other) const
         {

--- a/compiler/tests/generated/allocator/inheritance_types.h
+++ b/compiler/tests/generated/allocator/inheritance_types.h
@@ -34,14 +34,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Base(const Base&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Base(Base&& other)
-          : x(std::move(other.x))
-        {
-        }
-#else
         Base(Base&&) = default;
-#endif
         
         explicit
         Base(const arena&)
@@ -50,17 +43,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Base& operator=(Base other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Base& operator=(const Base&) = default;
         Base& operator=(Base&&) = default;
-#endif
 
         bool operator==(const Base& other) const
         {
@@ -100,9 +85,8 @@ namespace tests
 
         int32_t x;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
           : x()
         {
         }
@@ -111,15 +95,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : ::tests::Base(std::move(other)),
-            x(std::move(other.x))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -129,17 +105,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/allocator/maybe_blob_types.h
+++ b/compiler/tests/generated/allocator/maybe_blob_types.h
@@ -33,14 +33,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : b(std::move(other.b))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena&)
@@ -48,17 +41,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/allocator/with_enum_header_enum.h
+++ b/compiler/tests/generated/allocator/with_enum_header_enum.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 
 namespace tests
 {
@@ -12,17 +12,17 @@ namespace _bond_enumerators
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<std::int32_t>(5),
-            EnumValue2 = static_cast<std::int32_t>(10),
-            EnumValue3 = static_cast<std::int32_t>(-10),
-            EnumValue4 = static_cast<std::int32_t>(42),
-            Low = static_cast<std::int32_t>(1),
-            EnumValue5 = static_cast<std::int32_t>(-10),
-            EnumValue6 = static_cast<std::int32_t>(4294967286),
-            Int32Min = static_cast<std::int32_t>(-2147483647-1),
-            Int32Max = static_cast<std::int32_t>(2147483647),
-            UInt32Min = static_cast<std::int32_t>(0),
-            UInt32Max = static_cast<std::int32_t>(4294967295)
+            EnumValue1 = static_cast<int32_t>(5),
+            EnumValue2 = static_cast<int32_t>(10),
+            EnumValue3 = static_cast<int32_t>(-10),
+            EnumValue4 = static_cast<int32_t>(42),
+            Low = static_cast<int32_t>(1),
+            EnumValue5 = static_cast<int32_t>(-10),
+            EnumValue6 = static_cast<int32_t>(4294967286),
+            Int32Min = static_cast<int32_t>(-2147483647-1),
+            Int32Max = static_cast<int32_t>(2147483647),
+            UInt32Min = static_cast<int32_t>(0),
+            UInt32Max = static_cast<int32_t>(4294967295)
         };
     } // namespace EnumType1
 

--- a/compiler/tests/generated/allocator/with_enum_header_enum.h
+++ b/compiler/tests/generated/allocator/with_enum_header_enum.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace tests
 {
@@ -12,17 +12,17 @@ namespace _bond_enumerators
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<int32_t>(5),
-            EnumValue2 = static_cast<int32_t>(10),
-            EnumValue3 = static_cast<int32_t>(-10),
-            EnumValue4 = static_cast<int32_t>(42),
-            Low = static_cast<int32_t>(1),
-            EnumValue5 = static_cast<int32_t>(-10),
-            EnumValue6 = static_cast<int32_t>(4294967286),
-            Int32Min = static_cast<int32_t>(-2147483647-1),
-            Int32Max = static_cast<int32_t>(2147483647),
-            UInt32Min = static_cast<int32_t>(0),
-            UInt32Max = static_cast<int32_t>(4294967295)
+            EnumValue1 = static_cast<std::int32_t>(5),
+            EnumValue2 = static_cast<std::int32_t>(10),
+            EnumValue3 = static_cast<std::int32_t>(-10),
+            EnumValue4 = static_cast<std::int32_t>(42),
+            Low = static_cast<std::int32_t>(1),
+            EnumValue5 = static_cast<std::int32_t>(-10),
+            EnumValue6 = static_cast<std::int32_t>(4294967286),
+            Int32Min = static_cast<std::int32_t>(-2147483647-1),
+            Int32Max = static_cast<std::int32_t>(2147483647),
+            UInt32Min = static_cast<std::int32_t>(0),
+            UInt32Max = static_cast<std::int32_t>(4294967295)
         };
     } // namespace EnumType1
 

--- a/compiler/tests/generated/allocator/with_enum_header_types.cpp
+++ b/compiler/tests/generated/allocator/with_enum_header_types.cpp
@@ -10,37 +10,6 @@ namespace tests
     {
     namespace EnumType1
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
-            {
-                { "EnumValue1", EnumValue1 },
-                { "EnumValue2", EnumValue2 },
-                { "EnumValue3", EnumValue3 },
-                { "EnumValue4", EnumValue4 },
-                { "EnumValue5", EnumValue5 },
-                { "EnumValue6", EnumValue6 },
-                { "Int32Max", Int32Max },
-                { "Int32Min", Int32Min },
-                { "Low", Low },
-                { "UInt32Max", UInt32Max },
-                { "UInt32Min", UInt32Min }
-            };
-
-        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
-            {
-                { Int32Min, "Int32Min" },
-                { EnumValue3, "EnumValue3" },
-                { EnumValue5, "EnumValue5" },
-                { UInt32Min, "UInt32Min" },
-                { Low, "Low" },
-                { EnumValue1, "EnumValue1" },
-                { EnumValue2, "EnumValue2" },
-                { EnumValue4, "EnumValue4" },
-                { Int32Max, "Int32Max" },
-                { EnumValue6, "EnumValue6" },
-                { UInt32Max, "UInt32Max" }
-            };
-#else
         namespace
         {
             struct _hash_EnumType1
@@ -51,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -75,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum EnumType1& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum EnumType1> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -92,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/allocator/with_enum_header_types.h
+++ b/compiler/tests/generated/allocator/with_enum_header_types.h
@@ -34,21 +34,7 @@ namespace tests
             return "tests.EnumType1";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum EnumType1, std::string> _value_to_name_EnumType1;
 
-        inline const std::map<enum EnumType1, std::string>& GetValueToNameMap(enum EnumType1)
-        {
-            return _value_to_name_EnumType1;
-        }
-
-        extern const std::map<std::string, enum EnumType1> _name_to_value_EnumType1;
-
-        inline const std::map<std::string, enum EnumType1>& GetNameToValueMap(enum EnumType1)
-        {
-            return _name_to_value_EnumType1;
-        }
-#else
         template <typename Map = std::map<enum EnumType1, std::string> >
         inline const Map& GetValueToNameMap(enum EnumType1, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -88,7 +74,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum EnumType1 value);
 
         void FromString(const std::string& name, enum EnumType1& value);
@@ -144,9 +129,8 @@ namespace tests
         std::basic_string<wchar_t, std::char_traits<wchar_t>, typename std::allocator_traits<arena>::template rebind_alloc<wchar_t> > m_wstr_1;
         ::bond::maybe<std::basic_string<wchar_t, std::char_traits<wchar_t>, typename std::allocator_traits<arena>::template rebind_alloc<wchar_t> > > m_wstr_2;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
           : m_bool_1(true),
             m_bool_2(false),
             m_str_1("default string value"),
@@ -176,49 +160,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : m_bool_1(std::move(other.m_bool_1)),
-            m_bool_2(std::move(other.m_bool_2)),
-            m_bool_3(std::move(other.m_bool_3)),
-            m_str_1(std::move(other.m_str_1)),
-            m_str_2(std::move(other.m_str_2)),
-            m_int8_4(std::move(other.m_int8_4)),
-            m_int8_5(std::move(other.m_int8_5)),
-            m_int16_4(std::move(other.m_int16_4)),
-            m_int16_5(std::move(other.m_int16_5)),
-            m_int32_4(std::move(other.m_int32_4)),
-            m_int32_max(std::move(other.m_int32_max)),
-            m_int64_4(std::move(other.m_int64_4)),
-            m_int64_max(std::move(other.m_int64_max)),
-            m_uint8_2(std::move(other.m_uint8_2)),
-            m_uint8_3(std::move(other.m_uint8_3)),
-            m_uint16_2(std::move(other.m_uint16_2)),
-            m_uint16_3(std::move(other.m_uint16_3)),
-            m_uint32_3(std::move(other.m_uint32_3)),
-            m_uint32_max(std::move(other.m_uint32_max)),
-            m_uint64_3(std::move(other.m_uint64_3)),
-            m_uint64_max(std::move(other.m_uint64_max)),
-            m_double_3(std::move(other.m_double_3)),
-            m_double_4(std::move(other.m_double_4)),
-            m_double_5(std::move(other.m_double_5)),
-            m_float_3(std::move(other.m_float_3)),
-            m_float_4(std::move(other.m_float_4)),
-            m_float_7(std::move(other.m_float_7)),
-            m_enum1(std::move(other.m_enum1)),
-            m_enum2(std::move(other.m_enum2)),
-            m_enum3(std::move(other.m_enum3)),
-            m_enum_int32min(std::move(other.m_enum_int32min)),
-            m_enum_int32max(std::move(other.m_enum_int32max)),
-            m_enum_uint32_min(std::move(other.m_enum_uint32_min)),
-            m_enum_uint32_max(std::move(other.m_enum_uint32_max)),
-            m_wstr_1(std::move(other.m_wstr_1)),
-            m_wstr_2(std::move(other.m_wstr_2))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -262,17 +204,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/attributes_types.cpp
+++ b/compiler/tests/generated/attributes_types.cpp
@@ -10,17 +10,6 @@ namespace tests
     {
     namespace Enum
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum Enum> _name_to_value_Enum
-            {
-                { "Value1", Value1 }
-            };
-
-        const std::map<enum Enum, std::string> _value_to_name_Enum
-            {
-                { Value1, "Value1" }
-            };
-#else
         namespace
         {
             struct _hash_Enum
@@ -31,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum Enum value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum Enum, std::string, _hash_Enum> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -55,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum Enum& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum Enum> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -72,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum Enum value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum Enum, std::string, _hash_Enum> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/attributes_types.h
+++ b/compiler/tests/generated/attributes_types.h
@@ -38,21 +38,7 @@ namespace tests
             return "tests.Enum";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum Enum, std::string> _value_to_name_Enum;
 
-        inline const std::map<enum Enum, std::string>& GetValueToNameMap(enum Enum)
-        {
-            return _value_to_name_Enum;
-        }
-
-        extern const std::map<std::string, enum Enum> _name_to_value_Enum;
-
-        inline const std::map<std::string, enum Enum>& GetNameToValueMap(enum Enum)
-        {
-            return _name_to_value_Enum;
-        }
-#else
         template <typename Map = std::map<enum Enum, std::string> >
         inline const Map& GetValueToNameMap(enum Enum, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -72,7 +58,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum Enum value);
 
         void FromString(const std::string& name, enum Enum& value);
@@ -100,27 +85,12 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : f(std::move(other.f))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/basic_types_nsmapped_types.h
+++ b/compiler/tests/generated/basic_types_nsmapped_types.h
@@ -55,40 +55,12 @@ namespace nsmapped
         // Compiler generated copy ctor OK
         BasicTypes(const BasicTypes&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes(BasicTypes&& other)
-          : _bool(std::move(other._bool)),
-            _str(std::move(other._str)),
-            _wstr(std::move(other._wstr)),
-            _uint64(std::move(other._uint64)),
-            _uint16(std::move(other._uint16)),
-            _uint32(std::move(other._uint32)),
-            _uint8(std::move(other._uint8)),
-            _int8(std::move(other._int8)),
-            _int16(std::move(other._int16)),
-            _int32(std::move(other._int32)),
-            _int64(std::move(other._int64)),
-            _double(std::move(other._double)),
-            _float(std::move(other._float)),
-            _blob(std::move(other._blob))
-        {
-        }
-#else
         BasicTypes(BasicTypes&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes& operator=(BasicTypes other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         BasicTypes& operator=(const BasicTypes&) = default;
         BasicTypes& operator=(BasicTypes&&) = default;
-#endif
 
         bool operator==(const BasicTypes& other) const
         {

--- a/compiler/tests/generated/basic_types_types.h
+++ b/compiler/tests/generated/basic_types_types.h
@@ -55,40 +55,12 @@ namespace tests
         // Compiler generated copy ctor OK
         BasicTypes(const BasicTypes&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes(BasicTypes&& other)
-          : _bool(std::move(other._bool)),
-            _str(std::move(other._str)),
-            _wstr(std::move(other._wstr)),
-            _uint64(std::move(other._uint64)),
-            _uint16(std::move(other._uint16)),
-            _uint32(std::move(other._uint32)),
-            _uint8(std::move(other._uint8)),
-            _int8(std::move(other._int8)),
-            _int16(std::move(other._int16)),
-            _int32(std::move(other._int32)),
-            _int64(std::move(other._int64)),
-            _double(std::move(other._double)),
-            _float(std::move(other._float)),
-            _blob(std::move(other._blob))
-        {
-        }
-#else
         BasicTypes(BasicTypes&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes& operator=(BasicTypes other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         BasicTypes& operator=(const BasicTypes&) = default;
         BasicTypes& operator=(BasicTypes&&) = default;
-#endif
 
         bool operator==(const BasicTypes& other) const
         {

--- a/compiler/tests/generated/complex_types_types.h
+++ b/compiler/tests/generated/complex_types_types.h
@@ -32,26 +32,12 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&&)
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo&) const
         {
@@ -102,33 +88,12 @@ namespace tests
         // Compiler generated copy ctor OK
         ComplexTypes(const ComplexTypes&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        ComplexTypes(ComplexTypes&& other)
-          : li8(std::move(other.li8)),
-            sb(std::move(other.sb)),
-            vb(std::move(other.vb)),
-            nf(std::move(other.nf)),
-            msws(std::move(other.msws)),
-            bfoo(std::move(other.bfoo)),
-            m(std::move(other.m))
-        {
-        }
-#else
         ComplexTypes(ComplexTypes&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        ComplexTypes& operator=(ComplexTypes other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         ComplexTypes& operator=(const ComplexTypes&) = default;
         ComplexTypes& operator=(ComplexTypes&&) = default;
-#endif
 
         bool operator==(const ComplexTypes& other) const
         {

--- a/compiler/tests/generated/custom_alias_with_allocator_types.h
+++ b/compiler/tests/generated/custom_alias_with_allocator_types.h
@@ -36,9 +36,8 @@ namespace test
         ::bond::maybe<my::string<arena> > st1;
         my::set<my::list<my::map<int32_t, my::string<arena>, arena>, arena>, arena> na;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        foo(_bond_vc12_ctor_workaround_ = {})
+        foo()
           : l(),
             v(),
             s(),
@@ -53,25 +52,7 @@ namespace test
         // Compiler generated copy ctor OK
         foo(const foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo(foo&& other)
-          : l(std::move(other.l)),
-            v(std::move(other.v)),
-            s(std::move(other.s)),
-            m(std::move(other.m)),
-            st(std::move(other.st)),
-            d(std::move(other.d)),
-            l1(std::move(other.l1)),
-            v1(std::move(other.v1)),
-            s1(std::move(other.s1)),
-            m1(std::move(other.m1)),
-            st1(std::move(other.st1)),
-            na(std::move(other.na))
-        {
-        }
-#else
         foo(foo&&) = default;
-#endif
         
         explicit
         foo(const arena& allocator)
@@ -91,17 +72,9 @@ namespace test
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo& operator=(foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         foo& operator=(const foo&) = default;
         foo& operator=(foo&&) = default;
-#endif
 
         bool operator==(const foo& other) const
         {

--- a/compiler/tests/generated/custom_alias_without_allocator_types.h
+++ b/compiler/tests/generated/custom_alias_without_allocator_types.h
@@ -51,25 +51,7 @@ namespace test
         // Compiler generated copy ctor OK
         foo(const foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo(foo&& other)
-          : l(std::move(other.l)),
-            v(std::move(other.v)),
-            s(std::move(other.s)),
-            m(std::move(other.m)),
-            st(std::move(other.st)),
-            d(std::move(other.d)),
-            l1(std::move(other.l1)),
-            v1(std::move(other.v1)),
-            s1(std::move(other.s1)),
-            m1(std::move(other.m1)),
-            st1(std::move(other.st1)),
-            na(std::move(other.na))
-        {
-        }
-#else
         foo(foo&&) = default;
-#endif
         
         explicit
         foo(const arena&)
@@ -89,17 +71,9 @@ namespace test
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo& operator=(foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         foo& operator=(const foo&) = default;
         foo& operator=(foo&&) = default;
-#endif
 
         bool operator==(const foo& other) const
         {

--- a/compiler/tests/generated/defaults_types.cpp
+++ b/compiler/tests/generated/defaults_types.cpp
@@ -10,41 +10,6 @@ namespace tests
     {
     namespace EnumType1
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
-            {
-                { "EnumValue1", EnumValue1 },
-                { "EnumValue2", EnumValue2 },
-                { "EnumValue3", EnumValue3 },
-                { "EnumValue4", EnumValue4 },
-                { "EnumValue5", EnumValue5 },
-                { "EnumValue6", EnumValue6 },
-                { "HexNeg", HexNeg },
-                { "Int32Max", Int32Max },
-                { "Int32Min", Int32Min },
-                { "Low", Low },
-                { "OctNeg", OctNeg },
-                { "UInt32Max", UInt32Max },
-                { "UInt32Min", UInt32Min }
-            };
-
-        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
-            {
-                { Int32Min, "Int32Min" },
-                { HexNeg, "HexNeg" },
-                { OctNeg, "OctNeg" },
-                { EnumValue3, "EnumValue3" },
-                { EnumValue5, "EnumValue5" },
-                { UInt32Min, "UInt32Min" },
-                { Low, "Low" },
-                { EnumValue1, "EnumValue1" },
-                { EnumValue2, "EnumValue2" },
-                { EnumValue4, "EnumValue4" },
-                { Int32Max, "Int32Max" },
-                { EnumValue6, "EnumValue6" },
-                { UInt32Max, "UInt32Max" }
-            };
-#else
         namespace
         {
             struct _hash_EnumType1
@@ -55,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -79,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum EnumType1& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum EnumType1> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -96,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/defaults_types.h
+++ b/compiler/tests/generated/defaults_types.h
@@ -25,19 +25,19 @@ namespace tests
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<std::int32_t>(5),
-            EnumValue2 = static_cast<std::int32_t>(10),
-            EnumValue3 = static_cast<std::int32_t>(-10),
-            EnumValue4 = static_cast<std::int32_t>(42),
-            Low = static_cast<std::int32_t>(1),
-            EnumValue5 = static_cast<std::int32_t>(-10),
-            EnumValue6 = static_cast<std::int32_t>(4294967286),
-            Int32Min = static_cast<std::int32_t>(-2147483647-1),
-            Int32Max = static_cast<std::int32_t>(2147483647),
-            UInt32Min = static_cast<std::int32_t>(0),
-            UInt32Max = static_cast<std::int32_t>(4294967295),
-            HexNeg = static_cast<std::int32_t>(-255),
-            OctNeg = static_cast<std::int32_t>(-83)
+            EnumValue1 = static_cast<int32_t>(5),
+            EnumValue2 = static_cast<int32_t>(10),
+            EnumValue3 = static_cast<int32_t>(-10),
+            EnumValue4 = static_cast<int32_t>(42),
+            Low = static_cast<int32_t>(1),
+            EnumValue5 = static_cast<int32_t>(-10),
+            EnumValue6 = static_cast<int32_t>(4294967286),
+            Int32Min = static_cast<int32_t>(-2147483647-1),
+            Int32Max = static_cast<int32_t>(2147483647),
+            UInt32Min = static_cast<int32_t>(0),
+            UInt32Max = static_cast<int32_t>(4294967295),
+            HexNeg = static_cast<int32_t>(-255),
+            OctNeg = static_cast<int32_t>(-83)
         };
         
         inline BOND_CONSTEXPR const char* GetTypeName(enum EnumType1)

--- a/compiler/tests/generated/defaults_types.h
+++ b/compiler/tests/generated/defaults_types.h
@@ -25,19 +25,19 @@ namespace tests
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<int32_t>(5),
-            EnumValue2 = static_cast<int32_t>(10),
-            EnumValue3 = static_cast<int32_t>(-10),
-            EnumValue4 = static_cast<int32_t>(42),
-            Low = static_cast<int32_t>(1),
-            EnumValue5 = static_cast<int32_t>(-10),
-            EnumValue6 = static_cast<int32_t>(4294967286),
-            Int32Min = static_cast<int32_t>(-2147483647-1),
-            Int32Max = static_cast<int32_t>(2147483647),
-            UInt32Min = static_cast<int32_t>(0),
-            UInt32Max = static_cast<int32_t>(4294967295),
-            HexNeg = static_cast<int32_t>(-255),
-            OctNeg = static_cast<int32_t>(-83)
+            EnumValue1 = static_cast<std::int32_t>(5),
+            EnumValue2 = static_cast<std::int32_t>(10),
+            EnumValue3 = static_cast<std::int32_t>(-10),
+            EnumValue4 = static_cast<std::int32_t>(42),
+            Low = static_cast<std::int32_t>(1),
+            EnumValue5 = static_cast<std::int32_t>(-10),
+            EnumValue6 = static_cast<std::int32_t>(4294967286),
+            Int32Min = static_cast<std::int32_t>(-2147483647-1),
+            Int32Max = static_cast<std::int32_t>(2147483647),
+            UInt32Min = static_cast<std::int32_t>(0),
+            UInt32Max = static_cast<std::int32_t>(4294967295),
+            HexNeg = static_cast<std::int32_t>(-255),
+            OctNeg = static_cast<std::int32_t>(-83)
         };
         
         inline BOND_CONSTEXPR const char* GetTypeName(enum EnumType1)
@@ -50,21 +50,7 @@ namespace tests
             return "tests.EnumType1";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum EnumType1, std::string> _value_to_name_EnumType1;
 
-        inline const std::map<enum EnumType1, std::string>& GetValueToNameMap(enum EnumType1)
-        {
-            return _value_to_name_EnumType1;
-        }
-
-        extern const std::map<std::string, enum EnumType1> _name_to_value_EnumType1;
-
-        inline const std::map<std::string, enum EnumType1>& GetNameToValueMap(enum EnumType1)
-        {
-            return _name_to_value_EnumType1;
-        }
-#else
         template <typename Map = std::map<enum EnumType1, std::string> >
         inline const Map& GetValueToNameMap(enum EnumType1, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -108,7 +94,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum EnumType1 value);
 
         void FromString(const std::string& name, enum EnumType1& value);
@@ -197,64 +182,12 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : m_bool_1(std::move(other.m_bool_1)),
-            m_bool_2(std::move(other.m_bool_2)),
-            m_bool_3(std::move(other.m_bool_3)),
-            m_str_1(std::move(other.m_str_1)),
-            m_str_2(std::move(other.m_str_2)),
-            m_int8_4(std::move(other.m_int8_4)),
-            m_int8_5(std::move(other.m_int8_5)),
-            m_int16_4(std::move(other.m_int16_4)),
-            m_int16_5(std::move(other.m_int16_5)),
-            m_int32_4(std::move(other.m_int32_4)),
-            m_int32_max(std::move(other.m_int32_max)),
-            m_int64_4(std::move(other.m_int64_4)),
-            m_int64_max(std::move(other.m_int64_max)),
-            m_uint8_2(std::move(other.m_uint8_2)),
-            m_uint8_3(std::move(other.m_uint8_3)),
-            m_uint16_2(std::move(other.m_uint16_2)),
-            m_uint16_3(std::move(other.m_uint16_3)),
-            m_uint32_3(std::move(other.m_uint32_3)),
-            m_uint32_max(std::move(other.m_uint32_max)),
-            m_uint64_3(std::move(other.m_uint64_3)),
-            m_uint64_max(std::move(other.m_uint64_max)),
-            m_double_3(std::move(other.m_double_3)),
-            m_double_4(std::move(other.m_double_4)),
-            m_double_5(std::move(other.m_double_5)),
-            m_float_3(std::move(other.m_float_3)),
-            m_float_4(std::move(other.m_float_4)),
-            m_float_7(std::move(other.m_float_7)),
-            m_enum1(std::move(other.m_enum1)),
-            m_enum2(std::move(other.m_enum2)),
-            m_enum3(std::move(other.m_enum3)),
-            m_enum_int32min(std::move(other.m_enum_int32min)),
-            m_enum_int32max(std::move(other.m_enum_int32max)),
-            m_enum_uint32_min(std::move(other.m_enum_uint32_min)),
-            m_enum_uint32_max(std::move(other.m_enum_uint32_max)),
-            m_wstr_1(std::move(other.m_wstr_1)),
-            m_wstr_2(std::move(other.m_wstr_2)),
-            m_int64_neg_hex(std::move(other.m_int64_neg_hex)),
-            m_int64_neg_oct(std::move(other.m_int64_neg_oct))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/exports/service_types.h
+++ b/compiler/tests/generated/exports/service_types.h
@@ -34,27 +34,12 @@ namespace tests
         // Compiler generated copy ctor OK
         dummy(const dummy&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        dummy(dummy&& other)
-          : count(std::move(other.count))
-        {
-        }
-#else
         dummy(dummy&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        dummy& operator=(dummy other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         dummy& operator=(const dummy&) = default;
         dummy& operator=(dummy&&) = default;
-#endif
 
         bool operator==(const dummy& other) const
         {

--- a/compiler/tests/generated/exports/with_enum_header_types.h
+++ b/compiler/tests/generated/exports/with_enum_header_types.h
@@ -25,17 +25,17 @@ namespace tests
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<std::int32_t>(5),
-            EnumValue2 = static_cast<std::int32_t>(10),
-            EnumValue3 = static_cast<std::int32_t>(-10),
-            EnumValue4 = static_cast<std::int32_t>(42),
-            Low = static_cast<std::int32_t>(1),
-            EnumValue5 = static_cast<std::int32_t>(-10),
-            EnumValue6 = static_cast<std::int32_t>(4294967286),
-            Int32Min = static_cast<std::int32_t>(-2147483647-1),
-            Int32Max = static_cast<std::int32_t>(2147483647),
-            UInt32Min = static_cast<std::int32_t>(0),
-            UInt32Max = static_cast<std::int32_t>(4294967295)
+            EnumValue1 = static_cast<int32_t>(5),
+            EnumValue2 = static_cast<int32_t>(10),
+            EnumValue3 = static_cast<int32_t>(-10),
+            EnumValue4 = static_cast<int32_t>(42),
+            Low = static_cast<int32_t>(1),
+            EnumValue5 = static_cast<int32_t>(-10),
+            EnumValue6 = static_cast<int32_t>(4294967286),
+            Int32Min = static_cast<int32_t>(-2147483647-1),
+            Int32Max = static_cast<int32_t>(2147483647),
+            UInt32Min = static_cast<int32_t>(0),
+            UInt32Max = static_cast<int32_t>(4294967295)
         };
         
         inline BOND_CONSTEXPR const char* GetTypeName(enum EnumType1)

--- a/compiler/tests/generated/exports/with_enum_header_types.h
+++ b/compiler/tests/generated/exports/with_enum_header_types.h
@@ -25,17 +25,17 @@ namespace tests
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<int32_t>(5),
-            EnumValue2 = static_cast<int32_t>(10),
-            EnumValue3 = static_cast<int32_t>(-10),
-            EnumValue4 = static_cast<int32_t>(42),
-            Low = static_cast<int32_t>(1),
-            EnumValue5 = static_cast<int32_t>(-10),
-            EnumValue6 = static_cast<int32_t>(4294967286),
-            Int32Min = static_cast<int32_t>(-2147483647-1),
-            Int32Max = static_cast<int32_t>(2147483647),
-            UInt32Min = static_cast<int32_t>(0),
-            UInt32Max = static_cast<int32_t>(4294967295)
+            EnumValue1 = static_cast<std::int32_t>(5),
+            EnumValue2 = static_cast<std::int32_t>(10),
+            EnumValue3 = static_cast<std::int32_t>(-10),
+            EnumValue4 = static_cast<std::int32_t>(42),
+            Low = static_cast<std::int32_t>(1),
+            EnumValue5 = static_cast<std::int32_t>(-10),
+            EnumValue6 = static_cast<std::int32_t>(4294967286),
+            Int32Min = static_cast<std::int32_t>(-2147483647-1),
+            Int32Max = static_cast<std::int32_t>(2147483647),
+            UInt32Min = static_cast<std::int32_t>(0),
+            UInt32Max = static_cast<std::int32_t>(4294967295)
         };
         
         inline BOND_CONSTEXPR const char* GetTypeName(enum EnumType1)
@@ -48,21 +48,7 @@ namespace tests
             return "tests.EnumType1";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum EnumType1, std::string> _value_to_name_EnumType1;
 
-        inline const std::map<enum EnumType1, std::string>& GetValueToNameMap(enum EnumType1)
-        {
-            return _value_to_name_EnumType1;
-        }
-
-        extern const std::map<std::string, enum EnumType1> _name_to_value_EnumType1;
-
-        inline const std::map<std::string, enum EnumType1>& GetNameToValueMap(enum EnumType1)
-        {
-            return _name_to_value_EnumType1;
-        }
-#else
         template <typename Map = std::map<enum EnumType1, std::string> >
         inline const Map& GetValueToNameMap(enum EnumType1, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -102,7 +88,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         DllExport const std::string& ToString(enum EnumType1 value);
 
         DllExport void FromString(const std::string& name, enum EnumType1& value);
@@ -187,62 +172,12 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : m_bool_1(std::move(other.m_bool_1)),
-            m_bool_2(std::move(other.m_bool_2)),
-            m_bool_3(std::move(other.m_bool_3)),
-            m_str_1(std::move(other.m_str_1)),
-            m_str_2(std::move(other.m_str_2)),
-            m_int8_4(std::move(other.m_int8_4)),
-            m_int8_5(std::move(other.m_int8_5)),
-            m_int16_4(std::move(other.m_int16_4)),
-            m_int16_5(std::move(other.m_int16_5)),
-            m_int32_4(std::move(other.m_int32_4)),
-            m_int32_max(std::move(other.m_int32_max)),
-            m_int64_4(std::move(other.m_int64_4)),
-            m_int64_max(std::move(other.m_int64_max)),
-            m_uint8_2(std::move(other.m_uint8_2)),
-            m_uint8_3(std::move(other.m_uint8_3)),
-            m_uint16_2(std::move(other.m_uint16_2)),
-            m_uint16_3(std::move(other.m_uint16_3)),
-            m_uint32_3(std::move(other.m_uint32_3)),
-            m_uint32_max(std::move(other.m_uint32_max)),
-            m_uint64_3(std::move(other.m_uint64_3)),
-            m_uint64_max(std::move(other.m_uint64_max)),
-            m_double_3(std::move(other.m_double_3)),
-            m_double_4(std::move(other.m_double_4)),
-            m_double_5(std::move(other.m_double_5)),
-            m_float_3(std::move(other.m_float_3)),
-            m_float_4(std::move(other.m_float_4)),
-            m_float_7(std::move(other.m_float_7)),
-            m_enum1(std::move(other.m_enum1)),
-            m_enum2(std::move(other.m_enum2)),
-            m_enum3(std::move(other.m_enum3)),
-            m_enum_int32min(std::move(other.m_enum_int32min)),
-            m_enum_int32max(std::move(other.m_enum_int32max)),
-            m_enum_uint32_min(std::move(other.m_enum_uint32_min)),
-            m_enum_uint32_max(std::move(other.m_enum_uint32_max)),
-            m_wstr_1(std::move(other.m_wstr_1)),
-            m_wstr_2(std::move(other.m_wstr_2))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/field_modifiers_types.h
+++ b/compiler/tests/generated/field_modifiers_types.h
@@ -36,29 +36,12 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : o(std::move(other.o)),
-            r(std::move(other.r)),
-            ro(std::move(other.ro))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/generics_types.h
+++ b/compiler/tests/generated/generics_types.h
@@ -34,28 +34,12 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : t2(std::move(other.t2)),
-            n(std::move(other.n))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/import_types.h
+++ b/compiler/tests/generated/import_types.h
@@ -32,27 +32,12 @@ namespace import_test
         // Compiler generated copy ctor OK
         HasEmpty(const HasEmpty&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        HasEmpty(HasEmpty&& other)
-          : e(std::move(other.e))
-        {
-        }
-#else
         HasEmpty(HasEmpty&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        HasEmpty& operator=(HasEmpty other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         HasEmpty& operator=(const HasEmpty&) = default;
         HasEmpty& operator=(HasEmpty&&) = default;
-#endif
 
         bool operator==(const HasEmpty& other) const
         {

--- a/compiler/tests/generated/inheritance_types.h
+++ b/compiler/tests/generated/inheritance_types.h
@@ -32,27 +32,12 @@ namespace tests
         // Compiler generated copy ctor OK
         Base(const Base&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Base(Base&& other)
-          : x(std::move(other.x))
-        {
-        }
-#else
         Base(Base&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Base& operator=(Base other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Base& operator=(const Base&) = default;
         Base& operator=(Base&&) = default;
-#endif
 
         bool operator==(const Base& other) const
         {
@@ -99,28 +84,12 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : ::tests::Base(std::move(other)),
-            x(std::move(other.x))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/maybe_blob_types.h
+++ b/compiler/tests/generated/maybe_blob_types.h
@@ -31,27 +31,12 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : b(std::move(other.b))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/scoped_allocator/alias_key_types.h
+++ b/compiler/tests/generated/scoped_allocator/alias_key_types.h
@@ -26,9 +26,8 @@ namespace test
         std::map<std::basic_string<char, std::char_traits<char>, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc<char> > >, int32_t, std::less<std::basic_string<char, std::char_traits<char>, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc<char> > > >, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc<std::pair<const std::basic_string<char, std::char_traits<char>, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc<char> > >, int32_t> > > > m;
         std::set<int32_t, std::less<int32_t>, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc<int32_t> > > s;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        foo(_bond_vc12_ctor_workaround_ = {})
+        foo()
         {
         }
 
@@ -36,15 +35,7 @@ namespace test
         // Compiler generated copy ctor OK
         foo(const foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo(foo&& other)
-          : m(std::move(other.m)),
-            s(std::move(other.s))
-        {
-        }
-#else
         foo(foo&&) = default;
-#endif
         
         explicit
         foo(const arena& allocator)
@@ -54,17 +45,9 @@ namespace test
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo& operator=(foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         foo& operator=(const foo&) = default;
         foo& operator=(foo&&) = default;
-#endif
 
         bool operator==(const foo& other) const
         {

--- a/compiler/tests/generated/scoped_allocator/aliases_types.cpp
+++ b/compiler/tests/generated/scoped_allocator/aliases_types.cpp
@@ -10,17 +10,6 @@ namespace tests
     {
     namespace EnumToWrap
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
-            {
-                { "anEnumValue", anEnumValue }
-            };
-
-        const std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap
-            {
-                { anEnumValue, "anEnumValue" }
-            };
-#else
         namespace
         {
             struct _hash_EnumToWrap
@@ -31,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum EnumToWrap value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumToWrap, std::string, _hash_EnumToWrap> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -55,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum EnumToWrap& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum EnumToWrap> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -72,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum EnumToWrap value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumToWrap, std::string, _hash_EnumToWrap> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/scoped_allocator/aliases_types.h
+++ b/compiler/tests/generated/scoped_allocator/aliases_types.h
@@ -26,9 +26,8 @@ namespace tests
 
         std::vector<std::vector<T, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc<T> > >, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc<std::vector<T, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc<T> > > > > > aa;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
         {
         }
 
@@ -36,14 +35,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : aa(std::move(other.aa))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -52,17 +44,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {
@@ -115,21 +99,7 @@ namespace tests
             return "tests.EnumToWrap";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap;
 
-        inline const std::map<enum EnumToWrap, std::string>& GetValueToNameMap(enum EnumToWrap)
-        {
-            return _value_to_name_EnumToWrap;
-        }
-
-        extern const std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap;
-
-        inline const std::map<std::string, enum EnumToWrap>& GetNameToValueMap(enum EnumToWrap)
-        {
-            return _name_to_value_EnumToWrap;
-        }
-#else
         template <typename Map = std::map<enum EnumToWrap, std::string> >
         inline const Map& GetValueToNameMap(enum EnumToWrap, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -149,7 +119,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum EnumToWrap value);
 
         void FromString(const std::string& name, enum EnumToWrap& value);
@@ -180,14 +149,7 @@ namespace tests
         // Compiler generated copy ctor OK
         WrappingAnEnum(const WrappingAnEnum&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        WrappingAnEnum(WrappingAnEnum&& other)
-          : aWrappedEnum(std::move(other.aWrappedEnum))
-        {
-        }
-#else
         WrappingAnEnum(WrappingAnEnum&&) = default;
-#endif
         
         explicit
         WrappingAnEnum(const arena&)
@@ -196,17 +158,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        WrappingAnEnum& operator=(WrappingAnEnum other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         WrappingAnEnum& operator=(const WrappingAnEnum&) = default;
         WrappingAnEnum& operator=(WrappingAnEnum&&) = default;
-#endif
 
         bool operator==(const WrappingAnEnum& other) const
         {

--- a/compiler/tests/generated/scoped_allocator/attributes_types.cpp
+++ b/compiler/tests/generated/scoped_allocator/attributes_types.cpp
@@ -10,17 +10,6 @@ namespace tests
     {
     namespace Enum
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum Enum> _name_to_value_Enum
-            {
-                { "Value1", Value1 }
-            };
-
-        const std::map<enum Enum, std::string> _value_to_name_Enum
-            {
-                { Value1, "Value1" }
-            };
-#else
         namespace
         {
             struct _hash_Enum
@@ -31,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum Enum value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum Enum, std::string, _hash_Enum> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -55,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum Enum& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum Enum> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -72,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum Enum value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum Enum, std::string, _hash_Enum> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/scoped_allocator/attributes_types.h
+++ b/compiler/tests/generated/scoped_allocator/attributes_types.h
@@ -38,21 +38,7 @@ namespace tests
             return "tests.Enum";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum Enum, std::string> _value_to_name_Enum;
 
-        inline const std::map<enum Enum, std::string>& GetValueToNameMap(enum Enum)
-        {
-            return _value_to_name_Enum;
-        }
-
-        extern const std::map<std::string, enum Enum> _name_to_value_Enum;
-
-        inline const std::map<std::string, enum Enum>& GetNameToValueMap(enum Enum)
-        {
-            return _name_to_value_Enum;
-        }
-#else
         template <typename Map = std::map<enum Enum, std::string> >
         inline const Map& GetValueToNameMap(enum Enum, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -72,7 +58,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum Enum value);
 
         void FromString(const std::string& name, enum Enum& value);
@@ -94,9 +79,8 @@ namespace tests
 
         std::basic_string<char, std::char_traits<char>, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc<char> > > f;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
         {
         }
 
@@ -104,14 +88,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : f(std::move(other.f))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -120,17 +97,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/scoped_allocator/basic_types_nsmapped_types.h
+++ b/compiler/tests/generated/scoped_allocator/basic_types_nsmapped_types.h
@@ -39,9 +39,8 @@ namespace nsmapped
         float _float;
         ::bond::blob _blob;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        BasicTypes(_bond_vc12_ctor_workaround_ = {})
+        BasicTypes()
           : _bool(),
             _uint64(),
             _uint16(),
@@ -60,27 +59,7 @@ namespace nsmapped
         // Compiler generated copy ctor OK
         BasicTypes(const BasicTypes&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes(BasicTypes&& other)
-          : _bool(std::move(other._bool)),
-            _str(std::move(other._str)),
-            _wstr(std::move(other._wstr)),
-            _uint64(std::move(other._uint64)),
-            _uint16(std::move(other._uint16)),
-            _uint32(std::move(other._uint32)),
-            _uint8(std::move(other._uint8)),
-            _int8(std::move(other._int8)),
-            _int16(std::move(other._int16)),
-            _int32(std::move(other._int32)),
-            _int64(std::move(other._int64)),
-            _double(std::move(other._double)),
-            _float(std::move(other._float)),
-            _blob(std::move(other._blob))
-        {
-        }
-#else
         BasicTypes(BasicTypes&&) = default;
-#endif
         
         explicit
         BasicTypes(const arena& allocator)
@@ -101,17 +80,9 @@ namespace nsmapped
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes& operator=(BasicTypes other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         BasicTypes& operator=(const BasicTypes&) = default;
         BasicTypes& operator=(BasicTypes&&) = default;
-#endif
 
         bool operator==(const BasicTypes& other) const
         {

--- a/compiler/tests/generated/scoped_allocator/basic_types_types.h
+++ b/compiler/tests/generated/scoped_allocator/basic_types_types.h
@@ -39,9 +39,8 @@ namespace tests
         float _float;
         ::bond::blob _blob;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        BasicTypes(_bond_vc12_ctor_workaround_ = {})
+        BasicTypes()
           : _bool(),
             _uint64(),
             _uint16(),
@@ -60,27 +59,7 @@ namespace tests
         // Compiler generated copy ctor OK
         BasicTypes(const BasicTypes&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes(BasicTypes&& other)
-          : _bool(std::move(other._bool)),
-            _str(std::move(other._str)),
-            _wstr(std::move(other._wstr)),
-            _uint64(std::move(other._uint64)),
-            _uint16(std::move(other._uint16)),
-            _uint32(std::move(other._uint32)),
-            _uint8(std::move(other._uint8)),
-            _int8(std::move(other._int8)),
-            _int16(std::move(other._int16)),
-            _int32(std::move(other._int32)),
-            _int64(std::move(other._int64)),
-            _double(std::move(other._double)),
-            _float(std::move(other._float)),
-            _blob(std::move(other._blob))
-        {
-        }
-#else
         BasicTypes(BasicTypes&&) = default;
-#endif
         
         explicit
         BasicTypes(const arena& allocator)
@@ -101,17 +80,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes& operator=(BasicTypes other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         BasicTypes& operator=(const BasicTypes&) = default;
         BasicTypes& operator=(BasicTypes&&) = default;
-#endif
 
         bool operator==(const BasicTypes& other) const
         {

--- a/compiler/tests/generated/scoped_allocator/bond_meta_types.h
+++ b/compiler/tests/generated/scoped_allocator/bond_meta_types.h
@@ -28,9 +28,8 @@ namespace bondmeta
         std::basic_string<char, std::char_traits<char>, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc<char> > > full_name;
         std::basic_string<char, std::char_traits<char>, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc<char> > > name;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        HasMetaFields(_bond_vc12_ctor_workaround_ = {})
+        HasMetaFields()
         {
             InitMetadata("HasMetaFields", "deprecated.bondmeta.HasMetaFields");
         }

--- a/compiler/tests/generated/scoped_allocator/complex_types_types.h
+++ b/compiler/tests/generated/scoped_allocator/complex_types_types.h
@@ -35,13 +35,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&&)
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena&)
@@ -49,17 +43,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo&) const
         {
@@ -104,9 +90,8 @@ namespace tests
         ::bond::bonded< ::tests::Foo> bfoo;
         std::map<double, std::list<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc< ::bond::nullable< ::bond::bonded< ::tests::Bar> > > > >, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc< ::bond::nullable< ::bond::bonded< ::tests::Bar> > > > > > > >, std::less<double>, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc<std::pair<const double, std::list<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc< ::bond::nullable< ::bond::bonded< ::tests::Bar> > > > >, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc< ::bond::nullable< ::bond::bonded< ::tests::Bar> > > > > > > > > > > > m;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        ComplexTypes(_bond_vc12_ctor_workaround_ = {})
+        ComplexTypes()
         {
         }
 
@@ -114,20 +99,7 @@ namespace tests
         // Compiler generated copy ctor OK
         ComplexTypes(const ComplexTypes&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        ComplexTypes(ComplexTypes&& other)
-          : li8(std::move(other.li8)),
-            sb(std::move(other.sb)),
-            vb(std::move(other.vb)),
-            nf(std::move(other.nf)),
-            msws(std::move(other.msws)),
-            bfoo(std::move(other.bfoo)),
-            m(std::move(other.m))
-        {
-        }
-#else
         ComplexTypes(ComplexTypes&&) = default;
-#endif
         
         explicit
         ComplexTypes(const arena& allocator)
@@ -141,17 +113,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        ComplexTypes& operator=(ComplexTypes other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         ComplexTypes& operator=(const ComplexTypes&) = default;
         ComplexTypes& operator=(ComplexTypes&&) = default;
-#endif
 
         bool operator==(const ComplexTypes& other) const
         {

--- a/compiler/tests/generated/scoped_allocator/defaults_types.cpp
+++ b/compiler/tests/generated/scoped_allocator/defaults_types.cpp
@@ -10,41 +10,6 @@ namespace tests
     {
     namespace EnumType1
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
-            {
-                { "EnumValue1", EnumValue1 },
-                { "EnumValue2", EnumValue2 },
-                { "EnumValue3", EnumValue3 },
-                { "EnumValue4", EnumValue4 },
-                { "EnumValue5", EnumValue5 },
-                { "EnumValue6", EnumValue6 },
-                { "HexNeg", HexNeg },
-                { "Int32Max", Int32Max },
-                { "Int32Min", Int32Min },
-                { "Low", Low },
-                { "OctNeg", OctNeg },
-                { "UInt32Max", UInt32Max },
-                { "UInt32Min", UInt32Min }
-            };
-
-        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
-            {
-                { Int32Min, "Int32Min" },
-                { HexNeg, "HexNeg" },
-                { OctNeg, "OctNeg" },
-                { EnumValue3, "EnumValue3" },
-                { EnumValue5, "EnumValue5" },
-                { UInt32Min, "UInt32Min" },
-                { Low, "Low" },
-                { EnumValue1, "EnumValue1" },
-                { EnumValue2, "EnumValue2" },
-                { EnumValue4, "EnumValue4" },
-                { Int32Max, "Int32Max" },
-                { EnumValue6, "EnumValue6" },
-                { UInt32Max, "UInt32Max" }
-            };
-#else
         namespace
         {
             struct _hash_EnumType1
@@ -55,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -79,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum EnumType1& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum EnumType1> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -96,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/scoped_allocator/defaults_types.h
+++ b/compiler/tests/generated/scoped_allocator/defaults_types.h
@@ -25,19 +25,19 @@ namespace tests
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<std::int32_t>(5),
-            EnumValue2 = static_cast<std::int32_t>(10),
-            EnumValue3 = static_cast<std::int32_t>(-10),
-            EnumValue4 = static_cast<std::int32_t>(42),
-            Low = static_cast<std::int32_t>(1),
-            EnumValue5 = static_cast<std::int32_t>(-10),
-            EnumValue6 = static_cast<std::int32_t>(4294967286),
-            Int32Min = static_cast<std::int32_t>(-2147483647-1),
-            Int32Max = static_cast<std::int32_t>(2147483647),
-            UInt32Min = static_cast<std::int32_t>(0),
-            UInt32Max = static_cast<std::int32_t>(4294967295),
-            HexNeg = static_cast<std::int32_t>(-255),
-            OctNeg = static_cast<std::int32_t>(-83)
+            EnumValue1 = static_cast<int32_t>(5),
+            EnumValue2 = static_cast<int32_t>(10),
+            EnumValue3 = static_cast<int32_t>(-10),
+            EnumValue4 = static_cast<int32_t>(42),
+            Low = static_cast<int32_t>(1),
+            EnumValue5 = static_cast<int32_t>(-10),
+            EnumValue6 = static_cast<int32_t>(4294967286),
+            Int32Min = static_cast<int32_t>(-2147483647-1),
+            Int32Max = static_cast<int32_t>(2147483647),
+            UInt32Min = static_cast<int32_t>(0),
+            UInt32Max = static_cast<int32_t>(4294967295),
+            HexNeg = static_cast<int32_t>(-255),
+            OctNeg = static_cast<int32_t>(-83)
         };
         
         inline BOND_CONSTEXPR const char* GetTypeName(enum EnumType1)

--- a/compiler/tests/generated/scoped_allocator/defaults_types.h
+++ b/compiler/tests/generated/scoped_allocator/defaults_types.h
@@ -25,19 +25,19 @@ namespace tests
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<int32_t>(5),
-            EnumValue2 = static_cast<int32_t>(10),
-            EnumValue3 = static_cast<int32_t>(-10),
-            EnumValue4 = static_cast<int32_t>(42),
-            Low = static_cast<int32_t>(1),
-            EnumValue5 = static_cast<int32_t>(-10),
-            EnumValue6 = static_cast<int32_t>(4294967286),
-            Int32Min = static_cast<int32_t>(-2147483647-1),
-            Int32Max = static_cast<int32_t>(2147483647),
-            UInt32Min = static_cast<int32_t>(0),
-            UInt32Max = static_cast<int32_t>(4294967295),
-            HexNeg = static_cast<int32_t>(-255),
-            OctNeg = static_cast<int32_t>(-83)
+            EnumValue1 = static_cast<std::int32_t>(5),
+            EnumValue2 = static_cast<std::int32_t>(10),
+            EnumValue3 = static_cast<std::int32_t>(-10),
+            EnumValue4 = static_cast<std::int32_t>(42),
+            Low = static_cast<std::int32_t>(1),
+            EnumValue5 = static_cast<std::int32_t>(-10),
+            EnumValue6 = static_cast<std::int32_t>(4294967286),
+            Int32Min = static_cast<std::int32_t>(-2147483647-1),
+            Int32Max = static_cast<std::int32_t>(2147483647),
+            UInt32Min = static_cast<std::int32_t>(0),
+            UInt32Max = static_cast<std::int32_t>(4294967295),
+            HexNeg = static_cast<std::int32_t>(-255),
+            OctNeg = static_cast<std::int32_t>(-83)
         };
         
         inline BOND_CONSTEXPR const char* GetTypeName(enum EnumType1)
@@ -50,21 +50,7 @@ namespace tests
             return "tests.EnumType1";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum EnumType1, std::string> _value_to_name_EnumType1;
 
-        inline const std::map<enum EnumType1, std::string>& GetValueToNameMap(enum EnumType1)
-        {
-            return _value_to_name_EnumType1;
-        }
-
-        extern const std::map<std::string, enum EnumType1> _name_to_value_EnumType1;
-
-        inline const std::map<std::string, enum EnumType1>& GetNameToValueMap(enum EnumType1)
-        {
-            return _name_to_value_EnumType1;
-        }
-#else
         template <typename Map = std::map<enum EnumType1, std::string> >
         inline const Map& GetValueToNameMap(enum EnumType1, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -108,7 +94,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum EnumType1 value);
 
         void FromString(const std::string& name, enum EnumType1& value);
@@ -167,9 +152,8 @@ namespace tests
         int64_t m_int64_neg_hex;
         int64_t m_int64_neg_oct;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
           : m_bool_1(true),
             m_bool_2(false),
             m_str_1("default string value"),
@@ -201,51 +185,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : m_bool_1(std::move(other.m_bool_1)),
-            m_bool_2(std::move(other.m_bool_2)),
-            m_bool_3(std::move(other.m_bool_3)),
-            m_str_1(std::move(other.m_str_1)),
-            m_str_2(std::move(other.m_str_2)),
-            m_int8_4(std::move(other.m_int8_4)),
-            m_int8_5(std::move(other.m_int8_5)),
-            m_int16_4(std::move(other.m_int16_4)),
-            m_int16_5(std::move(other.m_int16_5)),
-            m_int32_4(std::move(other.m_int32_4)),
-            m_int32_max(std::move(other.m_int32_max)),
-            m_int64_4(std::move(other.m_int64_4)),
-            m_int64_max(std::move(other.m_int64_max)),
-            m_uint8_2(std::move(other.m_uint8_2)),
-            m_uint8_3(std::move(other.m_uint8_3)),
-            m_uint16_2(std::move(other.m_uint16_2)),
-            m_uint16_3(std::move(other.m_uint16_3)),
-            m_uint32_3(std::move(other.m_uint32_3)),
-            m_uint32_max(std::move(other.m_uint32_max)),
-            m_uint64_3(std::move(other.m_uint64_3)),
-            m_uint64_max(std::move(other.m_uint64_max)),
-            m_double_3(std::move(other.m_double_3)),
-            m_double_4(std::move(other.m_double_4)),
-            m_double_5(std::move(other.m_double_5)),
-            m_float_3(std::move(other.m_float_3)),
-            m_float_4(std::move(other.m_float_4)),
-            m_float_7(std::move(other.m_float_7)),
-            m_enum1(std::move(other.m_enum1)),
-            m_enum2(std::move(other.m_enum2)),
-            m_enum3(std::move(other.m_enum3)),
-            m_enum_int32min(std::move(other.m_enum_int32min)),
-            m_enum_int32max(std::move(other.m_enum_int32max)),
-            m_enum_uint32_min(std::move(other.m_enum_uint32_min)),
-            m_enum_uint32_max(std::move(other.m_enum_uint32_max)),
-            m_wstr_1(std::move(other.m_wstr_1)),
-            m_wstr_2(std::move(other.m_wstr_2)),
-            m_int64_neg_hex(std::move(other.m_int64_neg_hex)),
-            m_int64_neg_oct(std::move(other.m_int64_neg_oct))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -291,17 +231,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/scoped_allocator/field_modifiers_types.h
+++ b/compiler/tests/generated/scoped_allocator/field_modifiers_types.h
@@ -38,16 +38,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : o(std::move(other.o)),
-            r(std::move(other.r)),
-            ro(std::move(other.ro))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena&)
@@ -58,17 +49,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/scoped_allocator/generics_types.h
+++ b/compiler/tests/generated/scoped_allocator/generics_types.h
@@ -27,9 +27,8 @@ namespace tests
         T2 t2;
         ::bond::nullable< ::tests::Foo<T1, bool> > n;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
           : t2()
         {
         }
@@ -38,15 +37,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : t2(std::move(other.t2)),
-            n(std::move(other.n))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -56,17 +47,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/scoped_allocator/import_types.h
+++ b/compiler/tests/generated/scoped_allocator/import_types.h
@@ -26,9 +26,8 @@ namespace import_test
 
         ::empty::Empty e;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        HasEmpty(_bond_vc12_ctor_workaround_ = {})
+        HasEmpty()
         {
         }
 
@@ -36,14 +35,7 @@ namespace import_test
         // Compiler generated copy ctor OK
         HasEmpty(const HasEmpty&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        HasEmpty(HasEmpty&& other)
-          : e(std::move(other.e))
-        {
-        }
-#else
         HasEmpty(HasEmpty&&) = default;
-#endif
         
         explicit
         HasEmpty(const arena& allocator)
@@ -52,17 +44,9 @@ namespace import_test
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        HasEmpty& operator=(HasEmpty other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         HasEmpty& operator=(const HasEmpty&) = default;
         HasEmpty& operator=(HasEmpty&&) = default;
-#endif
 
         bool operator==(const HasEmpty& other) const
         {

--- a/compiler/tests/generated/scoped_allocator/inheritance_types.h
+++ b/compiler/tests/generated/scoped_allocator/inheritance_types.h
@@ -34,14 +34,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Base(const Base&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Base(Base&& other)
-          : x(std::move(other.x))
-        {
-        }
-#else
         Base(Base&&) = default;
-#endif
         
         explicit
         Base(const arena&)
@@ -50,17 +43,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Base& operator=(Base other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Base& operator=(const Base&) = default;
         Base& operator=(Base&&) = default;
-#endif
 
         bool operator==(const Base& other) const
         {
@@ -100,9 +85,8 @@ namespace tests
 
         int32_t x;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
           : x()
         {
         }
@@ -111,15 +95,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : ::tests::Base(std::move(other)),
-            x(std::move(other.x))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -129,17 +105,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/scoped_allocator/maybe_blob_types.h
+++ b/compiler/tests/generated/scoped_allocator/maybe_blob_types.h
@@ -33,14 +33,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : b(std::move(other.b))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena&)
@@ -48,17 +41,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/scoped_allocator/with_enum_header_enum.h
+++ b/compiler/tests/generated/scoped_allocator/with_enum_header_enum.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 
 namespace tests
 {
@@ -12,17 +12,17 @@ namespace _bond_enumerators
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<std::int32_t>(5),
-            EnumValue2 = static_cast<std::int32_t>(10),
-            EnumValue3 = static_cast<std::int32_t>(-10),
-            EnumValue4 = static_cast<std::int32_t>(42),
-            Low = static_cast<std::int32_t>(1),
-            EnumValue5 = static_cast<std::int32_t>(-10),
-            EnumValue6 = static_cast<std::int32_t>(4294967286),
-            Int32Min = static_cast<std::int32_t>(-2147483647-1),
-            Int32Max = static_cast<std::int32_t>(2147483647),
-            UInt32Min = static_cast<std::int32_t>(0),
-            UInt32Max = static_cast<std::int32_t>(4294967295)
+            EnumValue1 = static_cast<int32_t>(5),
+            EnumValue2 = static_cast<int32_t>(10),
+            EnumValue3 = static_cast<int32_t>(-10),
+            EnumValue4 = static_cast<int32_t>(42),
+            Low = static_cast<int32_t>(1),
+            EnumValue5 = static_cast<int32_t>(-10),
+            EnumValue6 = static_cast<int32_t>(4294967286),
+            Int32Min = static_cast<int32_t>(-2147483647-1),
+            Int32Max = static_cast<int32_t>(2147483647),
+            UInt32Min = static_cast<int32_t>(0),
+            UInt32Max = static_cast<int32_t>(4294967295)
         };
     } // namespace EnumType1
 

--- a/compiler/tests/generated/scoped_allocator/with_enum_header_enum.h
+++ b/compiler/tests/generated/scoped_allocator/with_enum_header_enum.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace tests
 {
@@ -12,17 +12,17 @@ namespace _bond_enumerators
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<int32_t>(5),
-            EnumValue2 = static_cast<int32_t>(10),
-            EnumValue3 = static_cast<int32_t>(-10),
-            EnumValue4 = static_cast<int32_t>(42),
-            Low = static_cast<int32_t>(1),
-            EnumValue5 = static_cast<int32_t>(-10),
-            EnumValue6 = static_cast<int32_t>(4294967286),
-            Int32Min = static_cast<int32_t>(-2147483647-1),
-            Int32Max = static_cast<int32_t>(2147483647),
-            UInt32Min = static_cast<int32_t>(0),
-            UInt32Max = static_cast<int32_t>(4294967295)
+            EnumValue1 = static_cast<std::int32_t>(5),
+            EnumValue2 = static_cast<std::int32_t>(10),
+            EnumValue3 = static_cast<std::int32_t>(-10),
+            EnumValue4 = static_cast<std::int32_t>(42),
+            Low = static_cast<std::int32_t>(1),
+            EnumValue5 = static_cast<std::int32_t>(-10),
+            EnumValue6 = static_cast<std::int32_t>(4294967286),
+            Int32Min = static_cast<std::int32_t>(-2147483647-1),
+            Int32Max = static_cast<std::int32_t>(2147483647),
+            UInt32Min = static_cast<std::int32_t>(0),
+            UInt32Max = static_cast<std::int32_t>(4294967295)
         };
     } // namespace EnumType1
 

--- a/compiler/tests/generated/scoped_allocator/with_enum_header_types.cpp
+++ b/compiler/tests/generated/scoped_allocator/with_enum_header_types.cpp
@@ -10,37 +10,6 @@ namespace tests
     {
     namespace EnumType1
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
-            {
-                { "EnumValue1", EnumValue1 },
-                { "EnumValue2", EnumValue2 },
-                { "EnumValue3", EnumValue3 },
-                { "EnumValue4", EnumValue4 },
-                { "EnumValue5", EnumValue5 },
-                { "EnumValue6", EnumValue6 },
-                { "Int32Max", Int32Max },
-                { "Int32Min", Int32Min },
-                { "Low", Low },
-                { "UInt32Max", UInt32Max },
-                { "UInt32Min", UInt32Min }
-            };
-
-        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
-            {
-                { Int32Min, "Int32Min" },
-                { EnumValue3, "EnumValue3" },
-                { EnumValue5, "EnumValue5" },
-                { UInt32Min, "UInt32Min" },
-                { Low, "Low" },
-                { EnumValue1, "EnumValue1" },
-                { EnumValue2, "EnumValue2" },
-                { EnumValue4, "EnumValue4" },
-                { Int32Max, "Int32Max" },
-                { EnumValue6, "EnumValue6" },
-                { UInt32Max, "UInt32Max" }
-            };
-#else
         namespace
         {
             struct _hash_EnumType1
@@ -51,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -75,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum EnumType1& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum EnumType1> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -92,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/scoped_allocator/with_enum_header_types.h
+++ b/compiler/tests/generated/scoped_allocator/with_enum_header_types.h
@@ -34,21 +34,7 @@ namespace tests
             return "tests.EnumType1";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum EnumType1, std::string> _value_to_name_EnumType1;
 
-        inline const std::map<enum EnumType1, std::string>& GetValueToNameMap(enum EnumType1)
-        {
-            return _value_to_name_EnumType1;
-        }
-
-        extern const std::map<std::string, enum EnumType1> _name_to_value_EnumType1;
-
-        inline const std::map<std::string, enum EnumType1>& GetNameToValueMap(enum EnumType1)
-        {
-            return _name_to_value_EnumType1;
-        }
-#else
         template <typename Map = std::map<enum EnumType1, std::string> >
         inline const Map& GetValueToNameMap(enum EnumType1, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -88,7 +74,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum EnumType1 value);
 
         void FromString(const std::string& name, enum EnumType1& value);
@@ -144,9 +129,8 @@ namespace tests
         std::basic_string<wchar_t, std::char_traits<wchar_t>, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc<wchar_t> > > m_wstr_1;
         ::bond::maybe<std::basic_string<wchar_t, std::char_traits<wchar_t>, std::scoped_allocator_adaptor<typename std::allocator_traits<arena>::template rebind_alloc<wchar_t> > > > m_wstr_2;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
           : m_bool_1(true),
             m_bool_2(false),
             m_str_1("default string value"),
@@ -176,49 +160,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : m_bool_1(std::move(other.m_bool_1)),
-            m_bool_2(std::move(other.m_bool_2)),
-            m_bool_3(std::move(other.m_bool_3)),
-            m_str_1(std::move(other.m_str_1)),
-            m_str_2(std::move(other.m_str_2)),
-            m_int8_4(std::move(other.m_int8_4)),
-            m_int8_5(std::move(other.m_int8_5)),
-            m_int16_4(std::move(other.m_int16_4)),
-            m_int16_5(std::move(other.m_int16_5)),
-            m_int32_4(std::move(other.m_int32_4)),
-            m_int32_max(std::move(other.m_int32_max)),
-            m_int64_4(std::move(other.m_int64_4)),
-            m_int64_max(std::move(other.m_int64_max)),
-            m_uint8_2(std::move(other.m_uint8_2)),
-            m_uint8_3(std::move(other.m_uint8_3)),
-            m_uint16_2(std::move(other.m_uint16_2)),
-            m_uint16_3(std::move(other.m_uint16_3)),
-            m_uint32_3(std::move(other.m_uint32_3)),
-            m_uint32_max(std::move(other.m_uint32_max)),
-            m_uint64_3(std::move(other.m_uint64_3)),
-            m_uint64_max(std::move(other.m_uint64_max)),
-            m_double_3(std::move(other.m_double_3)),
-            m_double_4(std::move(other.m_double_4)),
-            m_double_5(std::move(other.m_double_5)),
-            m_float_3(std::move(other.m_float_3)),
-            m_float_4(std::move(other.m_float_4)),
-            m_float_7(std::move(other.m_float_7)),
-            m_enum1(std::move(other.m_enum1)),
-            m_enum2(std::move(other.m_enum2)),
-            m_enum3(std::move(other.m_enum3)),
-            m_enum_int32min(std::move(other.m_enum_int32min)),
-            m_enum_int32max(std::move(other.m_enum_int32max)),
-            m_enum_uint32_min(std::move(other.m_enum_uint32_min)),
-            m_enum_uint32_max(std::move(other.m_enum_uint32_max)),
-            m_wstr_1(std::move(other.m_wstr_1)),
-            m_wstr_2(std::move(other.m_wstr_2))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -262,17 +204,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/type_aliases/alias_key_types.h
+++ b/compiler/tests/generated/type_aliases/alias_key_types.h
@@ -30,9 +30,8 @@ namespace test
         std::map< ::test::String, ::test::Int, std::less< ::test::String>, typename std::allocator_traits<arena>::template rebind_alloc<std::pair<const ::test::String, ::test::Int> > > m;
         std::set< ::test::Int, std::less< ::test::Int>, typename std::allocator_traits<arena>::template rebind_alloc< ::test::Int> > s;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        foo(_bond_vc12_ctor_workaround_ = {})
+        foo()
         {
         }
 
@@ -40,15 +39,7 @@ namespace test
         // Compiler generated copy ctor OK
         foo(const foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo(foo&& other)
-          : m(std::move(other.m)),
-            s(std::move(other.s))
-        {
-        }
-#else
         foo(foo&&) = default;
-#endif
         
         explicit
         foo(const arena& allocator)
@@ -58,17 +49,9 @@ namespace test
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo& operator=(foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         foo& operator=(const foo&) = default;
         foo& operator=(foo&&) = default;
-#endif
 
         bool operator==(const foo& other) const
         {

--- a/compiler/tests/generated/type_aliases/alias_with_allocator_types.h
+++ b/compiler/tests/generated/type_aliases/alias_with_allocator_types.h
@@ -54,9 +54,8 @@ namespace test
         ::bond::maybe< ::test::String> st1;
         ::test::NestedAliases na;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        foo(_bond_vc12_ctor_workaround_ = {})
+        foo()
           : d("foo")
         {
         }
@@ -65,25 +64,7 @@ namespace test
         // Compiler generated copy ctor OK
         foo(const foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo(foo&& other)
-          : l(std::move(other.l)),
-            v(std::move(other.v)),
-            s(std::move(other.s)),
-            m(std::move(other.m)),
-            st(std::move(other.st)),
-            d(std::move(other.d)),
-            l1(std::move(other.l1)),
-            v1(std::move(other.v1)),
-            s1(std::move(other.s1)),
-            m1(std::move(other.m1)),
-            st1(std::move(other.st1)),
-            na(std::move(other.na))
-        {
-        }
-#else
         foo(foo&&) = default;
-#endif
         
         explicit
         foo(const arena& allocator)
@@ -103,17 +84,9 @@ namespace test
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo& operator=(foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         foo& operator=(const foo&) = default;
         foo& operator=(foo&&) = default;
-#endif
 
         bool operator==(const foo& other) const
         {
@@ -175,9 +148,8 @@ namespace test
         ::test::TheFoo f;
         ::test::foo f1;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        withFoo(_bond_vc12_ctor_workaround_ = {})
+        withFoo()
         {
         }
 
@@ -185,15 +157,7 @@ namespace test
         // Compiler generated copy ctor OK
         withFoo(const withFoo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        withFoo(withFoo&& other)
-          : f(std::move(other.f)),
-            f1(std::move(other.f1))
-        {
-        }
-#else
         withFoo(withFoo&&) = default;
-#endif
         
         explicit
         withFoo(const arena& allocator)
@@ -203,17 +167,9 @@ namespace test
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        withFoo& operator=(withFoo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         withFoo& operator=(const withFoo&) = default;
         withFoo& operator=(withFoo&&) = default;
-#endif
 
         bool operator==(const withFoo& other) const
         {

--- a/compiler/tests/generated/type_aliases/aliases_types.cpp
+++ b/compiler/tests/generated/type_aliases/aliases_types.cpp
@@ -10,17 +10,6 @@ namespace tests
     {
     namespace EnumToWrap
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap
-            {
-                { "anEnumValue", anEnumValue }
-            };
-
-        const std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap
-            {
-                { anEnumValue, "anEnumValue" }
-            };
-#else
         namespace
         {
             struct _hash_EnumToWrap
@@ -31,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum EnumToWrap value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumToWrap, std::string, _hash_EnumToWrap> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -55,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum EnumToWrap& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum EnumToWrap> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -72,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum EnumToWrap value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumToWrap, std::string, _hash_EnumToWrap> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/type_aliases/aliases_types.h
+++ b/compiler/tests/generated/type_aliases/aliases_types.h
@@ -35,9 +35,8 @@ namespace tests
 
         ::tests::array10< ::tests::array<20, T> > aa;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
         {
         }
 
@@ -45,14 +44,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : aa(std::move(other.aa))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -61,17 +53,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {
@@ -124,21 +108,7 @@ namespace tests
             return "tests.EnumToWrap";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum EnumToWrap, std::string> _value_to_name_EnumToWrap;
 
-        inline const std::map<enum EnumToWrap, std::string>& GetValueToNameMap(enum EnumToWrap)
-        {
-            return _value_to_name_EnumToWrap;
-        }
-
-        extern const std::map<std::string, enum EnumToWrap> _name_to_value_EnumToWrap;
-
-        inline const std::map<std::string, enum EnumToWrap>& GetNameToValueMap(enum EnumToWrap)
-        {
-            return _name_to_value_EnumToWrap;
-        }
-#else
         template <typename Map = std::map<enum EnumToWrap, std::string> >
         inline const Map& GetValueToNameMap(enum EnumToWrap, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -158,7 +128,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum EnumToWrap value);
 
         void FromString(const std::string& name, enum EnumToWrap& value);
@@ -189,14 +158,7 @@ namespace tests
         // Compiler generated copy ctor OK
         WrappingAnEnum(const WrappingAnEnum&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        WrappingAnEnum(WrappingAnEnum&& other)
-          : aWrappedEnum(std::move(other.aWrappedEnum))
-        {
-        }
-#else
         WrappingAnEnum(WrappingAnEnum&&) = default;
-#endif
         
         explicit
         WrappingAnEnum(const arena&)
@@ -205,17 +167,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        WrappingAnEnum& operator=(WrappingAnEnum other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         WrappingAnEnum& operator=(const WrappingAnEnum&) = default;
         WrappingAnEnum& operator=(WrappingAnEnum&&) = default;
-#endif
 
         bool operator==(const WrappingAnEnum& other) const
         {

--- a/compiler/tests/generated/type_aliases/attributes_types.cpp
+++ b/compiler/tests/generated/type_aliases/attributes_types.cpp
@@ -10,17 +10,6 @@ namespace tests
     {
     namespace Enum
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum Enum> _name_to_value_Enum
-            {
-                { "Value1", Value1 }
-            };
-
-        const std::map<enum Enum, std::string> _value_to_name_Enum
-            {
-                { Value1, "Value1" }
-            };
-#else
         namespace
         {
             struct _hash_Enum
@@ -31,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum Enum value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum Enum, std::string, _hash_Enum> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -55,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum Enum& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum Enum> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -72,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum Enum value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum Enum, std::string, _hash_Enum> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/type_aliases/attributes_types.h
+++ b/compiler/tests/generated/type_aliases/attributes_types.h
@@ -38,21 +38,7 @@ namespace tests
             return "tests.Enum";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum Enum, std::string> _value_to_name_Enum;
 
-        inline const std::map<enum Enum, std::string>& GetValueToNameMap(enum Enum)
-        {
-            return _value_to_name_Enum;
-        }
-
-        extern const std::map<std::string, enum Enum> _name_to_value_Enum;
-
-        inline const std::map<std::string, enum Enum>& GetNameToValueMap(enum Enum)
-        {
-            return _name_to_value_Enum;
-        }
-#else
         template <typename Map = std::map<enum Enum, std::string> >
         inline const Map& GetValueToNameMap(enum Enum, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -72,7 +58,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum Enum value);
 
         void FromString(const std::string& name, enum Enum& value);
@@ -94,9 +79,8 @@ namespace tests
 
         std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > f;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
         {
         }
 
@@ -104,14 +88,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : f(std::move(other.f))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -120,17 +97,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/type_aliases/basic_types_nsmapped_types.h
+++ b/compiler/tests/generated/type_aliases/basic_types_nsmapped_types.h
@@ -38,9 +38,8 @@ namespace nsmapped
         float _float;
         ::bond::blob _blob;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        BasicTypes(_bond_vc12_ctor_workaround_ = {})
+        BasicTypes()
           : _bool(),
             _uint64(),
             _uint16(),
@@ -59,27 +58,7 @@ namespace nsmapped
         // Compiler generated copy ctor OK
         BasicTypes(const BasicTypes&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes(BasicTypes&& other)
-          : _bool(std::move(other._bool)),
-            _str(std::move(other._str)),
-            _wstr(std::move(other._wstr)),
-            _uint64(std::move(other._uint64)),
-            _uint16(std::move(other._uint16)),
-            _uint32(std::move(other._uint32)),
-            _uint8(std::move(other._uint8)),
-            _int8(std::move(other._int8)),
-            _int16(std::move(other._int16)),
-            _int32(std::move(other._int32)),
-            _int64(std::move(other._int64)),
-            _double(std::move(other._double)),
-            _float(std::move(other._float)),
-            _blob(std::move(other._blob))
-        {
-        }
-#else
         BasicTypes(BasicTypes&&) = default;
-#endif
         
         explicit
         BasicTypes(const arena& allocator)
@@ -100,17 +79,9 @@ namespace nsmapped
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes& operator=(BasicTypes other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         BasicTypes& operator=(const BasicTypes&) = default;
         BasicTypes& operator=(BasicTypes&&) = default;
-#endif
 
         bool operator==(const BasicTypes& other) const
         {

--- a/compiler/tests/generated/type_aliases/basic_types_types.h
+++ b/compiler/tests/generated/type_aliases/basic_types_types.h
@@ -38,9 +38,8 @@ namespace tests
         float _float;
         ::bond::blob _blob;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        BasicTypes(_bond_vc12_ctor_workaround_ = {})
+        BasicTypes()
           : _bool(),
             _uint64(),
             _uint16(),
@@ -59,27 +58,7 @@ namespace tests
         // Compiler generated copy ctor OK
         BasicTypes(const BasicTypes&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes(BasicTypes&& other)
-          : _bool(std::move(other._bool)),
-            _str(std::move(other._str)),
-            _wstr(std::move(other._wstr)),
-            _uint64(std::move(other._uint64)),
-            _uint16(std::move(other._uint16)),
-            _uint32(std::move(other._uint32)),
-            _uint8(std::move(other._uint8)),
-            _int8(std::move(other._int8)),
-            _int16(std::move(other._int16)),
-            _int32(std::move(other._int32)),
-            _int64(std::move(other._int64)),
-            _double(std::move(other._double)),
-            _float(std::move(other._float)),
-            _blob(std::move(other._blob))
-        {
-        }
-#else
         BasicTypes(BasicTypes&&) = default;
-#endif
         
         explicit
         BasicTypes(const arena& allocator)
@@ -100,17 +79,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        BasicTypes& operator=(BasicTypes other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         BasicTypes& operator=(const BasicTypes&) = default;
         BasicTypes& operator=(BasicTypes&&) = default;
-#endif
 
         bool operator==(const BasicTypes& other) const
         {

--- a/compiler/tests/generated/type_aliases/bond_meta_types.h
+++ b/compiler/tests/generated/type_aliases/bond_meta_types.h
@@ -28,9 +28,8 @@ namespace bondmeta
         std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > full_name;
         std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<arena>::template rebind_alloc<char> > name;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        HasMetaFields(_bond_vc12_ctor_workaround_ = {})
+        HasMetaFields()
         {
             InitMetadata("HasMetaFields", "deprecated.bondmeta.HasMetaFields");
         }

--- a/compiler/tests/generated/type_aliases/complex_types_types.h
+++ b/compiler/tests/generated/type_aliases/complex_types_types.h
@@ -34,13 +34,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&&)
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena&)
@@ -48,17 +42,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo&) const
         {
@@ -103,9 +89,8 @@ namespace tests
         ::bond::bonded< ::tests::Foo> bfoo;
         std::map<double, std::list<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, typename std::allocator_traits<arena>::template rebind_alloc< ::bond::nullable< ::bond::bonded< ::tests::Bar> > > >, typename std::allocator_traits<arena>::template rebind_alloc<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, typename std::allocator_traits<arena>::template rebind_alloc< ::bond::nullable< ::bond::bonded< ::tests::Bar> > > > > >, std::less<double>, typename std::allocator_traits<arena>::template rebind_alloc<std::pair<const double, std::list<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, typename std::allocator_traits<arena>::template rebind_alloc< ::bond::nullable< ::bond::bonded< ::tests::Bar> > > >, typename std::allocator_traits<arena>::template rebind_alloc<std::vector< ::bond::nullable< ::bond::bonded< ::tests::Bar> >, typename std::allocator_traits<arena>::template rebind_alloc< ::bond::nullable< ::bond::bonded< ::tests::Bar> > > > > > > > > m;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        ComplexTypes(_bond_vc12_ctor_workaround_ = {})
+        ComplexTypes()
         {
         }
 
@@ -113,20 +98,7 @@ namespace tests
         // Compiler generated copy ctor OK
         ComplexTypes(const ComplexTypes&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        ComplexTypes(ComplexTypes&& other)
-          : li8(std::move(other.li8)),
-            sb(std::move(other.sb)),
-            vb(std::move(other.vb)),
-            nf(std::move(other.nf)),
-            msws(std::move(other.msws)),
-            bfoo(std::move(other.bfoo)),
-            m(std::move(other.m))
-        {
-        }
-#else
         ComplexTypes(ComplexTypes&&) = default;
-#endif
         
         explicit
         ComplexTypes(const arena& allocator)
@@ -140,17 +112,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        ComplexTypes& operator=(ComplexTypes other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         ComplexTypes& operator=(const ComplexTypes&) = default;
         ComplexTypes& operator=(ComplexTypes&&) = default;
-#endif
 
         bool operator==(const ComplexTypes& other) const
         {

--- a/compiler/tests/generated/type_aliases/custom_alias_with_allocator_types.h
+++ b/compiler/tests/generated/type_aliases/custom_alias_with_allocator_types.h
@@ -52,9 +52,8 @@ namespace test
         ::bond::maybe< ::test::String> st1;
         ::test::NestedAliases na;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        foo(_bond_vc12_ctor_workaround_ = {})
+        foo()
           : l(),
             v(),
             s(),
@@ -69,25 +68,7 @@ namespace test
         // Compiler generated copy ctor OK
         foo(const foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo(foo&& other)
-          : l(std::move(other.l)),
-            v(std::move(other.v)),
-            s(std::move(other.s)),
-            m(std::move(other.m)),
-            st(std::move(other.st)),
-            d(std::move(other.d)),
-            l1(std::move(other.l1)),
-            v1(std::move(other.v1)),
-            s1(std::move(other.s1)),
-            m1(std::move(other.m1)),
-            st1(std::move(other.st1)),
-            na(std::move(other.na))
-        {
-        }
-#else
         foo(foo&&) = default;
-#endif
         
         explicit
         foo(const arena& allocator)
@@ -107,17 +88,9 @@ namespace test
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo& operator=(foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         foo& operator=(const foo&) = default;
         foo& operator=(foo&&) = default;
-#endif
 
         bool operator==(const foo& other) const
         {

--- a/compiler/tests/generated/type_aliases/custom_alias_without_allocator_types.h
+++ b/compiler/tests/generated/type_aliases/custom_alias_without_allocator_types.h
@@ -67,25 +67,7 @@ namespace test
         // Compiler generated copy ctor OK
         foo(const foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo(foo&& other)
-          : l(std::move(other.l)),
-            v(std::move(other.v)),
-            s(std::move(other.s)),
-            m(std::move(other.m)),
-            st(std::move(other.st)),
-            d(std::move(other.d)),
-            l1(std::move(other.l1)),
-            v1(std::move(other.v1)),
-            s1(std::move(other.s1)),
-            m1(std::move(other.m1)),
-            st1(std::move(other.st1)),
-            na(std::move(other.na))
-        {
-        }
-#else
         foo(foo&&) = default;
-#endif
         
         explicit
         foo(const arena&)
@@ -105,17 +87,9 @@ namespace test
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        foo& operator=(foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         foo& operator=(const foo&) = default;
         foo& operator=(foo&&) = default;
-#endif
 
         bool operator==(const foo& other) const
         {

--- a/compiler/tests/generated/type_aliases/defaults_types.cpp
+++ b/compiler/tests/generated/type_aliases/defaults_types.cpp
@@ -10,41 +10,6 @@ namespace tests
     {
     namespace EnumType1
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
-            {
-                { "EnumValue1", EnumValue1 },
-                { "EnumValue2", EnumValue2 },
-                { "EnumValue3", EnumValue3 },
-                { "EnumValue4", EnumValue4 },
-                { "EnumValue5", EnumValue5 },
-                { "EnumValue6", EnumValue6 },
-                { "HexNeg", HexNeg },
-                { "Int32Max", Int32Max },
-                { "Int32Min", Int32Min },
-                { "Low", Low },
-                { "OctNeg", OctNeg },
-                { "UInt32Max", UInt32Max },
-                { "UInt32Min", UInt32Min }
-            };
-
-        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
-            {
-                { Int32Min, "Int32Min" },
-                { HexNeg, "HexNeg" },
-                { OctNeg, "OctNeg" },
-                { EnumValue3, "EnumValue3" },
-                { EnumValue5, "EnumValue5" },
-                { UInt32Min, "UInt32Min" },
-                { Low, "Low" },
-                { EnumValue1, "EnumValue1" },
-                { EnumValue2, "EnumValue2" },
-                { EnumValue4, "EnumValue4" },
-                { Int32Max, "Int32Max" },
-                { EnumValue6, "EnumValue6" },
-                { UInt32Max, "UInt32Max" }
-            };
-#else
         namespace
         {
             struct _hash_EnumType1
@@ -55,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -79,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum EnumType1& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum EnumType1> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -96,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/type_aliases/defaults_types.h
+++ b/compiler/tests/generated/type_aliases/defaults_types.h
@@ -25,19 +25,19 @@ namespace tests
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<std::int32_t>(5),
-            EnumValue2 = static_cast<std::int32_t>(10),
-            EnumValue3 = static_cast<std::int32_t>(-10),
-            EnumValue4 = static_cast<std::int32_t>(42),
-            Low = static_cast<std::int32_t>(1),
-            EnumValue5 = static_cast<std::int32_t>(-10),
-            EnumValue6 = static_cast<std::int32_t>(4294967286),
-            Int32Min = static_cast<std::int32_t>(-2147483647-1),
-            Int32Max = static_cast<std::int32_t>(2147483647),
-            UInt32Min = static_cast<std::int32_t>(0),
-            UInt32Max = static_cast<std::int32_t>(4294967295),
-            HexNeg = static_cast<std::int32_t>(-255),
-            OctNeg = static_cast<std::int32_t>(-83)
+            EnumValue1 = static_cast<int32_t>(5),
+            EnumValue2 = static_cast<int32_t>(10),
+            EnumValue3 = static_cast<int32_t>(-10),
+            EnumValue4 = static_cast<int32_t>(42),
+            Low = static_cast<int32_t>(1),
+            EnumValue5 = static_cast<int32_t>(-10),
+            EnumValue6 = static_cast<int32_t>(4294967286),
+            Int32Min = static_cast<int32_t>(-2147483647-1),
+            Int32Max = static_cast<int32_t>(2147483647),
+            UInt32Min = static_cast<int32_t>(0),
+            UInt32Max = static_cast<int32_t>(4294967295),
+            HexNeg = static_cast<int32_t>(-255),
+            OctNeg = static_cast<int32_t>(-83)
         };
         
         inline BOND_CONSTEXPR const char* GetTypeName(enum EnumType1)

--- a/compiler/tests/generated/type_aliases/defaults_types.h
+++ b/compiler/tests/generated/type_aliases/defaults_types.h
@@ -25,19 +25,19 @@ namespace tests
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<int32_t>(5),
-            EnumValue2 = static_cast<int32_t>(10),
-            EnumValue3 = static_cast<int32_t>(-10),
-            EnumValue4 = static_cast<int32_t>(42),
-            Low = static_cast<int32_t>(1),
-            EnumValue5 = static_cast<int32_t>(-10),
-            EnumValue6 = static_cast<int32_t>(4294967286),
-            Int32Min = static_cast<int32_t>(-2147483647-1),
-            Int32Max = static_cast<int32_t>(2147483647),
-            UInt32Min = static_cast<int32_t>(0),
-            UInt32Max = static_cast<int32_t>(4294967295),
-            HexNeg = static_cast<int32_t>(-255),
-            OctNeg = static_cast<int32_t>(-83)
+            EnumValue1 = static_cast<std::int32_t>(5),
+            EnumValue2 = static_cast<std::int32_t>(10),
+            EnumValue3 = static_cast<std::int32_t>(-10),
+            EnumValue4 = static_cast<std::int32_t>(42),
+            Low = static_cast<std::int32_t>(1),
+            EnumValue5 = static_cast<std::int32_t>(-10),
+            EnumValue6 = static_cast<std::int32_t>(4294967286),
+            Int32Min = static_cast<std::int32_t>(-2147483647-1),
+            Int32Max = static_cast<std::int32_t>(2147483647),
+            UInt32Min = static_cast<std::int32_t>(0),
+            UInt32Max = static_cast<std::int32_t>(4294967295),
+            HexNeg = static_cast<std::int32_t>(-255),
+            OctNeg = static_cast<std::int32_t>(-83)
         };
         
         inline BOND_CONSTEXPR const char* GetTypeName(enum EnumType1)
@@ -50,21 +50,7 @@ namespace tests
             return "tests.EnumType1";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum EnumType1, std::string> _value_to_name_EnumType1;
 
-        inline const std::map<enum EnumType1, std::string>& GetValueToNameMap(enum EnumType1)
-        {
-            return _value_to_name_EnumType1;
-        }
-
-        extern const std::map<std::string, enum EnumType1> _name_to_value_EnumType1;
-
-        inline const std::map<std::string, enum EnumType1>& GetNameToValueMap(enum EnumType1)
-        {
-            return _name_to_value_EnumType1;
-        }
-#else
         template <typename Map = std::map<enum EnumType1, std::string> >
         inline const Map& GetValueToNameMap(enum EnumType1, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -108,7 +94,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum EnumType1 value);
 
         void FromString(const std::string& name, enum EnumType1& value);
@@ -167,9 +152,8 @@ namespace tests
         int64_t m_int64_neg_hex;
         int64_t m_int64_neg_oct;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
           : m_bool_1(true),
             m_bool_2(false),
             m_str_1("default string value"),
@@ -201,51 +185,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : m_bool_1(std::move(other.m_bool_1)),
-            m_bool_2(std::move(other.m_bool_2)),
-            m_bool_3(std::move(other.m_bool_3)),
-            m_str_1(std::move(other.m_str_1)),
-            m_str_2(std::move(other.m_str_2)),
-            m_int8_4(std::move(other.m_int8_4)),
-            m_int8_5(std::move(other.m_int8_5)),
-            m_int16_4(std::move(other.m_int16_4)),
-            m_int16_5(std::move(other.m_int16_5)),
-            m_int32_4(std::move(other.m_int32_4)),
-            m_int32_max(std::move(other.m_int32_max)),
-            m_int64_4(std::move(other.m_int64_4)),
-            m_int64_max(std::move(other.m_int64_max)),
-            m_uint8_2(std::move(other.m_uint8_2)),
-            m_uint8_3(std::move(other.m_uint8_3)),
-            m_uint16_2(std::move(other.m_uint16_2)),
-            m_uint16_3(std::move(other.m_uint16_3)),
-            m_uint32_3(std::move(other.m_uint32_3)),
-            m_uint32_max(std::move(other.m_uint32_max)),
-            m_uint64_3(std::move(other.m_uint64_3)),
-            m_uint64_max(std::move(other.m_uint64_max)),
-            m_double_3(std::move(other.m_double_3)),
-            m_double_4(std::move(other.m_double_4)),
-            m_double_5(std::move(other.m_double_5)),
-            m_float_3(std::move(other.m_float_3)),
-            m_float_4(std::move(other.m_float_4)),
-            m_float_7(std::move(other.m_float_7)),
-            m_enum1(std::move(other.m_enum1)),
-            m_enum2(std::move(other.m_enum2)),
-            m_enum3(std::move(other.m_enum3)),
-            m_enum_int32min(std::move(other.m_enum_int32min)),
-            m_enum_int32max(std::move(other.m_enum_int32max)),
-            m_enum_uint32_min(std::move(other.m_enum_uint32_min)),
-            m_enum_uint32_max(std::move(other.m_enum_uint32_max)),
-            m_wstr_1(std::move(other.m_wstr_1)),
-            m_wstr_2(std::move(other.m_wstr_2)),
-            m_int64_neg_hex(std::move(other.m_int64_neg_hex)),
-            m_int64_neg_oct(std::move(other.m_int64_neg_oct))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -291,17 +231,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/type_aliases/field_modifiers_types.h
+++ b/compiler/tests/generated/type_aliases/field_modifiers_types.h
@@ -38,16 +38,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : o(std::move(other.o)),
-            r(std::move(other.r)),
-            ro(std::move(other.ro))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena&)
@@ -58,17 +49,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/type_aliases/generics_types.h
+++ b/compiler/tests/generated/type_aliases/generics_types.h
@@ -27,9 +27,8 @@ namespace tests
         T2 t2;
         ::bond::nullable< ::tests::Foo<T1, bool> > n;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
           : t2()
         {
         }
@@ -38,15 +37,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : t2(std::move(other.t2)),
-            n(std::move(other.n))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -56,17 +47,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/type_aliases/import_types.h
+++ b/compiler/tests/generated/type_aliases/import_types.h
@@ -26,9 +26,8 @@ namespace import_test
 
         ::empty::Empty e;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        HasEmpty(_bond_vc12_ctor_workaround_ = {})
+        HasEmpty()
         {
         }
 
@@ -36,14 +35,7 @@ namespace import_test
         // Compiler generated copy ctor OK
         HasEmpty(const HasEmpty&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        HasEmpty(HasEmpty&& other)
-          : e(std::move(other.e))
-        {
-        }
-#else
         HasEmpty(HasEmpty&&) = default;
-#endif
         
         explicit
         HasEmpty(const arena& allocator)
@@ -52,17 +44,9 @@ namespace import_test
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        HasEmpty& operator=(HasEmpty other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         HasEmpty& operator=(const HasEmpty&) = default;
         HasEmpty& operator=(HasEmpty&&) = default;
-#endif
 
         bool operator==(const HasEmpty& other) const
         {

--- a/compiler/tests/generated/type_aliases/inheritance_types.h
+++ b/compiler/tests/generated/type_aliases/inheritance_types.h
@@ -34,14 +34,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Base(const Base&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Base(Base&& other)
-          : x(std::move(other.x))
-        {
-        }
-#else
         Base(Base&&) = default;
-#endif
         
         explicit
         Base(const arena&)
@@ -50,17 +43,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Base& operator=(Base other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Base& operator=(const Base&) = default;
         Base& operator=(Base&&) = default;
-#endif
 
         bool operator==(const Base& other) const
         {
@@ -100,9 +85,8 @@ namespace tests
 
         int32_t x;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
           : x()
         {
         }
@@ -111,15 +95,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : ::tests::Base(std::move(other)),
-            x(std::move(other.x))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -129,17 +105,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/type_aliases/maybe_blob_types.h
+++ b/compiler/tests/generated/type_aliases/maybe_blob_types.h
@@ -33,14 +33,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : b(std::move(other.b))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena&)
@@ -48,17 +41,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/type_aliases/with_enum_header_enum.h
+++ b/compiler/tests/generated/type_aliases/with_enum_header_enum.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 
 namespace tests
 {
@@ -12,17 +12,17 @@ namespace _bond_enumerators
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<std::int32_t>(5),
-            EnumValue2 = static_cast<std::int32_t>(10),
-            EnumValue3 = static_cast<std::int32_t>(-10),
-            EnumValue4 = static_cast<std::int32_t>(42),
-            Low = static_cast<std::int32_t>(1),
-            EnumValue5 = static_cast<std::int32_t>(-10),
-            EnumValue6 = static_cast<std::int32_t>(4294967286),
-            Int32Min = static_cast<std::int32_t>(-2147483647-1),
-            Int32Max = static_cast<std::int32_t>(2147483647),
-            UInt32Min = static_cast<std::int32_t>(0),
-            UInt32Max = static_cast<std::int32_t>(4294967295)
+            EnumValue1 = static_cast<int32_t>(5),
+            EnumValue2 = static_cast<int32_t>(10),
+            EnumValue3 = static_cast<int32_t>(-10),
+            EnumValue4 = static_cast<int32_t>(42),
+            Low = static_cast<int32_t>(1),
+            EnumValue5 = static_cast<int32_t>(-10),
+            EnumValue6 = static_cast<int32_t>(4294967286),
+            Int32Min = static_cast<int32_t>(-2147483647-1),
+            Int32Max = static_cast<int32_t>(2147483647),
+            UInt32Min = static_cast<int32_t>(0),
+            UInt32Max = static_cast<int32_t>(4294967295)
         };
     } // namespace EnumType1
 

--- a/compiler/tests/generated/type_aliases/with_enum_header_enum.h
+++ b/compiler/tests/generated/type_aliases/with_enum_header_enum.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace tests
 {
@@ -12,17 +12,17 @@ namespace _bond_enumerators
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<int32_t>(5),
-            EnumValue2 = static_cast<int32_t>(10),
-            EnumValue3 = static_cast<int32_t>(-10),
-            EnumValue4 = static_cast<int32_t>(42),
-            Low = static_cast<int32_t>(1),
-            EnumValue5 = static_cast<int32_t>(-10),
-            EnumValue6 = static_cast<int32_t>(4294967286),
-            Int32Min = static_cast<int32_t>(-2147483647-1),
-            Int32Max = static_cast<int32_t>(2147483647),
-            UInt32Min = static_cast<int32_t>(0),
-            UInt32Max = static_cast<int32_t>(4294967295)
+            EnumValue1 = static_cast<std::int32_t>(5),
+            EnumValue2 = static_cast<std::int32_t>(10),
+            EnumValue3 = static_cast<std::int32_t>(-10),
+            EnumValue4 = static_cast<std::int32_t>(42),
+            Low = static_cast<std::int32_t>(1),
+            EnumValue5 = static_cast<std::int32_t>(-10),
+            EnumValue6 = static_cast<std::int32_t>(4294967286),
+            Int32Min = static_cast<std::int32_t>(-2147483647-1),
+            Int32Max = static_cast<std::int32_t>(2147483647),
+            UInt32Min = static_cast<std::int32_t>(0),
+            UInt32Max = static_cast<std::int32_t>(4294967295)
         };
     } // namespace EnumType1
 

--- a/compiler/tests/generated/type_aliases/with_enum_header_types.cpp
+++ b/compiler/tests/generated/type_aliases/with_enum_header_types.cpp
@@ -10,37 +10,6 @@ namespace tests
     {
     namespace EnumType1
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
-            {
-                { "EnumValue1", EnumValue1 },
-                { "EnumValue2", EnumValue2 },
-                { "EnumValue3", EnumValue3 },
-                { "EnumValue4", EnumValue4 },
-                { "EnumValue5", EnumValue5 },
-                { "EnumValue6", EnumValue6 },
-                { "Int32Max", Int32Max },
-                { "Int32Min", Int32Min },
-                { "Low", Low },
-                { "UInt32Max", UInt32Max },
-                { "UInt32Min", UInt32Min }
-            };
-
-        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
-            {
-                { Int32Min, "Int32Min" },
-                { EnumValue3, "EnumValue3" },
-                { EnumValue5, "EnumValue5" },
-                { UInt32Min, "UInt32Min" },
-                { Low, "Low" },
-                { EnumValue1, "EnumValue1" },
-                { EnumValue2, "EnumValue2" },
-                { EnumValue4, "EnumValue4" },
-                { Int32Max, "Int32Max" },
-                { EnumValue6, "EnumValue6" },
-                { UInt32Max, "UInt32Max" }
-            };
-#else
         namespace
         {
             struct _hash_EnumType1
@@ -51,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -75,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum EnumType1& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum EnumType1> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -92,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/type_aliases/with_enum_header_types.h
+++ b/compiler/tests/generated/type_aliases/with_enum_header_types.h
@@ -34,21 +34,7 @@ namespace tests
             return "tests.EnumType1";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum EnumType1, std::string> _value_to_name_EnumType1;
 
-        inline const std::map<enum EnumType1, std::string>& GetValueToNameMap(enum EnumType1)
-        {
-            return _value_to_name_EnumType1;
-        }
-
-        extern const std::map<std::string, enum EnumType1> _name_to_value_EnumType1;
-
-        inline const std::map<std::string, enum EnumType1>& GetNameToValueMap(enum EnumType1)
-        {
-            return _name_to_value_EnumType1;
-        }
-#else
         template <typename Map = std::map<enum EnumType1, std::string> >
         inline const Map& GetValueToNameMap(enum EnumType1, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -88,7 +74,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum EnumType1 value);
 
         void FromString(const std::string& name, enum EnumType1& value);
@@ -144,9 +129,8 @@ namespace tests
         std::basic_string<wchar_t, std::char_traits<wchar_t>, typename std::allocator_traits<arena>::template rebind_alloc<wchar_t> > m_wstr_1;
         ::bond::maybe<std::basic_string<wchar_t, std::char_traits<wchar_t>, typename std::allocator_traits<arena>::template rebind_alloc<wchar_t> > > m_wstr_2;
         
-        struct _bond_vc12_ctor_workaround_ {};
         template <int = 0> // Workaround to avoid compilation if not used
-        Foo(_bond_vc12_ctor_workaround_ = {})
+        Foo()
           : m_bool_1(true),
             m_bool_2(false),
             m_str_1("default string value"),
@@ -176,49 +160,7 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : m_bool_1(std::move(other.m_bool_1)),
-            m_bool_2(std::move(other.m_bool_2)),
-            m_bool_3(std::move(other.m_bool_3)),
-            m_str_1(std::move(other.m_str_1)),
-            m_str_2(std::move(other.m_str_2)),
-            m_int8_4(std::move(other.m_int8_4)),
-            m_int8_5(std::move(other.m_int8_5)),
-            m_int16_4(std::move(other.m_int16_4)),
-            m_int16_5(std::move(other.m_int16_5)),
-            m_int32_4(std::move(other.m_int32_4)),
-            m_int32_max(std::move(other.m_int32_max)),
-            m_int64_4(std::move(other.m_int64_4)),
-            m_int64_max(std::move(other.m_int64_max)),
-            m_uint8_2(std::move(other.m_uint8_2)),
-            m_uint8_3(std::move(other.m_uint8_3)),
-            m_uint16_2(std::move(other.m_uint16_2)),
-            m_uint16_3(std::move(other.m_uint16_3)),
-            m_uint32_3(std::move(other.m_uint32_3)),
-            m_uint32_max(std::move(other.m_uint32_max)),
-            m_uint64_3(std::move(other.m_uint64_3)),
-            m_uint64_max(std::move(other.m_uint64_max)),
-            m_double_3(std::move(other.m_double_3)),
-            m_double_4(std::move(other.m_double_4)),
-            m_double_5(std::move(other.m_double_5)),
-            m_float_3(std::move(other.m_float_3)),
-            m_float_4(std::move(other.m_float_4)),
-            m_float_7(std::move(other.m_float_7)),
-            m_enum1(std::move(other.m_enum1)),
-            m_enum2(std::move(other.m_enum2)),
-            m_enum3(std::move(other.m_enum3)),
-            m_enum_int32min(std::move(other.m_enum_int32min)),
-            m_enum_int32max(std::move(other.m_enum_int32max)),
-            m_enum_uint32_min(std::move(other.m_enum_uint32_min)),
-            m_enum_uint32_max(std::move(other.m_enum_uint32_max)),
-            m_wstr_1(std::move(other.m_wstr_1)),
-            m_wstr_2(std::move(other.m_wstr_2))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         explicit
         Foo(const arena& allocator)
@@ -262,17 +204,9 @@ namespace tests
         }
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {

--- a/compiler/tests/generated/with_enum_header_enum.h
+++ b/compiler/tests/generated/with_enum_header_enum.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 
 namespace tests
 {
@@ -12,17 +12,17 @@ namespace _bond_enumerators
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<std::int32_t>(5),
-            EnumValue2 = static_cast<std::int32_t>(10),
-            EnumValue3 = static_cast<std::int32_t>(-10),
-            EnumValue4 = static_cast<std::int32_t>(42),
-            Low = static_cast<std::int32_t>(1),
-            EnumValue5 = static_cast<std::int32_t>(-10),
-            EnumValue6 = static_cast<std::int32_t>(4294967286),
-            Int32Min = static_cast<std::int32_t>(-2147483647-1),
-            Int32Max = static_cast<std::int32_t>(2147483647),
-            UInt32Min = static_cast<std::int32_t>(0),
-            UInt32Max = static_cast<std::int32_t>(4294967295)
+            EnumValue1 = static_cast<int32_t>(5),
+            EnumValue2 = static_cast<int32_t>(10),
+            EnumValue3 = static_cast<int32_t>(-10),
+            EnumValue4 = static_cast<int32_t>(42),
+            Low = static_cast<int32_t>(1),
+            EnumValue5 = static_cast<int32_t>(-10),
+            EnumValue6 = static_cast<int32_t>(4294967286),
+            Int32Min = static_cast<int32_t>(-2147483647-1),
+            Int32Max = static_cast<int32_t>(2147483647),
+            UInt32Min = static_cast<int32_t>(0),
+            UInt32Max = static_cast<int32_t>(4294967295)
         };
     } // namespace EnumType1
 

--- a/compiler/tests/generated/with_enum_header_enum.h
+++ b/compiler/tests/generated/with_enum_header_enum.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace tests
 {
@@ -12,17 +12,17 @@ namespace _bond_enumerators
     {
         enum EnumType1
         {
-            EnumValue1 = static_cast<int32_t>(5),
-            EnumValue2 = static_cast<int32_t>(10),
-            EnumValue3 = static_cast<int32_t>(-10),
-            EnumValue4 = static_cast<int32_t>(42),
-            Low = static_cast<int32_t>(1),
-            EnumValue5 = static_cast<int32_t>(-10),
-            EnumValue6 = static_cast<int32_t>(4294967286),
-            Int32Min = static_cast<int32_t>(-2147483647-1),
-            Int32Max = static_cast<int32_t>(2147483647),
-            UInt32Min = static_cast<int32_t>(0),
-            UInt32Max = static_cast<int32_t>(4294967295)
+            EnumValue1 = static_cast<std::int32_t>(5),
+            EnumValue2 = static_cast<std::int32_t>(10),
+            EnumValue3 = static_cast<std::int32_t>(-10),
+            EnumValue4 = static_cast<std::int32_t>(42),
+            Low = static_cast<std::int32_t>(1),
+            EnumValue5 = static_cast<std::int32_t>(-10),
+            EnumValue6 = static_cast<std::int32_t>(4294967286),
+            Int32Min = static_cast<std::int32_t>(-2147483647-1),
+            Int32Max = static_cast<std::int32_t>(2147483647),
+            UInt32Min = static_cast<std::int32_t>(0),
+            UInt32Max = static_cast<std::int32_t>(4294967295)
         };
     } // namespace EnumType1
 

--- a/compiler/tests/generated/with_enum_header_types.cpp
+++ b/compiler/tests/generated/with_enum_header_types.cpp
@@ -10,37 +10,6 @@ namespace tests
     {
     namespace EnumType1
     {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-        const std::map<std::string, enum EnumType1> _name_to_value_EnumType1
-            {
-                { "EnumValue1", EnumValue1 },
-                { "EnumValue2", EnumValue2 },
-                { "EnumValue3", EnumValue3 },
-                { "EnumValue4", EnumValue4 },
-                { "EnumValue5", EnumValue5 },
-                { "EnumValue6", EnumValue6 },
-                { "Int32Max", Int32Max },
-                { "Int32Min", Int32Min },
-                { "Low", Low },
-                { "UInt32Max", UInt32Max },
-                { "UInt32Min", UInt32Min }
-            };
-
-        const std::map<enum EnumType1, std::string> _value_to_name_EnumType1
-            {
-                { Int32Min, "Int32Min" },
-                { EnumValue3, "EnumValue3" },
-                { EnumValue5, "EnumValue5" },
-                { UInt32Min, "UInt32Min" },
-                { Low, "Low" },
-                { EnumValue1, "EnumValue1" },
-                { EnumValue2, "EnumValue2" },
-                { EnumValue4, "EnumValue4" },
-                { Int32Max, "Int32Max" },
-                { EnumValue6, "EnumValue6" },
-                { UInt32Max, "UInt32Max" }
-            };
-#else
         namespace
         {
             struct _hash_EnumType1
@@ -51,14 +20,9 @@ namespace tests
                 }
             };
         }
-#endif
         const std::string& ToString(enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)
@@ -75,11 +39,7 @@ namespace tests
 
         bool ToEnum(enum EnumType1& value, const std::string& name)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetNameToValueMap(value);
-#else
             const auto& map = GetNameToValueMap<std::unordered_map<std::string, enum EnumType1> >(value);
-#endif
             auto it = map.find(name);
 
             if (map.end() == it)
@@ -92,11 +52,7 @@ namespace tests
 
         bool FromEnum(std::string& name, enum EnumType1 value)
         {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-            const auto& map = GetValueToNameMap(value);
-#else
             const auto& map = GetValueToNameMap<std::unordered_map<enum EnumType1, std::string, _hash_EnumType1> >(value);
-#endif
             auto it = map.find(value);
 
             if (map.end() == it)

--- a/compiler/tests/generated/with_enum_header_types.h
+++ b/compiler/tests/generated/with_enum_header_types.h
@@ -34,21 +34,7 @@ namespace tests
             return "tests.EnumType1";
         }
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900) // Versions of MSVC prior to 1900 do not support magic statics
-        extern const std::map<enum EnumType1, std::string> _value_to_name_EnumType1;
 
-        inline const std::map<enum EnumType1, std::string>& GetValueToNameMap(enum EnumType1)
-        {
-            return _value_to_name_EnumType1;
-        }
-
-        extern const std::map<std::string, enum EnumType1> _name_to_value_EnumType1;
-
-        inline const std::map<std::string, enum EnumType1>& GetNameToValueMap(enum EnumType1)
-        {
-            return _name_to_value_EnumType1;
-        }
-#else
         template <typename Map = std::map<enum EnumType1, std::string> >
         inline const Map& GetValueToNameMap(enum EnumType1, ::bond::detail::mpl::identity<Map> = {})
         {
@@ -88,7 +74,6 @@ namespace tests
                 };
             return s_nameToValueMap;
         }
-#endif
         const std::string& ToString(enum EnumType1 value);
 
         void FromString(const std::string& name, enum EnumType1& value);
@@ -172,62 +157,12 @@ namespace tests
         // Compiler generated copy ctor OK
         Foo(const Foo&) = default;
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo(Foo&& other)
-          : m_bool_1(std::move(other.m_bool_1)),
-            m_bool_2(std::move(other.m_bool_2)),
-            m_bool_3(std::move(other.m_bool_3)),
-            m_str_1(std::move(other.m_str_1)),
-            m_str_2(std::move(other.m_str_2)),
-            m_int8_4(std::move(other.m_int8_4)),
-            m_int8_5(std::move(other.m_int8_5)),
-            m_int16_4(std::move(other.m_int16_4)),
-            m_int16_5(std::move(other.m_int16_5)),
-            m_int32_4(std::move(other.m_int32_4)),
-            m_int32_max(std::move(other.m_int32_max)),
-            m_int64_4(std::move(other.m_int64_4)),
-            m_int64_max(std::move(other.m_int64_max)),
-            m_uint8_2(std::move(other.m_uint8_2)),
-            m_uint8_3(std::move(other.m_uint8_3)),
-            m_uint16_2(std::move(other.m_uint16_2)),
-            m_uint16_3(std::move(other.m_uint16_3)),
-            m_uint32_3(std::move(other.m_uint32_3)),
-            m_uint32_max(std::move(other.m_uint32_max)),
-            m_uint64_3(std::move(other.m_uint64_3)),
-            m_uint64_max(std::move(other.m_uint64_max)),
-            m_double_3(std::move(other.m_double_3)),
-            m_double_4(std::move(other.m_double_4)),
-            m_double_5(std::move(other.m_double_5)),
-            m_float_3(std::move(other.m_float_3)),
-            m_float_4(std::move(other.m_float_4)),
-            m_float_7(std::move(other.m_float_7)),
-            m_enum1(std::move(other.m_enum1)),
-            m_enum2(std::move(other.m_enum2)),
-            m_enum3(std::move(other.m_enum3)),
-            m_enum_int32min(std::move(other.m_enum_int32min)),
-            m_enum_int32max(std::move(other.m_enum_int32max)),
-            m_enum_uint32_min(std::move(other.m_enum_uint32_min)),
-            m_enum_uint32_max(std::move(other.m_enum_uint32_max)),
-            m_wstr_1(std::move(other.m_wstr_1)),
-            m_wstr_2(std::move(other.m_wstr_2))
-        {
-        }
-#else
         Foo(Foo&&) = default;
-#endif
         
         
-#if defined(_MSC_VER) && (_MSC_VER < 1900)  // Versions of MSVC prior to 1900 do not support = default for move ctors
-        Foo& operator=(Foo other)
-        {
-            other.swap(*this);
-            return *this;
-        }
-#else
         // Compiler generated operator= OK
         Foo& operator=(const Foo&) = default;
         Foo& operator=(Foo&&) = default;
-#endif
 
         bool operator==(const Foo& other) const
         {


### PR DESCRIPTION
Clean up MSVC 2013 conditional code in C++ codegen. Also change the gbc
tests as per the codegen. To generate the tests:
> cd compiler
>  stack test :gbc-tests --test-arguments --accept

Note that this PR can only be merged after #1030 is merged.