### PR TITLE
Fix missing cmake call in build instruction for Linux and MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ In the root `bond` directory run:
 ```bash
 mkdir build
 cd build
+cmake ..
 make
 sudo make install
 ```
@@ -140,6 +141,7 @@ order to generate and build from makefiles, in the root `bond` directory run:
 ```bash
 mkdir build
 cd build
+cmake ..
 make
 sudo make install
 ```


### PR DESCRIPTION
CMake should be invoked to generate build script before running make, or there is nothing to make int he create build directory.