### PR TITLE
[ci] Revert happy install workaround

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -117,10 +117,6 @@
 
             choco install haskell-stack -y
 
-            # temp workaround: install ghc for happy install
-
-            choco install ghc --version 8.0.1 -y
-
             choco install dotnetcore-sdk -y
 
             # choco install updated the path, so re-read them from the registry and reset $env:path
@@ -130,12 +126,6 @@
             $userPath = [System.Environment]::GetEnvironmentVariable("Path","User")
 
             $env:Path = "$machinePath;$userPath"
-
-            # temp workaround: run cabal update and install happy
-
-            cabal update
-
-            cabal install happy-1.19.5
 
             if ($env:BOND_BUILD -eq "Doc") {
 


### PR DESCRIPTION
CI builds are failing with linker errors trying to install happy. This workaround no longer appears to be needed.

Remove the manual install step.