### PR TITLE
[c++] Forward declare GenericWriteVariableUnsigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ tag versions. The Bond compiler (`gbc`) and
 different versioning scheme, following the Haskell community's
 [package versioning policy](https://wiki.haskell.org/Package_versioning_policy).
 
+## Unreleased ##
+
+* IDL core version: TBD
+* C++ version: TBD (bug fix bump needed)
+* C# NuGet version: TBD
+* `gbc` & compiler library: TBD
+
+### C++ ###
+
+* Add forward declaration for `GenericWriteVariableUnsigned` to fix "C3861:
+  'GenericWriteVariableUnsigned': identifier not found" when using custom
+  streams that do not have their own implementation of
+  `WriteVariableUnsigned`. ([Issue
+  \#1115](https://github.com/microsoft/bond/issues/1115))
+
 ## 9.0.5: 2021-04-14 ##
 
 * IDL core version: 3.0

--- a/cpp/inc/bond/protocol/encoding.h
+++ b/cpp/inc/bond/protocol/encoding.h
@@ -30,6 +30,12 @@ implements_varint_write<Buffer, T,
     : std::true_type {};
 
 
+// GenericWriteVariableUnsigned and WriteVariableUnsigned are mutually
+// recursive, so we need a forward declaration of one of them.
+template<typename Buffer, typename T>
+inline void GenericWriteVariableUnsigned(Buffer& output, T value);
+
+
 template<typename Buffer, typename T>
 inline
 typename boost::enable_if<implements_varint_write<Buffer, T> >::type
@@ -56,7 +62,7 @@ WriteVariableUnsigned(Buffer& output, T value)
 
 template<typename Buffer, typename T>
 BOND_NO_INLINE
-void GenericWriteVariableUnsigned(Buffer& output, T value)
+inline void GenericWriteVariableUnsigned(Buffer& output, T value)
 {
     T x = value;
 


### PR DESCRIPTION
Some users are reporting that they are receiving error "C3861:
'GenericWriteVariableUnsigned': identifier not found" when building.

I think this happens when custom streams that _do not_ have their own
`WriteVariableUnsigned` member function.

Add a forward declaration of `GenericWriteVariableUnsigned`.

Fixes https://github.com/microsoft/bond/issues/1115