### PR TITLE
Indicate C++ minor version bump needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ different versioning scheme, following the Haskell community's
 ## Unreleased ##
 
 * IDL core version: TBD
-* C++ version: TBD (bug fix bump needed)
+* C++ version: TBD (minor version bump needed)
 * C# NuGet version: TBD
 * `gbc` & compiler library: TBD
 


### PR DESCRIPTION
The ability to apply a transform without an object is new functionality.

Indicate this via a minor version bump.