### PR TITLE
[doc] Explain how to enable Compact Binary v2 on C++

### DIFF
--- a/doc/src/bond_cpp.md
+++ b/doc/src/bond_cpp.md
@@ -1266,7 +1266,11 @@ Implemented in [`CompactBinaryReader`][compact_binary_reader_reference] and
 Version 2 of Compact Binary adds length prefix for structs. This enables
 deserialization of [`bonded<T>`](#understanding-bondedt) and skipping of
 unknown fields in constant time. The trade-off is double pass encoding,
-resulting in up to 30% slower serialization performance.
+resulting in up to 30% slower serialization performance. You can enable Compact
+Binary version 2 by instantiating the
+[`CompactBinaryReader`][compact_binary_reader_reference] and
+[`CompactBinaryWriter`][compact_binary_writer_reference] classes with their
+second optional constructor argument (`version`) set to the integer 2.
 
 See also [Compact Binary encoding reference][compact_binary_format_reference].
 


### PR DESCRIPTION
The docs extensively mention Compact Binary v2, however there are no
clear instructions on how to enable it unless you carefully read the
`CompactBinaryReader` and `CompactBinaryWriter` constructor docs.

I spent quite some time trying to figure it out until @chwarr pointed me
in the right direction. Hopefully the next reader finds it easier!

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>