### PR TITLE
Use non-deprecated bind/bind.hpp header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ different versioning scheme, following the Haskell community's
   declare members other than non-static data members, member enumerations,
   or member classes. ([Issue
   #1027](https://github.com/microsoft/bond/issues/1027))
+* Fixed Boost 1.73 warning "The practice of declaring the Bind placeholders
+  (_1, _2, ...) in the global namespace is deprecated." ([Pull request
+  #1036](https://github.com/microsoft/bond/pull/1036))
 
 ### C# ###
 

--- a/cpp/inc/bond/core/schema.h
+++ b/cpp/inc/bond/core/schema.h
@@ -10,7 +10,7 @@
 #include "reflection.h"
 #include "runtime_schema.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/make_shared.hpp>
 
 #include <limits>

--- a/cpp/test/compat/core/serialization.cpp
+++ b/cpp/test/compat/core/serialization.cpp
@@ -231,7 +231,7 @@ void Init(Test test, Compat& obj)
 
     // Erase field m_defaults
     fields.erase(
-        std::remove_if(fields.begin(), fields.end(), boost::bind<bool>(FieldIdEqual(), Compat::Schema::var::m_defaults::id, _1)),
+        std::remove_if(fields.begin(), fields.end(), boost::bind<bool>(FieldIdEqual(), Compat::Schema::var::m_defaults::id, boost::placeholders::_1)),
         fields.end());
 
     {

--- a/cpp/test/compat/core/serialization.cpp
+++ b/cpp/test/compat/core/serialization.cpp
@@ -7,7 +7,7 @@
 #include <bond/stream/output_buffer.h>
 #include <bond/protocol/simple_json_writer.h>
 #include <bond/protocol/random_protocol.h>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/assign/list_of.hpp>
 #include <climits>
 

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -24,7 +24,7 @@ void Marshal(uint16_t version = bond::v1)
 
     bond::OutputBuffer output;
     Factory<Writer>::Call(output, version, boost::bind(
-        bond::Marshal<bond::BuiltInProtocols, X, Writer>, obj, _1));
+        bond::Marshal<bond::BuiltInProtocols, X, Writer>, obj, boost::placeholders::_1));
 
     bond::InputBuffer input = output.GetBuffer();
 
@@ -43,7 +43,7 @@ void Serialize(uint16_t version = bond::v1)
 
     bond::OutputBuffer output;
     Factory<Writer>::Call(output, version, boost::bind(
-        bond::Serialize<bond::BuiltInProtocols, X, Writer>, obj, _1));
+        bond::Serialize<bond::BuiltInProtocols, X, Writer>, obj, boost::placeholders::_1));
 
     bond::InputBuffer input = output.GetBuffer();
     Reader reader(Factory<Reader>::Create(input, version));
@@ -69,7 +69,7 @@ void Apply(uint16_t version = bond::v1)
 
     bond::OutputBuffer output;
     Factory<Writer>::Call(output, version, boost::bind(
-        CallApply<bond::Serializer<Writer>, X>, boost::bind(bond::SerializeTo<bond::BuiltInProtocols, Writer>, _1), obj));
+        CallApply<bond::Serializer<Writer>, X>, boost::bind(bond::SerializeTo<bond::BuiltInProtocols, Writer>, boost::placeholders::_1), obj));
 
     bond::InputBuffer input = output.GetBuffer();
     Reader reader(Factory<Reader>::Create(input, version));
@@ -91,7 +91,7 @@ void SimpleApply(uint16_t version = bond::v1)
 
     typename Writer::Buffer output;
     Factory<Writer>::Call(output, version, boost::bind(
-        CallApply<bond::Serializer<Writer>, X>, boost::bind(bond::SerializeTo<bond::BuiltInProtocols, Writer>, _1), obj));
+        CallApply<bond::Serializer<Writer>, X>, boost::bind(bond::SerializeTo<bond::BuiltInProtocols, Writer>, boost::placeholders::_1), obj));
 }
 
 
@@ -114,7 +114,7 @@ Bonded(uint16_t version = bond::v1)
 
     bond::OutputBuffer output;
     Factory<Writer>::Call(output, version, boost::bind(
-        bond::Serialize<bond::BuiltInProtocols, X, Writer>, obj, _1));
+        bond::Serialize<bond::BuiltInProtocols, X, Writer>, obj, boost::placeholders::_1));
 
     bond::InputBuffer input = output.GetBuffer();
     Reader reader(Factory<Reader>::Create(input, version));
