### PR TITLE
[c#] Fix duplicate Compile item error with --grpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ different versioning scheme, following the Haskell community's
 * RapidJSON repository points to [Tencent](https://github.com/Tencent/rapidjson.git)
   and is at commit [8f4c021](https://github.com/Tencent/rapidjson/commit/8f4c021fa2f1e001d2376095928fc0532adf2ae6).
 
+### C# ###
+
+* Fixed MSB3105/CS2002 error about duplicate Compile items when a directory
+  contains multiple .bond files and `--gprc` is in `$BondOptions`. ([Issue
+  #1050](https://github.com/microsoft/bond/issues/1050))
+
 ## 9.0: 2020-05-26  ##
 * IDL core version: 3.0
 * C++ version: 9.0.0

--- a/cs/build/nuget/Common.targets
+++ b/cs/build/nuget/Common.targets
@@ -126,7 +126,7 @@
        selective.
 
        NOTE: This still won't catch changes to files imported outside the
-       BondCodegen item or metadata changes the require codegen to be
+       BondCodegen item or metadata changes that require codegen to be
        re-run. -->
   <Target Name="BondCodegenCs"
           Inputs="$(_PreExistingBondExe);@(BondCodegen)"
@@ -201,7 +201,7 @@
           Condition="$(BondOptions.Contains('--grpc'))
                      AND !$(BondOptions.Contains('--grpc=false'))">
         <AutoGen>true</AutoGen>
-        <DependentUpon>%(BondCodegen.Identity)</DependentUpon>
+        <DependentUpon>%(_BondCodegenWithDefaultOptions.Identity)</DependentUpon>
       </_BondGen_Grpc_BondOptions>
 
       <_BondGen_Grpc_Options

--- a/cs/test/grpc/services2.bond
+++ b/cs/test/grpc/services2.bond
@@ -1,0 +1,9 @@
+// The services in this test are split across two .bond files as a
+// regression test for https://github.com/microsoft/bond/issues/1050
+
+namespace UnitTest;
+
+service SimpleService2
+{
+    nothing Noop();
+}


### PR DESCRIPTION
When a project has multiple .bond files in `@BondCodegen` and specified
`--grpc` in `$BondOptions`, the C# code generation targets erroneously
added the generated files to the `@Compile` item multiple times.

This was caused because the `@_BondGen_Grpc_BondOptions` item
incorrectly used `%(BondCodegen.Identity)` when populating
`%DependentUpon`. Since `@_BondGen_Grpc_BondOptions` and `@BondCodegen`
are different items, this multiplied them together. A mapping was
intended instead, so the fix is to use
`%_BondGen_Grpc_BondOptions.Identity`. (This was likely a copy/paste bug
when `--grpc` support was added to the targets.)

Fixes https://github.com/microsoft/bond/issues/1050