### PR TITLE
[doc] Fix dead link in compilers page to custom type mapping documentation

### DIFF
--- a/doc/src/compiler.md
+++ b/doc/src/compiler.md
@@ -211,8 +211,9 @@ including a definition of another alias:
 using times = array<time>;
 ```
 
-Type aliases can optionally be mapped to custom types in the generated code for
-both [C#](bond_cs.html#custom-type-mappings) and [C++](bond_cpp.html#custom-type-mappings).
+Type aliases can optionally be mapped to custom types in the generated code
+for both [C++](bond_cpp.html#custom-type-mappings) and
+[C#](bond_cs.html#custom-type-mappings).
 
 See examples:
 

--- a/doc/src/compiler.md
+++ b/doc/src/compiler.md
@@ -211,8 +211,8 @@ including a definition of another alias:
 using times = array<time>;
 ```
 
-Type aliases can optionally be [mapped to custom types](#custom-type-mappings)
-in the generated code.
+Type aliases can optionally be mapped to custom types in the generated code for
+both [C#](bond_cs.html#custom-type-mappings) and [C++](bond_cpp.html#custom-type-mappings).
 
 See examples:
 


### PR DESCRIPTION
The link on the compilers page (http://microsoft.github.io/bond/manual/compiler.html#type-aliases) to the custom type mapping documentation is dead as it doesn't point to the correct page. Here's a PR to fix it.