### PR TITLE
[ci] Do not trigger AppVeyor build on .github/ changes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,8 +24,9 @@
         # NB: README.md is NOT in this list; the documentation build
         # consumes it.
         - CHANGELOG.md
-        # These files are only used by the Travis CI builds and don't affect
+        # These files are only used by the Linux CI builds and don't affect
         # the Windows builds.
+        - .github/**
         - .travis.yml
         - tools/ci-scripts/linux/**
 


### PR DESCRIPTION
The `.github/` directory contains GitHub Actions workflows, which do not
contribute to the AppVeyor builds.

Do not trigger AppVeyor build on .github/ changes.