### PR TITLE
[c++] Add an ability to apply transform to a schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ different versioning scheme, following the Haskell community's
   streams that do not have their own implementation of
   `WriteVariableUnsigned`. ([Issue
   \#1115](https://github.com/microsoft/bond/issues/1115))
+* Added an ability to apply transform to a schema.
 
 ## 9.0.5: 2021-04-14 ##
 

--- a/compiler/src/Language/Bond/Codegen/Cpp/ApplyOverloads.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/ApplyOverloads.hs
@@ -33,8 +33,7 @@ applyOverloads protocols cpp attr extern s@Struct {..} | null declParams = [lt|
                const ::bond::bonded< #{qualifiedName}>& value);
 
     #{extern}template #{attr}
-    bool Apply(const ::bond::InitSchemaDef& transform,
-               const #{qualifiedName}& value);
+    bool Apply< #{qualifiedName}>(const ::bond::InitSchemaDef& transform);
 
     #{extern}template #{attr}
     bool Apply(const ::bond::Null& transform,

--- a/compiler/tests/generated/apply/basic_types_apply.cpp
+++ b/compiler/tests/generated/apply/basic_types_apply.cpp
@@ -15,8 +15,7 @@ namespace bond
                const ::bond::bonded< ::tests::BasicTypes>& value);
 
     template 
-    bool Apply(const ::bond::InitSchemaDef& transform,
-               const ::tests::BasicTypes& value);
+    bool Apply< ::tests::BasicTypes>(const ::bond::InitSchemaDef& transform);
 
     template 
     bool Apply(const ::bond::Null& transform,

--- a/compiler/tests/generated/apply/basic_types_apply.h
+++ b/compiler/tests/generated/apply/basic_types_apply.h
@@ -19,8 +19,7 @@ namespace bond
                const ::bond::bonded< ::tests::BasicTypes>& value);
 
     extern template DllExport
-    bool Apply(const ::bond::InitSchemaDef& transform,
-               const ::tests::BasicTypes& value);
+    bool Apply< ::tests::BasicTypes>(const ::bond::InitSchemaDef& transform);
 
     extern template DllExport
     bool Apply(const ::bond::Null& transform,

--- a/cpp/inc/bond/core/apply.h
+++ b/cpp/inc/bond/core/apply.h
@@ -97,8 +97,8 @@ bool Apply(const Transform& transform, const T& value)
 template <typename T, typename Transform>
 bool Apply(const Transform& transform)
 {
-    detail::SchemaReader input;
-    return detail::SchemaReader::Parser{ input }.Apply(transform, typename schema<T>::type{});
+    SchemaReader input;
+    return SchemaReader::Parser{ input }.Apply(transform, typename schema<T>::type{});
 }
 
 
@@ -106,8 +106,8 @@ bool Apply(const Transform& transform)
 template <typename Transform>
 bool Apply(const Transform& transform, const RuntimeSchema& schema)
 {
-    detail::SchemaReader input;
-    return detail::SchemaReader::Parser{ input }.Apply(transform, schema);
+    SchemaReader input;
+    return SchemaReader::Parser{ input }.Apply(transform, schema);
 }
 
 } // namespace bond

--- a/cpp/inc/bond/core/apply.h
+++ b/cpp/inc/bond/core/apply.h
@@ -92,4 +92,22 @@ bool Apply(const Transform& transform, const T& value)
     return detail::ApplyTransform<Protocols>(transform, value);
 }
 
+
+/// @brief Apply transform to compile-time schema
+template <typename T, typename Transform>
+bool Apply(const Transform& transform)
+{
+    detail::SchemaReader input;
+    return detail::SchemaReader::Parser{ input }.Apply(transform, typename schema<T>::type{});
+}
+
+
+/// @brief Apply transform to runtime schema
+template <typename Transform>
+bool Apply(const Transform& transform, const RuntimeSchema& schema)
+{
+    detail::SchemaReader input;
+    return detail::SchemaReader::Parser{ input }.Apply(transform, schema);
+}
+
 } // namespace bond

--- a/cpp/inc/bond/core/bond_fwd.h
+++ b/cpp/inc/bond/core/bond_fwd.h
@@ -26,11 +26,11 @@ class bonded;
 template <typename Reader>
 class bonded<void, Reader>;
 
-template <typename V> struct
+template <typename T> struct
 remove_bonded;
 
-template <typename V> struct
-remove_bonded<bonded<V> >;
+template <typename T, typename Reader> struct
+remove_bonded<bonded<T, Reader> >;
 
 template <typename T, typename Reader, typename Enable = void>
 class value;

--- a/cpp/inc/bond/core/detail/protocol_visitors.h
+++ b/cpp/inc/bond/core/detail/protocol_visitors.h
@@ -187,6 +187,12 @@ BOND_NO_INLINE void Skip(Reader& reader, const bonded<T, Reader&>& bonded, const
     {}
 }
 
+struct SchemaReader;
+
+template <typename T>
+void Skip(SchemaReader&, const bonded<T, SchemaReader&>&, const std::nothrow_t&)
+{}
+
 
 template <typename T>
 inline void Skip(ProtocolReader& /*reader*/, const bonded<T>& /*bonded*/)

--- a/cpp/inc/bond/core/detail/protocol_visitors.h
+++ b/cpp/inc/bond/core/detail/protocol_visitors.h
@@ -177,7 +177,7 @@ inline void Skip(const bonded<T, Reader<Buffer, MarshaledBondedProtocols>&>& bon
 
 
 template <typename Reader, typename T>
-BOND_NO_INLINE void Skip(Reader& reader, const bonded<T, Reader&>& bonded, const std::nothrow_t&)
+BOND_NO_INLINE void Skip(Reader& reader, const bonded<T, Reader&>& bonded, const std::nothrow_t&) BOND_NOEXCEPT
 {
     try
     {
@@ -190,19 +190,19 @@ BOND_NO_INLINE void Skip(Reader& reader, const bonded<T, Reader&>& bonded, const
 struct SchemaReader;
 
 template <typename T>
-void Skip(SchemaReader&, const bonded<T, SchemaReader&>&, const std::nothrow_t&)
+void Skip(SchemaReader&, const bonded<T, SchemaReader&>&, const std::nothrow_t&) BOND_NOEXCEPT
 {}
 
 
 template <typename T>
-inline void Skip(ProtocolReader& /*reader*/, const bonded<T>& /*bonded*/)
+inline void Skip(ProtocolReader& /*reader*/, const bonded<T>& /*bonded*/) BOND_NOEXCEPT
 {
     // Not skipping for outer structures
 }
 
 
 template <typename T>
-inline void Skip(ProtocolReader& /*reader*/, const bonded<T>& /*bonded*/, const std::nothrow_t&)
+inline void Skip(ProtocolReader& /*reader*/, const bonded<T>& /*bonded*/, const std::nothrow_t&) BOND_NOEXCEPT
 {
     // Not skipping for outer structures
 }

--- a/cpp/inc/bond/core/detail/protocol_visitors.h
+++ b/cpp/inc/bond/core/detail/protocol_visitors.h
@@ -22,6 +22,7 @@ namespace bond
 {
 
 class RuntimeSchema;
+struct SchemaReader;
 
 template <typename Writer, typename Protocols>
 class Serializer;
@@ -186,8 +187,6 @@ BOND_NO_INLINE void Skip(Reader& reader, const bonded<T, Reader&>& bonded, const
     catch(...)
     {}
 }
-
-struct SchemaReader;
 
 template <typename T>
 void Skip(SchemaReader&, const bonded<T, SchemaReader&>&, const std::nothrow_t&) BOND_NOEXCEPT

--- a/cpp/inc/bond/core/reflection.h
+++ b/cpp/inc/bond/core/reflection.h
@@ -383,10 +383,29 @@ remove_bonded
 };
 
 
-template <typename T> struct
-remove_bonded<bonded<T> >
+template <typename T, typename Reader> struct
+remove_bonded<bonded<T, Reader> >
 {
     typedef typename remove_bonded<T>::type type;
+};
+
+
+template <typename T> struct
+remove_bonded_value
+{
+    typedef T type;
+};
+
+template <typename T, typename Reader> struct
+remove_bonded_value<bonded<T, Reader> >
+{
+    typedef T type;
+};
+
+template <typename T, typename Reader> struct
+remove_bonded_value<value<T, Reader> >
+{
+    typedef T type;
 };
 
 

--- a/cpp/inc/bond/core/schema.h
+++ b/cpp/inc/bond/core/schema.h
@@ -159,7 +159,18 @@ namespace detail
 
     template <typename T, typename Unused>
     once_flag SchemaCache<T, Unused>::flag;
+
+
+    struct SchemaReader
+    {
+        using Parser = StaticParser<SchemaReader&>;
+    };
 }
+
+
+template <typename Unused> struct
+uses_marshaled_bonded<detail::SchemaReader&, Unused> : std::false_type
+{};
 
 
 //
@@ -189,7 +200,7 @@ public:
     template <typename T>
     bool Base(const T& /*value*/) const
     {
-        TypeDef type = GetTypeDef<T>();
+        TypeDef type = GetTypeDef<typename remove_bonded<T>::type>();
         This().base_def.set(type);
         return false;
     }
@@ -202,7 +213,7 @@ public:
 
         field.id = id;
         field.metadata = metadata;
-        field.type = GetTypeDef<typename remove_maybe<T>::type>();
+        field.type = GetTypeDef<typename remove_bonded_value<T>::type>();
 
         This().fields.push_back(field);
         return false;
@@ -309,15 +320,7 @@ namespace detail
 template <typename T, typename Unused>
 void SchemaCache<T, Unused>::AppendStructDef(SchemaDef* s)
 {
-    // To apply InitSchemaDef transform we need a reference to an
-    // object T. However the transform never accesses the object or
-    // its fields. We can't construct an actual object since we
-    // need to support stateful allocators that can't allocate from
-    // a default-constructed instance and containers which allocate in
-    // default constructor.
-    //
-    // Thus, we make a dummy const T& from a nullptr.
-    Apply(InitSchemaDef(*s), static_cast<const T&>(*static_cast<T*>(0)));
+    Apply<T>(InitSchemaDef{ *s });
 }
 
 } // detail

--- a/cpp/inc/bond/core/schema.h
+++ b/cpp/inc/bond/core/schema.h
@@ -169,7 +169,7 @@ struct SchemaReader
 
 
 template <typename Unused> struct
-uses_marshaled_bonded<detail::SchemaReader&, Unused> : std::false_type
+uses_marshaled_bonded<SchemaReader&, Unused> : std::false_type
 {};
 
 

--- a/cpp/inc/bond/core/schema.h
+++ b/cpp/inc/bond/core/schema.h
@@ -159,13 +159,13 @@ namespace detail
 
     template <typename T, typename Unused>
     once_flag SchemaCache<T, Unused>::flag;
-
-
-    struct SchemaReader
-    {
-        using Parser = StaticParser<SchemaReader&>;
-    };
 }
+
+
+struct SchemaReader
+{
+    using Parser = StaticParser<SchemaReader&>;
+};
 
 
 template <typename Unused> struct

--- a/cpp/inc/bond/core/value.h
+++ b/cpp/inc/bond/core/value.h
@@ -151,7 +151,7 @@ BOND_NO_INLINE void Skip(Reader& input, const std::nothrow_t&)
 }
 
 template <typename T, typename Reader = detail::SchemaReader, typename boost::enable_if<std::is_same<Reader, detail::SchemaReader> >::type* = nullptr>
-void Skip(detail::SchemaReader&, const std::nothrow_t&)
+void Skip(detail::SchemaReader&, const std::nothrow_t&) BOND_NOEXCEPT
 {}
 
 template <typename Reader>
@@ -165,7 +165,7 @@ BOND_NO_INLINE void Skip(Reader& input, const RuntimeSchema& schema, const std::
     {}
 }
 
-inline void Skip(detail::SchemaReader&, const RuntimeSchema&, const std::nothrow_t&)
+inline void Skip(detail::SchemaReader&, const RuntimeSchema&, const std::nothrow_t&) BOND_NOEXCEPT
 {}
 
 template <typename Reader>
@@ -179,7 +179,7 @@ BOND_NO_INLINE void Skip(Reader& input, BondDataType type, const std::nothrow_t&
     {}
 }
 
-inline void Skip(detail::SchemaReader&, BondDataType, const std::nothrow_t&)
+inline void Skip(detail::SchemaReader&, BondDataType, const std::nothrow_t&) BOND_NOEXCEPT
 {}
 
 

--- a/cpp/inc/bond/core/value.h
+++ b/cpp/inc/bond/core/value.h
@@ -152,8 +152,8 @@ BOND_NO_INLINE void Skip(Reader& input, const std::nothrow_t&) BOND_NOEXCEPT
     {}
 }
 
-template <typename T, typename Reader = detail::SchemaReader, typename boost::enable_if<std::is_same<Reader, detail::SchemaReader> >::type* = nullptr>
-void Skip(detail::SchemaReader&, const std::nothrow_t&) BOND_NOEXCEPT
+template <typename T, typename Reader = SchemaReader, typename boost::enable_if<std::is_same<Reader, SchemaReader> >::type* = nullptr>
+void Skip(SchemaReader&, const std::nothrow_t&) BOND_NOEXCEPT
 {}
 
 template <typename Reader>
@@ -167,7 +167,7 @@ BOND_NO_INLINE void Skip(Reader& input, const RuntimeSchema& schema, const std::
     {}
 }
 
-inline void Skip(detail::SchemaReader&, const RuntimeSchema&, const std::nothrow_t&) BOND_NOEXCEPT
+inline void Skip(SchemaReader&, const RuntimeSchema&, const std::nothrow_t&) BOND_NOEXCEPT
 {}
 
 template <typename Reader>
@@ -181,7 +181,7 @@ BOND_NO_INLINE void Skip(Reader& input, BondDataType type, const std::nothrow_t&
     {}
 }
 
-inline void Skip(detail::SchemaReader&, BondDataType, const std::nothrow_t&) BOND_NOEXCEPT
+inline void Skip(SchemaReader&, BondDataType, const std::nothrow_t&) BOND_NOEXCEPT
 {}
 
 
@@ -406,19 +406,19 @@ typename boost::enable_if<is_basic_container<X> >::type
 inline DeserializeContainer(X& var, const T& element, Reader& input);
 
 template <typename Protocols, typename Transform, typename T>
-void DeserializeContainer(const Transform& transform, const value<T, detail::SchemaReader&>& element, detail::SchemaReader&)
+void DeserializeContainer(const Transform& transform, const value<T, SchemaReader&>& element, SchemaReader&)
 {
     transform.Container(element, 0);
 }
 
 template <typename Protocols, typename Transform, typename T1, typename T2>
-void DeserializeContainer(const Transform& transform, const value<std::pair<T1, T2>, detail::SchemaReader&>&, detail::SchemaReader& input)
+void DeserializeContainer(const Transform& transform, const value<std::pair<T1, T2>, SchemaReader&>&, SchemaReader& input)
 {
-    transform.Container(value<T1, detail::SchemaReader&>{ input, false }, value<T2, detail::SchemaReader&>{ input, false }, 0);
+    transform.Container(value<T1, SchemaReader&>{ input, false }, value<T2, SchemaReader&>{ input, false }, 0);
 }
 
 template <typename Protocols, typename Transform>
-void DeserializeContainer(const Transform& transform, const value<void, detail::SchemaReader&>& element, detail::SchemaReader& input);
+void DeserializeContainer(const Transform& transform, const value<void, SchemaReader&>& element, SchemaReader& input);
 
 
 // Specialization of value for containers with compile-time schema
@@ -478,7 +478,7 @@ typename boost::enable_if<is_basic_container<X> >::type
 inline DeserializeMap(X& var, BondDataType keyType, const T& element, Reader& input);
 
 template <typename Protocols, typename Transform>
-void DeserializeMap(const Transform& transform, BondDataType keyType, const value<void, detail::SchemaReader&>& element, detail::SchemaReader& input);
+void DeserializeMap(const Transform& transform, BondDataType keyType, const value<void, SchemaReader&>& element, SchemaReader& input);
 
 
 // Specialization of value for data described by runtime schema
@@ -636,7 +636,7 @@ private:
 
 
 template <typename Protocols, typename Transform>
-void DeserializeContainer(const Transform& transform, const value<void, detail::SchemaReader&>& element, detail::SchemaReader& input)
+void DeserializeContainer(const Transform& transform, const value<void, SchemaReader&>& element, SchemaReader& input)
 {
     switch (element.GetTypeId())
     {
@@ -883,7 +883,7 @@ inline DeserializeContainer(X& var, const T& element, Reader& input)
 
 
 template <typename Protocols, typename Transform>
-void DeserializeMap(const Transform& transform, BondDataType keyType, const value<void, detail::SchemaReader&>& element, detail::SchemaReader& input)
+void DeserializeMap(const Transform& transform, BondDataType keyType, const value<void, SchemaReader&>& element, SchemaReader& input)
 {
     switch (element.GetTypeId())
     {

--- a/cpp/inc/bond/core/value.h
+++ b/cpp/inc/bond/core/value.h
@@ -140,7 +140,7 @@ inline Skip(Reader& input, BondDataType type)
 
 
 template <typename T, typename Reader>
-BOND_NO_INLINE void Skip(Reader& input, const std::nothrow_t&)
+BOND_NO_INLINE void Skip(Reader& input, const std::nothrow_t&) BOND_NOEXCEPT
 {
     try
     {
@@ -155,7 +155,7 @@ void Skip(detail::SchemaReader&, const std::nothrow_t&) BOND_NOEXCEPT
 {}
 
 template <typename Reader>
-BOND_NO_INLINE void Skip(Reader& input, const RuntimeSchema& schema, const std::nothrow_t&)
+BOND_NO_INLINE void Skip(Reader& input, const RuntimeSchema& schema, const std::nothrow_t&) BOND_NOEXCEPT
 {
     try
     {
@@ -169,7 +169,7 @@ inline void Skip(detail::SchemaReader&, const RuntimeSchema&, const std::nothrow
 {}
 
 template <typename Reader>
-BOND_NO_INLINE void Skip(Reader& input, BondDataType type, const std::nothrow_t&)
+BOND_NO_INLINE void Skip(Reader& input, BondDataType type, const std::nothrow_t&) BOND_NOEXCEPT
 {
     try
     {

--- a/cpp/inc/bond/core/value.h
+++ b/cpp/inc/bond/core/value.h
@@ -150,6 +150,10 @@ BOND_NO_INLINE void Skip(Reader& input, const std::nothrow_t&)
     {}
 }
 
+template <typename T, typename Reader = detail::SchemaReader, typename boost::enable_if<std::is_same<Reader, detail::SchemaReader> >::type* = nullptr>
+void Skip(detail::SchemaReader&, const std::nothrow_t&)
+{}
+
 template <typename Reader>
 BOND_NO_INLINE void Skip(Reader& input, const RuntimeSchema& schema, const std::nothrow_t&)
 {
@@ -161,6 +165,9 @@ BOND_NO_INLINE void Skip(Reader& input, const RuntimeSchema& schema, const std::
     {}
 }
 
+inline void Skip(detail::SchemaReader&, const RuntimeSchema&, const std::nothrow_t&)
+{}
+
 template <typename Reader>
 BOND_NO_INLINE void Skip(Reader& input, BondDataType type, const std::nothrow_t&)
 {
@@ -171,6 +178,10 @@ BOND_NO_INLINE void Skip(Reader& input, BondDataType type, const std::nothrow_t&
     catch(...)
     {}
 }
+
+inline void Skip(detail::SchemaReader&, BondDataType, const std::nothrow_t&)
+{}
+
 
 // value_common implements common functionality related to skipping unread values
 template <typename T, typename Reader>
@@ -392,6 +403,20 @@ template <typename Protocols, typename X, typename T, typename Reader>
 typename boost::enable_if<is_basic_container<X> >::type
 inline DeserializeContainer(X& var, const T& element, Reader& input);
 
+template <typename Protocols, typename Transform, typename T>
+void DeserializeContainer(const Transform& transform, const value<T, detail::SchemaReader&>& element, detail::SchemaReader&)
+{
+    transform.Container(element, 0);
+}
+
+template <typename Protocols, typename Transform, typename T1, typename T2>
+void DeserializeContainer(const Transform& transform, const value<std::pair<T1, T2>, detail::SchemaReader&>&, detail::SchemaReader& input)
+{
+    transform.Container(value<T1, detail::SchemaReader&>{ input, false }, value<T2, detail::SchemaReader&>{ input, false }, 0);
+}
+
+template <typename Protocols, typename Transform>
+void DeserializeContainer(const Transform& transform, const value<void, detail::SchemaReader&>& element, detail::SchemaReader& input);
 
 
 // Specialization of value for containers with compile-time schema
@@ -449,6 +474,9 @@ inline DeserializeMap(X& var, BondDataType keyType, const T& element, Reader& in
 template <typename Protocols, typename X, typename T, typename Reader>
 typename boost::enable_if<is_basic_container<X> >::type
 inline DeserializeMap(X& var, BondDataType keyType, const T& element, Reader& input);
+
+template <typename Protocols, typename Transform>
+void DeserializeMap(const Transform& transform, BondDataType keyType, const value<void, detail::SchemaReader&>& element, detail::SchemaReader& input);
 
 
 // Specialization of value for data described by runtime schema
@@ -603,6 +631,24 @@ private:
     RuntimeSchema _schema;
     mutable bool _skip;
 };
+
+
+template <typename Protocols, typename Transform>
+void DeserializeContainer(const Transform& transform, const value<void, detail::SchemaReader&>& element, detail::SchemaReader& input)
+{
+    switch (element.GetTypeId())
+    {
+    case bond::BT_SET:
+    case bond::BT_MAP:
+    case bond::BT_LIST:
+    case bond::BT_STRUCT:
+        transform.Container(element, 0);
+        break;
+    default:
+        detail::BasicTypeContainer<Protocols>(transform, element.GetTypeId(), input, 0);
+        break;
+    }
+}
 
 
 template <typename Protocols, typename X, typename I, typename T>
@@ -831,6 +877,24 @@ inline DeserializeContainer(X& var, const T& element, Reader& input)
     }
 
     input.ReadContainerEnd();
+}
+
+
+template <typename Protocols, typename Transform>
+void DeserializeMap(const Transform& transform, BondDataType keyType, const value<void, detail::SchemaReader&>& element, detail::SchemaReader& input)
+{
+    switch (element.GetTypeId())
+    {
+    case bond::BT_SET:
+    case bond::BT_MAP:
+    case bond::BT_LIST:
+    case bond::BT_STRUCT:
+        detail::MapByKey<Protocols>(transform, keyType, element, input, 0);
+        break;
+    default:
+        detail::MapByElement<Protocols>(transform, keyType, element.GetTypeId(), input, 0);
+        break;
+    }
 }
 
 

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -6,6 +6,7 @@
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/numeric.hpp>
 
+#include <iterator>
 #include <map>
 #include <sstream>
 
@@ -287,9 +288,7 @@ private:
 
     void FormatValue(const std::wstring& value) const
     {
-        std::string str(value.size(), ' ');
-        std::transform(value.begin(), value.end(), str.begin(), [](wchar_t wc) { return char(wc); });
-        _this << str;
+        std::transform(value.begin(), value.end(), std::ostreambuf_iterator<char>(_this), [](wchar_t wc) { return char(wc); });
     }
 
     template <typename T, typename boost::enable_if<bond::is_basic_type<T> >::type* = nullptr>

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -164,7 +164,7 @@ public:
         if (!_structs)
             return true;
 
-        TypeName(value);
+        StructName(value);
         return false;
     }
 
@@ -175,7 +175,7 @@ public:
             return true;
 
         _this << "    " << id << ": " << ToString(metadata.modifier) << " ";
-        _this << TypeName(value);
+        TypeName(value);
         _this << " " << metadata.name;
 
         if (metadata.default_value.nothing)
@@ -206,7 +206,7 @@ public:
         }
 
         _this << "<";
-        _this << TypeName(value);
+        TypeName(value);
         _this << ">";
     }
 
@@ -226,9 +226,9 @@ public:
         }
 
         _this << "<";
-        _this << TypeName(key);
+        TypeName(key);
         _this << ", ";
-        _this << TypeName(value);
+        TypeName(value);
         _this << ">";
     }
 
@@ -251,28 +251,29 @@ public:
     }
 
 private:
-    template <typename T, typename Reader, typename boost::enable_if<bond::is_basic_type<T> >::type* = nullptr>
-    std::string TypeName(const bond::value<T, Reader>& /*value*/) const
+    template <typename T>
+    const std::string& StructName(const T& value) const
     {
-        return bond::detail::type<typename std::conditional<std::is_enum<T>::value, std::int32_t, T>::type>::name();
+        BuildIDL that{ *_structs };
+        Apply(that, value);
+        return *that._qualifiedName;
+    }
+
+    template <typename T, typename Reader, typename boost::enable_if<bond::is_basic_type<T> >::type* = nullptr>
+    void TypeName(const bond::value<T, Reader>& /*value*/) const
+    {
+        _this << bond::detail::type<typename std::conditional<std::is_enum<T>::value, std::int32_t, T>::type>::name();
     }
 
     template <typename T>
-    std::string TypeName(const T& value) const
+    void TypeName(const T& value) const
     {
-        const auto type = bond::GetTypeId(value);
-        if (type == bond::BT_STRUCT)
-        {
-            BuildIDL that{ *_structs };
-            Apply(that, value);
-            return *that._qualifiedName;
-        }
+        _container = bond::GetTypeId(value);
+
+        if (_container == bond::BT_STRUCT)
+            _this << StructName(value);
         else
-        {
-            _container = type;
             Apply(*this, value);
-            return {};
-        }
     }
 
     template <typename T, typename Enable = void> struct

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -179,7 +179,7 @@ public:
     template <typename T, typename Reader>
     void Container(const bond::value<T, Reader>& value, std::size_t size) const
     {
-        UT_AssertAreEqual(size, 0);
+        BOOST_VERIFY(size == 0);
 
         switch (_container)
         {
@@ -199,7 +199,7 @@ public:
     template <typename K, typename T, typename Reader>
     void Container(const bond::value<K, Reader>& key, const bond::value<T, Reader>& value, std::size_t size) const
     {
-        UT_AssertAreEqual(size, 0);
+        BOOST_VERIFY(size == 0);
 
         switch (_container)
         {

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -166,7 +166,7 @@ public:
         if (!_structs)
             return true;
 
-        _this.seekp(-3, std::ios_base::end);
+        _this.seekp(-3, std::ios_base::end);    // Undo the added "\n{\n" in Base.
         _this << " : " << StructName(value) << "\n{\n";
         return false;
     }
@@ -256,7 +256,7 @@ private:
         const char* labels[] = { "list", "set", "map" };
         _this << labels[_container - bond::BT_LIST] << '<';
         (void)std::initializer_list<int>{ (TypeName(value), _this << ", ", 0)... };
-        _this.seekp(-2, std::ios_base::end);
+        _this.seekp(-2, std::ios_base::end);    // Undo the last ", ".
         _this << '>';
     }
 

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -198,12 +198,15 @@ public:
             break;
         case bond::BT_SET:
             _this << "set";
+            break;
         default:
             assert(false);
             break;
         }
 
-        _this << "<" << GetTypeName(value) << ">";
+        _this << "<";
+        _this << GetTypeName(value);
+        _this << ">";
     }
 
     template <typename K, typename T, typename Reader>
@@ -221,7 +224,11 @@ public:
             break;
         }
 
-        _this << "<" << GetTypeName(key) << ", " << GetTypeName(value) << ">";
+        _this << "<";
+        _this << GetTypeName(key);
+        _this << ", ";
+        _this << GetTypeName(value);
+        _this << ">";
     }
 
     template <typename T>
@@ -235,11 +242,11 @@ public:
 
     void End() const
     {
-        if (_cache)
-        {
-            _this << "};\n";
-            _cache->emplace(_qualifiedName, _this.str());
-        }
+        if (!_cache)
+            return;
+
+        _this << "};\n";
+        _cache->emplace(_qualifiedName, _this.str());
     }
 
 private:
@@ -273,50 +280,50 @@ private:
         }
     }
 
+    template <typename T>
+    void FormatDefaultValue(const T& value) const
+    {
+        if (value != T{})
+            _this << " = " << value;
+    }
+
     template <typename T, typename boost::enable_if<std::is_same<T, bool> >::type* = nullptr>
     void DefaultValue(const bond::Variant& value) const
     {
-        if (value.uint_value != T{})
-            _this << " = " << std::boolalpha << bool(value.uint_value);
+        _this << std::boolalpha;
+        FormatDefaultValue(bool(value.uint_value));
     }
 
     template <typename T, typename boost::enable_if_c<std::is_unsigned<T>::value && !std::is_same<T, bool>::value>::type* = nullptr>
     void DefaultValue(const bond::Variant& value) const
     {
-        if (value.uint_value != T{})
-            _this << " = " << value.uint_value;
+        FormatDefaultValue(value.uint_value);
     }
 
     template <typename T, typename boost::enable_if<bond::is_signed_int_or_enum<T> >::type* = nullptr>
     void DefaultValue(const bond::Variant& value) const
     {
-        if (value.int_value != T{})
-            _this << " = " << value.int_value;
+        FormatDefaultValue(value.int_value);;
     }
 
     template <typename T, typename boost::enable_if<std::is_floating_point<T> >::type* = nullptr>
     void DefaultValue(const bond::Variant& value) const
     {
-        if (value.double_value != T{})
-            _this << " = " << value.double_value;
+        FormatDefaultValue(value.double_value);
     }
 
     template <typename T, typename boost::enable_if<bond::is_string<T> >::type* = nullptr>
     void DefaultValue(const bond::Variant& value) const
     {
-        if (value.string_value != T{})
-            _this << " = " << value.string_value;
+        FormatDefaultValue(value.string_value);
     }
 
     template <typename T, typename boost::enable_if<bond::is_wstring<T> >::type* = nullptr>
     void DefaultValue(const bond::Variant& value) const
     {
-        if (value.wstring_value != T{})
-        {
-            std::string str(value.wstring_value.size(), ' ');
-            std::transform(value.wstring_value.begin(), value.wstring_value.end(), str.begin(), [](wchar_t wc) { return char(wc); });
-            _this << " = " << str;
-        }
+        std::string str(value.wstring_value.size(), ' ');
+        std::transform(value.wstring_value.begin(), value.wstring_value.end(), str.begin(), [](wchar_t wc) { return char(wc); });
+        FormatDefaultValue(str);
     }
 
     template <typename T, typename boost::disable_if<bond::is_basic_type<T> >::type* = nullptr>

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -144,15 +144,16 @@ class BuildIDL : public bond::Transform
 {
 public:
     explicit BuildIDL(std::map<std::string, std::string>& cache)
-        : _structs{ &cache }
+        : _structs{ &cache },
+          _qualifiedName{ nullptr }
     {}
 
     void Begin(const bond::Metadata& metadata) const
     {
-        _qualifiedName = metadata.qualified_name;
+        _qualifiedName = &metadata.qualified_name;
 
-        if (_structs->find(_qualifiedName) == _structs->end())
-            _this << "struct " << _qualifiedName << "\n{\n";
+        if (_structs->find(*_qualifiedName) == _structs->end())
+            _this << "struct " << *_qualifiedName << "\n{\n";
         else
             _structs = {};
     }
@@ -246,7 +247,7 @@ public:
             return;
 
         _this << "};\n";
-        _structs->emplace(_qualifiedName, _this.str());
+        _structs->emplace(*_qualifiedName, _this.str());
     }
 
 private:
@@ -264,7 +265,7 @@ private:
         {
             BuildIDL that{ *_structs };
             Apply(that, value);
-            return that._qualifiedName;
+            return *that._qualifiedName;
         }
         else
         {
@@ -334,7 +335,7 @@ private:
     {}
 
     mutable std::map<std::string, std::string>* _structs;
-    mutable std::string _qualifiedName;
+    mutable const std::string* _qualifiedName;
     mutable std::ostringstream _this;
     mutable bond::BondDataType _container;
 };

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -1,7 +1,9 @@
 #include "precompiled.h"
 #include "apply_tests.h"
-#include "apply_test_apply.h"   // Note that we don't want to include apply_test_reflection.h so that
-                                // we only see pre-generated Apply overloads.
+#include "apply_test_reflection.h"
+#include "apply_test_apply.h"   // Note that pre-generated Apply overloads will be chosen
+                                // even though apply_test_reflection.h is included.
+#include <sstream>
 
 void Init(unittest::apply::Struct& obj)
 {
@@ -134,6 +136,197 @@ Bonded(uint16_t version = bond::v1)
 }
 
 
+class BuildIDL : public bond::Transform
+{
+public:
+    explicit BuildIDL(std::ostream& out)
+        : _out{ out }
+    {}
+
+    template <typename T>
+    bool Base(const T& value) const
+    {
+        GetTypeName(value);
+        return false;
+    }
+
+    void Begin(const bond::Metadata& metadata) const
+    {
+        _qualifiedName = metadata.qualified_name;
+        _this << "struct " << _qualifiedName << "\n{\n";
+    }
+
+    template <typename T>
+    bool Field(uint16_t id, const bond::Metadata& metadata, const T& value) const
+    {
+        _this << "    " << id << ": " << ToString(metadata.modifier) << " ";
+        _this << GetTypeName(value);
+        _this << " " << metadata.name;
+
+        if (metadata.default_value.nothing)
+        {
+            _this << " = nothing";
+        }
+        else
+        {
+            DefaultValue<typename bond::remove_bonded_value<T>::type>(metadata.default_value);
+        }
+
+        _this << ";\n";
+        return false;
+    }
+
+    template <typename T, typename Reader>
+    void Container(const bond::value<T, Reader>& value, std::size_t size) const
+    {
+        UT_AssertAreEqual(size, 0);
+
+        switch (_container)
+        {
+        case bond::BT_LIST:
+            _this << "list";
+            break;
+        case bond::BT_SET:
+            _this << "set";
+        default:
+            assert(false);
+            break;
+        }
+
+        _this << "<" << GetTypeName(value) << ">";
+    }
+
+    template <typename K, typename T, typename Reader>
+    void Container(const bond::value<K, Reader>& key, const bond::value<T, Reader>& value, std::size_t size) const
+    {
+        UT_AssertAreEqual(size, 0);
+
+        switch (_container)
+        {
+        case bond::BT_MAP:
+            _this << "map";
+            break;
+        default:
+            assert(false);
+            break;
+        }
+
+        _this << "<" << GetTypeName(key) << ", " << GetTypeName(value) << ">";
+    }
+
+    template <typename T>
+    bool UnknownField(std::uint16_t /*id*/, const T& /*value*/) const noexcept
+    {
+        return false;
+    }
+
+    void UnknownEnd() const noexcept
+    {}
+
+    void End() const
+    {
+        _this << "};\n";
+        _this.flush();
+        _out << _this.str();
+    }
+
+private:
+    template <typename T, typename Reader, typename boost::enable_if_c<bond::is_basic_type<T>::value && !std::is_enum<T>::value>::type* = nullptr>
+    std::string GetTypeName(const bond::value<T, Reader>& /*value*/) const
+    {
+        return bond::detail::type<T>::name();
+    }
+
+    template <typename T, typename Reader, typename boost::enable_if<std::is_enum<T> >::type* = nullptr>
+    std::string GetTypeName(const bond::value<T, Reader>& /*value*/) const
+    {
+        return bond::detail::type<typename std::underlying_type<T>::type>::name();
+    }
+
+    template <typename T, typename Reader, typename boost::disable_if<bond::is_basic_type<T> >::type* = nullptr>
+    std::string GetTypeName(const bond::value<T, Reader>& value) const
+    {
+        const auto type = bond::GetTypeId(value);
+        if (type == bond::BT_STRUCT)
+        {
+            BuildIDL that{ _out };
+            Apply(that, value);
+            return that._qualifiedName;
+        }
+        else
+        {
+            _container = type;
+            Apply(*this, value);
+            return {};
+        }
+    }
+
+    template <typename T, typename Reader>
+    std::string GetTypeName(const bond::bonded<T, Reader>& value) const
+    {
+        BuildIDL that{ _out };
+        Apply(that, value);
+        return that._qualifiedName;
+    }
+
+    template <typename T, typename boost::enable_if<std::is_same<T, bool> >::type* = nullptr>
+    void DefaultValue(const bond::Variant& value) const
+    {
+        if (value.uint_value != T{})
+            _this << " = " << std::boolalpha << bool(value.uint_value);
+    }
+
+    template <typename T, typename boost::enable_if_c<std::is_unsigned<T>::value && !std::is_same<T, bool>::value>::type* = nullptr>
+    void DefaultValue(const bond::Variant& value) const
+    {
+        if (value.uint_value != T{})
+            _this << " = " << value.uint_value;
+    }
+
+    template <typename T, typename boost::enable_if<bond::is_signed_int_or_enum<T> >::type* = nullptr>
+    void DefaultValue(const bond::Variant& value) const
+    {
+        if (value.int_value != T{})
+            _this << " = " << value.int_value;
+    }
+
+    template <typename T, typename boost::enable_if<std::is_floating_point<T> >::type* = nullptr>
+    void DefaultValue(const bond::Variant& value) const
+    {
+        if (value.double_value != T{})
+            _this << " = " << value.double_value;
+    }
+
+    template <typename T, typename boost::enable_if<bond::is_string<T> >::type* = nullptr>
+    void DefaultValue(const bond::Variant& value) const
+    {
+        if (value.string_value != T{})
+            _this << " = " << value.string_value;
+    }
+
+    template <typename T, typename boost::enable_if<bond::is_wstring<T> >::type* = nullptr>
+    void DefaultValue(const bond::Variant& value) const
+    {
+        if (value.wstring_value != T{})
+        {
+            std::string str(value.wstring_value.size(), ' ');
+            std::transform(value.wstring_value.begin(), value.wstring_value.end(), str.begin(), [](wchar_t wc) { return char(wc); });
+            _this << " = " << str;
+        }
+    }
+
+    template <typename T, typename boost::disable_if<bond::is_basic_type<T> >::type* = nullptr>
+    void DefaultValue(const bond::Variant& /*value*/) const
+    {}
+
+    std::ostream& _out;
+    mutable std::string _qualifiedName;
+    mutable std::ostringstream _this;
+    mutable bond::BondDataType _container;
+};
+
+
+
 template <typename Reader, typename Writer>
 struct Tests
 {
@@ -153,6 +346,14 @@ struct Tests
         Bonded<Reader, Writer, X>(Reader::version);
 
         bond::RuntimeSchema schema = bond::GetRuntimeSchema<X>();
+
+        std::ostringstream s1;
+        Apply<X>(BuildIDL{ s1 });
+        std::ostringstream s2;
+        Apply(BuildIDL{ s2 }, schema);
+        std::string idl1 = s1.str();
+        std::string idl2 = s2.str();
+        UT_AssertAreEqual(idl1, idl2);
     }
 };
 

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -204,12 +204,12 @@ public:
     }
 
     template <typename T>
