### PR TITLE
[c#] Be explicit about codegen target dependencies

### DIFF
--- a/cs/build/nuget/Common.targets
+++ b/cs/build/nuget/Common.targets
@@ -177,6 +177,7 @@
   -->
   <Target Name="BondCompileCs"
           BeforeTargets="CoreCompile"
+          DependsOnTargets="BondCodegenCs"
           Condition="'@(BondCodegen)' != ''">
 
     <ItemGroup>


### PR DESCRIPTION
The MSBuild target `BondCompileCs` depends on the target `BondCodegenCs`
to populate the `@_BondCodegenWithDefaultOptions` item. It is currently
always running after `BondCompileCs` since it comes after that target in
the .targets file. Adding an explicit `DependsOnTargets="BondCodegenCs"`
is more robust.