### PR TITLE
Avoid `stdext::checked_array_iterator` for modern MSVC

### DIFF
--- a/cpp/inc/bond/core/detail/sdl.h
+++ b/cpp/inc/bond/core/detail/sdl.h
@@ -24,7 +24,7 @@
 namespace bond { namespace detail
 {
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1915
 
 template<class Iterator> inline
 stdext::checked_array_iterator<Iterator> make_checked_array_iterator(


### PR DESCRIPTION
I work on MSVC's STL, and we'd like you to stop using one of our old non-Standard extensions, as we're working towards eventually removing it.

In VS 2005, MSVC's non-Standard extension `stdext::checked_array_iterator` was added to provide guaranteed bounds checking. At the same time, MSVC began emitting Microsoft "deprecation" warnings for using raw pointers as output iterators.

In VS 2017 15.8 (`_MSC_VER` `1915`; see our handy [decoder table][]), we stopped emitting those Microsoft "deprecation" warnings for using raw pointers as output iterators. Those warnings were incredibly annoying since they warned about perfectly correct, Standard-conforming code, and led users to generally disregard and silence such warnings. Also, the library was never the right place to implement them because of insufficient context. Instead, we began encouraging wider use of static analysis, which has sufficient context to emit better warnings about writing too many elements into a raw pointer. See our old blog post [STL Features and Fixes in VS 2017 15.8][] for more info. (This was *internal* [MSVC-PR-120709][].)

In VS 2022 17.8 (`_MSC_VER` `1938`), we began emitting proper Microsoft deprecation warnings for the `stdext::checked_array_iterator` family, as this has been superseded not only by static analysis but also by C++20 `std::span` and downlevel-available `gsl::span`. ("Proper", in this case, because this is about actual Microsoft machinery.) These warnings were initially emitted for `/std:c++17` and later, as a way to initially mitigate their impact while encouraging an ecosystem cleanup. (This was microsoft/STL#3818.)

In the upcoming VS 2022 17.11, we are unconditionally deprecating the `stdext::checked_array_iterator` family, as we're getting serious about eventual removal. (This was microsoft/STL#4605.)

In this PR, because Bond apparently supports compilers down to VS 2015, I'm refining the guard to use `stdext::checked_array_iterator` for MSVC older than VS 2017 15.8, where avoiding those "raw pointers as output iterators" warnings was necessary. For all recent MSVC versions, the portable (and still bounds-checked by your logic!) codepath is selected. In the long term, you may want to consider using C++20 `std::span` or taking a dependency on `gsl::span`, or similar changes (e.g. upgrading builtin arrays to `std::array`s, etc.).

[decoder table]: https://github.com/microsoft/STL/wiki/Macro-_MSVC_STL_UPDATE
[STL Features and Fixes in VS 2017 15.8]: https://devblogs.microsoft.com/cppblog/stl-features-and-fixes-in-vs-2017-15-8/
[MSVC-PR-120709]: https://devdiv.visualstudio.com/DevDiv/_git/msvc/pullrequest/120709
