### PR TITLE
[c++ grpc] Pass --init to update gRPC submodules

### DIFF
--- a/tools/ci-scripts/linux/build_cpp-grpc-master.zsh
+++ b/tools/ci-scripts/linux/build_cpp-grpc-master.zsh
@@ -7,7 +7,7 @@ pushd "$BOND_ROOT/thirdparty/grpc"
 git fetch origin master
 git checkout origin/master
 git submodule sync --recursive
-git submodule update --recursive
+git submodule update --init --recursive
 popd
 
 BOND_CMAKE_FLAGS="$BOND_CMAKE_FLAGS -DBOND_SKIP_GBC_TESTS=TRUE -DBOND_SKIP_CORE_TESTS=TRUE -DgRPC_ZLIB_PROVIDER=package"


### PR DESCRIPTION
Sometimes gRPC adds new submodule dependencies, so we need to pass the
`--init` flag to `git submodule update` so that new submodules are
initialized, lest the build fail.