@@ -122,7 +122,7 @@ Bonded(uint16_t version = bond::v1)
 
     bond::OutputBuffer output2;
     Factory<Writer>::Call(output2, version, boost::bind(
-        &bond::bonded<X>::template Serialize<bond::BuiltInProtocols, Writer>, bonded, _1));
+        &bond::bonded<X>::template Serialize<bond::BuiltInProtocols, Writer>, bonded, boost::placeholders::_1));
 
     bond::InputBuffer input2 = output2.GetBuffer();
     Reader reader2(Factory<Reader>::Create(input2, version));

--- a/cpp/test/core/exception_tests.cpp
+++ b/cpp/test/core/exception_tests.cpp
@@ -259,7 +259,7 @@ TEST_CASE_BEGIN(TransformException)
     typename Writer::Buffer buffer(4096);
     
     Factory<Writer>::Call(buffer, bond::v1, boost::bind(
-        bond::Serialize<bond::BuiltInProtocols, T, Writer>, InitRandom<T>(2, 2), _1));
+        bond::Serialize<bond::BuiltInProtocols, T, Writer>, InitRandom<T>(2, 2), boost::placeholders::_1));
 
     {
         for (int i = 0;; ++i)

--- a/cpp/test/core/marshal.cpp
+++ b/cpp/test/core/marshal.cpp
@@ -9,7 +9,7 @@ void MarshalingTest(uint16_t version = bond::v1)
     typename Writer::Buffer output_buffer;
     
     Factory<Writer>::Call(output_buffer, version, boost::bind(
-        bond::Marshal<bond::BuiltInProtocols, T, Writer>, from, _1));
+        bond::Marshal<bond::BuiltInProtocols, T, Writer>, from, boost::placeholders::_1));
     
     T to;
     bond::InputBuffer input(output_buffer.GetBuffer());
@@ -38,7 +38,7 @@ void TranscodingTest(uint16_t version = bond::v1)
     typename Writer::Buffer output_buffer;
 
     Factory<Writer>::Call(output_buffer, version, boost::bind(
-        bond::Marshal<bond::BuiltInProtocols, T, Writer>, from, _1));
+        bond::Marshal<bond::BuiltInProtocols, T, Writer>, from, boost::placeholders::_1));
     
     // Trans-marshal to Simple Protocol using runtime schema
     bond::OutputBuffer simple_buffer;
@@ -58,7 +58,7 @@ void TranscodingTest(uint16_t version = bond::v1)
         {
             bond::InputBuffer input(simple_buffer.GetBuffer());
 	    Factory<Writer>::Call(writer_buffer, version, boost::bind(
-                 bond::SelectProtocolAndApply<T, bond::BuiltInProtocols, bond::InputBuffer, bond::Marshaler<Writer> >, input, boost::bind(bond::MarshalTo<bond::BuiltInProtocols, Writer>, _1)));
+                 bond::SelectProtocolAndApply<T, bond::BuiltInProtocols, bond::InputBuffer, bond::Marshaler<Writer> >, input, boost::bind(bond::MarshalTo<bond::BuiltInProtocols, Writer>, boost::placeholders::_1)));
         }
 
         T to;
@@ -76,7 +76,7 @@ void TranscodingTest(uint16_t version = bond::v1)
         {
             bond::InputBuffer input(simple_buffer.GetBuffer());
 	    Factory<Writer>::Call(writer_buffer, version, boost::bind(
-                 bond::SelectProtocolAndApply<bond::BuiltInProtocols, bond::InputBuffer, bond::Marshaler<Writer> >, bond::GetRuntimeSchema<T>(), input, boost::bind(bond::MarshalTo<bond::BuiltInProtocols, Writer>, _1)));
+                 bond::SelectProtocolAndApply<bond::BuiltInProtocols, bond::InputBuffer, bond::Marshaler<Writer> >, bond::GetRuntimeSchema<T>(), input, boost::bind(bond::MarshalTo<bond::BuiltInProtocols, Writer>, boost::placeholders::_1)));
         }
 
         T to;

