### PR TITLE
[c#] Refer to $(EnableDefaultItems) in dup codegen error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ different versioning scheme, following the Haskell community's
   use buffer allocators other than `new byte[]` (e.g.
   `ArrayPool<byte>.Rent()`). ([Pull request
   \#1128](https://github.com/microsoft/bond/pull/1128))
+* The error message emitted when duplicate .bond items are detected by the
+  MSBuild codegen now correctly refers to `$(EnableDefaultItems)` as the
+  switch that controls this behavior. ([Issue
+  \#1110](https://github.com/microsoft/bond/issues/1110))
 
 ## 9.0.5: 2021-04-14 ##
 

--- a/cs/build/nuget/Common.targets
+++ b/cs/build/nuget/Common.targets
@@ -102,8 +102,8 @@
           ItemName="_BondCodegenFiltered"/>
     </RemoveDuplicates>
 
-    <PropertyGroup Condition=" '$(EnableDefaultCompileItems)' == 'true' ">
-      <_DefaultItemsMessage> The Bond package includes BondCodegen items for all .bond files from your project directory by default. You can either remove these items from your project file, or set the 'EnableDefaultCompileItems' property to 'false' if you want to explicitly include them in your project file. To set per-item metadata, use the item update syntax (https://docs.microsoft.com/en-us/visualstudio/msbuild/item-element-msbuild#examples).</_DefaultItemsMessage>
+    <PropertyGroup Condition=" '$(EnableDefaultItems)' == 'true' ">
+      <_DefaultItemsMessage> The Bond package includes BondCodegen items for all .bond files from your project directory by default. You can either remove these items from your project file, or set the 'EnableDefaultItems' property to 'false' if you want to explicitly include them in your project file. To set per-item metadata, use the item update syntax (https://docs.microsoft.com/en-us/visualstudio/msbuild/item-element-msbuild#examples).</_DefaultItemsMessage>
     </PropertyGroup>
 
     <!-- The RemoveDuplicates task preserves the input order, so this is an


### PR DESCRIPTION
The "Duplicate BondCodegen items were included" error message says that
the `$(EnableDefaultCompileItems)` property can be set to false to stop
automatic inclusion. The automatic inclusion behavior is conditioned on
the `$(EnableDefaultItems)` property, not
`$(EnableDefaultCompileItems)`.

Revise the error message to mention `$(EnableDefaultItems)`.

Fixes https://github.com/microsoft/bond/issues/1110