### PR TITLE
[c#] Ignore msbuild.binlog files

### DIFF
--- a/cs/.gitignore
+++ b/cs/.gitignore
@@ -24,3 +24,6 @@ _ReSharper.*
 *.opensdf
 *.psess
 *.VC.db
+
+# MSBuild binary log
+msbuild.binlog

--- a/examples/cs/.gitignore
+++ b/examples/cs/.gitignore
@@ -2,9 +2,12 @@
 bin/
 obj/
 TestResults/
+tools/
+Debug/
+Release/
 
 # Nuget packages 
-packages/Newtonsoft.Json.*/
+packages/
 
 # Profiler artifacts
 *.exe.manifest
@@ -17,5 +20,10 @@ _ReSharper.*
 *.sdf
 *.suo
 *.user
+*.opendb
 *.opensdf
 *.psess
+*.VC.db
+
+# MSBuild binary log
+msbuild.binlog


### PR DESCRIPTION
Also, synchronize the .gitignore files used for the C# source tree and
the examples tree.