### PR TITLE
[doc] Handle robocopy exit codes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -300,7 +300,11 @@
 
                     robocopy ..\html . /E /J /MIR /MT /NFL /XD .git 2>&1
 
-                    if ($LASTEXITCODE -ne 0) { throw "Robocopy documentation failed: $LASTEXITCODE" }
+                    # Robocopy uses exit codes 0-7 to convey details about
+                    # what was copied. Exit code 8 starts the range of
+                    # errors.
+
+                    if ($LASTEXITCODE -ge 8) { throw "Robocopy documentation failed: $LASTEXITCODE" }
 
                     git add --all .
 


### PR DESCRIPTION
Robocopy uses exit codes 0-7 to convey details about what was copied.
Exit code 8 starts the range of errors.

Only fail if robocopy exits with a value greater than or equal to 8.