### PR TITLE
[c#] support for system.collections.immutable collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,11 @@ different versioning scheme, following the Haskell community's
   code will be generated for them. See [issue \#1131, Bond-over-gRPC will be
   deprecated February 2022](https://github.com/microsoft/bond/issues/1131),
   for the full announcement.
-* Added compiler and deserialization support for using [System.Collections.Immutable](https://www.nuget.org/packages/System.Collections.Immutable/#readme-body-tab) collections as container type aliases.
+* Added codegen and deserialization support for container type aliases to
+  use
+  [System.Collections.Immutable](https://learn.microsoft.com/dotnet/api/system.collections.immutable)
+  collections. (Pull request
+  [\#1161](https://github.com/microsoft/bond/pull/1161))
 
 ## 10.0: 2022-03-07 ##
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ different versioning scheme, following the Haskell community's
   code will be generated for them. See [issue \#1131, Bond-over-gRPC will be
   deprecated February 2022](https://github.com/microsoft/bond/issues/1131),
   for the full announcement.
+* Added compiler and deserialization support for using [System.Collections.Immutable](https://www.nuget.org/packages/System.Collections.Immutable/#readme-body-tab) collections as container type aliases.
 
 ## 10.0: 2022-03-07 ##
 

--- a/compiler/tests/TestMain.hs
+++ b/compiler/tests/TestMain.hs
@@ -144,6 +144,16 @@ tests = testGroup "Compiler tests"
             , verifyCsCodegen "inheritance"
             , verifyCsCodegen "aliases"
             , verifyCsCodegen "complex_inheritance"
+            , verifyCodegen
+                [ "c#"
+                , "--using=ImmutableArray=System.Collections.Immutable.ImmutableArray<{0}>"
+                , "--using=ImmutableList=System.Collections.Immutable.ImmutableList<{0}>"
+                , "--using=ImmutableHashSet=System.Collections.Immutable.ImmutableHashSet<{0}>"
+                , "--using=ImmutableSortedSet=System.Collections.Immutable.ImmutableSortedSet<{0}>"
+                , "--using=ImmutableDictionary=System.Collections.Immutable.ImmutableDictionary<{0},{1}>"
+                , "--using=ImmutableSortedDictionary=System.Collections.Immutable.ImmutableSortedDictionary<{0},{1}>"
+                ]
+                "immutable_collections"
             , verifyCodegenVariation
                 [ "c#"
                 , "--preview-constructor-parameters"

--- a/compiler/tests/generated/collection-interfaces/immutable_collections_types.cs
+++ b/compiler/tests/generated/collection-interfaces/immutable_collections_types.cs
@@ -1,0 +1,56 @@
+
+
+// suppress "Missing XML comment for publicly visible type or member"
+#pragma warning disable 1591
+
+
+#region ReSharper warnings
+// ReSharper disable PartialTypeWithSinglePart
+// ReSharper disable RedundantNameQualifier
+// ReSharper disable InconsistentNaming
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedParameter.Local
+// ReSharper disable RedundantUsingDirective
+#endregion
+
+namespace tests
+{
+    using System.Collections.Generic;
+
+    [global::Bond.Schema]
+    [System.CodeDom.Compiler.GeneratedCode("gbc", "0.12.1.0")]
+    public partial class ImmutableCollectionsHolder
+    {
+        [global::Bond.Id(0)]
+        public System.Collections.Immutable.ImmutableArray<string> ImmutableArrayString { get; set; }
+
+        [global::Bond.Id(1)]
+        public System.Collections.Immutable.ImmutableList<string> ImmutableListString { get; set; }
+
+        [global::Bond.Id(2)]
+        public System.Collections.Immutable.ImmutableHashSet<string> ImmutableHashSetString { get; set; }
+
+        [global::Bond.Id(3)]
+        public System.Collections.Immutable.ImmutableSortedSet<int> ImmutableSortedSetInt { get; set; }
+
+        [global::Bond.Id(4)]
+        public System.Collections.Immutable.ImmutableDictionary<string,string> ImmutableDictionaryStringMap { get; set; }
+
+        [global::Bond.Id(5)]
+        public System.Collections.Immutable.ImmutableSortedDictionary<int,string> ImmutableSortedDictionaryStringMap { get; set; }
+
+        public ImmutableCollectionsHolder()
+            : this("tests.ImmutableCollectionsHolder", "ImmutableCollectionsHolder")
+        {}
+
+        protected ImmutableCollectionsHolder(string fullName, string name)
+        {
+            ImmutableArrayString = System.Collections.Immutable.ImmutableArray<string>.Empty;
+            ImmutableListString = System.Collections.Immutable.ImmutableList<string>.Empty;
+            ImmutableHashSetString = System.Collections.Immutable.ImmutableHashSet<string>.Empty;
+            ImmutableSortedSetInt = System.Collections.Immutable.ImmutableSortedSet<int>.Empty;
+            ImmutableDictionaryStringMap = System.Collections.Immutable.ImmutableDictionary<string,string>.Empty;
+            ImmutableSortedDictionaryStringMap = System.Collections.Immutable.ImmutableSortedDictionary<int,string>.Empty;
+        }
+    }
+} // tests

--- a/compiler/tests/generated/immutable_collections_types.cs
+++ b/compiler/tests/generated/immutable_collections_types.cs
@@ -1,0 +1,56 @@
+
+
+// suppress "Missing XML comment for publicly visible type or member"
+#pragma warning disable 1591
+
+
+#region ReSharper warnings
+// ReSharper disable PartialTypeWithSinglePart
+// ReSharper disable RedundantNameQualifier
+// ReSharper disable InconsistentNaming
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedParameter.Local
+// ReSharper disable RedundantUsingDirective
+#endregion
+
+namespace tests
+{
+    using System.Collections.Generic;
+
+    [global::Bond.Schema]
+    [System.CodeDom.Compiler.GeneratedCode("gbc", "0.12.1.0")]
+    public partial class ImmutableCollectionsHolder
+    {
+        [global::Bond.Id(0)]
+        public System.Collections.Immutable.ImmutableArray<string> ImmutableArrayString { get; set; }
+
+        [global::Bond.Id(1)]
+        public System.Collections.Immutable.ImmutableList<string> ImmutableListString { get; set; }
+
+        [global::Bond.Id(2)]
+        public System.Collections.Immutable.ImmutableHashSet<string> ImmutableHashSetString { get; set; }
+
+        [global::Bond.Id(3)]
+        public System.Collections.Immutable.ImmutableSortedSet<int> ImmutableSortedSetInt { get; set; }
+
+        [global::Bond.Id(4)]
+        public System.Collections.Immutable.ImmutableDictionary<string,string> ImmutableDictionaryStringMap { get; set; }
+
+        [global::Bond.Id(5)]
+        public System.Collections.Immutable.ImmutableSortedDictionary<int,string> ImmutableSortedDictionaryStringMap { get; set; }
+
+        public ImmutableCollectionsHolder()
+            : this("tests.ImmutableCollectionsHolder", "ImmutableCollectionsHolder")
+        {}
+
+        protected ImmutableCollectionsHolder(string fullName, string name)
+        {
+            ImmutableArrayString = System.Collections.Immutable.ImmutableArray<string>.Empty;
+            ImmutableListString = System.Collections.Immutable.ImmutableList<string>.Empty;
+            ImmutableHashSetString = System.Collections.Immutable.ImmutableHashSet<string>.Empty;
+            ImmutableSortedSetInt = System.Collections.Immutable.ImmutableSortedSet<int>.Empty;
+            ImmutableDictionaryStringMap = System.Collections.Immutable.ImmutableDictionary<string,string>.Empty;
+            ImmutableSortedDictionaryStringMap = System.Collections.Immutable.ImmutableSortedDictionary<int,string>.Empty;
+        }
+    }
+} // tests

--- a/compiler/tests/schema/immutable_collections.bond
+++ b/compiler/tests/schema/immutable_collections.bond
@@ -1,0 +1,18 @@
+namespace tests
+
+using ImmutableArray<T> = list<T>;
+using ImmutableList<T> = list<T>;
+using ImmutableHashSet<T> = set<T>;
+using ImmutableSortedSet<T> = set<T>;
+using ImmutableDictionary<K, V> = map<K, V>;
+using ImmutableSortedDictionary<K, V> = map<K, V>;
+
+struct ImmutableCollectionsHolder
+{
+	0: ImmutableArray<string> ImmutableArrayString;
+	1: ImmutableList<string> ImmutableListString;
+	2: ImmutableHashSet<string> ImmutableHashSetString;
+	3: ImmutableSortedSet<int32> ImmutableSortedSetInt;
+	4: ImmutableDictionary<string, string> ImmutableDictionaryStringMap;
+	5: ImmutableSortedDictionary<int32, string> ImmutableSortedDictionaryStringMap;
+}

--- a/compiler/tests/schema/immutable_collections.bond
+++ b/compiler/tests/schema/immutable_collections.bond
@@ -9,10 +9,10 @@ using ImmutableSortedDictionary<K, V> = map<K, V>;
 
 struct ImmutableCollectionsHolder
 {
-	0: ImmutableArray<string> ImmutableArrayString;
-	1: ImmutableList<string> ImmutableListString;
-	2: ImmutableHashSet<string> ImmutableHashSetString;
-	3: ImmutableSortedSet<int32> ImmutableSortedSetInt;
-	4: ImmutableDictionary<string, string> ImmutableDictionaryStringMap;
-	5: ImmutableSortedDictionary<int32, string> ImmutableSortedDictionaryStringMap;
+    0: ImmutableArray<string> ImmutableArrayString;
+    1: ImmutableList<string> ImmutableListString;
+    2: ImmutableHashSet<string> ImmutableHashSetString;
+    3: ImmutableSortedSet<int32> ImmutableSortedSetInt;
+    4: ImmutableDictionary<string, string> ImmutableDictionaryStringMap;
+    5: ImmutableSortedDictionary<int32, string> ImmutableSortedDictionaryStringMap;
 }

--- a/cs/cs.sln
+++ b/cs/cs.sln
@@ -247,6 +247,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "default-ignore-output", "te
 		{21E175D5-BBDD-4B63-8FB7-38899BF2F9D1} = {21E175D5-BBDD-4B63-8FB7-38899BF2F9D1}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "immutable_collections", "..\examples\cs\core\immutable_collections\immutable_collections.csproj", "{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -881,6 +883,24 @@ Global
 		{98BF6B10-F821-4402-8923-5F7B726BBFC8}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{98BF6B10-F821-4402-8923-5F7B726BBFC8}.Release|Win32.ActiveCfg = Release|Any CPU
 		{98BF6B10-F821-4402-8923-5F7B726BBFC8}.Release|Win32.Build.0 = Release|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Debug|Win32.Build.0 = Debug|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Fields|Any CPU.ActiveCfg = Release|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Fields|Any CPU.Build.0 = Release|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Fields|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Fields|Mixed Platforms.Build.0 = Release|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Fields|Win32.ActiveCfg = Release|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Fields|Win32.Build.0 = Release|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Release|Win32.ActiveCfg = Release|Any CPU
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}.Release|Win32.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -920,6 +940,7 @@ Global
 		{4FACD9A1-B8AC-4D76-B4B5-B71607EA8F8C} = {621A2166-EEE0-4A27-88AA-5BE5AC996452}
 		{3805B86E-2BE3-4FFA-A11C-B4981069EC88} = {4268A1D3-AF40-4120-B021-D95A0F754221}
 		{98BF6B10-F821-4402-8923-5F7B726BBFC8} = {8CF1F5CD-548F-4323-869E-AA5903C88B6A}
+		{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6} = {621A2166-EEE0-4A27-88AA-5BE5AC996452}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6EB58560-CA9C-4F6C-B916-CCA6C7FE2A2B}

--- a/cs/nuget/bond.csharp.test.csproj
+++ b/cs/nuget/bond.csharp.test.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="NUnit" Version="3.10.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.*" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -38,6 +39,9 @@
     </BondCodegen>
     <BondCodegen Update="..\test\core\UnitTest.bond">
       <Options>$(BondOptions) --using="DateTime=System.DateTime"</Options>
+    </BondCodegen>
+    <BondCodegen Update="ImmutableCollections.bond">
+      <Options>$(BondOptions) --using="ImmutableArray=System.Collections.Immutable.ImmutableArray&lt;{0}&gt;" --using="ImmutableList=System.Collections.Immutable.ImmutableList&lt;{0}&gt;" --using="ImmutableHashSet=System.Collections.Immutable.ImmutableHashSet&lt;{0}&gt;" --using="ImmutableSortedSet=System.Collections.Immutable.ImmutableSortedSet&lt;{0}&gt;" --using="ImmutableDictionary=System.Collections.Immutable.ImmutableDictionary&lt;{0},{1}&gt;" --using="ImmutableSortedDictionary=System.Collections.Immutable.ImmutableSortedDictionary&lt;{0},{1}&gt;"</Options>
     </BondCodegen>
   </ItemGroup>
 </Project>

--- a/cs/src/core/Comparer.cs
+++ b/cs/src/core/Comparer.cs
@@ -59,7 +59,16 @@ namespace Bond
                     return Expression.Call(null, comparerEqual.MakeGenericMethod(type), left, right);
 
                 if (type.IsBondContainer())
-                    return EnumerablesEqual(left, right);
+                {
+                    if (type.IsValueType())
+                    {
+                        return StructsEqual(left, right);
+                    }
+                    else
+                    {
+                        return EnumerablesEqual(left, right);
+                    }
+                }
 
                 if (type.IsGenericType() && type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
                     return KeyValuePairEqual(left, right);

--- a/cs/src/core/expressions/DeserializerTransform.cs
+++ b/cs/src/core/expressions/DeserializerTransform.cs
@@ -83,8 +83,9 @@ namespace Bond.Expressions
         static readonly MethodInfo bufferBlockCopy =
             Reflection.MethodInfoOf((byte[] a) => Buffer.BlockCopy(a, default(int), a, default(int), default(int)));
 
-        // Immutable collection types are represented/identified as strings to avoid depending on the
-        // System.Collections.Immutable nuget package
+        // Immutable collection types are represented/identified as strings
+        // to avoid depending on the System.Collections.Immutable assembly
+        // or NuGet package
         static readonly HashSet<string> immutableListSetTypeNames = new HashSet<string>
         {
             "System.Collections.Immutable.ImmutableArray`1",

--- a/cs/src/core/expressions/DeserializerTransform.cs
+++ b/cs/src/core/expressions/DeserializerTransform.cs
@@ -83,6 +83,24 @@ namespace Bond.Expressions
         static readonly MethodInfo bufferBlockCopy =
             Reflection.MethodInfoOf((byte[] a) => Buffer.BlockCopy(a, default(int), a, default(int), default(int)));
 
+        // Immutable collection types are represented/identified as strings to avoid depending on the
+        // System.Collections.Immutable nuget package
+        static readonly HashSet<string> immutableListSetTypeNames = new HashSet<string>
+        {
+            "System.Collections.Immutable.ImmutableArray`1",
+            "System.Collections.Immutable.ImmutableList`1",
+            "System.Collections.Immutable.ImmutableHashSet`1",
+            "System.Collections.Immutable.ImmutableSortedSet`1",
+        };
+
+        static readonly HashSet<string> immutableMapTypeNames = new HashSet<string>
+        {
+            "System.Collections.Immutable.ImmutableDictionary`2",
+            "System.Collections.Immutable.ImmutableSortedDictionary`2",
+        };
+
+        static readonly HashSet<string> immutableCollectionTypeNames = new HashSet<string>(immutableListSetTypeNames.Concat(immutableMapTypeNames));
+
         public DeserializerTransform(
             Expression<Func<R, int, object>> deferredDeserialize,
             Factory factory,
@@ -408,20 +426,44 @@ namespace Bond.Expressions
                             }
                         }
 
-                        var add = container.Type.GetMethod(typeof(ICollection<>), "Add", item.Type);
+                        // For System.Collections.Immutable lists/sets, use the builders to construct them, since ICollection<T>.Add()
+                        // is not supported for them.
+                        var containerGenericTypeDef = container.Type.GetGenericTypeDefinition();
+                        if (immutableListSetTypeNames.Contains(containerGenericTypeDef.FullName))
+                        {
+                            var builderType = container.Type.GetTypeInfo().GetDeclaredNestedType("Builder").MakeGenericType(item.Type);
+                            var builder = Expression.Variable(builderType, container + "_builder");
+                            var builderAdd = builderType.GetMethod(typeof(ICollection<>), "Add", item.Type);
 
-                        addItem = Expression.Block(
-                            Value(valueParser, item, elementType, itemSchemaType, initialize: true),
-                            Expression.Call(container, add, item));
+                            addItem = Expression.Block(
+                                Value(valueParser, item, elementType, itemSchemaType, initialize: true),
+                                Expression.Call(builder, builderAdd, item));
 
-                        parameters = new[] { item };
+                            var toBuilderMethod = container.Type.FindMethod("ToBuilder");
+                            var toImmutableMethod = builderType.FindMethod("ToImmutable");
+                            var constructBuilder = Expression.Assign(builder, Expression.Call(container, toBuilderMethod));
+                            var reconstructImmutable = Expression.Assign(container, Expression.Call(builder, toImmutableMethod));
+
+                            parameters = new[] { item, builder };
+                            beforeLoop = Expression.Block(beforeLoop, constructBuilder);
+                            afterLoop = Expression.Block(afterLoop, reconstructImmutable);
+                        }
+                        else
+                        {
+                            var add = container.Type.GetMethod(typeof(ICollection<>), "Add", item.Type);
+
+                            addItem = Expression.Block(
+                                Value(valueParser, item, elementType, itemSchemaType, initialize: true),
+                                Expression.Call(container, add, item));
+
+                            parameters = new[] { item };
+                        }
                     }
 
                     return Expression.Block(
                         parameters,
                         beforeLoop,
-                        ControlExpression.While(next,
-                            addItem),
+                        ControlExpression.While(next, addItem),
                         afterLoop);
                 });
         }
@@ -451,19 +493,48 @@ namespace Bond.Expressions
                             Expression.Assign(map, newContainer(map.Type, schemaType, cappedCount)));
                     }
 
-                    var add = map.Type.GetDeclaredProperty(typeof(IDictionary<,>), "Item", value.Type);
+                    // For System.Collections.Immutable maps, use the builders to construct them, since
+                    // the setter IDictionary<K,V>.Item[] is not supported for them.
+                    var mapGenericTypeDef = map.Type.GetGenericTypeDefinition();
+                    if (immutableMapTypeNames.Contains(mapGenericTypeDef.FullName))
+                    {
+                        var builderType = map.Type.GetTypeInfo().GetDeclaredNestedType("Builder").MakeGenericType(itemSchemaType.Key, itemSchemaType.Value);
+                        var builder = Expression.Variable(builderType, map + "_builder");
+                        var builderAdd = builderType.GetDeclaredProperty(typeof(IDictionary<,>), "Item", value.Type);
 
-                    Expression addItem = Expression.Block(
-                        Value(keyParser, key, keyType, itemSchemaType.Key, initialize: true),
-                        nextValue,
-                        Value(valueParser, value, valueType, itemSchemaType.Value, initialize: true),
-                        Expression.Assign(Expression.Property(map, add, new Expression[] { key }), value));
+                        var addItem = Expression.Block(
+                            Value(keyParser, key, keyType, itemSchemaType.Key, initialize: true),
+                            nextValue,
+                            Value(valueParser, value, valueType, itemSchemaType.Value, initialize: true),
+                            Expression.Assign(Expression.Property(builder, builderAdd, new Expression[] { key }), value));
 
-                    return Expression.Block(
-                        new [] { key, value },
-                        init,
-                        ControlExpression.While(nextKey,
-                            addItem));
+                        var toBuilderMethod = map.Type.FindMethod("ToBuilder");
+                        var toImmutableMethod = builderType.FindMethod("ToImmutable");
+                        var constructBuilder = Expression.Assign(builder, Expression.Call(map, toBuilderMethod));
+                        var reconstructImmutable = Expression.Assign(map, Expression.Call(builder, toImmutableMethod));
+
+                        return Expression.Block(
+                            new[] { key, value, builder },
+                            init,
+                            constructBuilder,
+                            ControlExpression.While(nextKey, addItem),
+                            reconstructImmutable);
+                    }
+                    else
+                    {
+                        var add = map.Type.GetDeclaredProperty(typeof(IDictionary<,>), "Item", value.Type);
+
+                        var addItem = Expression.Block(
+                            Value(keyParser, key, keyType, itemSchemaType.Key, initialize: true),
+                            nextValue,
+                            Value(valueParser, value, valueType, itemSchemaType.Value, initialize: true),
+                            Expression.Assign(Expression.Property(map, add, new Expression[] { key }), value));
+
+                        return Expression.Block(
+                            new[] { key, value },
+                            init,
+                            ControlExpression.While(nextKey, addItem));
+                    }
                 });
         }
 
