### PR TITLE
Add notes about March 2025 project shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ tag versions. The Bond compiler (`gbc`) and
 different versioning scheme, following the Haskell community's
 [package versioning policy](https://wiki.haskell.org/Package_versioning_policy).
 
+## Bond open-source project ending March 2025
+
+The Bond open-source project will be ending development on March 31, 2025.
+For more information, see [the shutdown announcement
+issue](https://github.com/microsoft/bond/issues/1215).
+
 ## 13.0.1: 2024-10-02 ##
 
 * IDL core version: 3.0

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Microsoft in high scale services.
 
 Bond is published on GitHub at [https://github.com/microsoft/bond/](https://github.com/microsoft/bond/).
 
+## Bond open-source project ending March 2025
+
+The Bond open-source project will be ending development on March 31, 2025.
+For more information, see [the shutdown announcement
+issue](https://github.com/microsoft/bond/issues/1215).
+
+## Documentation
+
 For details, see the User's Manuals:
 
 * [C++](https://microsoft.github.io/bond/manual/bond_cpp.html)


### PR DESCRIPTION
The Bond open-source project will be ending development on March 31, 2025.

Add notes about this to the README and the CHANGELOG.