### PR TITLE
Use "field id" phrasing in schema evolution

### DIFF
--- a/doc/src/bond_cpp.md
+++ b/doc/src/bond_cpp.md
@@ -242,7 +242,7 @@ These following changes will break wire compatibility and are not recommended:
 - Incompatible change of field types (any type change *not* covered above);
   e.g.: `int32` to `string`, `string` to `wstring`, `float` to
   `nullable<float>`
-- Changing of field ordinals
+- Changing of field ordinals/ids
 - Changing of inheritance hierarchy (add/remove/substituting base struct)
 - Changing between `required` and `optional` directly
 - Changing the default value of a field
@@ -251,8 +251,9 @@ These following changes will break wire compatibility and are not recommended:
 
 Some best practices and other considerations to keep in mind:
 
-- When removing a field, comment it out rather than removing it altogether so
-  that the field ordinal is not reused in future edits of the schema
+- When removing a field, comment it out rather than removing it altogether
+  so that neither the field ordinal nor name are reused in future edits of
+  the schema
 - When working with untagged protocols like
   [SimpleBinaryProtocol](#simple-binary), great care must be taken to ensure
   the same [schema](#runtime-schema) is used when deserializing the payload as

--- a/doc/src/bond_cs.md
+++ b/doc/src/bond_cs.md
@@ -324,7 +324,7 @@ These following changes will break wire compatibility and are not recommended:
 - Incompatible change of field types (any type change *not* covered above);
   e.g.: `int32` to `string`, `string` to `wstring`, `float` to
   `nullable<float>`
-- Changing of field ordinals
+- Changing of field ordinals/ids
 - Changing of inheritance hierarchy (add/remove/substituting base struct)
 - Changing between `required` and `optional` directly
 - Changing the default value of a field
@@ -333,8 +333,9 @@ These following changes will break wire compatibility and are not recommended:
 
 Some best practices and other considerations to keep in mind:
 
-- When removing a field, comment it out rather than removing it altogether so
-  that the field ordinal is not reused in future edits of the schema
+- When removing a field, comment it out rather than removing it altogether
+  so that the neither the field ordinal nor name are reused in future edits
+  of the schema
 - When working with untagged protocols like
   [SimpleBinaryProtocol](#simple-binary), great care must be taken to ensure
   the same [schema](#runtime-schema) is used when deserializing the payload as

--- a/doc/src/compiler.md
+++ b/doc/src/compiler.md
@@ -110,8 +110,8 @@ struct Example : Base
 }
 ```
 
-Field definition consists of an ordinal, type, name and optional default value.
-Field type can be:
+Field definition consists of an ordinal/id, type, name, and a default value.
+The fields type's can be:
 
 - Basic type: `bool`, `uint8`, `uint16`, `uint32`, `uint64`, `int8`, `int16`,
 `int32`, `int64`, `float`, `double`, `string`, `wstring`.
@@ -124,7 +124,7 @@ Field type can be:
 An optional default value can be specified for fields of basic types. For
 integers the default can be specified as either a decimal number or a
 hexadecimal number prefixed with `0x`. The only explicit default value allowed
-for containers is [`nothing`](#default-value-of-nothing). Enum fields must have
+for containers is [`nothing`](#default-value-of-nothing). Enum fields _must_ have
 an explicit default value which must be one of the enum named constants or
 [`nothing`](#default-value-of-nothing).
 


### PR DESCRIPTION
The schema evolution documentation refers to "field ordinals", which is
terminology that may not be familiar to all users of Bond.

Refer to "field ordinals" as "field ordinals/ids" in schemea evolution
and compiler documentation.

Add minor clarification and emphasize around when default values are
optional or required.