@@ -558,7 +629,15 @@ namespace Bond.Expressions
             }
             else if (schemaType.IsGenericType())
             {
-                schemaType = schemaType.GetGenericTypeDefinition().MakeGenericType(type.GetTypeInfo().GenericTypeArguments);
+                // All System.Collections.Immutable collections have a static field ImmutableX<T>.Empty
+                // which is the simplest constructor.
+                var schemaGenericTypeDef = schemaType.GetGenericTypeDefinition();
+                if (immutableCollectionTypeNames.Contains(schemaGenericTypeDef.FullName))
+                {
+                    return Expression.Field(null, schemaType.GetTypeInfo().GetDeclaredField("Empty"));
+                }
+
+                schemaType = schemaGenericTypeDef.MakeGenericType(type.GetTypeInfo().GenericTypeArguments);
             }
             else if (schemaType.IsArray)
             {

--- a/cs/test/core/Core.csproj
+++ b/cs/test/core/Core.csproj
@@ -41,6 +41,9 @@
     <BondCodegen Update="UnitTest.bond">
       <Options>$(BondOptions) --using="DateTime=System.DateTime"</Options>
     </BondCodegen>
+    <BondCodegen Update="ImmutableCollections.bond">
+      <Options>$(BondOptions) --using="ImmutableArray=System.Collections.Immutable.ImmutableArray&lt;{0}&gt;" --using="ImmutableList=System.Collections.Immutable.ImmutableList&lt;{0}&gt;" --using="ImmutableHashSet=System.Collections.Immutable.ImmutableHashSet&lt;{0}&gt;" --using="ImmutableSortedSet=System.Collections.Immutable.ImmutableSortedSet&lt;{0}&gt;" --using="ImmutableDictionary=System.Collections.Immutable.ImmutableDictionary&lt;{0},{1}&gt;" --using="ImmutableSortedDictionary=System.Collections.Immutable.ImmutableSortedDictionary&lt;{0},{1}&gt;"</Options>
+    </BondCodegen>
     <!-- Resharper Workaround -->
     <Compile Include="$(IntermediateOutputPath)\Aliases_types.cs" Condition="False" />
     <Compile Include="$(IntermediateOutputPath)\Bond File With Spaces_types.cs" Condition="False" />
@@ -49,12 +52,14 @@
     <Compile Include="$(IntermediateOutputPath)\NamespaceConflictBond_types.cs" Condition="False" />
     <Compile Include="$(IntermediateOutputPath)\ReadOnly_types.cs" Condition="False" />
     <Compile Include="$(IntermediateOutputPath)\UnitTest_types.cs" Condition="False" />
+    <Compile Include="$(IntermediateOutputPath)\ImmutableCollections_types.cs" Condition="False" />
     <!-- End Resharper Workaround -->
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="NUnit" Version="3.10.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.*" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\attributes\Attributes.csproj" />

--- a/cs/test/core/ImmutableCollections.bond
+++ b/cs/test/core/ImmutableCollections.bond
@@ -9,10 +9,10 @@ using ImmutableSortedDictionary<K, V> = map<K, V>;
 
 struct ImmutableCollectionsHolder
 {
-	0: ImmutableArray<string> ImmutableArrayString;
-	1: ImmutableList<string> ImmutableListString;
-	2: ImmutableHashSet<string> ImmutableHashSetString;
-	3: ImmutableSortedSet<int32> ImmutableSortedSetInt;
-	4: ImmutableDictionary<string, string> ImmutableDictionaryStringMap;
-	5: ImmutableSortedDictionary<int32, string> ImmutableSortedDictionaryStringMap;
+    0: ImmutableArray<string> ImmutableArrayString;
+    1: ImmutableList<string> ImmutableListString;
+    2: ImmutableHashSet<string> ImmutableHashSetString;
+    3: ImmutableSortedSet<int32> ImmutableSortedSetInt;
+    4: ImmutableDictionary<string, string> ImmutableDictionaryStringMap;
+    5: ImmutableSortedDictionary<int32, string> ImmutableSortedDictionaryStringMap;
 }

--- a/cs/test/core/ImmutableCollections.bond
+++ b/cs/test/core/ImmutableCollections.bond
@@ -1,0 +1,18 @@
+﻿namespace UnitTest.ImmutableCollections
+
+using ImmutableArray<T> = list<T>;
+using ImmutableList<T> = list<T>;
+using ImmutableHashSet<T> = set<T>;
+using ImmutableSortedSet<T> = set<T>;
+using ImmutableDictionary<K, V> = map<K, V>;
+using ImmutableSortedDictionary<K, V> = map<K, V>;
+
+struct ImmutableCollectionsHolder
+{
+	0: ImmutableArray<string> ImmutableArrayString;
+	1: ImmutableList<string> ImmutableListString;
+	2: ImmutableHashSet<string> ImmutableHashSetString;
+	3: ImmutableSortedSet<int32> ImmutableSortedSetInt;
+	4: ImmutableDictionary<string, string> ImmutableDictionaryStringMap;
+	5: ImmutableSortedDictionary<int32, string> ImmutableSortedDictionaryStringMap;
+}

--- a/cs/test/core/SerializationTests.cs
+++ b/cs/test/core/SerializationTests.cs
@@ -439,6 +439,12 @@
             Assert.IsNotNull(new EnsureSpacesInPathsWork());
         }
 