-    bool UnknownField(std::uint16_t /*id*/, const T& /*value*/) const noexcept
+    bool UnknownField(std::uint16_t /*id*/, const T& /*value*/) const BOND_NOEXCEPT
     {
         return !_structs;
     }
 
-    void UnknownEnd() const noexcept
+    void UnknownEnd() const BOND_NOEXCEPT
     {}
 
     void End() const
@@ -321,7 +321,7 @@ private:
     }
 
     template <typename T, typename boost::disable_if<bond::is_basic_type<T> >::type* = nullptr>
-    void DefaultValue(const bond::Variant& /*var*/) const
+    void DefaultValue(const bond::Variant& /*var*/) const BOND_NOEXCEPT
     {}
 
     mutable std::map<std::string, std::string>* _structs;

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -154,7 +154,7 @@ public:
         _qualifiedName = &metadata.qualified_name;
 
         if (_structs->find(*_qualifiedName) == _structs->end())
-            _this << "struct " << *_qualifiedName << "\n{\n";
+            _this << std::boolalpha << "struct " << *_qualifiedName << "\n{\n";
         else
             _structs = {};
     }
@@ -283,11 +283,6 @@ private:
     void FormatValue(const T& value) const
     {
         _this << value;
-    }
-
-    void FormatValue(bool value) const
-    {
-        _this << std::boolalpha << value;
     }
 
     void FormatValue(const std::wstring& value) const

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -166,7 +166,7 @@ public:
         if (!_structs)
             return true;
 
