### PR TITLE
[c#] Add new style license and icon to NuGet pkgs.

### DIFF
--- a/cs/nuget/bond.compiler.csharp.nuspec
+++ b/cs/nuget/bond.compiler.csharp.nuspec
@@ -7,8 +7,9 @@
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://github.com/microsoft/bond/</projectUrl>
-    <licenseUrl>https://github.com/microsoft/bond/blob/master/LICENSE</licenseUrl>
+    <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <icon>images\bond-logo-64x64-transparent.png</icon>
     <iconUrl>https://raw.githubusercontent.com/microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
     <summary>The Bond project's code generation C# MSBuild targets</summary>
     <description>
@@ -49,6 +50,8 @@
     <file target="build\netstandard1.6" src="cs\build\nuget\Common.props" />
     <file target="build\netstandard1.6" src="cs\build\nuget\Common.targets" />
     <file target="build\netstandard1.6\cps" src="cs\build\nuget\cps\*.xaml" />
+
+    <file target="images\" src="doc\src\logos\bond-logo-64x64-transparent.png" />
 
     <file target="readme.txt" src="cs\nuget\readme.txt" />
 

--- a/cs/nuget/bond.compiler.nuspec
+++ b/cs/nuget/bond.compiler.nuspec
@@ -7,8 +7,9 @@
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
         <projectUrl>https://github.com/microsoft/bond/</projectUrl>
-        <licenseUrl>https://github.com/microsoft/bond/blob/master/LICENSE</licenseUrl>
+        <license type="expression">MIT</license>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <icon>images\bond-logo-64x64-transparent.png</icon>
         <iconUrl>https://raw.githubusercontent.com/microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
         <summary>The Bond project's code generator</summary>
         <description>
@@ -24,6 +25,8 @@
         <tags>Bond .NET C# serialization</tags>
     </metadata>
     <files>
+        <file target="images\" src="doc\src\logos\bond-logo-64x64-transparent.png" />
+
         <file target="tools" src="cs\tools\gbc.exe" />
         <file target="tools\inc\bond\core" src="idl\bond\core\bond.bond" />
         <file target="tools\inc\bond\core" src="idl\bond\core\bond_const.bond" />

--- a/cs/nuget/bond.core.csharp.nuspec
+++ b/cs/nuget/bond.core.csharp.nuspec
@@ -7,8 +7,9 @@
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
         <projectUrl>https://github.com/microsoft/bond/</projectUrl>
-        <licenseUrl>https://github.com/microsoft/bond/blob/master/LICENSE</licenseUrl>
+        <license type="expression">MIT</license>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <icon>images\bond-logo-64x64-transparent.png</icon>
         <iconUrl>https://raw.githubusercontent.com/microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
         <summary>Bond is an open source, cross-platform, cross-language framework for working with schematized data.</summary>
         <description>
@@ -24,66 +25,68 @@
         <tags>Bond .NET C# serialization</tags>
     </metadata>
     <files>
-        <file target="lib\net45" src="net45\Bond.Attributes.dll" />
-        <file target="lib\net45" src="net45\Bond.Attributes.pdb" />
-        <file target="lib\net45" src="net45\Bond.Attributes.xml" />
-        <file target="lib\net45" src="net45\Bond.IO.dll" />
-        <file target="lib\net45" src="net45\Bond.IO.pdb" />
-        <file target="lib\net45" src="net45\Bond.IO.xml" />
-        <file target="lib\net45" src="net45\Bond.Reflection.dll" />
-        <file target="lib\net45" src="net45\Bond.Reflection.pdb" />
-        <file target="lib\net45" src="net45\Bond.Reflection.xml" />
-        <file target="lib\net45" src="net45\Bond.dll" />
-        <file target="lib\net45" src="net45\Bond.pdb" />
-        <file target="lib\net45" src="net45\Bond.xml" />
+        <file target="images\" src="doc\src\logos\bond-logo-64x64-transparent.png" />
 
-        <file target="lib\net46" src="net45\Bond.Attributes.dll" />
-        <file target="lib\net46" src="net45\Bond.Attributes.pdb" />
-        <file target="lib\net46" src="net45\Bond.Attributes.xml" />
-        <file target="lib\net46" src="net46\Bond.IO.dll" />
-        <file target="lib\net46" src="net46\Bond.IO.pdb" />
-        <file target="lib\net46" src="net46\Bond.IO.xml" />
-        <file target="lib\net46" src="net45\Bond.Reflection.dll" />
-        <file target="lib\net46" src="net45\Bond.Reflection.pdb" />
-        <file target="lib\net46" src="net45\Bond.Reflection.xml" />
-        <file target="lib\net46" src="net45\Bond.dll" />
-        <file target="lib\net46" src="net45\Bond.pdb" />
-        <file target="lib\net46" src="net45\Bond.xml" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.Attributes.dll" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.Attributes.pdb" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.Attributes.xml" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.IO.dll" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.IO.pdb" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.IO.xml" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.Reflection.dll" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.Reflection.pdb" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.Reflection.xml" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.dll" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.pdb" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.xml" />
 
-        <file target="lib\netstandard1.0" src="netstandard1.0\Bond.Attributes.dll" />
-        <file target="lib\netstandard1.0" src="netstandard1.0\Bond.Attributes.pdb" />
-        <file target="lib\netstandard1.0" src="netstandard1.0\Bond.Attributes.xml" />
-        <file target="lib\netstandard1.0" src="netstandard1.0\Bond.Reflection.dll" />
-        <file target="lib\netstandard1.0" src="netstandard1.0\Bond.Reflection.pdb" />
-        <file target="lib\netstandard1.0" src="netstandard1.0\Bond.Reflection.xml" />
-        <file target="lib\netstandard1.0" src="netstandard1.0\Bond.dll" />
-        <file target="lib\netstandard1.0" src="netstandard1.0\Bond.pdb" />
-        <file target="lib\netstandard1.0" src="netstandard1.0\Bond.xml" />
+        <file target="lib\net46" src="cs\bin\retail\net45\Bond.Attributes.dll" />
+        <file target="lib\net46" src="cs\bin\retail\net45\Bond.Attributes.pdb" />
+        <file target="lib\net46" src="cs\bin\retail\net45\Bond.Attributes.xml" />
+        <file target="lib\net46" src="cs\bin\retail\net46\Bond.IO.dll" />
+        <file target="lib\net46" src="cs\bin\retail\net46\Bond.IO.pdb" />
+        <file target="lib\net46" src="cs\bin\retail\net46\Bond.IO.xml" />
+        <file target="lib\net46" src="cs\bin\retail\net45\Bond.Reflection.dll" />
+        <file target="lib\net46" src="cs\bin\retail\net45\Bond.Reflection.pdb" />
+        <file target="lib\net46" src="cs\bin\retail\net45\Bond.Reflection.xml" />
+        <file target="lib\net46" src="cs\bin\retail\net45\Bond.dll" />
+        <file target="lib\net46" src="cs\bin\retail\net45\Bond.pdb" />
+        <file target="lib\net46" src="cs\bin\retail\net45\Bond.xml" />
 
-        <file target="lib\netstandard1.3" src="netstandard1.0\Bond.Attributes.dll" />
-        <file target="lib\netstandard1.3" src="netstandard1.0\Bond.Attributes.pdb" />
-        <file target="lib\netstandard1.3" src="netstandard1.0\Bond.Attributes.xml" />
-        <file target="lib\netstandard1.3" src="netstandard1.0\Bond.Reflection.dll" />
-        <file target="lib\netstandard1.3" src="netstandard1.0\Bond.Reflection.pdb" />
-        <file target="lib\netstandard1.3" src="netstandard1.0\Bond.Reflection.xml" />
-        <file target="lib\netstandard1.3" src="netstandard1.0\Bond.dll" />
-        <file target="lib\netstandard1.3" src="netstandard1.0\Bond.pdb" />
-        <file target="lib\netstandard1.3" src="netstandard1.0\Bond.xml" />
-        <file target="lib\netstandard1.3" src="netstandard1.3\Bond.IO.dll" />
-        <file target="lib\netstandard1.3" src="netstandard1.3\Bond.IO.pdb" />
-        <file target="lib\netstandard1.3" src="netstandard1.3\Bond.IO.xml" />
+        <file target="lib\netstandard1.0" src="cs\bin\retail\netstandard1.0\Bond.Attributes.dll" />
+        <file target="lib\netstandard1.0" src="cs\bin\retail\netstandard1.0\Bond.Attributes.pdb" />
+        <file target="lib\netstandard1.0" src="cs\bin\retail\netstandard1.0\Bond.Attributes.xml" />
+        <file target="lib\netstandard1.0" src="cs\bin\retail\netstandard1.0\Bond.Reflection.dll" />
+        <file target="lib\netstandard1.0" src="cs\bin\retail\netstandard1.0\Bond.Reflection.pdb" />
+        <file target="lib\netstandard1.0" src="cs\bin\retail\netstandard1.0\Bond.Reflection.xml" />
+        <file target="lib\netstandard1.0" src="cs\bin\retail\netstandard1.0\Bond.dll" />
+        <file target="lib\netstandard1.0" src="cs\bin\retail\netstandard1.0\Bond.pdb" />
+        <file target="lib\netstandard1.0" src="cs\bin\retail\netstandard1.0\Bond.xml" />
 
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.Attributes.dll" />
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.Attributes.pdb" />
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.Attributes.xml" />
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.IO.dll" />
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.IO.pdb" />
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.IO.xml" />
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.Reflection.dll" />
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.Reflection.pdb" />
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.Reflection.xml" />
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.dll" />
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.pdb" />
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.xml" />
+        <file target="lib\netstandard1.3" src="cs\bin\retail\netstandard1.0\Bond.Attributes.dll" />
+        <file target="lib\netstandard1.3" src="cs\bin\retail\netstandard1.0\Bond.Attributes.pdb" />
+        <file target="lib\netstandard1.3" src="cs\bin\retail\netstandard1.0\Bond.Attributes.xml" />
+        <file target="lib\netstandard1.3" src="cs\bin\retail\netstandard1.0\Bond.Reflection.dll" />
+        <file target="lib\netstandard1.3" src="cs\bin\retail\netstandard1.0\Bond.Reflection.pdb" />
+        <file target="lib\netstandard1.3" src="cs\bin\retail\netstandard1.0\Bond.Reflection.xml" />
+        <file target="lib\netstandard1.3" src="cs\bin\retail\netstandard1.0\Bond.dll" />
+        <file target="lib\netstandard1.3" src="cs\bin\retail\netstandard1.0\Bond.pdb" />
+        <file target="lib\netstandard1.3" src="cs\bin\retail\netstandard1.0\Bond.xml" />
+        <file target="lib\netstandard1.3" src="cs\bin\retail\netstandard1.3\Bond.IO.dll" />
+        <file target="lib\netstandard1.3" src="cs\bin\retail\netstandard1.3\Bond.IO.pdb" />
+        <file target="lib\netstandard1.3" src="cs\bin\retail\netstandard1.3\Bond.IO.xml" />
+
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.Attributes.dll" />
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.Attributes.pdb" />
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.Attributes.xml" />
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.IO.dll" />
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.IO.pdb" />
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.IO.xml" />
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.Reflection.dll" />
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.Reflection.pdb" />
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.Reflection.xml" />
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.dll" />
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.pdb" />
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.xml" />
     </files>
 </package>

--- a/cs/nuget/bond.csharp.nuspec
+++ b/cs/nuget/bond.csharp.nuspec
@@ -7,8 +7,9 @@
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
         <projectUrl>https://github.com/microsoft/bond/</projectUrl>
-        <licenseUrl>https://github.com/microsoft/bond/blob/master/LICENSE</licenseUrl>
+        <license type="expression">MIT</license>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <icon>images\bond-logo-64x64-transparent.png</icon>
         <iconUrl>https://raw.githubusercontent.com/microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
         <summary>Bond is an open source, cross-platform, cross-language framework for working with schematized data.</summary>
         <description>
@@ -33,6 +34,8 @@
         <file target="build" src="cs\build\nuget\Common.props" />
         <file target="build" src="cs\build\nuget\Common.targets" />
         <file target="build\cps" src="cs\build\nuget\cps\*.xaml" />
+
+        <file target="images\" src="doc\src\logos\bond-logo-64x64-transparent.png" />
 
         <file target="readme.txt" src="cs\nuget\readme.txt" />
 

--- a/cs/nuget/bond.grpc.csharp.nuspec
+++ b/cs/nuget/bond.grpc.csharp.nuspec
@@ -7,8 +7,9 @@
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
         <projectUrl>https://github.com/microsoft/bond/</projectUrl>
-        <licenseUrl>https://github.com/microsoft/bond/blob/master/LICENSE</licenseUrl>
+        <license type="expression">MIT</license>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <icon>images\bond-logo-64x64-transparent.png</icon>
         <iconUrl>https://raw.githubusercontent.com/microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
         <summary>Bindings for using Microsoft Bond with gRPC</summary>
         <description>
@@ -28,12 +29,14 @@
         </dependencies>
     </metadata>
     <files>
-        <file target="lib\net45" src="net45\Bond.Grpc.dll" />
-        <file target="lib\net45" src="net45\Bond.Grpc.pdb" />
-        <file target="lib\net45" src="net45\Bond.Grpc.xml" />
+        <file target="images\" src="doc\src\logos\bond-logo-64x64-transparent.png" />
 
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.Grpc.dll" />
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.Grpc.pdb" />
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.Grpc.xml" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.Grpc.dll" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.Grpc.pdb" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.Grpc.xml" />
+
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.Grpc.dll" />
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.Grpc.pdb" />
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.Grpc.xml" />
     </files>
 </package>

--- a/cs/nuget/bond.runtime.csharp.nuspec
+++ b/cs/nuget/bond.runtime.csharp.nuspec
@@ -7,8 +7,9 @@
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
         <projectUrl>https://github.com/microsoft/bond/</projectUrl>
-        <licenseUrl>https://github.com/microsoft/bond/blob/master/LICENSE</licenseUrl>
+        <license type="expression">MIT</license>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <icon>images\bond-logo-64x64-transparent.png</icon>
         <iconUrl>https://raw.githubusercontent.com/microsoft/bond/master/doc/src/logos/bond-logo-64x64-transparent.png</iconUrl>
         <summary>Bond is an open source, cross-platform, cross-language framework for working with schematized data.</summary>
         <description>
@@ -28,20 +29,22 @@
         </dependencies>
     </metadata>
     <files>
-        <file target="lib\net45" src="net45\Bond.JSON.dll" />
-        <file target="lib\net45" src="net45\Bond.JSON.pdb" />
-        <file target="lib\net45" src="net45\Bond.JSON.xml" />
+        <file target="images\" src="doc\src\logos\bond-logo-64x64-transparent.png" />
 
-        <file target="lib\netstandard1.0" src="netstandard1.0\Bond.JSON.dll" />
-        <file target="lib\netstandard1.0" src="netstandard1.0\Bond.JSON.pdb" />
-        <file target="lib\netstandard1.0" src="netstandard1.0\Bond.JSON.xml" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.JSON.dll" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.JSON.pdb" />
+        <file target="lib\net45" src="cs\bin\retail\net45\Bond.JSON.xml" />
 
-        <file target="lib\netstandard1.3" src="netstandard1.0\Bond.JSON.dll" />
-        <file target="lib\netstandard1.3" src="netstandard1.0\Bond.JSON.pdb" />
-        <file target="lib\netstandard1.3" src="netstandard1.0\Bond.JSON.xml" />
+        <file target="lib\netstandard1.0" src="cs\bin\retail\netstandard1.0\Bond.JSON.dll" />
+        <file target="lib\netstandard1.0" src="cs\bin\retail\netstandard1.0\Bond.JSON.pdb" />
+        <file target="lib\netstandard1.0" src="cs\bin\retail\netstandard1.0\Bond.JSON.xml" />
 
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.JSON.dll" />
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.JSON.pdb" />
-        <file target="lib\netstandard1.6" src="netstandard1.6\Bond.JSON.xml" />
+        <file target="lib\netstandard1.3" src="cs\bin\retail\netstandard1.0\Bond.JSON.dll" />
+        <file target="lib\netstandard1.3" src="cs\bin\retail\netstandard1.0\Bond.JSON.pdb" />
+        <file target="lib\netstandard1.3" src="cs\bin\retail\netstandard1.0\Bond.JSON.xml" />
+
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.JSON.dll" />
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.JSON.pdb" />
+        <file target="lib\netstandard1.6" src="cs\bin\retail\netstandard1.6\Bond.JSON.xml" />
     </files>
 </package>


### PR DESCRIPTION
The nuspec elements `iconUrl` and `licenseUrl` are deprecated in favor of
the `icon` and `license` elements.

This commit replaces `licenseUrl` with `license` (The two cannot
co-exist.) and adds `icon`. (The current recommendation is to have both
for compatibility.)

The `icon` element requires that the icon file be in the package, so the
packages all now use the repository root as the base for their files and
include the icon .png.