### PR TITLE
Fix documents' links to .md

### DIFF
--- a/doc/src/bond_cpp.md
+++ b/doc/src/bond_cpp.md
@@ -22,7 +22,7 @@ Bond is published on GitHub at
 Basic example
 =============
 
-In Bond data schemas are defined using idl-like [syntax](compiler.html#idl-syntax):
+In Bond data schemas are defined using idl-like [syntax](compiler.md#idl-syntax):
 
 ```
 namespace example
@@ -35,7 +35,7 @@ struct Record
 ```
 
 In order to use the schema in a C++ program, it needs to be compiled using the
-Bond compiler [`gbc`](compiler.html). This step is sometimes also referred to as
+Bond compiler [`gbc`](compiler.md). This step is sometimes also referred to as
 code generation (or codegen) because the compilation generates C++ code
 corresponding to the schema definition.
 
@@ -470,7 +470,7 @@ constructable from `boost::shared_ptr<SchemaDef>` but only explicitly from
 `const SchemaDef&`.
 
 A serialized representation of `SchemaDef` can be also obtained directly from
-a schema definition IDL file using [bond compiler](compiler.html#runtime-schema).
+a schema definition IDL file using [bond compiler](compiler.md#runtime-schema).
 
 See example: `examples/cpp/core/runtime_schema`.
 
@@ -538,7 +538,7 @@ class bonded;
 
 The class template has two parameters. The first one, `T`, represents schema
 (or type) of the data. Usually it is a struct defined via Bond
-[IDL](compiler.html#idl-syntax) but it can also be `void` (see
+[IDL](compiler.md#idl-syntax) but it can also be `void` (see
 [`bonded<void>`][bonded_void_reference]) if we want to work with data for which
 schema is not known at compile-time. The second parameter, `Reader`, specifies
 representation of the data. The default, `ProtocolReader` is a variant type
@@ -1371,14 +1371,14 @@ represented using the `boost::posix_time::ptime` class and serialized as
 
 Defining a custom type mapping involves three steps:
 
-- Define a [type alias](compiler.html#type-aliases) in the schema.
+- Define a [type alias](compiler.md#type-aliases) in the schema.
 - Specify during codegen a C++ type to represent the alias.
 - Implement an appropriate concept for the custom C++ type.
 
 Codegen parameters
 ------------------
 
-When generating code for a schema that uses [type aliases](compiler.html#type-aliases), the
+When generating code for a schema that uses [type aliases](compiler.md#type-aliases), the
 user can specify a custom type to represent each alias in the generated code:
 
 ```
@@ -2016,70 +2016,70 @@ References
 [Bond-over-gRPC overview][bond_over_grpc]
 ----------------------------
 
-[API_reference]: ../reference/cpp/index.html
+[API_reference]: ../reference/cpp/index.md
 
-[compiler]: compiler.html
+[compiler]: compiler.md
 
-[bond_py]: bond_py.html
+[bond_py]: bond_py.md
 
-[bond_cs]: bond_cs.html
+[bond_cs]: bond_cs.md
 
-[bond_java]: bond_java.html
+[bond_java]: bond_java.md
 
-[bond_over_grpc]: bond_over_grpc.html
+[bond_over_grpc]: bond_over_grpc.md
 
 [serializing_transform_ref]:
-../reference/cpp/structbond_1_1_serializing_transform.html
+../reference/cpp/structbond_1_1_serializing_transform.md
 
 [deserializing_transform_ref]:
-../reference/cpp/structbond_1_1_deserializing_transform.html
+../reference/cpp/structbond_1_1_deserializing_transform.md
 
 [modifying_transform_ref]:
-../reference/cpp/structbond_1_1_modifying_transform.html
+../reference/cpp/structbond_1_1_modifying_transform.md
 
-[transforms_h]: ../reference/cpp/transforms_8h_source.html
+[transforms_h]: ../reference/cpp/transforms_8h_source.md
 
 [field_template_reference]:
-../reference/cpp/structbond_1_1reflection_1_1_field_template.html
+../reference/cpp/structbond_1_1reflection_1_1_field_template.md
 
-[maybe_reference]: ../reference/cpp/classbond_1_1maybe.html
+[maybe_reference]: ../reference/cpp/classbond_1_1maybe.md
 
 [nullable_reference]:
-../reference/cpp/classbond_1_1nullable_3_01_t_00_01_allocator_00_01false_01_4.html
+../reference/cpp/classbond_1_1nullable_3_01_t_00_01_allocator_00_01false_01_4.md
 
-[bonded_reference]: ../reference/cpp/classbond_1_1bonded.html
+[bonded_reference]: ../reference/cpp/classbond_1_1bonded.md
 
 [bonded_void_reference]:
-../reference/cpp/classbond_1_1bonded_3_01void_00_01_reader_01_4.html
+../reference/cpp/classbond_1_1bonded_3_01void_00_01_reader_01_4.md
 
-[blob_reference]: ../reference/cpp/classbond_1_1blob.html
+[blob_reference]: ../reference/cpp/classbond_1_1blob.md
 
 [compact_binary_reader_reference]:
-../reference/cpp/classbond_1_1_compact_binary_reader.html
+../reference/cpp/classbond_1_1_compact_binary_reader.md
 
 [compact_binary_writer_reference]:
-../reference/cpp/classbond_1_1_compact_binary_writer.html
+../reference/cpp/classbond_1_1_compact_binary_writer.md
 
 [compact_binary_format_reference]:
-../reference/cpp/compact__binary_8h_source.html
+../reference/cpp/compact__binary_8h_source.md
 
 [fast_binary_reader_reference]:
-../reference/cpp/classbond_1_1_fast_binary_reader.html
+../reference/cpp/classbond_1_1_fast_binary_reader.md
 
 [fast_binary_writer_reference]:
-../reference/cpp/classbond_1_1_fast_binary_writer.html
+../reference/cpp/classbond_1_1_fast_binary_writer.md
 
 [fast_binary_format_reference]:
-../reference/cpp/fast__binary_8h_source.html
+../reference/cpp/fast__binary_8h_source.md
 
 [simple_binary_reader_reference]:
-../reference/cpp/classbond_1_1_simple_binary_reader.html
+../reference/cpp/classbond_1_1_simple_binary_reader.md
 
 [simple_binary_writer_reference]:
-../reference/cpp/classbond_1_1_simple_binary_writer.html
+../reference/cpp/classbond_1_1_simple_binary_writer.md
 
 [simple_json_reader_reference]:
-../reference/cpp/classbond_1_1_simple_json_reader.html
+../reference/cpp/classbond_1_1_simple_json_reader.md
 
 [simple_json_writer_reference]:
-../reference/cpp/classbond_1_1_simple_json_writer.html
+../reference/cpp/classbond_1_1_simple_json_writer.md

--- a/doc/src/bond_cs.md
+++ b/doc/src/bond_cs.md
@@ -23,7 +23,7 @@ Basic example
 =============
 
 In Bond data schemas are defined using idl-like
-[syntax](compiler.html#idl-syntax):
+[syntax](compiler.md#idl-syntax):
 
 ```
 namespace Examples
@@ -46,7 +46,7 @@ gbc c# example.bond
 
 Using the generated C# code, we can write a simple program that will
 serialize and deserialize an instance of the Record schema using [Compact
-Binary](bond_cpp.html#compact-binary) protocol:
+Binary](bond_cpp.md#compact-binary) protocol:
 
 ```csharp
 namespace Examples
@@ -86,7 +86,7 @@ Code generation
 ===============
 
 In order to use a Bond schema in a C# program, it needs to be compiled using the
-Bond compiler [`gbc`](compiler.html). The compiler generates C# classes that
+Bond compiler [`gbc`](compiler.md). The compiler generates C# classes that
 represent the schema. By default schema fields are represented by public
 auto-properties initialized in the default constructor.
 
@@ -94,7 +94,7 @@ The mapping between Bond and C# type systems is mostly obvious, but it is worth
 noting that, unlike C# reference types, Bond types are not nullable. This means
 that `string` in Bond IDL will be mapped to C# `string`, which is a reference
 type, but the value `null` will not be valid. In order to allow `null` values, a
-type must be declared as [`nullable`](bond_cpp.html#nullable-types), e.g.:
+type must be declared as [`nullable`](bond_cpp.md#nullable-types), e.g.:
 
 ```
 struct Foo
@@ -104,7 +104,7 @@ struct Foo
 ```
 
 The value `null` is also legal for fields declared in Bond IDL to have a [default
-of `nothing`](bond_cpp.html#default-value-of-nothing), e.g.:
+of `nothing`](bond_cpp.md#default-value-of-nothing), e.g.:
 
 ```
 struct Bar
@@ -252,7 +252,7 @@ Marshaling
 ==========
 
 Since Bond supports multiple serialization
-[protocols](bond_cpp.html#protocols), application endpoints either have to
+[protocols](bond_cpp.md#protocols), application endpoints either have to
 agree on a particular protocol, or include protocol metadata in the payload.
 Marshaling APIs provide the standard way to do the latter, by automatically
 adding a payload header with the protocol identifier and version.
@@ -371,7 +371,7 @@ payload (e.g. when the payload was created from an older version of the
 schema).
 
 Additionally, some protocols can omit
-[`optional` non-struct fields](bond_cpp.html#required-fields) set to their
+[`optional` non-struct fields](bond_cpp.md#required-fields) set to their
 default values, reducing payload size.
 
 Default value of `nothing`
@@ -407,7 +407,7 @@ value of the field doesn't have a serialized representation. What this means
 in practice depends on whether the field is `optional` or `required`.
 Optional fields set to `nothing` are usually omitted during serialization
 [^2], just like for any other default values.
-[Required fields](bond_cpp.html#required-fields), by definition, can never
+[Required fields](bond_cpp.md#required-fields), by definition, can never
 be omitted. Since `nothing` has no serialized representation, an attempt to
 serialize an object with required fields set to `nothing` will result in a
 runtime exception. If a null value needs to be represented in the serialized
@@ -952,7 +952,7 @@ Serialize.To(writer, Schema<T>.RuntimeSchema.SchemaDef);
 ```
 
 A serialized representation of `SchemaDef` can be also obtained directly from
-a schema definition IDL file using [bond compiler](compiler.html#runtime-schema).
+a schema definition IDL file using [bond compiler](compiler.md#runtime-schema).
 
 See also the following example:
 
@@ -1127,7 +1127,7 @@ using the `DateTime` class and serialized as `int64`.
 
 Defining a custom type mapping involves three steps:
 
-- Define a [type alias](compiler.html#type-aliases) in the schema.
+- Define a [type alias](compiler.md#type-aliases) in the schema.
 - Specify during codegen a C# type to represent the alias.
 - Implement an appropriate converter for the custom C# type.
 
@@ -1135,7 +1135,7 @@ Codegen parameters
 ------------------
 
 When generating code for a schema that uses [type
-aliases](compiler.html#type-aliases), the user can specify a custom type to
+aliases](compiler.md#type-aliases), the user can specify a custom type to
 represent each alias in the generated code:
 
 ```
@@ -1264,7 +1264,7 @@ the containing structs.
 Using Xml namespace inherently limits some of flexibility of Bond
 deserialization. In particular a document with namespaces can't be deserialized
 into a schema that is compatible but has a different name, for example
-a [view](compiler.html#struct-views) of the payload schema.
+a [view](compiler.md#struct-views) of the payload schema.
 
 See also the following example:
 
@@ -1399,7 +1399,7 @@ represent schema fields and thus are not decorated with Bond attributes.
 ### RequiredAttribute ###
 
 By default fields of Bond schemas are optional. [Required
-fields](bond_cpp.html#required-fields) must be marked with the `Required`
+fields](bond_cpp.md#required-fields) must be marked with the `Required`
 attribute.
 
 ```csharp
@@ -1618,18 +1618,18 @@ Bond.Compiler.CSharp to perform code generation at build time.
 
 [![Bond.Runtime.CSharp NuGet package](https://img.shields.io/nuget/v/Bond.Runtime.CSharp.svg?style=flat)](https://www.nuget.org/packages/Bond.Runtime.CSharp/)
 **Bond.Runtime.CSharp** - Additional assemblies that may be needed at
-runtime depending on which Bond [protocols](bond_cpp.html#protocols) are
+runtime depending on which Bond [protocols](bond_cpp.md#protocols) are
 being used. Needed for Simple JSON.
 
 [![Bond.Compiler.CSharp NuGet package](https://img.shields.io/nuget/v/Bond.Compiler.CSharp.svg?style=flat)](https://www.nuget.org/packages/Bond.Compiler.CSharp/)
 **Bond.Compiler.CSharp** - A package with the
-[Bond compiler (gbc)](compiler.html) and MSBuild targets for C# code
+[Bond compiler (gbc)](compiler.md) and MSBuild targets for C# code
 generation. Bond.CSharp includes similar functionality, but pulls in lots of
 dependencies. Bond.Complier.CSharp has no dependencies.
 
 [![Bond.Compiler NuGet package](https://img.shields.io/nuget/v/Bond.Compiler.svg?style=flat)](https://www.nuget.org/packages/Bond.Compiler/)
 **Bond.Compiler** - A tools-only package that contains the
-[Bond compiler (gbc)](compiler.html). This is useful if you want to
+[Bond compiler (gbc)](compiler.md). This is useful if you want to
 integrate gbc into a build process that isn't using C# or MSBuild.
 
 For example, if you want to use Bond's Compact Binary protocol but want to
@@ -1679,14 +1679,14 @@ References
 [Bond-over-gRPC overview][bond_over_grpc]
 ----------------------------
 
-[bond_over_grpc]: bond_over_grpc.html
-[bond_cpp]: bond_cpp.html
-[bond_java]: bond_java.html
-[bond_py]: bond_py.html
-[compiler]: compiler.html
+[bond_over_grpc]: bond_over_grpc.md
+[bond_cpp]: bond_cpp.md
+[bond_java]: bond_java.md
+[bond_py]: bond_py.md
+[compiler]: compiler.md
 
 [compact_binary_format_reference]:
-../reference/cpp/compact__binary_8h_source.html
+../reference/cpp/compact__binary_8h_source.md
 
 [fast_binary_format_reference]:
-../reference/cpp/fast__binary_8h_source.html
+../reference/cpp/fast__binary_8h_source.md

--- a/doc/src/bond_java.md
+++ b/doc/src/bond_java.md
@@ -22,7 +22,7 @@ Basic example
 =============
 
 In Bond data schemas are defined using idl-like
-[syntax](compiler.html#idl-syntax):
+[syntax](compiler.md#idl-syntax):
 
 ```
 namespace examples
@@ -45,7 +45,7 @@ gbc java example.bond
 
 Using the generated Java code, we can write a simple program that will
 serialize and deserialize an instance of the Record schema using the [Compact
-Binary](bond_cpp.html#compact-binary) protocol:
+Binary](bond_cpp.md#compact-binary) protocol:
 
 ```java
 package examples;
@@ -80,7 +80,7 @@ Code generation
 ===============
 
 In order to use a Bond schema in a Java program, it needs to be compiled using
-the Bond compiler [`gbc`](compiler.html). The compiler generates Java classes
+the Bond compiler [`gbc`](compiler.md). The compiler generates Java classes
 that represent the schema. Schema fields are represented by public fields, and
 collection fields will be automatically initialized to an empty instance.
 
@@ -89,7 +89,7 @@ worth noting that, unlike Java reference types, Bond types are not nullable.
 This means that `string` in Bond IDL will be mapped to `java.lang.String`, which
 is a reference type, but the value `null` will not be valid. In order to allow
 `null` values, a type must be declared as
-[`nullable`](bond_cpp.html#nullable-types),
+[`nullable`](bond_cpp.md#nullable-types),
 e.g.:
 
 ```
@@ -100,7 +100,7 @@ struct Foo
 ```
 
 The value `null` is also legal for fields declared in Bond IDL to have a
-[default of `nothing`](bond_cpp.html#default-value-of-nothing), e.g.:
+[default of `nothing`](bond_cpp.md#default-value-of-nothing), e.g.:
 
 ```
 struct Bar
@@ -170,7 +170,7 @@ See also the following example:
 Marshaling
 ==========
 
-Since Bond supports multiple serialization [protocols](bond_cpp.html#protocols),
+Since Bond supports multiple serialization [protocols](bond_cpp.md#protocols),
 application endpoints either have to agree on a particular protocol, or include
 protocol metadata in the payload. Marshaling APIs provide the standard way to do
 the latter by automatically adding a payload header with the protocol identifier
@@ -302,7 +302,7 @@ payload (e.g. when the payload was created from an older version of the
 schema).
 
 Additionally, some protocols can omit
-[`optional` non-struct fields](bond_cpp.html#required-fields) set to their
+[`optional` non-struct fields](bond_cpp.md#required-fields) set to their
 default values, reducing payload size.
 
 Default value of `nothing`
@@ -335,7 +335,7 @@ value of the field doesn't have a serialized representation. What this means
 in practice depends on whether the field is `optional` or `required`.
 Optional fields set to `nothing` are usually omitted during serialization
 [^2], just like for any other default values.
-[Required fields](bond_cpp.html#required-fields), by definition, can never
+[Required fields](bond_cpp.md#required-fields), by definition, can never
 be omitted. Since `nothing` has no serialized representation, an attempt to
 serialize an object with required fields set to `nothing` will result in a
 runtime exception. If a null value needs to be represented in the serialized
@@ -515,7 +515,7 @@ serializer.serialize(Record.BOND_TYPE.buildSchemaDef(), writer);
 
 A serialized representation of `SchemaDef` can be also obtained directly from
 a schema definition IDL file using the [bond
-compiler](compiler.html#runtime-schema).
+compiler](compiler.md#runtime-schema).
 
 See also the following example:
 
@@ -675,13 +675,13 @@ References
 [Python User's Manual][bond_py]
 ----------------------------
 
-[bond_cpp]: bond_cpp.html
-[bond_cs]: bond_cs.html
-[bond_py]: bond_py.html
-[compiler]: compiler.html
+[bond_cpp]: bond_cpp.md
+[bond_cs]: bond_cs.md
+[bond_py]: bond_py.md
+[compiler]: compiler.md
 
 [compact_binary_format_reference]:
-../reference/cpp/compact__binary_8h_source.html
+../reference/cpp/compact__binary_8h_source.md
 
 [fast_binary_format_reference]:
-../reference/cpp/fast__binary_8h_source.html
+../reference/cpp/fast__binary_8h_source.md

--- a/doc/src/bond_over_grpc.md
+++ b/doc/src/bond_over_grpc.md
@@ -10,8 +10,8 @@ to send Bond objects via [gRPC](http://www.grpc.io/).
 ## Defining Services ##
 
 The Bond IDL has been extended to support the definition of
-[services](compiler.html#service-definition) and
-[generic services](compiler.html#generic-service). These definitions are
+[services](compiler.md#service-definition) and
+[generic services](compiler.md#generic-service). These definitions are
 used by the Bond compiler to generate classes that provide:
 
 * a service base that can be used as the basis for implementing services'
@@ -124,7 +124,7 @@ types. Note also that Bond-over-gRPC does not provide synchronous APIs in C#
 by design.
 
 For more information about gRPC in C#, take a look at the
-[gRPC C# tutorial](http://www.grpc.io/docs/tutorials/basic/csharp.html).
+[gRPC C# tutorial](http://www.grpc.io/docs/tutorials/basic/csharp.md).
 
 There is a [Bond-over-gRPC standalone example project](https://github.com/microsoft/bond-grpc-examples).
 
@@ -275,7 +275,7 @@ of `bonded` request objects and `ClientContext` arguments, see the pingpong
 example.
 
 For more information about gRPC in C++, take a look at the
-[gRPC C++ tutorial](http://www.grpc.io/docs/tutorials/basic/c.html);
+[gRPC C++ tutorial](http://www.grpc.io/docs/tutorials/basic/c.md);
 however, keep in mind that the Bond-over-gRPC APIs diverge significantly
 from those documented there.
 

--- a/doc/src/bond_py.md
+++ b/doc/src/bond_py.md
@@ -321,12 +321,12 @@ References
 [Boost Python][boost_python]
 ----------------------------
 
-[compiler]: compiler.html
+[compiler]: compiler.md
 
-[bond_cpp]: bond_cpp.html
+[bond_cpp]: bond_cpp.md
 
-[bond_cs]: bond_cs.html
+[bond_cs]: bond_cs.md
 
-[boost_python]: http://www.boost.org/doc/libs/1_54_0/libs/python/doc/index.html
+[boost_python]: http://www.boost.org/doc/libs/1_54_0/libs/python/doc/index.md
 
-[boost_python_build]: http://www.boost.org/doc/libs/1_54_0/libs/python/doc/building.html
+[boost_python_build]: http://www.boost.org/doc/libs/1_54_0/libs/python/doc/building.md

--- a/doc/src/compiler.md
+++ b/doc/src/compiler.md
@@ -3,7 +3,7 @@
 Command line options
 ====================
 
-<div class="sourceCode"><object width="100%" height="600" data="gbc.html"/></div>
+<div class="sourceCode"><object width="100%" height="600" data="gbc.md"/></div>
 
 IDL syntax
 ==========

--- a/doc/src/reference_index.md
+++ b/doc/src/reference_index.md
@@ -1,4 +1,4 @@
 Bond Reference
 ==============
 
-- [C++](cpp\index.html)
+- [C++](cpp\index.md)

--- a/doc/src/why_bond.md
+++ b/doc/src/why_bond.md
@@ -12,10 +12,10 @@ like to include a link to it in this document, please send a pull request.
 Meta schema
 -----------
 
-Bond has a very rich [type system](manual/compiler.html#idl-syntax). It is
+Bond has a very rich [type system](manual/compiler.md#idl-syntax). It is
 probably most similar to Thrift in this respect. Some notable additions in Bond
-are inheritance, [type aliases](manual/bond_cpp.html#type-aliases) and
-[generics](manual/bond_cpp.html#generic-struct). One type system feature not
+are inheritance, [type aliases](manual/bond_cpp.md#type-aliases) and
+[generics](manual/bond_cpp.md#generic-struct). One type system feature not
 present in Bond that Avro, and recently Protocol Buffers, have are unions. Bond
 uses schemas with optional fields to represent unions.
 
@@ -30,8 +30,8 @@ STL containers like `std::vector` however user can easily map custom types
 (e.g. use `boost::multi_index_container`  in a generated C++ struct or map 
 a `uint64` schema field to a `System.DateTime` field in a generated C# class). 
 Bond generated C++ structs can also use custom allocators. See [custom type 
-mappings](manual/bond_cpp.html#custom-type-mappings) for [more 
-details](manual/bond_cs.html#custom-type-mappings).
+mappings](manual/bond_cpp.md#custom-type-mappings) for [more 
+details](manual/bond_cs.md#custom-type-mappings).
 
 Protocols
 ---------
@@ -58,20 +58,20 @@ One unique feature of Bond is that serialization and deserialization are not
 fundamental operations hard-coded in the generated code. In fact there is no 
 code generated that is specific to serialization and deserialization. Instead 
 Bond programming model exposes parsers and 
-[transforms](manual/bond_cpp.html#transforms) which are composable by the user 
+[transforms](manual/bond_cpp.md#transforms) which are composable by the user 
 using meta-programming techniques. Some examples how this is used internally 
 should give a taste of the flexibility of the architecture:
 
 - Bond Python implementation doesn't involve *any* Python specific generated 
   code. It is fully built by driving Boost Python library using 
   meta-programming interfaces in Bond C++ implementation. A basic Python 
-  [example](manual/bond_py.html#basic-example) is literally 7 lines of code.
+  [example](manual/bond_py.md#basic-example) is literally 7 lines of code.
 
 - Bond can serialize and deserialize arbitrary instances of `std::tuple<T...>` 
   without any generated code. This is possible because serializer and 
   deserializer are constructed at C++ compile time and the C++ parameter pack 
   expansion effectively gives us compile-time C++ reflection for 
-  [tuples](manual/bond_cpp.html#tuples).
+  [tuples](manual/bond_cpp.md#tuples).
 
 - In C# implementation we have parsers for payload and for objects and we have 
   transforms that can consume data from a parser and serialize or deserialize 


### PR DESCRIPTION
Fix #1044 - Replace the links in the doc/src/*.md with links to .md file.