### PR TITLE
Add support for Boost 1.83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ different versioning scheme, following the Haskell community's
   runtime if custom allocators for containers are used. Newer MSVC versions and
   other compilers are not affected, neither are Release builds with MSVC 14.0. This
   can be worked around by using newer MSVC version or building in Release configuration.
+* Added support for Boost 1.83.
 
 ### C# ###
 

--- a/examples/cpp/core/multiprecision/multiprecision.cpp
+++ b/examples/cpp/core/multiprecision/multiprecision.cpp
@@ -4,6 +4,7 @@
 #include <bond/stream/output_buffer.h>
 
 #include <boost/multiprecision/miller_rabin.hpp>
+#include <boost/random.hpp>
 
 using namespace examples::multiprecision;
 

--- a/examples/cpp/core/multiprecision/multiprecision.h
+++ b/examples/cpp/core/multiprecision/multiprecision.h
@@ -75,7 +75,7 @@ namespace bond
             // Bond expects that blob with default value is empty
             return 0;
         else
-            return num.backend().size() * sizeof(limb_type);
+            return static_cast<uint32_t>(num.backend().size() * sizeof(limb_type));
     }
 
 

--- a/tools/ci-scripts/linux/image-builder/build_boosts.zsh
+++ b/tools/ci-scripts/linux/image-builder/build_boosts.zsh
@@ -2,7 +2,7 @@
 
 set -eux
 
-BOOST_VERSIONS=(1.61.0 1.62.0 1.63.0 1.64.0 1.65.1 1.66.0 1.67.0)
+BOOST_VERSIONS=(1.61.0 1.62.0 1.63.0 1.64.0 1.65.1 1.66.0 1.67.0 1.83.0)
 BOOST_LIBRARIES="chrono,date_time,python,system,test,thread"
 
 BUILD_ROOT=/tmp/boosts

--- a/tools/ci-scripts/windows/Get-BoostLocation.ps1
+++ b/tools/ci-scripts/windows/Get-BoostLocation.ps1
@@ -22,7 +22,7 @@ param
     [string]
     $Version,
 
-    [ValidateSet('12.0', '14.0', '14.1', '14.2')]
+    [ValidateSet('12.0', '14.0', '14.1', '14.2', '14.3')]
     [string]
     $VcToolsetVer
 )

--- a/tools/ci-scripts/windows/Install-Boost.ps1
+++ b/tools/ci-scripts/windows/Install-Boost.ps1
@@ -28,7 +28,7 @@ param
     [string]
     $Version,
 
-    [ValidateSet('12.0', '14.0', '14.1', '14.2')]
+    [ValidateSet('12.0', '14.0', '14.1', '14.2', '14.3')]
     [string]
     $VcToolsetVer,
     
@@ -123,13 +123,26 @@ function Install-BoostComponent([string]$Component)
             -InstallDir $workDir `
             -PackageVersion $Version
 
-        Move-Item `
-            -Path ([System.IO.Path]::Combine($workDir, $packageId, 'lib', 'native', 'address-model-32', 'lib', '*')) `
-            -Destination $lib32Dir
+        if ($Version -gt 1.66)
+        {
+            $sourceFolder = ([System.IO.Path]::Combine($workDir, $packageId, 'lib', 'native'))
+            $itemsToMove32 = Get-ChildItem -Path $sourceFolder | Where-Object { $_.Name -like "*x32*" }
+            $itemsToMove64 = Get-ChildItem -Path $sourceFolder | Where-Object { $_.Name -like "*x64*" }
+            
+            $itemsToMove32 | ForEach-Object { Move-Item -Path $_.FullName -Destination $lib32Dir }
+            $itemsToMove64 | ForEach-Object { Move-Item -Path $_.FullName -Destination $lib64Dir }
 
-        Move-Item `
-            -Path ([System.IO.Path]::Combine($workDir, $packageId, 'lib', 'native', 'address-model-64', 'lib', '*')) `
-            -Destination $lib64Dir
+        } 
+        else 
+        {
+            Move-Item `
+                -Path ([System.IO.Path]::Combine($workDir, $packageId, 'lib', 'native', 'address-model-64', 'lib', '*')) `
+                -Destination $lib64Dir
+
+            Move-Item `
+                -Path ([System.IO.Path]::Combine($workDir, $packageId, 'lib', 'native', 'address-model-32', 'lib', '*')) `
+                -Destination $lib32Dir   
+        }
     }
 }
 


### PR DESCRIPTION
This adds Boost 1.83 and MSVC 14.3 as options to C++ CI scripts. Additionally, the `multiprecision` build error due to use of deprecated random number generator is fixed.