### PR TITLE
[doc] Do not fail build when there are no changes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -310,9 +310,12 @@
 
                     if ($LASTEXITCODE -ne 0) { throw "git add failed: $LASTEXITCODE" }
 
-                    git commit -m "Update documentation"
+                    # Don't test exit code of 'git commit'. When there is
+                    # nothing to commit, it exits with 1. The push below
+                    # should still exit with 0 after not doing anything, so
+                    # the build will still pass.
 
-                    if ($LASTEXITCODE -ne 0) { throw "git commit failed: $LASTEXITCODE" }
+                    git commit -m "Update documentation"
 
                     git push origin gh-pages 2>&1 | out-null
 


### PR DESCRIPTION
During the doc build, if there are no changes, `git commit` [exits with
1 and the build fails][1].

Don't test exit code of `git commit`. The subsequent `git push` will
exit with 0 even if there is nothing to do, so subsequent tests will see
a $LASTEXITCODE of 0.

[1]: https://ci.appveyor.com/project/MicrosoftBond/bond/branch/master/job/j8ujo6s6pb59an50