### PR TITLE
[c#] Support defining AliasConveters in any assembly

### DIFF
--- a/cs/src/core/expressions/TypeAlias.cs
+++ b/cs/src/core/expressions/TypeAlias.cs
@@ -111,8 +111,11 @@ namespace Bond.Expressions
         static Type GetConverter(Type type)
         {
             var name = type.AssemblyQualifiedName;
-            var converterName = type.Namespace + ".BondTypeAliasConverter" + name.Substring(type.FullName.Length);
-            return Type.GetType(converterName);
+            var converterName = type.Namespace + ".BondTypeAliasConverter";
+            // First try to locate converter class in the same assembly of the target type,
+            // If not found, try to locate in any assembly:
+            return Type.GetType(converterName + name.Substring(type.FullName.Length)) 
+                   ?? Type.GetType(converterName);
         }
     }
 }


### PR DESCRIPTION
This will allow the user to create a `BondTypeAliasConverter`s for types like System.TimeSpan once,
and use in any generated code (independent of the generated type namespace).

In my case, I want to distribute a library with common converters, which is currently not doable in C# (I can do this in C++)

The logic is simple: try to locate converter class in the same assembly of the target type, if not found, try to locate in any assembly.

related to issue #279