### PR TITLE
Fix compatibility with .NET 9 Preview

### DIFF
--- a/cs/src/core/expressions/DeserializerTransform.cs
+++ b/cs/src/core/expressions/DeserializerTransform.cs
@@ -523,7 +523,7 @@ namespace Bond.Expressions
                         else
                         {
                             var capacity = container.Type.GetDeclaredProperty("Capacity", count.Type);
-                            if (capacity != null)
+                            if (capacity != null && capacity.CanWrite)
                             {
                                 var cappedCount = Expression.Variable(typeof(int), container + "_count");
                                 beforeLoop = ApplyCountCap(


### PR DESCRIPTION
.NET 9 Preview has introduced read only `Capacity` properties. We now only write to that property if it is not read only.