-        _this.seekp(-3, std::ios_base::end);    // Undo the added "\n{\n" in Base.
+        _this.seekp(-3, std::ios_base::end);    // Undo the added "\n{\n" in Begin.
         _this << " : " << StructName(value) << "\n{\n";
         return false;
     }

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -242,8 +242,8 @@ private:
         return bond::detail::type<std::int32_t>::name();
     }
 
-    template <typename T, typename Reader, typename boost::disable_if<bond::is_basic_type<T> >::type* = nullptr>
-    std::string GetTypeName(const bond::value<T, Reader>& value) const
+    template <typename T>
+    std::string GetTypeName(const T& value) const
     {
         const auto type = bond::GetTypeId(value);
         if (type == bond::BT_STRUCT)
@@ -258,14 +258,6 @@ private:
             Apply(*this, value);
             return {};
         }
-    }
-
-    template <typename T, typename Reader>
-    std::string GetTypeName(const bond::bonded<T, Reader>& value) const
-    {
-        BuildIDL that{ _out };
-        Apply(that, value);
-        return that._qualifiedName;
     }
 
     template <typename T, typename boost::enable_if<std::is_same<T, bool> >::type* = nullptr>

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -167,9 +167,7 @@ public:
             return true;
 
         _this.seekp(-3, std::ios_base::end);
