### PR TITLE
minimal changes for ghc-8.10.7

### DIFF
--- a/compiler/Main.hs
+++ b/compiler/Main.hs
@@ -35,10 +35,10 @@ main = do
     options <- (if null args then withArgs ["--help=all"] else id) getOptions
     setJobs $ jobs options
     case options of
-        Cpp {..}    -> cppCodegen options
-        Cs {..}     -> csCodegen options
-        Java {..}   -> javaCodegen options
-        Schema {..} -> writeSchema options
+        Cpp {}    -> cppCodegen options
+        Cs {}     -> csCodegen options
+        Java {}   -> javaCodegen options
+        Schema {} -> writeSchema options
         _           -> print options
 
 setJobs :: Maybe Int -> IO ()

--- a/compiler/src/Language/Bond/Codegen/Cpp/Util.hs
+++ b/compiler/src/Language/Bond/Codegen/Cpp/Util.hs
@@ -54,7 +54,7 @@ classParams :: Declaration -> String
 classParams = angles . sepBy ", " paramName . declParams
 
 qualifiedClassName :: MappingContext -> Declaration -> String
-qualifiedClassName cpp s@Struct {..} = qualifiedName <> classParams s
+qualifiedClassName cpp s@Struct {} = qualifiedName <> classParams s
   where
     qualifiedName = unpack $ toLazyText $ getDeclTypeName cpp s
 qualifiedClassName _ _ = error "qualifiedClassName: impossible happened."
