### PR TITLE
[java] Pin to Gradle 6

### DIFF
--- a/tools/ci-scripts/linux/image-builder/Dockerfile
+++ b/tools/ci-scripts/linux/image-builder/Dockerfile
@@ -52,7 +52,7 @@ RUN nuget install NUnit.ConsoleRunner -OutputDirectory /root -Version 3.8.0 -Non
 RUN add-apt-repository ppa:cwchien/gradle && \
     apt-get update && \
     apt-get -y install \
-    gradle \
+    gradle-6.8.3 \
     openjdk-8-jdk-headless
 
 # Components for ghc


### PR DESCRIPTION
The Java Gradle files use Gradle 6 features, like `maven`. Newer
versions of Gradle do not support this.

Pin to Gradle 6 until this can be reworked.