### PR TITLE
Update Ubuntu image: use newer Git

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: "ubuntu-latest"
 
     container:
-      image: bondciimages.azurecr.io/ubuntu-1604:build-32869346
+      image: bondciimages.azurecr.io/ubuntu-1604:build-38421604
 
     strategy:
       fail-fast: false
@@ -28,12 +28,6 @@ jobs:
     env: ${{ matrix.env }}
 
     steps:
-      - name: "Update git - ver has to be at least Git 2.18"
-        run: |
-          add-apt-repository ppa:git-core/ppa -y
-          apt-get update
-          apt-get install --no-install-recommends git -y
-
       - name: "Git checkout"
         uses: "actions/checkout@v2"
         with:

--- a/.github/workflows/linux_cron.yml
+++ b/.github/workflows/linux_cron.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: "ubuntu-latest"
 
     container:
-      image: bondciimages.azurecr.io/ubuntu-1604:build-32869346
+      image: bondciimages.azurecr.io/ubuntu-1604:build-38421604
 
     strategy:
       fail-fast: false
@@ -50,12 +50,6 @@ jobs:
     env: ${{ matrix.env }}
 
     steps:
-      - name: "Update git - ver has to be at least Git 2.18"
-        run: |
-          add-apt-repository ppa:git-core/ppa -y
-          apt-get update
-          apt-get install --no-install-recommends git -y
-
       - name: "Git checkout"
         uses: "actions/checkout@v2"
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ env:
     - FLAVOR="cpp-grpc-master" BOOST="1.66.0" COMPILER="clang" CRON_ONLY="true"
 script:
     - if [ "$CRON_ONLY" = "true" ] && [ "$TRAVIS_EVENT_TYPE" != "cron" ] ; then echo "Skipping cron-only job"; exit 0; fi
-    - CI_BUILD_IMAGE=bondciimages.azurecr.io/ubuntu-1604:build-32869346
+    - CI_BUILD_IMAGE=bondciimages.azurecr.io/ubuntu-1604:build-38421604
     - if [ "$TRAVIS_OS_NAME" == "linux" ]; then echo "Hardware:"; grep model\ name /proc/cpuinfo | uniq -c; free -m; fi
     - time travis_retry docker pull $CI_BUILD_IMAGE
     - docker images # Dump the image ID


### PR DESCRIPTION
The GitHub Actions workflows need a newer version of Git installed than
the version the Ubuntu 16.04 image comes with. In commit e1d1f39e ([ci]
Enable GitHub Actions for Linux CI, 2021-01-13), the Dockerfile that
creates the image we use was updated to install a newer version.

Switch the CI pipelines to this image. Remove GitHub Actions
step that installs the newer Git.