### PR TITLE
[c++] [python] Replace deprecated std::ptr_fun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ tag versions. The Bond compiler (`gbc`) and
 different versioning scheme, following the Haskell community's
 [package versioning policy](https://wiki.haskell.org/Package_versioning_policy).
 
+## Unreleased ##
+
+* IDL core version: TBD
+* C++ version: TBD (bug fix bump needed)
+* C# NuGet version: TBD
+* `gbc` & compiler library: TBD
+
+### C++/Python ###
+
+* Removed use of deprecated `std::ptr_fun` in the Python library. ([Issue
+  \#1080](https://github.com/microsoft/bond/issues/1080))
+
 ## 9.0.4: 2020-11-23 ##
 
 * IDL core version: 3.0

--- a/python/inc/bond/python/converters.h
+++ b/python/inc/bond/python/converters.h
@@ -25,6 +25,9 @@
 #include <bond/core/blob.h>
 #include <bond/core/nullable.h>
 
+#include <algorithm>
+#include <cctype>
+
 namespace bond
 {
 namespace python
@@ -78,7 +81,11 @@ private:
     void pythonize()
     {
         // TODO: this may result in name conflict, e.g. list<string> and list_string_
-        std::replace_if(_name.begin(), _name.end(), std::not1(std::ptr_fun(isalnum)), '_');
+        std::replace_if(
+            _name.begin(),
+            _name.end(),
+            [](unsigned char c) { return isalnum(c) == 0; },
+            '_');
     }
 
     std::string _name;


### PR DESCRIPTION
`std::ptr_fun` is deprecated in C++11 and removed in C++17.

Replace its one use with a lambda.

Fixes https://github.com/microsoft/bond/issues/1080