### PR TITLE
[c#] Add explicit NuGet.Config with sources

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>


### PR DESCRIPTION
Add an explicit NuGet.Config file that configures NuGet.org as Bond's
package source. This helps avoid an error restoring packages when Bond
is a submodule of a repo that uses a private package feed.