+        [Test]
+        public void ImmutableCollections()
+        {
+            TestSerialization<ImmutableCollections.ImmutableCollectionsHolder>();
+        }
+
         void TestTypePromotion<From, To>()
         {
             TestFieldSerialization<From, To>();

--- a/cs/test/core/UnitTest.bond
+++ b/cs/test/core/UnitTest.bond
@@ -2,6 +2,7 @@ import "bond/core/bond.bond"
 import "Aliases.bond"
 // Uses mixed slashes to test gbc can deal with that
 import "dir1\dir2/Bond File With Spaces.bond"
+import "ImmutableCollections.bond"
 
 namespace UnitTest
 

--- a/cs/test/coreNS10/CoreNS10.csproj
+++ b/cs/test/coreNS10/CoreNS10.csproj
@@ -44,6 +44,9 @@
     <BondCodegen Include="..\core\UnitTest.bond">
       <Options>$(BondOptions) --using="DateTime=System.DateTime"</Options>
     </BondCodegen>
+    <BondCodegen Include="..\core\ImmutableCollections.bond">
+      <Options>$(BondOptions) --using="ImmutableArray=System.Collections.Immutable.ImmutableArray&lt;{0}&gt;" --using="ImmutableList=System.Collections.Immutable.ImmutableList&lt;{0}&gt;" --using="ImmutableHashSet=System.Collections.Immutable.ImmutableHashSet&lt;{0}&gt;" --using="ImmutableSortedSet=System.Collections.Immutable.ImmutableSortedSet&lt;{0}&gt;" --using="ImmutableDictionary=System.Collections.Immutable.ImmutableDictionary&lt;{0},{1}&gt;" --using="ImmutableSortedDictionary=System.Collections.Immutable.ImmutableSortedDictionary&lt;{0},{1}&gt;"</Options>
+    </BondCodegen>
     <!-- uses mixed slashes to test the targets can deal with that -->
     <BondCodegen Include="..\core\import dir with spaces\dir1/dir2/Bond File With Spaces.bond" />
     <!-- Resharper Workaround -->
@@ -54,12 +57,14 @@
     <Compile Include="$(IntermediateOutputPath)\NamespaceConflictBond_types.cs" Condition="False" />
     <Compile Include="$(IntermediateOutputPath)\ReadOnly_types.cs" Condition="False" />
     <Compile Include="$(IntermediateOutputPath)\UnitTest_types.cs" Condition="False" />
+    <Compile Include="$(IntermediateOutputPath)\ImmutableCollections_types.cs" Condition="False" />
     <!-- End Resharper Workaround -->
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="NUnit" Version="3.10.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.*" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\attributes\Attributes.csproj" AdditionalProperties="TargetFramework=$(BondTargetFramework)" />

--- a/doc/src/bond_cs.md
+++ b/doc/src/bond_cs.md
@@ -1177,18 +1177,31 @@ type aliases don't require a user defined converter.
 
 - `examples/cs/core/container_alias`
 
-Bond provides special support for using the [System.Collections.Immutable](https://www.nuget.org/packages/System.Collections.Immutable/#readme-body-tab) collections as container type aliases. The following aliases are supported:
+System.Collection.Immutable support
+-----------------------------------
 
-- vector\<T\> -> `ImmutableArray<T>`, `ImmutableList<T>`
-- list\<T\> -> `ImmutableArray<T>`, `ImmutableList<T>`, `ImmutableHashSet<T>`, `ImmutableSortedSet<T>`
-- set\<T\> -> `ImmutableHashSet<T>`, `ImmutableSortedSet<T>`
-- map\<K, V\> -> `ImmutableDictionary<K, V>`, `ImmutableSortedDictionary<K, V>`
+Bond provides special support for using the
+[System.Collections.Immutable](https://learn.microsoft.com/dotnet/api/system.collections.immutable)
+collections as container type aliases. The following aliases are supported:
 
-During code generation, immutable collection fields are handled specially - they do not have parameterless constructors, and so the Bond compiler will instead use the static `Empty` field is used as the default value, e.g. [ImmutableList\<T\>.Empty](https://learn.microsoft.com/en-us/dotnet/api/system.collections.immutable.immutablelist-1.empty).
+| Underlying Bond type | Supported System.Collections.Immutable container                                        |
+|----------------------|-----------------------------------------------------------------------------------------|
+| `vector<T>`          | `ImmutableArray<T>`, `ImmutableList<T>`                                                 |
+| `list<T>`            | `ImmutableArray<T>`, `ImmutableHashSet<T>`, `ImmutableList<T>`, `ImmutableSortedSet<T>` |
+| `set<T>`             | `ImmutableHashSet<T>`, `ImmutableSortedSet<T>`                                          |
+| `map<K, V>`          | `ImmutableDictionary<K, V>`, `ImmutableSortedDictionary<K, V>`                          |
 
-When deserializing immutable collections, Bond will use the inner `Builder` classes to efficiently reconstruct the collection, e.g. [ImmutableList\<T\>.Builder](https://learn.microsoft.com/en-us/dotnet/api/system.collections.immutable.immutablelist-1.builder).
+During code generation, immutable collection fields are handled specially.
+Since they do not have parameterless constructors, the Bond compiler will
+instead use the static `Empty` field is used as the default value, e.g.
+[ImmutableList\<T\>.Empty](https://learn.microsoft.com/dotnet/api/system.collections.immutable.immutablelist-1.empty).
 
-See the below project for examples on using immutable collections as container aliases:
+When deserializing immutable collections, Bond will use the inner `Builder`
+classes to efficiently reconstruct the collection, e.g.
+[ImmutableList\<T\>.Builder](https://learn.microsoft.com/dotnet/api/system.collections.immutable.immutablelist-1.builder).
+
+See the below project for examples on using immutable collections as
+container aliases:
 
 - `examples/cs/core/immutable_collections_alias`
 

--- a/doc/src/bond_cs.md
+++ b/doc/src/bond_cs.md
@@ -1177,6 +1177,21 @@ type aliases don't require a user defined converter.
 
 - `examples/cs/core/container_alias`
 
+Bond provides special support for using the [System.Collections.Immutable](https://www.nuget.org/packages/System.Collections.Immutable/#readme-body-tab) collections as container type aliases. The following aliases are supported:
+
+- vector\<T\> -> `ImmutableArray<T>`, `ImmutableList<T>`
+- list\<T\> -> `ImmutableArray<T>`, `ImmutableList<T>`, `ImmutableHashSet<T>`, `ImmutableSortedSet<T>`
+- set\<T\> -> `ImmutableHashSet<T>`, `ImmutableSortedSet<T>`
+- map\<K, V\> -> `ImmutableDictionary<K, V>`, `ImmutableSortedDictionary<K, V>`
+
+During code generation, immutable collection fields are handled specially - they do not have parameterless constructors, and so the Bond compiler will instead use the static `Empty` field is used as the default value, e.g. [ImmutableList\<T\>.Empty](https://learn.microsoft.com/en-us/dotnet/api/system.collections.immutable.immutablelist-1.empty).
+
+When deserializing immutable collections, Bond will use the inner `Builder` classes to efficiently reconstruct the collection, e.g. [ImmutableList\<T\>.Builder](https://learn.microsoft.com/en-us/dotnet/api/system.collections.immutable.immutablelist-1.builder).
+
+See the below project for examples on using immutable collections as container aliases:
+
+- `examples/cs/core/immutable_collections_alias`
+
 Converter
 ---------
 

--- a/examples/cs/core/immutable_collections/Program.cs
+++ b/examples/cs/core/immutable_collections/Program.cs
@@ -1,0 +1,56 @@
+﻿namespace Examples
+{
+    using Bond;
+    using Bond.IO.Unsafe;
+    using Bond.Protocols;
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+
+    static class Program
+    {
+        static void Main(string[] args)
+        {
+            var random = new Random();
+            var ints = new int[100];
+            for (int i = 0; i < ints.Length; i++)
+            {
+                ints[i] = random.Next();
+            }
+
+            var strings = new string[100];
+            for (int i = 0; i < strings.Length; i++)
+            {
+                strings[i] = $"string{i}";
+            }
+
+            var stringToStringMap = strings.Select((str) => new KeyValuePair<string, string>(str, str));
+            var intToStringMap = strings.Select((str, idx) => new KeyValuePair<int, string>(idx, str));
+
+            var src = new ImmutableCollectionsHolder()
+            {
+                ImmutableArrayOfStrings = ImmutableArray.CreateRange(strings),
+                ImmutableHashSetOfStrings = ImmutableHashSet.CreateRange(strings),
+                ImmutableListOfStrings = ImmutableList.CreateRange(strings),
+                ImmutableSortedIntToStringDictionary = ImmutableSortedDictionary.CreateRange(intToStringMap),
+                ImmutableSortedSetOfInts = ImmutableSortedSet.CreateRange(ints),
+                ImmutableStringToStringDictionary = ImmutableDictionary.CreateRange(stringToStringMap),
+            };
+
+            var outputBuffer = new OutputBuffer();
+            var writer = new CompactBinaryWriter<OutputBuffer>(outputBuffer);
+            Serialize.To(writer, src);
+
+            var inputBuffer = new InputBuffer(outputBuffer.Data);
+            var reader = new CompactBinaryReader<InputBuffer>(inputBuffer);
+            var dst = Deserialize<ImmutableCollectionsHolder>.From(reader);
+            ThrowIfFalse(Comparer.Equal(src, dst));
+        }
+
+        static void ThrowIfFalse(bool b)
+        {
+            if (!b) throw new Exception("Assertion failed");
+        }
+    }
+}

--- a/examples/cs/core/immutable_collections/immutable_collections.csproj
+++ b/examples/cs/core/immutable_collections/immutable_collections.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\..\..\cs\build\nuget\Bond.CSharp.props" />
+  <PropertyGroup>
+    <ProjectGuid>{9CC2754E-501D-4DB3-8EAA-8B91025E5DF6}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>immutable_collections</RootNamespace>
+    <AssemblyName>immutable_collections</AssemblyName>
+    <TargetFrameworks>net45</TargetFrameworks>
+    <BondOptions>--using="ImmutableArray=System.Collections.Immutable.ImmutableArray&lt;{0}&gt;" --using="ImmutableList=System.Collections.Immutable.ImmutableList&lt;{0}&gt;" --using="ImmutableHashSet=System.Collections.Immutable.ImmutableHashSet&lt;{0}&gt;" --using="ImmutableSortedSet=System.Collections.Immutable.ImmutableSortedSet&lt;{0}&gt;" --using="ImmutableDictionary=System.Collections.Immutable.ImmutableDictionary&lt;{0},{1}&gt;" --using="ImmutableSortedDictionary=System.Collections.Immutable.ImmutableSortedDictionary&lt;{0},{1}&gt;"</BondOptions>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Resharper Workaround -->
+    <Compile Include="$(IntermediateOutputPath)\schema_types.cs" Condition="False" />
+    <!-- End Resharper Workaround -->
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\cs\src\attributes\Attributes.csproj" />
+    <ProjectReference Include="..\..\..\..\cs\src\core\Bond.csproj" />
+    <ProjectReference Include="..\..\..\..\cs\src\io\IO.csproj" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
+  </ItemGroup>
+  <Import Project="$(BOND_PATH)\build\nuget\Bond.CSharp.targets" />
+</Project>

--- a/examples/cs/core/immutable_collections/schema.bond
+++ b/examples/cs/core/immutable_collections/schema.bond
@@ -9,10 +9,10 @@ using ImmutableSortedDictionary<K, V> = map<K, V>;
 
 struct ImmutableCollectionsHolder
 {
-	0: ImmutableArray<string> ImmutableArrayOfStrings;
-	1: ImmutableList<string> ImmutableListOfStrings;
-	2: ImmutableHashSet<string> ImmutableHashSetOfStrings;
-	3: ImmutableSortedSet<int32> ImmutableSortedSetOfInts;
-	4: ImmutableDictionary<string, string> ImmutableStringToStringDictionary;
-	5: ImmutableSortedDictionary<int32, string> ImmutableSortedIntToStringDictionary;
+    0: ImmutableArray<string> ImmutableArrayOfStrings;
+    1: ImmutableList<string> ImmutableListOfStrings;
+    2: ImmutableHashSet<string> ImmutableHashSetOfStrings;
+    3: ImmutableSortedSet<int32> ImmutableSortedSetOfInts;
+    4: ImmutableDictionary<string, string> ImmutableStringToStringDictionary;
+    5: ImmutableSortedDictionary<int32, string> ImmutableSortedIntToStringDictionary;
 }

--- a/examples/cs/core/immutable_collections/schema.bond
+++ b/examples/cs/core/immutable_collections/schema.bond
@@ -1,0 +1,18 @@
+﻿namespace Examples
+
+using ImmutableArray<T> = list<T>;
+using ImmutableList<T> = list<T>;
+using ImmutableHashSet<T> = set<T>;
+using ImmutableSortedSet<T> = set<T>;
+using ImmutableDictionary<K, V> = map<K, V>;
+using ImmutableSortedDictionary<K, V> = map<K, V>;
+
+struct ImmutableCollectionsHolder
+{
+	0: ImmutableArray<string> ImmutableArrayOfStrings;
+	1: ImmutableList<string> ImmutableListOfStrings;
+	2: ImmutableHashSet<string> ImmutableHashSetOfStrings;
+	3: ImmutableSortedSet<int32> ImmutableSortedSetOfInts;
+	4: ImmutableDictionary<string, string> ImmutableStringToStringDictionary;
+	5: ImmutableSortedDictionary<int32, string> ImmutableSortedIntToStringDictionary;
+}


### PR DESCRIPTION
Closes #1159

Adds proper support for immutable collections as laid out in the issue description. Implemented this in a way such that the Bond C# package doesn't actually depend on System.Collections.Immutable, roughly following how it was done [in Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json/blob/master/Src/Newtonsoft.Json/Utilities/ImmutableCollectionsUtils.cs). 

The collections are constructed using the builders, which performs a lot better doing bulk operations.

The change to the codegen in Haskell is small, but since I don't have much experience, any suggestions to make it more idiomatic are welcome. 

Added unit tests both for the compiler and for [de]serialization in C#.