### PR TITLE
[c#] Move Position Computation Into PushLengthCheck Args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ different versioning scheme, following the Haskell community's
 
 ### C# ###
 
-* Fixed a regression writing to non-seekable streams using `OutputStream`.
-  The fix in commit
+* Fixed a regression writing to non-seekable streams using
+  `CompactBinaryWriter`. The fix in commit
   [b0fd4a1](https://github.com/microsoft/bond/commit/b0fd4a15a7cae946dd2855122559ca59cc34dbea#diff-9534daaa1fb3d4776494b25c8bba3939L212)
   inadvertently added a call to `Stream.Position` in the Release
   configuration. This call is only indented to be made when Bond is built in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ tag versions. The Bond compiler (`gbc`) and
 different versioning scheme, following the Haskell community's
 [package versioning policy](https://wiki.haskell.org/Package_versioning_policy).
 
+## Unreleased ##
+* Move computation of length in PushLengthCheck back into the function argument
+  This reverts [b0fd4a1](https://github.com/microsoft/bond/commit/b0fd4a15a7cae946dd2855122559ca59cc34dbea#diff-9534daaa1fb3d4776494b25c8bba3939L212) to previous behavior where length is only computed in the Debug build configuration
+  This resolves exceptions occurring in a `Stream` that is not seekable
+
 ## 9.0.1: 2020-07-14 ##
 * IDL core version: 3.0
 * C++ version: 9.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,7 @@ different versioning scheme, following the Haskell community's
 [package versioning policy](https://wiki.haskell.org/Package_versioning_policy).
 
 ## Unreleased ##
-* Move computation of length in PushLengthCheck back into the function argument
-  This reverts [b0fd4a1](https://github.com/microsoft/bond/commit/b0fd4a15a7cae946dd2855122559ca59cc34dbea#diff-9534daaa1fb3d4776494b25c8bba3939L212) to previous behavior where length is only computed in the Debug build configuration
-  This resolves exceptions occurring in a `Stream` that is not seekable
+* Move computation of length in PushLengthCheck back into the function argument reverting [b0fd4a1](https://github.com/microsoft/bond/commit/b0fd4a15a7cae946dd2855122559ca59cc34dbea#diff-9534daaa1fb3d4776494b25c8bba3939L212) to previous behavior where length is only computed in the Debug build configuration. This resolves exceptions occurring in Streams that are not seekable.
 
 ## 9.0.1: 2020-07-14 ##
 * IDL core version: 3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,19 @@ different versioning scheme, following the Haskell community's
 [package versioning policy](https://wiki.haskell.org/Package_versioning_policy).
 
 ## Unreleased ##
-* Move computation of length in PushLengthCheck back into the function argument reverting [b0fd4a1](https://github.com/microsoft/bond/commit/b0fd4a15a7cae946dd2855122559ca59cc34dbea#diff-9534daaa1fb3d4776494b25c8bba3939L212) to previous behavior where length is only computed in the Debug build configuration. This resolves exceptions occurring in Streams that are not seekable.
+* IDL core version: TBD
+* C++ version: TBD
+* C# NuGet version: bug fix bump needed
+* `gbc` & compiler library: TBD
+
+### C# ###
+
+* Fixed a regression writing to non-seekable streams using `OutputStream`.
+  The fix in commit
+  [b0fd4a1](https://github.com/microsoft/bond/commit/b0fd4a15a7cae946dd2855122559ca59cc34dbea#diff-9534daaa1fb3d4776494b25c8bba3939L212)
+  inadvertently added a call to `Stream.Position` in the Release
+  configuration. This call is only indented to be made when Bond is built in
+  the Debug configuration.
 
 ## 9.0.1: 2020-07-14 ##
 * IDL core version: 3.0

--- a/cs/src/core/protocols/CompactBinary.cs
+++ b/cs/src/core/protocols/CompactBinary.cs
@@ -210,8 +210,7 @@ namespace Bond.Protocols
                 lengths.RemoveFirst();
 
                 output.WriteVarUInt32(length);
-                long position = checked(output.Position + length);
-                PushLengthCheck(position);
+                PushLengthCheck(checked(output.Position + length));
             }
         }
 

--- a/cs/test/core/StreamTests.cs
+++ b/cs/test/core/StreamTests.cs
@@ -220,8 +220,9 @@
             return buf;
         }
 
-        // WriteStructBegin uses position in DEBUG configuration which would fail this test
-        // Test needs to validate position is not accessed in RELEASE so conditional is set
+        // WriteStructBegin should only access Stream.Position in the DEBUG
+        // configuration, so we only execute this test in the RELEASE
+        // configuration.
         [Conditional("RELEASE")]
         private void Stream_PositionLength_NotAccessedOnWriteStructBeginImplementation()
         {

--- a/cs/test/core/StreamTests.cs
+++ b/cs/test/core/StreamTests.cs
@@ -123,7 +123,7 @@
         [Test]
         public void Stream_PositionLength_NotAccessedOnWriteStructBegin()
         {
-            this.Stream_PositionLength_NotAccessedOnWriteStructBeginImplementation();
+            Stream_PositionLength_NotAccessedOnWriteStructBeginImplementation();
         }
 
         [Test]
@@ -220,12 +220,14 @@
             return buf;
         }
 
+        // WriteStructBegin uses position in DEBUG configuration which would fail this test
+        // Test needs to validate position is not accessed in RELEASE so conditional is set
         [Conditional("RELEASE")]
         private void Stream_PositionLength_NotAccessedOnWriteStructBeginImplementation()
         {
             var stream = new NonSeekableStream();
-            var output = new OutputStream(stream, 11);
-            var writer = new CompactBinaryWriter<OutputStream>(output, 2);
+            var output = new OutputStream(stream, bufferLength:11);
+            var writer = new CompactBinaryWriter<OutputStream>(output, version:2);
             var firstPass = writer.GetFirstPassWriter();
             firstPass.WriteStructBegin(new Metadata());
             firstPass.WriteStructEnd();

--- a/cs/test/core/StreamTests.cs
+++ b/cs/test/core/StreamTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace UnitTest
 {
     using System;
+    using System.Diagnostics;
     using System.IO;
     using System.Runtime.InteropServices;
     using NUnit.Framework;
@@ -120,6 +121,12 @@
         }
 
         [Test]
+        public void Stream_PositionLength_NotAccessedOnWriteStructBegin()
+        {
+            this.Stream_PositionLength_NotAccessedOnWriteStructBeginImplementation();
+        }
+
+        [Test]
         public void ReadBytes_DifferentSizesAndPositions_ReadCorrectly()
         {
             var buffer = MakeSequential(5 * 1024);
@@ -211,6 +218,54 @@
             }
 
             return buf;
+        }
+
+        [Conditional("RELEASE")]
+        private void Stream_PositionLength_NotAccessedOnWriteStructBeginImplementation()
+        {
+            var stream = new NonSeekableStream();
+            var output = new OutputStream(stream, 11);
+            var writer = new CompactBinaryWriter<OutputStream>(output, 2);
+            var firstPass = writer.GetFirstPassWriter();
+            firstPass.WriteStructBegin(new Metadata());
+            firstPass.WriteStructEnd();
+            writer.WriteStructBegin(new Metadata());
+        }
+
+        private class NonSeekableStream : Stream
+        {
+            public override void Flush()
+            {
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                return 0;
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+            }
+
+            public override bool CanRead { get; }
+            public override bool CanSeek => false;
+            public override bool CanWrite { get; }
+            public override long Length => throw new NotSupportedException();
+            public override long Position
+            {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
         }
     }
 


### PR DESCRIPTION
This pull request attempts to fix a regression introduced in [b0fd4a1](https://github.com/microsoft/bond/commit/b0fd4a15a7cae946dd2855122559ca59cc34dbea#diff-9534daaa1fb3d4776494b25c8bba3939L212). 

The previous code for `CompactBinary.WriteStructBegin` would not access the `output.Position` in the Release build configuration whereas the changes introduced caused it to now be accessed regardless of configuration. This can cause exceptions in scenarios where the `Stream` is not seekable.

The fix moves the computation of the length back into the arguments of the function which ensures it will not be executed outside of the Debug build configuration.