-        _this << " : ";
-        _this << StructName(value);
-        _this << "\n{\n";
+        _this << " : " << StructName(value) << "\n{\n";
         return false;
     }
 

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -226,8 +226,7 @@ public:
     void End() const
     {
         _this << "};\n";
-        _this.flush();
-        _out << _this.str();
+        _out << _this.rdbuf();
     }
 
 private:
@@ -321,7 +320,7 @@ private:
 
     std::ostream& _out;
     mutable std::string _qualifiedName;
-    mutable std::ostringstream _this;
+    mutable std::stringstream _this;
     mutable bond::BondDataType _container;
 };
 

--- a/cpp/test/core/apply_tests.cpp
+++ b/cpp/test/core/apply_tests.cpp
@@ -239,7 +239,7 @@ private:
     template <typename T, typename Reader, typename boost::enable_if<std::is_enum<T> >::type* = nullptr>
     std::string GetTypeName(const bond::value<T, Reader>& /*value*/) const
     {
-        return bond::detail::type<typename std::underlying_type<T>::type>::name();
+        return bond::detail::type<std::int32_t>::name();
     }
 
     template <typename T, typename Reader, typename boost::disable_if<bond::is_basic_type<T> >::type* = nullptr>


### PR DESCRIPTION
Sometimes it is necessary to apply a custom transform to a schema, rather than an object or a serialized data. One such use case is the `bond::InitSchemaDef` which is applied to a compile-time schema in order to generate a corresponding runtime one.

One way to achieve that is to apply it to a dummy object. That is not always possible or convenient to do, like in this case,, and we choose to rely on some undefined behavior and fake objects.

There is no canonical way of doing the same for runtime schema, and instead a manual traversal of `bond::SchemaDef` structure is needed, or more tricky ways of using one of the existing protocol readers.

This change is adding two more overloads to `bond::Apply` that would make such transformation possible in a canonical and legal way.