### PR TITLE
Conditionally enable CMake policy CMP0077

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@ cmake_minimum_required (VERSION 3.1)
 project (bond)
 cmake_policy (SET CMP0022 NEW)
 
+if (POLICY CMP0077)
+    # Allow CMake 3.13+ to override options when using FetchContent/add_subdirectory.
+    cmake_policy(SET CMP0077 NEW)
+endif ()
+
 set (CMAKE_MODULE_PATH
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake
     ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/cmake-modules)


### PR DESCRIPTION
Projects that import Bond using add_subdirectory pointed at a git submodule may want to set `BOND_ENABLE_GRPC` and `BOND_FIND_RAPIDJSON` through top-level CMakeLists.txt. However, this doesn't work without creating an identical option() in the importing project. Enabling CMP0077 in CMake 3.13+ changes the behavior of option() to allow importing projects to set default values for the variables without touching the cache.

Documentation for CMP0077: https://cmake.org/cmake/help/latest/policy/CMP0077.html