### PR TITLE
[c#] Use https apt source to fetch mono

### DIFF
--- a/tools/ci-scripts/linux/image-builder/Dockerfile
+++ b/tools/ci-scripts/linux/image-builder/Dockerfile
@@ -8,6 +8,8 @@ VOLUME /root/bond
 # Enable PPAs
 RUN apt-get update && \
     apt-get -y install \
+    apt-transport-https \
+    ca-certificates \
     software-properties-common
 
 # Components for gbc
@@ -38,7 +40,7 @@ RUN wget -qO- https://get.haskellstack.org/ | sh
 
 # Components for C#. See http://www.mono-project.com/download/#download-lin
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
-    echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | tee /etc/apt/sources.list.d/mono-official.list && \
+    echo "deb https://download.mono-project.com/repo/ubuntu xenial main" | tee /etc/apt/sources.list.d/mono-official.list && \
     apt-get update && \
     apt-get -y install \
     mono-devel \


### PR DESCRIPTION
The Mono apt source has started redirecting to https. The CI image
Dockerfile wasn't installing the needed components to have apt connect
over https.

Install the missing components. Use an explicit https source instead of
relying on the redirection.