@@ -102,13 +102,13 @@ defaultValue _ _ (DefaultBool False) = "false"
 defaultValue _ _ (DefaultInteger x) = [lt|#{x}|]
 defaultValue _ _ (DefaultFloat x) = [lt|#{x}|]
 defaultValue _ _ (DefaultNothing) = mempty
-defaultValue m (BT_UserDefined a@Alias {..} args) d = defaultValue m (resolveAlias a args) d
+defaultValue m (BT_UserDefined a@Alias {} args) d = defaultValue m (resolveAlias a args) d
 defaultValue _ _ _ = error "defaultValue: impossible happened."
 
 enumValue :: ToText a => MappingContext -> Type -> a -> Text
 enumValue cpp (BT_UserDefined e@Enum {..} _) x =
     [lt|#{getQualifiedName cpp $ getDeclNamespace cpp e}::_bond_enumerators::#{declName}::#{x}|]
-enumValue cpp (BT_UserDefined a@Alias {..} args) e = enumValue cpp (resolveAlias a args) e
+enumValue cpp (BT_UserDefined a@Alias {} args) e = enumValue cpp (resolveAlias a args) e
 enumValue _ _ _ = error "enumValue: impossible happened."
 
 -- schema metadata static member definitions

--- a/compiler/src/Language/Bond/Codegen/Cs/Util.hs
+++ b/compiler/src/Language/Bond/Codegen/Cs/Util.hs
@@ -64,19 +64,19 @@ propertyAttributes cs Field {..} =
 
 -- C# class/struct/interface attributes
 typeAttributes :: MappingContext -> Declaration -> Text
-typeAttributes cs s@Struct {..} =
+typeAttributes cs s@Struct {} =
     optionalTypeAttributes cs s
  <> [lt|[global::Bond.Schema]
     |]
  <> generatedCodeAttr
 
 -- C# enum attributes
-typeAttributes cs e@Enum {..} =
+typeAttributes cs e@Enum {} =
     optionalTypeAttributes cs e
  <> generatedCodeAttr
 
 -- C# service attributes
-typeAttributes cs s@Service {..} =
+typeAttributes cs s@Service {} =
     optionalTypeAttributes cs s
     <> generatedCodeAttr
 
@@ -125,7 +125,7 @@ defaultValue cs Field {fieldDefault = Nothing, ..} = implicitDefault fieldType
     implicitDefault (BT_Bonded t) = Just [lt|global::Bond.Bonded<#{getTypeName cs t}>.Empty|]
     implicitDefault t@(BT_TypeParam _) = Just [lt|global::Bond.GenericFactory.Create<#{getInstanceTypeName cs t}>()|]
     implicitDefault t@BT_Blob = newInstance t
-    implicitDefault t@(BT_UserDefined a@Alias {..} args)
+    implicitDefault t@(BT_UserDefined a@Alias {} args)
         | isImmutableCollection cs t = staticEmptyField t
         | customAliasMapping cs a = newInstance t
         | otherwise = implicitDefault $ resolveAlias a args

--- a/compiler/src/Language/Bond/Codegen/Java/Class_java.hs
+++ b/compiler/src/Language/Bond/Codegen/Java/Class_java.hs
@@ -143,7 +143,7 @@ fieldDefaultValueInitParamExpr _ BT_Double (Just (DefaultFloat val)) = [lt|, #{v
 fieldDefaultValueInitParamExpr _ BT_Double (Just (DefaultInteger val)) = [lt|, #{val}D|]
 fieldDefaultValueInitParamExpr _ BT_String (Just (DefaultString val)) = [lt|, "#{val}"|]
 fieldDefaultValueInitParamExpr _ BT_WString (Just (DefaultString val)) = [lt|, "#{val}"|]
-fieldDefaultValueInitParamExpr java (BT_UserDefined e@Enum {..} _) (Just (DefaultEnum val)) = [lt|, #{qualifiedDeclaredTypeName java e}.#{val}|]
+fieldDefaultValueInitParamExpr java (BT_UserDefined e@Enum {} _) (Just (DefaultEnum val)) = [lt|, #{qualifiedDeclaredTypeName java e}.#{val}|]
 fieldDefaultValueInitParamExpr _ _ _ = mempty
 
 
@@ -218,7 +218,7 @@ makeStructBuilderMember_makeGenericType declName declParams = [lt|
             }
 |]
     where
-        checkArg t@TypeParam {..} = [lt|#{ensureNotNullArgument (typeParamVarName t)};|]
+        checkArg t@TypeParam {} = [lt|#{ensureNotNullArgument (typeParamVarName t)};|]
         castExpr = [lt|(StructBondTypeImpl)|]
 
 

--- a/compiler/src/Language/Bond/Codegen/Java/Util.hs
+++ b/compiler/src/Language/Bond/Codegen/Java/Util.hs
@@ -58,7 +58,7 @@ isPrimitiveNonEnumBondType _ = False
 
 -- returns a value indicating whether a type is a Bond primitive type or enum
 isPrimitiveBondType :: Type -> Bool
-isPrimitiveBondType (BT_UserDefined Enum {..} _) = True
+isPrimitiveBondType (BT_UserDefined Enum {} _) = True
 isPrimitiveBondType t = isPrimitiveNonEnumBondType t
 
 -- returns a value indicating whether a type is a generic struct type with generic type parameters

--- a/compiler/src/Language/Bond/Codegen/TypeMapping.hs
+++ b/compiler/src/Language/Bond/Codegen/TypeMapping.hs
@@ -398,7 +398,7 @@ idlType (BT_Set element) = "set<" <>> elementTypeName element <<> ">"
 idlType (BT_Map key value) = "map<" <>> elementTypeName key <<>> ", " <>> elementTypeName value <<> ">"
 idlType (BT_Bonded type_) = "bonded<" <>> elementTypeName type_ <<> ">"
 idlType (BT_TypeParam param) = pureText $ paramName param
-idlType (BT_UserDefined a@Alias {..} args) = aliasTypeName a args
+idlType (BT_UserDefined a@Alias {} args) = aliasTypeName a args
 idlType (BT_UserDefined decl args) = declQualifiedTypeName decl <<>> (angles <$> commaSepTypeNames args)
 
 -- C++ type mapping
@@ -443,7 +443,7 @@ cppTypeCustomAlloc scoped alloc (BT_Map key value) = "std::map<" <>> elementType
 cppTypeCustomAlloc _ _ t = cppType t
 
 cppTypeExpandAliases :: (Type -> TypeNameBuilder) -> Type -> TypeNameBuilder
-cppTypeExpandAliases _ (BT_UserDefined a@Alias {..} args) = aliasTypeName a args
+cppTypeExpandAliases _ (BT_UserDefined a@Alias {} args) = aliasTypeName a args
 cppTypeExpandAliases m t = m t
 
 comparer :: Type -> TypeNameBuilder
@@ -516,7 +516,7 @@ csTypeAnnotation _ (BT_Maybe a@(BT_UserDefined Alias{} _)) = typeName a
 csTypeAnnotation _ (BT_TypeParam (TypeParam _ Nothing)) = pure "global::Bond.Tag.classT"
 csTypeAnnotation _ (BT_TypeParam (TypeParam _ (Just Value))) = pure "global::Bond.Tag.structT"
 csTypeAnnotation _ (BT_UserDefined Alias {aliasType = BT_Blob} _) = pure "global::Bond.Tag.blob"
-csTypeAnnotation m t@(BT_UserDefined a@Alias {..} args)
+csTypeAnnotation m t@(BT_UserDefined a@Alias {} args)
    | isContainer t = m t
    | otherwise = typeName $ resolveAlias a args
 csTypeAnnotation _ (BT_UserDefined decl args) = declTypeName decl <<>> (angles <$> commaSepTypeNames args)

--- a/compiler/src/Language/Bond/Parser.hs
+++ b/compiler/src/Language/Bond/Parser.hs
@@ -150,7 +150,7 @@ findStruct name = doFind <?> "qualified struct name"
     doFind = do
         symb <- findSymbol name
         case symb of
-            Struct {..} -> return symb
+            Struct {} -> return symb
             _ -> fail $ "The " ++ showPretty symb ++ " is invalid in this context. Expected a struct."
 
 -- namespace
@@ -473,4 +473,4 @@ isInBounds value _ = value >= (toInteger (minBound :: a)) && value <= (toInteger
 -- sets source position
 setSourcePos ::  MonadParsec e s m => SourcePos -> m ()
 setSourcePos src = updateParserState setPos
-    where setPos (State s o (PosState i o' _ t l)) =  State s o (PosState i o' src t l)
+    where setPos st = st { statePosState = (statePosState st) { pstateSourcePos = src } }

--- a/compiler/src/Language/Bond/Syntax/Util.hs
+++ b/compiler/src/Language/Bond/Syntax/Util.hs
@@ -61,7 +61,7 @@ isScalar BT_Float = True
 isScalar BT_Double = True
 isScalar BT_Bool = True
 isScalar (BT_TypeParam (TypeParam _ (Just Value))) = True
-isScalar (BT_UserDefined Enum {..} _) = True
+isScalar (BT_UserDefined Enum {} _) = True
 isScalar (BT_UserDefined a@Alias {} args) = isScalar $ resolveAlias a args
 isScalar _ = False
 
@@ -174,7 +174,7 @@ fmapType f x = f x
 foldMapFields :: (Monoid m) => (Field -> m) -> Type -> m
 foldMapFields f t = case t of
     (BT_UserDefined   Struct {..} _) -> optional (foldMapFields f) structBase <> F.foldMap f structFields
-    (BT_UserDefined a@Alias {..} args) -> foldMapFields f $ resolveAlias a args
+    (BT_UserDefined a@Alias {} args) -> foldMapFields f $ resolveAlias a args
     _ -> mempty
 
 -- | Like 'foldMapFields' but takes a 'Declaration' as an argument instead of 'Type'.

--- a/compiler/stack.yaml
+++ b/compiler/stack.yaml
@@ -5,7 +5,7 @@
 # Resolver to choose a 'specific' stackage snapshot or a compiler version.
 # A snapshot resolver dictates the compiler version and the set of packages
 # to be used for project dependencies. For example:
-resolver: lts-14.4
+resolver: lts-18.28
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/compiler/stack.yaml.lock
+++ b/compiler/stack.yaml.lock
@@ -7,13 +7,13 @@ packages:
 - completed:
     hackage: quickcheck-arbitrary-template-0.2.1.0@sha256:01f9deb34f8af3e6b879ee984b0be8803eb9c31e389490b5ddb8ca5fde32957c,2026
     pantry-tree:
-      size: 625
       sha256: a79d0b9f39f1096774a34f502c209dc70c85bc43f164e2925cb6b7a3f7ad82c8
+      size: 625
   original:
     hackage: quickcheck-arbitrary-template-0.2.1.0
 snapshots:
 - completed:
-    size: 523884
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/4.yaml
-    sha256: 16f24be248b42c9e16d59db84378836b1e7c239448a041cae46d32daffa45a8b
-  original: lts-14.4
+    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
+    size: 590100
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
+  original: lts-18.28

--- a/tools/ci-scripts/linux/image-builder/Dockerfile
+++ b/tools/ci-scripts/linux/image-builder/Dockerfile
@@ -50,7 +50,7 @@ RUN wget -qO- https://get.haskellstack.org/ | sh
 # Components for ghc
 RUN add-apt-repository ppa:hvr/ghc -y && \
     apt-get update && \
-    apt-get -y install ghc-8.6.5
+    apt-get -y install ghc-8.10.7
 
 # Install more recent git
 RUN add-apt-repository ppa:git-core/ppa -y && \


### PR DESCRIPTION
Possible steppingstone for #1199. Not sure about the accuracy of the changes, especially compiler/src/Language/Bond/Parser.hs#476

I was able to get this to compile on Apple Silicon when using [GHCup](https://www.haskell.org/ghcup/) and installing/setting the ghc version to 8.10.7 via `ghcup tui`.

Needed to `brew remove haskell-stack` and `cabal` and `ghc` first. Also, you will need `brew install llvm@13`.