### PR TITLE
Add Doxygen path to build path of Doc step in CI pipeline

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -164,7 +164,7 @@
 
                 $env:Path += "C:\Program Files\doxygen\bin"
 
-                Get-Command pandoc, doxygen
+                Get-Command doxygen,pandoc
 
             }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -273,8 +273,6 @@
 
                 cmake ../doc
 
-                Get-ChildItem
-
             }
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -162,6 +162,10 @@
 
                 $env:Path = "$machinePath;$userPath"
 
+                $env:Path += "C:\Program Files\doxygen\bin"
+
+                Get-Command pandoc, doxygen
+
             }
 
             if (($env:BOND_BUILD -eq 'C++') -and (-not ($env:BOND_CMAKE_FLAGS -match '-DBOND_ENABLE_GRPC=FALSE'))) {
@@ -268,6 +272,8 @@
                 cd build
 
                 cmake ../doc
+
+                Get-ChildItem
 
             }
 


### PR DESCRIPTION
Attempt to fix doc build issue #1086 by doing a manual refresh env in Appveyor script after installing Doxygen.

In my local testing when I didn't do refreshenv, doxygen was not found and CMake didn't generate the `documentation` target.