--- a/cpp/test/core/pass_through.cpp
+++ b/cpp/test/core/pass_through.cpp
@@ -352,7 +352,7 @@ void DefaultValuesTranscodingTest(T to, uint16_t version1 = bond::v1, uint16_t v
     typename Writer2::Buffer output_buffer(4096);
 
     Factory<Writer2>::Call(output_buffer, version2, boost::bind(
-        &bond::bonded<Bonded>::template Serialize<Protocols, Writer2>, bonded1, _1));
+        &bond::bonded<Bonded>::template Serialize<Protocols, Writer2>, bonded1, boost::placeholders::_1));
 
     typename Reader2::Buffer input_buffer(output_buffer.GetBuffer());
     Reader2 input = Factory<Reader2>::Create(input_buffer, version2);

--- a/cpp/test/core/required_fields_tests.cpp
+++ b/cpp/test/core/required_fields_tests.cpp
@@ -111,7 +111,7 @@ TEST_CASE_BEGIN(OptionalToRequired)
     typename Writer::Buffer buffer(1024);
 
     Factory<Writer>::Call(buffer, bond::v1, boost::bind(
-        bond::Serialize<Protocols, From, Writer>, from, _1));
+        bond::Serialize<Protocols, From, Writer>, from, boost::placeholders::_1));
 
     {
         To to;

--- a/cpp/test/core/unit_test_util.h
+++ b/cpp/test/core/unit_test_util.h
@@ -17,7 +17,7 @@ using bond::string_length;
 
 #include <boost/mpl/copy.hpp>
 #include <boost/assign/list_of.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 
 using namespace std;

--- a/cpp/test/core/unit_test_util.h
+++ b/cpp/test/core/unit_test_util.h
@@ -278,7 +278,7 @@ Reader Serialize(const T& x, uint16_t version = bond::v1)
 
     // serialize value to output
     Factory<Writer>::Call(output_buffer, version, boost::bind(
-        bond::Serialize<Protocols, T, Writer>, x, _1));
+        bond::Serialize<Protocols, T, Writer>, x, boost::placeholders::_1));
 
     typename Reader::Buffer input_buffer(output_buffer.GetBuffer());
     return Factory<Reader>::Create(input_buffer, version);
@@ -309,7 +309,7 @@ Reader Merge(const Payload& payload, const T& x, uint16_t version = bond::v1)
 
     // merge x with serialized payload into output
     Factory<Writer>::Call(output_buffer, version, boost::bind(
-        bond::Merge<Protocols, T, Reader, Writer>, x, Serialize<Reader, Writer, Protocols>(payload, version), _1));
+        bond::Merge<Protocols, T, Reader, Writer>, x, Serialize<Reader, Writer, Protocols>(payload, version), boost::placeholders::_1));
 
     typename Reader::Buffer input_buffer(output_buffer.GetBuffer());
 

--- a/examples/cpp/core/runtime_binding/runtime_binding.cpp
+++ b/examples/cpp/core/runtime_binding/runtime_binding.cpp
@@ -2,7 +2,7 @@
 
 #include <bond/core/bond.h>
 #include <bond/stream/output_buffer.h>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 using namespace examples::runtime_binding;
 

--- a/examples/cpp/core/runtime_binding/runtime_binding.cpp
+++ b/examples/cpp/core/runtime_binding/runtime_binding.cpp
@@ -54,12 +54,12 @@ void Map(const bond::RuntimeSchema& from_schema, std::string from_name,
     // Find the field from_name in from_schema ...
     Field from = find_if(from_schema.GetStruct().fields.begin(), 
                          from_schema.GetStruct().fields.end(),
-                         boost::bind(&ByName, _1, from_name));
+                         boost::bind(&ByName, boost::placeholders::_1, from_name));
     
     // ... and field to_name in to_schema
     Field to = find_if(to_schema.GetStruct().fields.begin(), 
                        to_schema.GetStruct().fields.end(),
-                       boost::bind(&ByName, _1, to_name));
+                       boost::bind(&ByName, boost::placeholders::_1, to_name));
     
     // Add mapping (for clarity omits error checking)
     mappings[from->id].path.push_back(to->id);


### PR DESCRIPTION
boost/bind.hpp is deprecated and recommends using boost/bind/bind.hpp instead, see: https://github.com/boostorg/bind/blob/develop/include/boost/bind.hpp